### PR TITLE
Change checkout-deps script to do a user install of AMBuild

### DIFF
--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -118,7 +118,6 @@ if [ $? -eq 1 ]; then
     python setup.py install
   else
     python setup.py build
-    echo "About to install AMBuild - press Ctrl+C to abort, otherwise enter your password for sudo."
-    sudo python setup.py install
+    python setup.py install --user
   fi
 fi


### PR DESCRIPTION
Installing a development dependency system-wide seems silly.