### PR TITLE
Give functags their correct types for transitional syntax.

### DIFF
--- a/plugins/include/clientprefs.inc
+++ b/plugins/include/clientprefs.inc
@@ -165,9 +165,10 @@ forward OnClientCookiesCached(client);
  * @param action		CookieMenuAction being performed.
  * @param info			Info data passed.
  * @param buffer		Outbut buffer.
- * @param maxlen		Max length of the output buffer.			
+ * @param maxlen		Max length of the output buffer.
+ * @noreturn			
  */
-functag public CookieMenuHandler(client, CookieMenuAction:action, any:info, String:buffer[], maxlen);
+functag public void CookieMenuHandler(client, CookieMenuAction:action, any:info, String:buffer[], maxlen);
 
 /**
  * Add a new prefab item to the client cookie settings menu.

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -456,7 +456,7 @@ native Handle:FindConVar(const String:name[]);
  * @param newValue		String containing the new value of the convar.
  * @noreturn
  */
-functag public ConVarChanged(Handle:convar, const String:oldValue[], const String:newValue[]);
+functag public void ConVarChanged(Handle:convar, const String:oldValue[], const String:newValue[]);
 
 /**
  * Creates a hook for when a console variable's value is changed.

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -641,9 +641,9 @@ native SQL_UnlockDatabase(Handle:database);
  *						empty even if an error condition exists, so it is important 
  *						to check the actual Handle value instead.
  * @param data			Data passed in via the original threaded invocation.
- * @param 
+ * @noreturn
  */
-functag public SQLTCallback(Handle:owner, Handle:hndl, const String:error[], any:data);
+functag public void SQLTCallback(Handle:owner, Handle:hndl, const String:error[], any:data);
 
 /**
  * Tells whether two database handles both point to the same database 
@@ -713,7 +713,7 @@ native Transaction:SQL_CreateTransaction();
  * @param queryData     An array of each data value passed to SQL_AddQuery().
  * @noreturn
  */
-functag public SQLTxnSuccess(Handle:db, any:data, numQueries, Handle:results[], any:queryData[]);
+functag public void SQLTxnSuccess(Handle:db, any:data, numQueries, Handle:results[], any:queryData[]);
 
 /**
  * Callback for a failed transaction.
@@ -726,7 +726,7 @@ functag public SQLTxnSuccess(Handle:db, any:data, numQueries, Handle:results[], 
  * @param queryData     An array of each data value passed to SQL_AddQuery().
  * @noreturn
  */
-functag public SQLTxnFailure(Handle:db, any:data, numQueries, const String:error[], failIndex, any:queryData[]);
+functag public void SQLTxnFailure(Handle:db, any:data, numQueries, const String:error[], failIndex, any:queryData[]);
 
 /**
  * Adds a query to a transaction object.

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -357,7 +357,7 @@ native Call_Cancel();
  * @param numParams			Number of parameters passed to the native.
  * @return 					Value for the native call to return.
  */
-functag public NativeCall(Handle:plugin, numParams);
+functag public int NativeCall(Handle:plugin, numParams);
 
 /**
  * Creates a dynamic native.  This should only be called in AskPluginLoad(), or 
@@ -499,7 +499,7 @@ native FormatNativeString(out_param,
  * @param data			Data passed to the RequestFrame native.
  * @noreturn
  */
-functag public RequestFrameCallback(any:data);
+functag public void RequestFrameCallback(any:data);
 
 /**
  * Creates a single use Next Frame hook.

--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -150,9 +150,8 @@ enum MenuSource
  * @param action			The action of the menu.
  * @param param1			First action parameter (usually the client).
  * @param param2			Second action parameter (usually the item).
- * @noreturn
  */
-functag public MenuHandler(Menu:menu, MenuAction:action, param1, param2);
+functag public int MenuHandler(Menu:menu, MenuAction:action, param1, param2);
 
 /**
  * Creates a new, empty menu using the default style.
@@ -528,7 +527,7 @@ stock bool:VoteMenuToAll(Handle:menu, time, flags=0)
  *							defines.
  * @noreturn
  */
-functag public VoteHandler(Menu:menu,
+functag public void VoteHandler(Menu:menu,
 						   num_votes, 
 						   num_clients,
 						   const client_info[][2], 

--- a/plugins/include/sdktools_entoutput.inc
+++ b/plugins/include/sdktools_entoutput.inc
@@ -42,8 +42,9 @@
  * @param caller		Entity index of the caller.
  * @param activator		Entity index of the activator.
  * @param delay			Delay in seconds? before the event gets fired.
+ * @noreturn
  */
-functag public EntityOutput(const String:output[], caller, activator, Float:delay);
+functag public void EntityOutput(const String:output[], caller, activator, Float:delay);
 
 /**
  * Add an entity output hook on a entity classname

--- a/plugins/include/sorting.inc
+++ b/plugins/include/sorting.inc
@@ -98,7 +98,7 @@ native SortStrings(String:array[][], array_size, SortOrder:order = Sort_Ascendin
  *						0 if first is equal to second
  *						1 if first should go after second
  */
-functag public SortFunc1D(elem1, elem2, const array[], Handle:hndl);
+functag public int SortFunc1D(elem1, elem2, const array[], Handle:hndl);
 
 /** 
  * Sorts a custom 1D array.  You must pass in a comparison function.
@@ -163,7 +163,7 @@ native SortADTArray(Handle:array, SortOrder:order, SortType:type);
  *					0 if first is equal to second
  *					1 if first should go after second
  */
-functag public SortFuncADTArray(index1, index2, Handle:array, Handle:hndl);
+functag public int SortFuncADTArray(index1, index2, Handle:array, Handle:hndl);
 
 /**
  * Custom sorts an ADT Array. You must pass in a comparison function.

--- a/plugins/include/textparse.inc
+++ b/plugins/include/textparse.inc
@@ -108,7 +108,7 @@ native bool:SMC_GetErrorString(SMCError:error, String:buffer[], buf_max);
  * @param smc			The SMC Parse Handle.
  * @noreturn
  */
-functag public SMC_ParseStart(Handle:smc);
+functag public void SMC_ParseStart(Handle:smc);
 
 /**
  * Sets the SMC_ParseStart function of a parse Handle.
@@ -128,7 +128,7 @@ native SMC_SetParseStart(Handle:smc, SMC_ParseStart:func);
  * @param failed		True if parsing failed, false otherwise.
  * @noreturn
  */
-functag public SMC_ParseEnd(Handle:smc, bool:halted, bool:failed);
+functag public void SMC_ParseEnd(Handle:smc, bool:halted, bool:failed);
 
 /**
  * Sets the SMC_ParseEnd of a parse handle.

--- a/plugins/include/topmenus.inc
+++ b/plugins/include/topmenus.inc
@@ -127,7 +127,7 @@ enum TopMenuObject
  * @param maxlength			Output buffer (if used).
  * @noreturn
  */
-functag public TopMenuHandler(Handle:topmenu, 
+functag public void TopMenuHandler(Handle:topmenu, 
 							  TopMenuAction:action,
 							  TopMenuObject:topobj_id,
 							  param,

--- a/plugins/include/usermessages.inc
+++ b/plugins/include/usermessages.inc
@@ -147,8 +147,9 @@ functag public Action:MsgHook(UserMsg:msg_id, Handle:msg, const players[], playe
  *
  * @param msg_id		Message index.
  * @param sent			True if message was sent, false if blocked.
+ * @noreturn
  */
-functag public MsgPostHook(UserMsg:msg_id, bool:sent);
+functag public void MsgPostHook(UserMsg:msg_id, bool:sent);
 
 /**
  * Hooks a user message.


### PR DESCRIPTION
Also fixed up where the documentation for return values was incorrect or missing.
