### PR TITLE
Fix FindStringIndex native not returning INVALID_STRING_INDEX when string not found (bug 6144).

### DIFF
--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -113,7 +113,15 @@ static cell_t FindStringIndex(IPluginContext *pContext, const cell_t *params)
 
 	pContext->LocalToString(params[2], &str);
 
-	return pTable->FindStringIndex(str);
+	int strindex = pTable->FindStringIndex(str);
+
+	// INVALID_STRING_INDEX is 65535 at time of writing, but already defined in sp inc files as -1
+	if (strindex == INVALID_STRING_INDEX)
+	{
+		return -1;
+	}
+
+	return strindex;
 }
 
 static cell_t ReadStringTable(IPluginContext *pContext, const cell_t *params)


### PR DESCRIPTION
This should resolve bug 6144. The SP definition of INVALID_STRING_INDEX in sdktools_stringtables.inc doesn't match the sdk version. (-1 and 65535 respectively).

Updating the define in the SP inc file to be "correct" would cause plugins to need to be recompiled to get the fix. Instead, I've updated the only native that uses this to return the value that plugins are expecting.
