### PR TITLE
Add WritePackFunction and ReadPackFunction natives

### DIFF
--- a/core/CDataPack.h
+++ b/core/CDataPack.h
@@ -51,12 +51,14 @@ public: //IDataReader
 	const char *ReadString(size_t *len) const;
 	void *GetMemory() const;
 	void *ReadMemory(size_t *size) const;
+	cell_t ReadFunction() const;
 public: //IDataPack
 	void ResetSize();
 	void PackCell(cell_t cell);
 	void PackFloat(float val);
 	void PackString(const char *string);
 	size_t CreateMemory(size_t size, void **addr);
+	void PackFunction(cell_t function);
 public:
 	void Initialize();
 private:
@@ -66,6 +68,14 @@ private:
 	mutable char *m_curptr;
 	size_t m_capacity;
 	size_t m_size;
+
+	enum DataPackType {
+		Raw,
+		Cell,
+		Float,
+		String,
+		Function
+	};
 };
 
 #endif //_INCLUDE_SOURCEMOD_CDATAPACK_H_

--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -73,6 +73,16 @@ native WritePackFloat(Handle:pack, Float:val);
 native WritePackString(Handle:pack, const String:str[]);
 
 /**
+ * Packs a function pointer into a data pack.
+ *
+ * @param pack		Handle to the data pack.
+ * @param fktptr	Function pointer to add.
+ * @noreturn
+ * @error			Invalid handle.
+ */
+native WritePackFunction(Handle:pack, Function:fktptr);
+
+/**
  * Reads a cell from a data pack.
  *
  * @param pack		Handle to the data pack.
@@ -100,6 +110,15 @@ native Float:ReadPackFloat(Handle:pack);
  * @error			Invalid handle, or bounds error.
  */
 native ReadPackString(Handle:pack, String:buffer[], maxlen);
+
+/**
+ * Reads a function pointer from a data pack.
+ *
+ * @param pack		Handle to the data pack.
+ * @return			Function pointer.
+ * @error			Invalid handle, or bounds error.
+ */
+native Function ReadPackFunction(Handle:pack);
 
 /**
  * Resets the position in a data pack.

--- a/public/IDataPack.h
+++ b/public/IDataPack.h
@@ -113,6 +113,13 @@ namespace SourceMod
 		* @return			Pointer to the data, or NULL if out of bounds.
 		*/
 		virtual void *ReadMemory(size_t *size) const =0;
+
+		/**
+		 * @brief Reads a function pointer from the data stream.
+		 *
+		 * @return			A function pointer read from the current position.
+		 */
+		virtual cell_t ReadFunction() const =0;
 	};
 
 	/**
@@ -160,6 +167,13 @@ namespace SourceMod
 		 * @return			Current position of the stream beforehand.
 		 */
 		virtual size_t CreateMemory(size_t size, void **addr) =0;
+
+		/**
+		 * @brief Packs one function pointer into the data stream.
+		 *
+		 * @param function	The function pointer to write.
+		 */
+		virtual void PackFunction(cell_t function) =0;
 	};
 }
 


### PR DESCRIPTION
Adds type safety to CDataPack. Cells can't be read as Float anymore. Now
you're able to store a function pointer in a datapack and be sure the
pointer can't be read as a cell and a cell can't be read as a function
pointer.

1 more byte is used in the datapack data stream per entry to store the type now.
