### PR TITLE
Update CStrike extension CSWeaponDrop to use Vector overload on CS:GO.

### DIFF
--- a/extensions/cstrike/forwards.cpp
+++ b/extensions/cstrike/forwards.cpp
@@ -152,12 +152,20 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 #endif
 }
 
-DETOUR_DECL_MEMBER3(DetourCSWeaponDrop, void, CBaseEntity *, weapon, bool, something, bool, toss)
+#if SOURCE_ENGINE == SE_CSGO
+DETOUR_DECL_MEMBER3(DetourCSWeaponDrop, void, CBaseEntity *, weapon, Vector, vec, bool, unknown)
+#else
+DETOUR_DECL_MEMBER3(DetourCSWeaponDrop, void, CBaseEntity *, weapon, bool, bDropShield, bool, bThrowForward)
+#endif
 {
 	if (g_pIgnoreCSWeaponDropDetour)
 	{
 		g_pIgnoreCSWeaponDropDetour = false;
-		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, something, toss);
+#if SOURCE_ENGINE == SE_CSGO
+		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, vec, unknown);
+#else
+		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, bDropShield, bThrowForward);
+#endif
 		return;
 	}
 
@@ -170,8 +178,14 @@ DETOUR_DECL_MEMBER3(DetourCSWeaponDrop, void, CBaseEntity *, weapon, bool, somet
 	g_pCSWeaponDropForward->Execute(&result);
 
 
-	if (result == Pl_Continue)
-		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, something, toss);
+	if (result >= Pl_Continue)
+	{
+#if SOURCE_ENGINE == SE_CSGO
+		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, vec, unknown);
+#else
+		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, bDropShield, bThrowForward);
+#endif
+	}
 
 	return;
 }

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -226,6 +226,20 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	static ICallWrapper *pWrapper = NULL;
 	if (!pWrapper)
 	{
+#if SOURCE_ENGINE == SE_CSGO
+		REGISTER_NATIVE_ADDR("CSWeaponDrop",
+			PassInfo pass[3]; \
+			pass[0].flags = PASSFLAG_BYVAL; \
+			pass[0].type = PassType_Basic; \
+			pass[0].size = sizeof(CBaseEntity *); \
+			pass[1].flags = PASSFLAG_BYVAL; \
+			pass[1].type = PassType_Basic; \
+			pass[1].size = sizeof(Vector); \
+			pass[2].flags = PASSFLAG_BYVAL; \
+			pass[2].type = PassType_Basic; \
+			pass[2].size = sizeof(bool); \
+			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 3))
+#else
 		REGISTER_NATIVE_ADDR("CSWeaponDrop",
 			PassInfo pass[3]; \
 			pass[0].flags = PASSFLAG_BYVAL; \
@@ -238,6 +252,7 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 			pass[2].type  = PassType_Basic; \
 			pass[2].size  = sizeof(bool); \
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 3))
+#endif
 	}
 
 	CBaseEntity *pEntity;
@@ -270,7 +285,11 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	if (params[4] == 1 && g_pCSWeaponDropDetoured)
 		g_pIgnoreCSWeaponDropDetour = true;
 
+#if SOURCE_ENGINE == SE_CSGO
+	unsigned char vstk[sizeof(CBaseEntity *) * 2 + sizeof(bool) + sizeof(Vector)];
+#else
 	unsigned char vstk[sizeof(CBaseEntity *) * 2 + sizeof(bool) * 2];
+#endif
 	unsigned char *vptr = vstk;
 
 	// <psychonic> first one is always false. second is true to toss, false to just drop
@@ -278,9 +297,15 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	vptr += sizeof(CBaseEntity *);
 	*(CBaseEntity **)vptr = pWeapon;
 	vptr += sizeof(CBaseEntity *);
+#if SOURCE_ENGINE == SE_CSGO
+	*(Vector *)vptr = vec3_origin;
+	vptr += sizeof(Vector);
+	*(bool *)vptr = false;
+#else
 	*(bool *)vptr = false;
 	vptr += sizeof(bool);
 	*(bool *)vptr = (params[3]) ? true : false;
+#endif
 
  	pWrapper->Execute(vstk, NULL);
 

--- a/gamedata/sm-cstrike.games/game.csgo.txt
+++ b/gamedata/sm-cstrike.games/game.csgo.txt
@@ -89,9 +89,9 @@
 			"CSWeaponDrop"//Wildcard first 6 bytes for CS:S DM
 			{
 				"library"		"server"
-				"windows"		"\x2A\x2A\x2A\x2A\x2A\x2A\x56\x8B\xF1\x8B\x06\x8B\x2A\x2A\x2A\x2A\x2A\xFF\xD0\x80\x2A\x2A\x00\xF3"
-				"linux"			"@_ZN9CCSPlayer12CSWeaponDropEP17CBaseCombatWeaponbb"
-				"mac"			"@_ZN9CCSPlayer12CSWeaponDropEP17CBaseCombatWeaponbb"
+				"windows"		"\x2A\x2A\x2A\x2A\x2A\x2A\x81\xEC\x2A\x2A\x2A\x2A\x53\x8B\x5D\x08\x56\x57\x6A\x00\x68"
+				"linux"			"@_ZN9CCSPlayer12CSWeaponDropEP17CBaseCombatWeapon6Vectorb"
+				"mac"			"@_ZN9CCSPlayer12CSWeaponDropEP17CBaseCombatWeapon6Vectorb"
 			}
 			"TerminateRound"
 			{


### PR DESCRIPTION
The (bool, bool) version that we detour and call is now used in far fewer cases in favor of a new (Vector, bool) overload (which the former one now wraps).
