### PR TITLE
GetEntityClassname should handle the case where the world entity has not been created yet

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1170,6 +1170,12 @@ const char *CHalfLife2::GetEntityClassname(CBaseEntity *pEntity)
 	if (offset == -1)
 	{
 		CBaseEntity *pGetterEnt = ReferenceToEntity(0);
+		if (pGetterEnt == NULL)
+		{
+			// If we don't have a world entity yet, we'll have to rely on the given entity
+			pGetterEnt = pEntity;
+		}
+
 		datamap_t *pMap = GetDataMap(pGetterEnt);
 		
 		sm_datatable_info_t info;


### PR DESCRIPTION
This fixes a case where some metamod plugins were creating entities in a LevelInit pre-hook (thus, before the world entity was initialized).

The above use case is probably bad, but at least this would ensure the same behavior of pre-1.6, and I don't see anything too bad about this change.
