### PR TITLE
Clean up the struct syntax and force it to use newdecls.

### DIFF
--- a/plugins/include/core.inc
+++ b/plugins/include/core.inc
@@ -42,10 +42,10 @@
 
 struct PlVers
 {
-	version,
-	String:filevers[],
-	String:date[],
-	String:time[]
+	public int version;
+	public const char[] filevers;
+	public const char[] date;
+	public const char[] time;
 };
 
 /**
@@ -111,10 +111,10 @@ enum PluginInfo
  */
 struct Extension
 {
-	const String:name[],	/**< Short name */
-	const String:file[],	/**< Default file name */
-	bool:autoload,			/**< Whether or not to auto-load */
-	bool:required,			/**< Whether or not to require */
+	public const char[] name;	/**< Short name */
+	public const char[] file;	/**< Default file name */
+	public bool autoload;		/**< Whether or not to auto-load */
+	public bool required;		/**< Whether or not to require */
 };
 
 /**
@@ -122,9 +122,9 @@ struct Extension
  */
 struct SharedPlugin
 {
-	const String:name[],	/**< Short name */
-	const String:file[],	/**< File name */
-	bool:required,			/**< Whether or not to require */
+	public const char[] name;	/**< Short name */
+	public const char[] file;	/**< File name */
+	public bool required;		/**< Whether or not to require */
 };
 
 public Float:NULL_VECTOR[3];		/**< Pass this into certain functions to act as a C++ NULL */

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -40,11 +40,11 @@
  */
 struct Plugin
 {
-   const String:name[],			/**< Plugin Name */
-   const String:description[],	/**< Plugin Description */
-   const String:author[],		/**< Plugin Author */
-   const String:version[],		/**< Plugin Version */
-   const String:url[],			/**< Plugin URL */
+   public const char[] name;		/**< Plugin Name */
+   public const char[] description;	/**< Plugin Description */
+   public const char[] author;		/**< Plugin Author */
+   public const char[] version;		/**< Plugin Version */
+   public const char[] url;			/**< Plugin URL */
 };
 
 #include <core>

--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -264,14 +264,14 @@ typedef struct svalue_s {
   int lvalue;
 } svalue;
 
-#define DECLFLAG_ONLY_NEW        0x01 // Only new-style types are allowed.
 #define DECLFLAG_ARGUMENT        0x02 // The declaration is for an argument.
 #define DECLFLAG_VARIABLE        0x04 // The declaration is for a variable.
 #define DECLFLAG_ENUMROOT        0x08 // Multi-dimensional arrays should have an enumroot.
 #define DECLFLAG_MAYBE_FUNCTION  0x10 // Might be a named function.
 #define DECLFLAG_DYNAMIC_ARRAYS  0x20 // Dynamic arrays are allowed.
 #define DECLFLAG_OLD             0x40 // Known old-style declaration.
-#define DECLMASK_NAMED_DECL      (DECLFLAG_ARGUMENT | DECLFLAG_VARIABLE | DECLFLAG_MAYBE_FUNCTION)
+#define DECLFLAG_FIELD           0x80 // Struct field.
+#define DECLMASK_NAMED_DECL      (DECLFLAG_ARGUMENT | DECLFLAG_VARIABLE | DECLFLAG_MAYBE_FUNCTION | DECLFLAG_FIELD)
 
 typedef struct {
   // Array information.

--- a/sourcepawn/compiler/sctracker.h
+++ b/sourcepawn/compiler/sctracker.h
@@ -51,7 +51,7 @@ typedef struct structarg_s
 {
   int tag;
   int dimcount;
-  cell dims[sDIMEN_MAX];
+  int dims[sDIMEN_MAX];
   char name[sNAMEMAX+1];
   int fconst;
   int ident;


### PR DESCRIPTION
This patch cleans up the `struct` syntax to make it look like methodmaps. All the old gross parsing is removed in favor of `parse_decl`. The results of that are then just copied into the struct definition.

This also removes commas from the struct syntax and forces struct names to start with an uppercase letter.

As far as we know structs are not used outside of Core since there is no API to use them. So this shouldn't break anything, and will make it much easier for a post-transitional compiler to handle structs as if they were classes.
