### PR TITLE
sm_reskick_immunity access check should not check for commands.

### DIFF
--- a/plugins/reservedslots.sp
+++ b/plugins/reservedslots.sp
@@ -279,7 +279,7 @@ SelectKickClient()
 	
 		new flags = GetUserFlagBits(i);
 		
-		if (IsFakeClient(i) || flags & ADMFLAG_ROOT || flags & ADMFLAG_RESERVATION || CheckCommandAccess(i, "sm_reskick_immunity", ADMFLAG_RESERVATION, false))
+		if (IsFakeClient(i) || flags & ADMFLAG_ROOT || flags & ADMFLAG_RESERVATION || CheckCommandAccess(i, "sm_reskick_immunity", ADMFLAG_RESERVATION, true))
 		{
 			continue;
 		}


### PR DESCRIPTION
The override_only parameter of CheckCommandAccess should be set to true, rather than false to skip checking commands as `sm_reskick_immunity` isn't a command that exists.
