### PR TITLE
Allow CloseHandle() on nulls.

### DIFF
--- a/core/logic/smn_handles.cpp
+++ b/core/logic/smn_handles.cpp
@@ -53,6 +53,10 @@ static cell_t sm_IsValidHandle(IPluginContext *pContext, const cell_t *params)
 static cell_t sm_CloseHandle(IPluginContext *pContext, const cell_t *params)
 {
 	Handle_t hndl = static_cast<Handle_t>(params[1]);
+
+	if (!hndl)
+		return 0;
+
 	HandleSecurity sec;
 
 	sec.pIdentity = NULL;


### PR DESCRIPTION
I don't think there's any reason not to do this. It makes working with handles a lot easier, and long-term, we want them to be garbage collected anyway.
