### PR TITLE
Block off operators for post-transitional compiler.

### DIFF
--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -244,6 +244,7 @@ stock RoundFloat(Float:value)
  * User defined operators.
  *
  */
+#if !defined __sourcepawn2__
 #pragma rational Float
 
 native bool:__FLOAT_GT__(Float:a, Float:b);
@@ -368,6 +369,7 @@ stock bool:operator<=(oper1, Float:oper2)
 forward operator%(Float:oper1, Float:oper2);
 forward operator%(Float:oper1, oper2);
 forward operator%(oper1, Float:oper2);
+#endif // __sourcepawn2__
 
 #define FLOAT_PI 3.1415926535897932384626433832795
 


### PR DESCRIPTION
These will all be builtin in the future. Post-transitional compiler won't parse operators or #pragma rational.
