### PR TITLE
Fix inconsistencies with OnClientDisconnected calls (bug 5988)

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -746,8 +746,10 @@ void PlayerManager::OnSourceModLevelEnd()
 		{
 #if SOURCE_ENGINE == SE_DOTA
 			OnClientDisconnect(m_Players[i].GetIndex(), 0);
+			OnClientDisconnect_Post(m_Players[i].GetIndex(), 0);
 #else
 			OnClientDisconnect(m_Players[i].GetEdict());
+			OnClientDisconnect_Post(m_Players[i].GetEdict());
 #endif
 		}
 	}
@@ -791,13 +793,6 @@ void PlayerManager::OnClientDisconnect(edict_t *pEntity)
 		pListener = (*iter);
 		pListener->OnClientDisconnecting(client);
 	}
-
-	InvalidatePlayer(pPlayer);
-
-	if (m_ListenClient == client)
-	{
-		m_ListenClient = 0;
-	}
 }
 
 #if SOURCE_ENGINE == SE_DOTA
@@ -810,6 +805,19 @@ void PlayerManager::OnClientDisconnect_Post(edict_t *pEntity)
 {
 	int client = IndexOfEdict(pEntity);
 #endif
+	CPlayer *pPlayer = &m_Players[client];
+	if (!pPlayer->IsConnected())
+	{
+		/* We don't care, prevent a double call */
+		return;
+	}
+
+	InvalidatePlayer(pPlayer);
+
+	if (m_ListenClient == client)
+	{
+		m_ListenClient = 0;
+	}
 
 	cell_t res;
 


### PR DESCRIPTION
As reported on bug 5988, https://bugs.alliedmods.net/show_bug.cgi?id=5988
The OnClientDisconnect_Post forward and corresponding IClientListener::OnClientDisconnected function are not called for fakeclients (bots), and can also be called a bit later than OnClientDisconnect/OnClientDisconnecting (rather than instantly after) for non-bots if the disconnect is from a map change.

Attached patch unifies the logic for players/bots disconnected from a map change, having OnClientDisconnect/_Post called in sequence the same as would happen when the funcs are called from the hook on IServerGameClients::ClientDisconnect. To prevent double calls of the post forward and listener, the IsConnected guard from the pre function is copied.

@KyleSanderson thoughts?
