### PR TITLE
Fix usage of `class` keyword in some includes.

### DIFF
--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -254,12 +254,12 @@ native TF2_SetPlayerPowerPlay(client, bool:enabled);
  *
  * @param client		Player's index.
  * @param team			Team to disguise the player as (only TFTeam_Red and TFTeam_Blue have an effect)
- * @param class			TFClassType class to disguise the player as
+ * @param classType		TFClassType class to disguise the player as
  * @param target		Specific target player to disguise as (0 for any)
  * @noreturn
  * @error				Invalid client index, client not in game, or no mod support.
  */
-native TF2_DisguisePlayer(client, TFTeam:team, TFClassType:class, target=0);
+native TF2_DisguisePlayer(client, TFTeam:team, TFClassType:classType, target=0);
 
 /**
  * Removes the current disguise from a client. Only has an effect on spies.

--- a/plugins/include/tf2_stocks.inc
+++ b/plugins/include/tf2_stocks.inc
@@ -335,19 +335,19 @@ stock TFClassType:TF2_GetPlayerClass(client)
  * Note: If setting player class in a player spawn hook weapons should be set to false.
  *
  * @param client		Player's index.
- * @param class			TFClassType class symbol.
+ * @param classType		TFClassType class symbol.
  * @param weapons		This paramater is ignored.
  * @param persistent	If true changes the players desired class so the change stays after death.
  * @noreturn
  * @error				Invalid client index.
  */
-stock TF2_SetPlayerClass(client, TFClassType:class, bool:weapons=true, bool:persistent=true)
+stock TF2_SetPlayerClass(client, TFClassType:classType, bool:weapons=true, bool:persistent=true)
 {
-	SetEntProp(client, Prop_Send, "m_iClass", _:class);
+	SetEntProp(client, Prop_Send, "m_iClass", _:classType);
 	
 	if (persistent)
 	{
-		SetEntProp(client, Prop_Send, "m_iDesiredPlayerClass", _:class);
+		SetEntProp(client, Prop_Send, "m_iDesiredPlayerClass", _:classType);
 	}
 }
 


### PR DESCRIPTION
Grepped through all the SP includes, it appears these are the only two files which are accidentally using the `class` keyword.
