### PR TITLE
Port nominations.sp to the transitional syntax and API.

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -96,7 +96,7 @@ public void OnConfigsExecuted()
 	BuildMapMenu();
 }
 
-public void OnNominationRemoved(char[] map, int owner)
+public void OnNominationRemoved(const char[] map, int owner)
 {
 	int status;
 	
@@ -300,8 +300,8 @@ void BuildMapMenu()
 		g_MapMenu.AddItem(map, map);
 		g_mapTrie.SetValue(map, status);
 	}
-	
-	g_MapMenu.SetExitButton(true);
+
+	g_MapMenu.ExitButton = true;
 
 	delete excludeMaps;
 }

--- a/sourcepawn/compiler/sc3.c
+++ b/sourcepawn/compiler/sc3.c
@@ -2191,6 +2191,14 @@ restart:
 
           if (!method || !method->target) {
             error(105, map->name, lexstr);
+
+            // Fetch a fake function so errors aren't as crazy.
+            char tmpname[METHOD_NAMEMAX + 1];
+            strcpy(tmpname, map->name);
+            strcat(tmpname, ".");
+            strcat(tmpname, lexstr);
+            tmpname[sNAMEMAX] = '\0';
+            sym = fetchfunc(tmpname);
           } else {
             implicitthis = &thisval;
             sym = method->target;


### PR DESCRIPTION
This is a complete port of nominations to the new syntax and available transitional API. This helped iron out a few bugs in spcomp and should serve as an example of what the new stuff looks like.
