### PR TITLE
Pause dependent plugins on SetFailState (bug 6120)

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1147,7 +1147,7 @@ void CPluginManager::LoadAll_SecondPass()
 			if (!RunSecondPass(pPlugin, error, sizeof(error)))
 			{
 				g_Logger.LogError("[SM] Unable to load plugin \"%s\": %s", pPlugin->GetFilename(), error);
-				pPlugin->SetErrorState(Plugin_Failed, "%s", error);
+				pPlugin->SetErrorState(Plugin_BadLoad, "%s", error);
 			}
 		}
 	}
@@ -2224,7 +2224,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const CCommand &c
 			const sm_plugininfo_t *info = pl->GetPublicInfo();
 
 			rootmenu->ConsolePrint("  Filename: %s", pl->GetFilename());
-			if (pl->GetStatus() <= Plugin_Error)
+			if (pl->GetStatus() <= Plugin_Error || pl->GetStatus() == Plugin_Failed)
 			{
 				if (IS_STR_FILLED(info->name))
 				{
@@ -2247,7 +2247,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const CCommand &c
 				{
 					rootmenu->ConsolePrint("  URL: %s", info->url);
 				}
-				if (pl->GetStatus() == Plugin_Error)
+				if (pl->GetStatus() == Plugin_Error || pl->GetStatus() == Plugin_Failed)
 				{
 					rootmenu->ConsolePrint("  Error: %s", pl->m_errormsg);
 				}

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -380,7 +380,7 @@ static cell_t SetFailState(IPluginContext *pContext, const cell_t *params)
 
 	if (params[0] == 1)
 	{
-		pPlugin->SetErrorState(Plugin_Error, "%s", str);
+		pPlugin->SetErrorState(Plugin_Failed, "%s", str);
 
 		return pContext->ThrowNativeErrorEx(SP_ERROR_ABORTED, "%s", str);
 	}
@@ -391,12 +391,12 @@ static cell_t SetFailState(IPluginContext *pContext, const cell_t *params)
 		g_pSM->FormatString(buffer, sizeof(buffer), pContext, params, 1);
 		if (pContext->GetLastNativeError() != SP_ERROR_NONE)
 		{
-			pPlugin->SetErrorState(Plugin_Error, "%s", str);
+			pPlugin->SetErrorState(Plugin_Failed, "%s", str);
 			return pContext->ThrowNativeErrorEx(SP_ERROR_ABORTED, "Formatting error (%s)", str);
 		}
 		else
 		{
-			pPlugin->SetErrorState(Plugin_Error, "%s", buffer);
+			pPlugin->SetErrorState(Plugin_Failed, "%s", buffer);
 			return pContext->ThrowNativeErrorEx(SP_ERROR_ABORTED, "%s", buffer);
 		}
 	}


### PR DESCRIPTION
When a plugin calls SetFailState it is paused and all natives it
registered are unavailable. Other plugins, which depend on those natives
keep running and error whenever they try to call those natives.

This correctly sets the dependent plugins to an error state and also calls OnLibraryRemoved correctly for all libraries as if the
plugin which called SetFailState was unloaded.

As a sideeffect OnPluginPauseChange is called again, when a plugin changes its pause state.