### PR TITLE
Remove the /TP (compile as C++) msvc flag from projects that should be compiling as C.

### DIFF
--- a/sourcepawn/compiler/AMBuilder
+++ b/sourcepawn/compiler/AMBuilder
@@ -17,6 +17,7 @@ if compiler.cc.behavior == 'gcc':
 elif compiler.cc.behavior == 'msvc':
   compiler.linkflags.remove('/SUBSYSTEM:WINDOWS')
   compiler.linkflags.append('/SUBSYSTEM:CONSOLE')
+  compiler.cxxflags.remove('/TP')
  
 if builder.target_platform == 'linux':
   compiler.defines += [

--- a/sourcepawn/jit/AMBuilder
+++ b/sourcepawn/jit/AMBuilder
@@ -17,6 +17,9 @@ binary.compiler.includes += [
 if builder.target_platform == 'linux':
   binary.compiler.postlink += ['-lpthread', '-lrt']
 
+if binary.compiler.cc.behavior == 'msvc':
+  binary.compiler.cxxflags.remove('/TP')
+
 binary.sources += [
   'BaseRuntime.cpp',
   'engine2.cpp',


### PR DESCRIPTION
This corrects an issue where ambuild's VS project generator was adding the /TP flag (which comes from the root AMBuildScript) on the spcomp and jit projects, preventing them from being built until the flag was removed.
