### PR TITLE
Use updated IServerTools iface on TF2 for getting tempent list and FindEntityByClassname

### DIFF
--- a/extensions/sdktools/tempents.cpp
+++ b/extensions/sdktools/tempents.cpp
@@ -314,7 +314,7 @@ void TempEntityManager::Initialize()
 	{
 		return;
 	}
-#endif
+#endif // == TF2
 
 	if (!g_pGameConf->GetOffset("GetTEName", &m_NameOffs))
 	{

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -789,7 +789,7 @@ static cell_t NativeFindEntityByClassname(IPluginContext *pContext, const cell_t
 
 	return -1;
 }
-#endif
+#endif // >= ORANGEBOX && != TF2
 
 static cell_t FindEntityByClassname(IPluginContext *pContext, const cell_t *params)
 {
@@ -820,7 +820,7 @@ static cell_t FindEntityByClassname(IPluginContext *pContext, const cell_t *para
 	{
 		return NativeFindEntityByClassname(pContext, params);
 	}
-#endif
+#endif // >= SE_ORANGEBOX
 
 	if (!pCall)
 	{
@@ -857,7 +857,7 @@ static cell_t FindEntityByClassname(IPluginContext *pContext, const cell_t *para
 			return NativeFindEntityByClassname(pContext, params);
 #else
 			return pContext->ThrowNativeError("%s", error);
-#endif
+#endif // >= ORANGEBOX
 		}
 	}
 
@@ -869,7 +869,7 @@ static cell_t FindEntityByClassname(IPluginContext *pContext, const cell_t *para
 	FINISH_CALL_SIMPLE(&pEntity);
 
 	return gamehelpers->EntityToBCompatRef(pEntity);
-#endif
+#endif // == TF2
 }
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX


### PR DESCRIPTION
Today's TF2 update added some new functions to IServerTools to make our lives mildly easier, thanks to TonyP @ Valve.

Attached patch changes our s_pTempEntities and FindEntityByClassname getters to use the new interface functions rather than rely on byte signatures or symbol names. These SDKTools changes can also be enabled for HL2:DM, DoD:S, CS:S, and SDK Base 2013 mods once they receive the game/SDK changes.

Existing gamedata for these is intentionally (albeit confusingly) left in tact so that our gamedata updater will not remove them from existing installs that may not yet have the new logic.
