### PR TITLE
Close file handle on success in pc_opensrc.

### DIFF
--- a/sourcepawn/compiler/libpawnc.c
+++ b/sourcepawn/compiler/libpawnc.c
@@ -148,6 +148,7 @@ void *pc_opensrc(char *filename)
 
 	src->pos = src->buffer;
 	src->end = src->buffer + length;
+	fclose(fp);
 	return src;
 
 err:


### PR DESCRIPTION
`pc_opensrc` is leaking file handles after the `src_file_t` refactor.

I'm fairly certain that the file handle shouldn't be sticking around anyway, as the `fp` field of the `src_file_t` states:
`// Set if writing.`
and the field isn't set within `pc_opensrc`, so it simply goes unused and leaks.

This fixes an issue I encountered when dealing with a plugin with many included files (100+).
