### PR TITLE
Fix postinc/dec operations on accessors.

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -718,7 +718,6 @@ SC_FUNC void pushval(cell val);
 SC_FUNC void popreg(regid reg);
 SC_FUNC void genarray(int dims, int _autozero);
 SC_FUNC void swap1(void);
-SC_FUNC void xchg(void);
 SC_FUNC void ffswitch(int label);
 SC_FUNC void ffcase(cell value,char *labelname,int newtable);
 SC_FUNC void ffcall(symbol *sym,const char *label,int numargs);

--- a/sourcepawn/compiler/sc4.c
+++ b/sourcepawn/compiler/sc4.c
@@ -1394,12 +1394,6 @@ SC_FUNC void jmp_eq0(int number)
   code_idx+=opcodes(1)+opargs(1);
 }
 
-SC_FUNC void xchg(void)
-{
-  stgwrite("\txchg\n");
-  code_idx+=opcodes(1);
-}
-
 /* write a value in hexadecimal; optionally adds a newline */
 SC_FUNC void outval(cell val,int newline)
 {


### PR DESCRIPTION
The code I wrote for postinc/dec on setters turned out to be bogus. This should fix it.

Normally you're supposed to use `check_userop` to do the heavy lifting for inc/dec operations. Unfortunately it's a big hack (surprise). spcomp fetches the value twice, which in this case, would involve calling the getter twice.

The new code changes `check_userop` to treat accessors as if they were rvalues - so it doesn't try to save/restore anything. The code before `check_userop` sets up the stack beforehand so we can safely recover the original object and pre-incremented value later.

In the vast majority of cases we won't have a user operator, so all the saving/restoring work is pointless. But like most of spcomp it's pretty hard to disentangle semantic logic from code generation.
