### PR TITLE
Quell isNaN MSVC performance warning.

### DIFF
--- a/public/amtl/am-utility.h
+++ b/public/amtl/am-utility.h
@@ -224,7 +224,7 @@ static inline bool
 IsNaN(double v)
 {
 #ifdef _MSC_VER
-  return _isnan(v);
+  return !!_isnan(v);
 #else
   return isnan(v);
 #endif


### PR DESCRIPTION
This prints for every file that includes am-utility. This should significantly reduce the noise while performing a build on Windows.
