### PR TITLE
Fix message string for error 102.

### DIFF
--- a/sourcepawn/compiler/sc1.c
+++ b/sourcepawn/compiler/sc1.c
@@ -3972,7 +3972,7 @@ static void domethodmap(LayoutSpec spec)
     }
 
     if ((parent = methodmap_find_by_name(str)) == NULL) {
-      error(102, str);
+      error(102, spectype, str);
     } else if (parent->spec != spec) {
       error(129);
     }

--- a/sourcepawn/compiler/sc7.c
+++ b/sourcepawn/compiler/sc7.c
@@ -95,14 +95,14 @@ static void grow_stgbuffer(char **buffer, int *curmax, int requiredsize)
    * over a few kBytes, there is probably a run-away expression
    */
   if (requiredsize>sSTG_MAX)
-    error(102,"staging buffer");    /* staging buffer overflow (fatal error) */
+    error(163);    /* staging buffer overflow (fatal error) */
   *curmax=requiredsize+sSTG_GROW;
   if (*buffer!=NULL)
     p=(char *)realloc(*buffer,*curmax*sizeof(char));
   else
     p=(char *)malloc(*curmax*sizeof(char));
   if (p==NULL)
-    error(102,"staging buffer");    /* staging buffer overflow (fatal error) */
+    error(163);    /* staging buffer overflow (fatal error) */
   *buffer=p;
   if (clear)
     **buffer='\0';


### PR DESCRIPTION
This PR is for [bug 6187](https://bugs.alliedmods.net/show_bug.cgi?id=6187).

After further inspection, there seems to be an issue with the string associated for error 102:

`/*102*/  "cannot find %s %s\n",`

It expects 2 string parameters, but only one is ever passed in at all call sites.

I'm not sure if I did this correctly, but I edited the string and then ran scpack on the sc5.scp file.
