### PR TITLE
Mark usage correctly when invoking special natives.

### DIFF
--- a/sourcepawn/compiler/sc1.c
+++ b/sourcepawn/compiler/sc1.c
@@ -4214,7 +4214,10 @@ static void dodelete()
   {
     pushval(1);
     ffcall(map->dtor->target, NULL, 1);
-    markusage(map->dtor->target, uREAD);
+
+    // Only mark usage if we're not skipping codegen.
+    if (sc_status != statSKIP)
+      markusage(map->dtor->target, uREAD);
   }
 
   if (zap) {

--- a/sourcepawn/compiler/sc4.c
+++ b/sourcepawn/compiler/sc4.c
@@ -1415,7 +1415,9 @@ SC_FUNC void invoke_getter(methodmap_method_t *method)
   pushreg(sPRI);
   pushval(1);
   ffcall(method->getter, NULL, 1);
-  markusage(method->getter, uREAD);
+
+  if (sc_status != statSKIP)
+    markusage(method->getter, uREAD);
 }
 
 SC_FUNC void invoke_setter(methodmap_method_t *method, int save)
@@ -1433,5 +1435,7 @@ SC_FUNC void invoke_setter(methodmap_method_t *method, int save)
   ffcall(method->setter, NULL, 2);
   if (save)
     popreg(sPRI);
-  markusage(method->setter, uREAD);
+
+  if (sc_status != statSKIP)
+    markusage(method->setter, uREAD);
 }

--- a/sourcepawn/compiler/tests/ok-reparse-delete.sp
+++ b/sourcepawn/compiler/tests/ok-reparse-delete.sp
@@ -1,0 +1,12 @@
+methodmap Handle {
+	public native ~Handle();
+}
+
+stock Crab(Handle h)
+{
+	delete h;
+}
+
+public main()
+{
+}


### PR DESCRIPTION
Two horrible bugs: one, don't call markusage() if we're parsing but not generating code. This misaligns all the native indexes in some scenarios, because ffcall() increments a global counter and the file output uses the same logic to increment its own counter.

Second, invoke_setter() was calling markusage() on the wrong function.
