### PR TITLE
Actually add spacing to compile.sh

### DIFF
--- a/plugins/compile.sh
+++ b/plugins/compile.sh
@@ -4,25 +4,25 @@ cd "$(dirname "$0")"
 test -e compiled || mkdir compiled
 
 if [[ $# -ne 0 ]]; then
-	for i in "$@"; 
+	for sourcefile in "$@"
 	do
-		smxfile="`echo $i | sed -e 's/\.sp$/\.smx/'`";
-		echo -e "Compiling $i...";
-		./spcomp $i -ocompiled/$smxfile
+		smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`"
+		echo -e "\nCompiling $sourcefile..."
+		./spcomp $sourcefile -ocompiled/$smxfile
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ]; then
-			exit 1;
+			exit 1
 		fi
 	done
 else
 	for sourcefile in *.sp
 	do
 		smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`"
-		echo -e "Compiling $sourcefile ..."
+		echo -e "\nCompiling $sourcefile ..."
 		./spcomp $sourcefile -ocompiled/$smxfile
 		RETVAL=$?
 		if [ $RETVAL -ne 0 ]; then
-			exit 1;
+			exit 1
 		fi
 	done
 fi

--- a/plugins/compile.sh
+++ b/plugins/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 cd "$(dirname "$0")"
 
 test -e compiled || mkdir compiled
@@ -9,10 +9,6 @@ if [[ $# -ne 0 ]]; then
 		smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`"
 		echo -e "\nCompiling $sourcefile..."
 		./spcomp $sourcefile -ocompiled/$smxfile
-		RETVAL=$?
-		if [ $RETVAL -ne 0 ]; then
-			exit 1
-		fi
 	done
 else
 	for sourcefile in *.sp
@@ -20,9 +16,5 @@ else
 		smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`"
 		echo -e "\nCompiling $sourcefile ..."
 		./spcomp $sourcefile -ocompiled/$smxfile
-		RETVAL=$?
-		if [ $RETVAL -ne 0 ]; then
-			exit 1
-		fi
 	done
 fi


### PR DESCRIPTION
The only "confusing" part now is that extra newline between the copyright and header size.

Formatting has also been updated to match the majority of the file (no `;`).

Some output (ignore the fact that I'm using 1.5.1-this is a testing directory just to make sure things compile):
>Compiling basechat.sp ...
SourcePawn Compiler 1.5.1
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

>Header size:           3044 bytes
Code size:            10684 bytes
Data size:             3460 bytes
Stack/heap size:      16384 bytes; Total requirements:   33572 bytes

>Compiling basecomm.sp ...
SourcePawn Compiler 1.5.1
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

>Header size:           4296 bytes
Code size:            17004 bytes
Data size:             4976 bytes
Stack/heap size:      16384 bytes; Total requirements:   42660 bytes

>Compiling basecommands.sp ...
SourcePawn Compiler 1.5.1
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

>Header size:           4884 bytes
Code size:            20308 bytes
Data size:             5220 bytes
Stack/heap size:      16384 bytes; Total requirements:   46796 bytes

>Compiling basetriggers.sp ...
SourcePawn Compiler 1.5.1
Copyright (c) 1997-2006, ITB CompuPhase, (C)2004-2008 AlliedModders, LLC

>Header size:           3300 bytes
Code size:             9980 bytes
Data size:             2876 bytes
Stack/heap size:      16384 bytes; Total requirements:   32540 bytes