### PR TITLE
Introduce a typedef keyword.

### DIFF
--- a/plugins/basebans.sp
+++ b/plugins/basebans.sp
@@ -118,18 +118,21 @@ LoadBanReasons()
 		decl String:sectionName[255];
 		if(!KvGetSectionName(g_hKvBanReasons, sectionName, sizeof(sectionName)))
 		{
-			return SetFailState("Error in %s: File corrupt or in the wrong format", g_BanReasonsPath);
+			SetFailState("Error in %s: File corrupt or in the wrong format", g_BanReasonsPath);
+			return;
 		}
 
 		if(strcmp(sectionName, "banreasons") != 0)
 		{
-			return SetFailState("Error in %s: Couldn't find 'banreasons'", g_BanReasonsPath);
+			SetFailState("Error in %s: Couldn't find 'banreasons'", g_BanReasonsPath);
+			return;
 		}
 		
 		//Reset kvHandle
 		KvRewind(g_hKvBanReasons);
 	} else {
-		return SetFailState("Error in %s: File not found, corrupt or in the wrong format", g_BanReasonsPath);
+		SetFailState("Error in %s: File not found, corrupt or in the wrong format", g_BanReasonsPath);
+		return;
 	}
 }
 

--- a/plugins/include/clientprefs.inc
+++ b/plugins/include/clientprefs.inc
@@ -168,7 +168,13 @@ forward OnClientCookiesCached(client);
  * @param maxlen		Max length of the output buffer.
  * @noreturn			
  */
-functag public void CookieMenuHandler(client, CookieMenuAction:action, any:info, String:buffer[], maxlen);
+typedef CookieMenuHandler = function void (
+  int client,
+  CookieMenuAction action,
+  any info,
+  char[] buffer,
+  int maxlen
+);
 
 /**
  * Add a new prefab item to the client cookie settings menu.

--- a/plugins/include/commandfilters.inc
+++ b/plugins/include/commandfilters.inc
@@ -140,7 +140,7 @@ stock ReplyToTargetError(client, reason)
  * @param clients       Array to fill with unique, valid client indexes.
  * @return              True if pattern was recognized, false otherwise.
  */
-functag public bool:MultiTargetFilter(const String:pattern[], Handle:clients);
+typedef MultiTargetFilter = function bool (const char[] pattern, Handle clients);
 
 /**
  * Adds a multi-target filter function for ProcessTargetString().

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -328,7 +328,7 @@ native FormatActivitySource(client, target, const String:namebuf[], maxlength);
  * @return				An Action value.  Not handling the command
  *						means that Source will report it as "not found."
  */
-functag public Action:SrvCmd(args);
+typedef SrvCmd = function Action (int args);
 
 /**
  * Creates a server-only console command, or hooks an already existing one.  
@@ -352,7 +352,7 @@ native RegServerCmd(const String:cmd[], SrvCmd:callback, const String:descriptio
  * @return				An Action value.  Not handling the command
  *						means that Source will report it as "not found."
  */
-functag public Action:ConCmd(client, args);
+typedef ConCmd = function Action (int client, int args);
 
 /**
  * Creates a console command, or hooks an already existing one.
@@ -456,7 +456,7 @@ native Handle:FindConVar(const String:name[]);
  * @param newValue		String containing the new value of the convar.
  * @noreturn
  */
-functag public void ConVarChanged(Handle:convar, const String:oldValue[], const String:newValue[]);
+typedef ConVarChanged = function void (Handle convar, const char[] oldValue, const char[] newValue);
 
 /**
  * Creates a hook for when a console variable's value is changed.
@@ -905,7 +905,7 @@ native RemoveServerTag(const String:tag[]);
  * @param argc          Argument count.
  * @return				Action to take (see extended notes above).
  */
-functag public Action:CommandListener(client, const String:command[], argc);
+typedef CommandListener = function Action (int client, const char[] command, int argc);
 
 #define FEATURECAP_COMMANDLISTENER  "command listener"
 

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -643,7 +643,7 @@ native SQL_UnlockDatabase(Handle:database);
  * @param data			Data passed in via the original threaded invocation.
  * @noreturn
  */
-functag public void SQLTCallback(Handle:owner, Handle:hndl, const String:error[], any:data);
+typedef SQLTCallback = function void (Handle owner, Handle hndl, const char[] error, any data);
 
 /**
  * Tells whether two database handles both point to the same database 
@@ -713,7 +713,7 @@ native Transaction:SQL_CreateTransaction();
  * @param queryData     An array of each data value passed to SQL_AddQuery().
  * @noreturn
  */
-functag public void SQLTxnSuccess(Handle:db, any:data, numQueries, Handle:results[], any:queryData[]);
+typedef SQLTxnSuccess = function void (Handle db, any data, int numQueries, Handle[] results, any[] queryData);
 
 /**
  * Callback for a failed transaction.
@@ -726,7 +726,7 @@ functag public void SQLTxnSuccess(Handle:db, any:data, numQueries, Handle:result
  * @param queryData     An array of each data value passed to SQL_AddQuery().
  * @noreturn
  */
-functag public void SQLTxnFailure(Handle:db, any:data, numQueries, const String:error[], failIndex, any:queryData[]);
+typedef SQLTxnFailure = function void (Handle db, any data, int numQueries, const char[] error, int failIndex, any[] queryData);
 
 /**
  * Adds a query to a transaction object.

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -35,6 +35,7 @@
 #endif
 #define _float_included
 
+#if !defined __sourcepawn2__
 /**
  * Converts an integer into a floating point value.
  *
@@ -42,6 +43,7 @@
  * @return				Floating point value.
  */
 native Float:float(value);
+#endif
 
 /**
  * Multiplies two floats together.

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -357,7 +357,7 @@ native Call_Cancel();
  * @param numParams			Number of parameters passed to the native.
  * @return 					Value for the native call to return.
  */
-functag public int NativeCall(Handle:plugin, numParams);
+typedef NativeCall = function int (Handle plugin, int numParams);
 
 /**
  * Creates a dynamic native.  This should only be called in AskPluginLoad(), or 
@@ -508,7 +508,7 @@ native FormatNativeString(out_param,
  * @param data			Data passed to the RequestFrame native.
  * @noreturn
  */
-functag public void RequestFrameCallback(any:data);
+typedef RequestFrameCallback = function void (any data);
 
 /**
  * Creates a single use Next Frame hook.

--- a/plugins/include/logging.inc
+++ b/plugins/include/logging.inc
@@ -123,7 +123,7 @@ forward Action:OnLogAction(Handle:source,
  * @return				Plugin_Handled or Plugin_Stop will prevent the message 
  * 						from being written to the log file.
  */
-functag public Action:GameLogHook(const String:message[]);
+typedef GameLogHook = function Action (const char[] message);
 
 /**
  * Adds a game log hook.

--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -151,7 +151,7 @@ enum MenuSource
  * @param param1			First action parameter (usually the client).
  * @param param2			Second action parameter (usually the item).
  */
-functag public int MenuHandler(Menu:menu, MenuAction:action, param1, param2);
+typedef MenuHandler = function int (Menu menu, MenuAction action, int param1, int param2);
 
 /**
  * Creates a new, empty menu using the default style.
@@ -527,12 +527,14 @@ stock bool:VoteMenuToAll(Handle:menu, time, flags=0)
  *							defines.
  * @noreturn
  */
-functag public void VoteHandler(Menu:menu,
-						   num_votes, 
-						   num_clients,
-						   const client_info[][2], 
-						   num_items,
-						   const item_info[][2]);	   
+typedef VoteHandler = function void (
+  Menu menu,
+  int num_votes, 
+  int num_clients,
+  const int client_info[][2], 
+  int num_items,
+  const int item_info[][2]
+);
 
 /**
  * Sets an advanced vote handling callback.  If this callback is set,

--- a/plugins/include/sdktools_entoutput.inc
+++ b/plugins/include/sdktools_entoutput.inc
@@ -44,7 +44,7 @@
  * @param delay			Delay in seconds? before the event gets fired.
  * @noreturn
  */
-functag public void EntityOutput(const String:output[], caller, activator, Float:delay);
+typedef EntityOutput = function void (const char[] output, int caller, int activator, float delay);
 
 /**
  * Add an entity output hook on a entity classname

--- a/plugins/include/sdktools_sound.inc
+++ b/plugins/include/sdktools_sound.inc
@@ -283,7 +283,16 @@ native Float:GetDistGainFromSoundLevel(soundlevel, Float:distance);
  * @return		Plugin_Continue to allow the sound to be played, Plugin_Stop to block it, 
  *			  Plugin_Changed when any parameter has been modified.
  */
-functag public Action:AmbientSHook(String:sample[PLATFORM_MAX_PATH], &entity, &Float:volume, &level, &pitch, Float:pos[3], &flags, &Float:delay);
+typedef AmbientSHook = function Action (
+  char sample[PLATFORM_MAX_PATH],
+  int &entity,
+  float &volume,
+  int &level,
+  int &pitch,
+  float pos[3],
+  int &flags,
+  float &delay
+);
 
 /**
  * Called when a sound is going to be emitted to one or more clients.
@@ -301,7 +310,17 @@ functag public Action:AmbientSHook(String:sample[PLATFORM_MAX_PATH], &entity, &F
  * @return			Plugin_Continue to allow the sound to be played, Plugin_Stop to block it, 
  *				  Plugin_Changed when any parameter has been modified.
  */
-functag public Action:NormalSHook(clients[64], &numClients, String:sample[PLATFORM_MAX_PATH], &entity, &channel, &Float:volume, &level, &pitch, &flags);
+typedef NormalSHook = function Action (
+  int clients[64],
+  int &numClients,
+  char sample[PLATFORM_MAX_PATH],
+  int &entity,
+  int &channel,
+  float &volume,
+  int &level,
+  int &pitch,
+  int &flags
+);
 
 /**
  * Hooks all played ambient sounds.

--- a/plugins/include/sdktools_tempents.inc
+++ b/plugins/include/sdktools_tempents.inc
@@ -44,7 +44,7 @@
  * @param delay		Delay in seconds to send the TE.
  * @return		Plugin_Continue to allow the transmission of the TE, Plugin_Stop to block it.
  */
-functag public Action:TEHook(const String:te_name[], const Players[], numClients, Float:delay);
+typedef TEHook = function Action (const char[] te_name, const int[] Players, int numClients, float delay);
 
 /**
  * Hooks a temp entity.

--- a/plugins/include/sorting.inc
+++ b/plugins/include/sorting.inc
@@ -98,7 +98,7 @@ native SortStrings(String:array[][], array_size, SortOrder:order = Sort_Ascendin
  *						0 if first is equal to second
  *						1 if first should go after second
  */
-functag public int SortFunc1D(elem1, elem2, const array[], Handle:hndl);
+typedef SortFunc1D = function int (int elem1, int elem2, const int[] array, Handle hndl);
 
 /** 
  * Sorts a custom 1D array.  You must pass in a comparison function.
@@ -163,7 +163,7 @@ native SortADTArray(Handle:array, SortOrder:order, SortType:type);
  *					0 if first is equal to second
  *					1 if first should go after second
  */
-functag public int SortFuncADTArray(index1, index2, Handle:array, Handle:hndl);
+typedef SortFuncADTArray = function int (int index1, int index2, Handle array, Handle hndl);
 
 /**
  * Custom sorts an ADT Array. You must pass in a comparison function.

--- a/plugins/include/textparse.inc
+++ b/plugins/include/textparse.inc
@@ -108,7 +108,7 @@ native bool:SMC_GetErrorString(SMCError:error, String:buffer[], buf_max);
  * @param smc			The SMC Parse Handle.
  * @noreturn
  */
-functag public void SMC_ParseStart(Handle:smc);
+typedef SMC_ParseStart = function void (Handle smc);
 
 /**
  * Sets the SMC_ParseStart function of a parse Handle.
@@ -128,7 +128,7 @@ native SMC_SetParseStart(Handle:smc, SMC_ParseStart:func);
  * @param failed		True if parsing failed, false otherwise.
  * @noreturn
  */
-functag public void SMC_ParseEnd(Handle:smc, bool:halted, bool:failed);
+typedef SMC_ParseEnd = function void (Handle smc, bool halted, bool failed);
 
 /**
  * Sets the SMC_ParseEnd of a parse handle.
@@ -149,7 +149,7 @@ native SMC_SetParseEnd(Handle:smc, SMC_ParseEnd:func);
  * @param opt_quotes	True if the section name was quote-enclosed in the file.
  * @return				An SMCResult action to take.
  */
-functag public SMCResult:SMC_NewSection(Handle:smc, const String:name[], bool:opt_quotes);
+typedef SMC_NewSection = function SMCResult (Handle smc, const char[] name, bool opt_quotes);
 
 /**
  * Called when the parser finds a new key/value pair.
@@ -162,7 +162,7 @@ functag public SMCResult:SMC_NewSection(Handle:smc, const String:name[], bool:op
  * @param value_quotes	Whether or not the value was enclosed in quotes.
  * @return				An SMCResult action to take.
  */
-functag public SMCResult:SMC_KeyValue(Handle:smc, const String:key[], const String:value[], bool:key_quotes, bool:value_quotes);
+typedef SMC_KeyValue = function SMCResult (Handle smc, const char[] key, const char[] value, bool key_quotes, bool value_quotes);
 
 /**
  * Called when the parser finds the end of the current section.
@@ -170,7 +170,7 @@ functag public SMCResult:SMC_KeyValue(Handle:smc, const String:key[], const Stri
  * @param smc			The SMC Parse Handle.
  * @return				An SMCResult action to take.
  */
-functag public SMCResult:SMC_EndSection(Handle:smc);
+typedef SMC_EndSection = function SMCResult (Handle smc);
 
 /**
  * Sets the three main reader functions.
@@ -191,7 +191,7 @@ native SMC_SetReaders(Handle:smc, SMC_NewSection:ns, SMC_KeyValue:kv, SMC_EndSec
  * @param lineno		The line number it occurs on.
  * @return				An SMCResult action to take.
  */
-functag public SMCResult:SMC_RawLine(Handle:smc, const String:line[], lineno);
+typedef SMC_RawLine = function SMCResult (Handle smc, const char[] line, int lineno);
 
 /**
  * Sets a raw line reader on an SMC parser Handle.

--- a/plugins/include/topmenus.inc
+++ b/plugins/include/topmenus.inc
@@ -127,12 +127,14 @@ enum TopMenuObject
  * @param maxlength			Output buffer (if used).
  * @noreturn
  */
-functag public void TopMenuHandler(Handle:topmenu, 
-							  TopMenuAction:action,
-							  TopMenuObject:topobj_id,
-							  param,
-							  String:buffer[],
-							  maxlength);
+typedef TopMenuHandler = function void (
+  Handle topmenu, 
+  TopMenuAction action,
+  TopMenuObject topobj_id,
+  int param,
+  char[] buffer,
+  int maxlength
+);
 
 /**
  * Creates a TopMenu.

--- a/plugins/include/usermessages.inc
+++ b/plugins/include/usermessages.inc
@@ -140,7 +140,7 @@ native EndMessage();
  *						blocks the message from being sent, and Plugin_Continue 
  *						resumes normal functionality.
  */
-functag public Action:MsgHook(UserMsg:msg_id, Handle:msg, const players[], playersNum, bool:reliable, bool:init);
+typedef MsgHook = function Action (UserMsg msg_id, Handle msg, const int[] players, int playersNum, bool reliable, bool init);
 
 /**
  * Called when a message hook has completed.
@@ -149,7 +149,7 @@ functag public Action:MsgHook(UserMsg:msg_id, Handle:msg, const players[], playe
  * @param sent			True if message was sent, false if blocked.
  * @noreturn
  */
-functag public void MsgPostHook(UserMsg:msg_id, bool:sent);
+typedef MsgPostHook = function void (UserMsg msg_id, bool sent);
 
 /**
  * Hooks a user message.

--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -357,7 +357,7 @@ typedef struct {
 /*  Tokens recognized by lex()
  *  Some of these constants are assigned as well to the variable "lastst" (see SC1.C)
  */
-enum {
+enum TokenKind {
   /* value of first multi-character operator */
   tFIRST     = 256,
   /* multi-character operators */
@@ -431,6 +431,7 @@ enum {
   tSWITCH,
   tTAGOF,
   tTHEN,
+  tTYPEDEF,
   tVOID,
   tWHILE,
   /* compiler directives */

--- a/sourcepawn/compiler/sc2.c
+++ b/sourcepawn/compiler/sc2.c
@@ -1961,7 +1961,7 @@ char *sc_tokens[] = {
          "public",
          "return",
          "sizeof", "sleep", "static", "stock", "struct", "switch",
-         "tagof", "*then",
+         "tagof", "*then", "typedef",
          "void",
          "while",
          "#assert", "#define", "#else", "#elseif", "#emit", "#endif", "#endinput",
@@ -1969,7 +1969,7 @@ char *sc_tokens[] = {
          "#tryinclude", "#undef",
          ";", ";", "-integer value-", "-rational value-", "-identifier-",
          "-label-", "-string-"
-       };
+};
 
 static full_token_t *advance_token_ptr()
 {

--- a/sourcepawn/compiler/sctracker.h
+++ b/sourcepawn/compiler/sctracker.h
@@ -22,7 +22,7 @@ typedef struct funcarg_s
   int tagcount;
   int tags[sTAGS_MAX];
   int dimcount;
-  cell dims[sDIMEN_MAX];
+  int dims[sDIMEN_MAX];
   int ident;
   int fconst;
   int ommittable;


### PR DESCRIPTION
The funcenum parsing is a total mess, and the syntax is not what I'd like going forward. This patch introduces a `typedef` keyword with the following grammar:

```
typedef ::= "typedef" symbol "=" full-type-expr term
full-type-expr ::= func-type-expr
                 | "(" func-type-expr ")"
func-type-expr ::= "function" type-name "(" typedef-args? ")"
typedef-args ::= "..."
               | typedef-arg ("," typedef-arg)* (", " "...")?
typedef-arg ::= new-arg-decl
```
