### PR TITLE
Compile.sh spacing improvements

### DIFF
--- a/plugins/compile.sh
+++ b/plugins/compile.sh
@@ -5,18 +5,21 @@ test -e compiled || mkdir compiled
 
 if [[ $# -ne 0 ]]
 then
-    for i in "$@"; 
-    do
-        smxfile="`echo $i | sed -e 's/\.sp$/\.smx/'`";
-	    echo -n "Compiling $i...";
-	    ./spcomp $i -ocompiled/$smxfile
+	for sourcefile in "$@"; 
+	do
+		smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`";
+		echo -e "\nCompiling $sourcefile...";
+		./spcomp $i -ocompiled/$smxfile
     done
 else
 
 for sourcefile in *.sp
 do
 	smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`"
-	echo -n "Compiling $sourcefile ..."
+	echo -e "\nCompiling $sourcefile ..."
 	./spcomp $sourcefile -ocompiled/$smxfile
 done
 fi
+
+echo -e "\n"
+read -n1 -rsp "Press any key to continue..."


### PR DESCRIPTION
Previously, when compiling, there would be no newlines between files.  While this barely affects single files, when compiling many files at the same time, it becomes troublesome to see which file is currently compiling.  In addition, a `pause`-like command has also been added.
I'll try to do the same to `compile.exe` if only I could find the file that creates it...

Before:

```
Compiling test1.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           3512 bytes
Code size:             6980 bytes
Data size:             2288 bytes
Stack/heap size:      16384 bytes; Total requirements:   29164 bytes
Compiling test2.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           6628 bytes
Code size:            29180 bytes
Data size:             5420 bytes
Stack/heap size:      16384 bytes; Total requirements:   57612 bytes
Compiling test3.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           2952 bytes
Code size:             3736 bytes
Data size:             1700 bytes
Stack/heap size:      16384 bytes; Total requirements:   24772 bytes
Compiling test4.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           3580 bytes
Code size:             6936 bytes
Data size:             2288 bytes
Stack/heap size:      16384 bytes; Total requirements:   29188 bytes
```

After:

```

Compiling test1.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           3512 bytes
Code size:             6980 bytes
Data size:             2288 bytes
Stack/heap size:      16384 bytes; Total requirements:   29164 bytes

Compiling test2.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           6628 bytes
Code size:            29180 bytes
Data size:             5420 bytes
Stack/heap size:      16384 bytes; Total requirements:   57612 bytes

Compiling test3.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           2952 bytes
Code size:             3736 bytes
Data size:             1700 bytes
Stack/heap size:      16384 bytes; Total requirements:   24772 bytes

Compiling test4.sp...SourcePawn Compiler 1.6.0-dev+4454
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

Header size:           3580 bytes
Code size:             6936 bytes
Data size:             2288 bytes
Stack/heap size:      16384 bytes; Total requirements:   29188 bytes

Press any key to continue...
```
