### PR TITLE
Fix bug in variadic argument parsing. (bug 6195)

### DIFF
--- a/sourcepawn/compiler/sc1.c
+++ b/sourcepawn/compiler/sc1.c
@@ -3395,7 +3395,7 @@ int parse_decl(declinfo_t *decl, int flags)
   decl->type.size = 1;
 
   // Match early varargs as old decl.
-  if (matchtoken(tELLIPS))
+  if (lexpeek(tELLIPS))
     return parse_old_decl(decl, flags);
 
   // Must attempt to match const first, since it's a common prefix.

--- a/sourcepawn/compiler/tests/ok-varargs.sp
+++ b/sourcepawn/compiler/tests/ok-varargs.sp
@@ -1,0 +1,7 @@
+stock MyFormat( const String:formatString[], ... )
+{
+}
+
+public main()
+{
+}


### PR DESCRIPTION
Whoops. Consumed the token instead of peeking for it.
