### PR TITLE
Unkeyword "class", make it contextual.

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -395,7 +395,6 @@ enum {
   tCASE,
   tCELLSOF,
   tCHAR,
-  tCLASS,
   tCONST,
   tCONTINUE,
   tDECL,

--- a/sourcepawn/compiler/sc1.c
+++ b/sourcepawn/compiler/sc1.c
@@ -1526,12 +1526,17 @@ static void parse(void)
     case 0:
       /* ignore zero's */
       break;
+    case tSYMBOL:
+      if (strcmp(tok.str, "class") == 0) {
+        domethodmap(Layout_Class);
+        break;
+      }
+      // Fallthrough.
     case tINT:
     case tOBJECT:
     case tCHAR:
     case tVOID:
     case tLABEL:
-    case tSYMBOL:
       lexpush();
       // Fallthrough.
     case tNEW:
@@ -1562,9 +1567,6 @@ static void parse(void)
       break;
     case tMETHODMAP:
       domethodmap(Layout_MethodMap);
-      break;
-    case tCLASS:
-      domethodmap(Layout_Class);
       break;
     case '}':
       error(54);                /* unmatched closing brace */

--- a/sourcepawn/compiler/sc2.c
+++ b/sourcepawn/compiler/sc2.c
@@ -1949,7 +1949,7 @@ char *sc_tokens[] = {
          "...", "..", "::",
          "assert",
          "*begin", "break",
-         "case", "cellsof", "char", "class", "const", "continue",
+         "case", "cellsof", "char", "const", "continue",
          "decl", "default", "defined", "delete", "do",
          "else", "*end", "enum", "exit",
          "for", "forward", "funcenum", "functag", "function",

--- a/sourcepawn/compiler/tests/ok-class-arg.sp
+++ b/sourcepawn/compiler/tests/ok-class-arg.sp
@@ -1,0 +1,7 @@
+f(const char[] class)
+{
+}
+
+public OnPluginStart()
+{
+}


### PR DESCRIPTION
Turned out this broke too much source code. We'll have to peek for "class" as a non-keyword instead.
