### PR TITLE
Fix line ending parsing issues in spcomp on windows

### DIFF
--- a/sourcepawn/compiler/libpawnc.c
+++ b/sourcepawn/compiler/libpawnc.c
@@ -116,7 +116,7 @@ void *pc_opensrc(char *filename)
 	}
 	#endif
 
-	return fopen(filename,"rt");
+	return fopen(filename,"rb");
 }
 
 /* pc_createsrc()


### PR DESCRIPTION
fgetpos fails with UNIX \n new lines on windows if the file was open in
textual mode.
