### PR TITLE
Add support to Get/SetEntPropEnt for FIELD_CLASSPTR and FIELD_EDICT datadesc fields.

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -1699,16 +1699,7 @@ static cell_t SetEntPropEnt(IPluginContext *pContext, const cell_t *params)
 	case PropEnt_Handle:
 		{
 			CBaseHandle &hndl = *(CBaseHandle *) ((uint8_t *) pEntity + offset);
-
-			if (!pOther)
-			{
-				hndl.Set(NULL);
-			}
-			else
-			{
-				IHandleEntity *pHandleEnt = (IHandleEntity *) pOther;
-				hndl.Set(pHandleEnt);
-			}
+			hndl.Set((IHandleEntity *) pOther);
 
 			if (params[2] == Prop_Send && (pEdict != NULL))
 			{


### PR DESCRIPTION
FIELD_CLASSPTR is only used for CBaseEntity ptrs and FIELD_EDICT uses edict_t ptrs - both perfect fits for the existing GetEntPropEnt and SetEntPropEnt.
