### PR TITLE
Fix a case where bots can leave server without disconnect notice (hibern...

### DIFF
--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -174,6 +174,7 @@ public:
 	void OnClientSettingsChanged(edict_t *pEntity);
 	//void OnClientSettingsChanged_Pre(edict_t *pEntity);
 #endif
+	void OnServerHibernationUpdate(bool bHibernating);
 public: //IPlayerManager
 	void AddClientListener(IClientListener *listener);
 	void RemoveClientListener(IClientListener *listener);


### PR DESCRIPTION
...ation), triggering other issues.

Right now, in supported games that have hibernation (Left 4 Dead and released later) and those that have faux-hibernation (newer Orangebox and 2013 SDK games), all bots in the server get kicked when the server hibernates.

@KyleSanderson came across a very odd issue in SM that turned out to be caused by ClientDisconnect not being called for a bot. We narrowed it down to bots that were added immediately at map start OnMapStart/ServerActivate that were removed when the server hibernated. This is due to them not being fully spawned yet in the engine (confirmed by IClient::IsSpawned). It triggers the player_disconnect event, but does not notify the gamedll (and our hook).

This can be easily reproduced by calling CreateFakeClient in OnMapStart on CS:S.

My proposed fix is to just consider all bots to be leaving/gone when the server starts hibernating, similar to how to we do for map change.
