### PR TITLE
Update SDKTools entity output functions to use core's GetEntityClassname instead of own.

### DIFF
--- a/extensions/sdktools/output.cpp
+++ b/extensions/sdktools/output.cpp
@@ -115,7 +115,7 @@ void EntityOutputManager::FireEventDetour(void *pOutput, CBaseEntity *pActivator
 	// Fast lookup failed - check the slow way for hooks that haven't fired yet
 	if ((fastLookup = EntityOutputs->Retrieve(sOutput, (void **)&pOutputName)) == false)
 	{
-		const char *classname = GetEntityClassname(pCaller);
+		const char *classname = gamehelpers->GetEntityClassname(pCaller);
 		if (!classname)
 		{
 			return;
@@ -352,22 +352,4 @@ const char *EntityOutputManager::FindOutputName(void *pOutput, CBaseEntity *pCal
 	}
 
 	return NULL;
-}
-
-const char *EntityOutputManager::GetEntityClassname(CBaseEntity *pEntity)
-{
-	static int offset = -1;
-	if (offset == -1)
-	{
-		datamap_t *pMap = gamehelpers->GetDataMap(pEntity);
-		sm_datatable_info_t info;
-		if (!gamehelpers->FindDataMapInfo(pMap, "m_iClassname", &info))
-		{
-			return NULL;
-		}
-		
-		offset = info.actual_offset;
-	}
-
-	return *(const char **)(((unsigned char *)pEntity) + offset);
 }

--- a/extensions/sdktools/output.h
+++ b/extensions/sdktools/output.h
@@ -108,8 +108,6 @@ public:
 	void OnHookAdded();
 	void OnHookRemoved();
 
-	const char *GetEntityClassname(CBaseEntity *pEntity);
-
 private:
 	bool enabled;
 

--- a/extensions/sdktools/outputnatives.cpp
+++ b/extensions/sdktools/outputnatives.cpp
@@ -46,7 +46,7 @@ cell_t HookSingleEntityOutput(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid Entity index %i (%i)", gamehelpers->ReferenceToIndex(params[1]), params[1]);
 	}
 
-	const char *classname = g_OutputManager.GetEntityClassname(pEntity);
+	const char *classname = gamehelpers->GetEntityClassname(pEntity);
 
 	char *outputname;
 	pContext->LocalToString(params[2], &outputname);
@@ -226,7 +226,7 @@ cell_t UnHookSingleEntityOutput(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid Entity index %i (%i)", gamehelpers->ReferenceToIndex(params[1]), params[1]);
 	}
 
-	const char *classname = g_OutputManager.GetEntityClassname(pEntity);
+	const char *classname = gamehelpers->GetEntityClassname(pEntity);
 
 	char *outputname;
 	pContext->LocalToString(params[2], &outputname);


### PR DESCRIPTION
The entity output detouring functionality in SDKTools has its own GetEntityClassname function. It slightly differs from GetEntityClassname in core, missing some updates. This is due to the output code being written before IGameHelpers exposed this function.
