### PR TITLE
Fix crash with malformed arguments (bug 6176).

### DIFF
--- a/sourcepawn/compiler/sc1.c
+++ b/sourcepawn/compiler/sc1.c
@@ -6652,6 +6652,10 @@ static void statement(int *lastindent,int allow_decl)
     }
 
     if (is_decl) {
+      if (!allow_decl) {
+        error(3);
+        return;
+      }
       lexpush();
       autozero = TRUE;
       lastst = tNEW;

--- a/sourcepawn/compiler/tests/fail-missing-arg-comma.sp
+++ b/sourcepawn/compiler/tests/fail-missing-arg-comma.sp
@@ -1,0 +1,4 @@
+stock void Function( float array1[ 3 ] float array2[ 3 ] )
+{
+
+}

--- a/sourcepawn/compiler/tests/fail-missing-arg-comma.txt
+++ b/sourcepawn/compiler/tests/fail-missing-arg-comma.txt
@@ -1,0 +1,1 @@
+(1) : error 001: expected token: ")", but found "-identifier-"


### PR DESCRIPTION
There is a place I'm calling `declloc()` without first checking that it's okay, and it crashes in some malformed code. Simple fix. Unfortunately the error recovery is pretty bad here. Clang and GCC both have one clean error when you forget a comma - spcomp flips out and gives you like 5 errors. Oh well.
