### PR TITLE
Fix automatic language detection on CS:GO (bug 6163).

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -648,8 +648,11 @@ QueryCvarCookie_t ConVarManager::QueryClientConVar(edict_t *pPlayer, const char 
 		return InvalidQueryCvarCookie;
 	}
 
-	ConVarQuery query = {cookie, pCallback, (cell_t)hndl, IndexOfEdict(pPlayer)};
-	m_ConVarQueries.push_back(query);
+	if (pCallback != NULL)
+	{
+		ConVarQuery query = { cookie, pCallback, (cell_t) hndl, IndexOfEdict(pPlayer) };
+		m_ConVarQueries.push_back(query);
+	}
 #endif
 
 	return cookie;
@@ -753,6 +756,13 @@ void ConVarManager::OnQueryCvarValueFinished(QueryCvarCookie_t cookie, CEntityIn
 void ConVarManager::OnQueryCvarValueFinished(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue)
 #endif // SE_DOTA
 {
+#if SOURCE_ENGINE == SE_CSGO
+	if (g_Players.HandleConVarQuery(cookie, pPlayer, result, cvarName, cvarValue))
+	{
+		return;
+	}
+#endif
+
 	IPluginFunction *pCallback = NULL;
 	cell_t value = 0;
 	List<ConVarQuery>::iterator iter;

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -502,6 +502,9 @@ bool PlayerManager::OnClientConnect(edict_t *pEntity, const char *pszName, const
 	/* Get the client's language */
 	if (m_QueryLang)
 	{
+#if SOURCE_ENGINE == SE_CSGO
+		pPlayer->m_LangId = translator->GetServerLanguage();
+#else
 		const char *name;
 		if (!pPlayer->IsFakeClient() && (name=engine->GetClientConVarValue(client, "cl_language")))
 		{
@@ -510,6 +513,7 @@ bool PlayerManager::OnClientConnect(edict_t *pEntity, const char *pszName, const
 		} else {
 			pPlayer->m_LangId = translator->GetServerLanguage();
 		}
+#endif
 	}
 	
 	List<IClientListener *>::iterator iter;
@@ -727,6 +731,13 @@ void PlayerManager::OnClientPutInServer(edict_t *pEntity, const char *playername
 		}
 		pPlayer->Authorize_Post();
 	}
+#if SOURCE_ENGINE == SE_CSGO
+	else
+	{
+		// Not a bot
+		pPlayer->m_LanguageCookie = g_ConVarManager.QueryClientConVar(pEntity, "cl_language", NULL, 0);
+	}
+#endif
 
 	if (playerinfo)
 	{
@@ -1862,6 +1873,24 @@ void CmdMaxplayersCallback()
 	g_Players.MaxPlayersChanged();
 }
 
+#if SOURCE_ENGINE == SE_CSGO
+bool PlayerManager::HandleConVarQuery(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue)
+{
+	for (int i = 1; i <= m_maxClients; i++)
+	{
+		if (m_Players[i].m_LanguageCookie == cookie)
+		{
+			unsigned int langid;
+			m_Players[i].m_LangId = (translator->GetLanguageByName(cvarValue, &langid)) ? langid : translator->GetServerLanguage();
+
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif
+
 
 /*******************
  *** PLAYER CODE ***
@@ -1886,6 +1915,9 @@ CPlayer::CPlayer()
 	m_bIsReplay = false;
 	m_Serial.value = -1;
 	m_SteamAccountID = 0;
+#if SOURCE_ENGINE == SE_CSGO
+	m_LanguageCookie = InvalidQueryCvarCookie;
+#endif
 }
 
 void CPlayer::Initialize(const char *name, const char *ip, edict_t *pEntity)
@@ -1966,6 +1998,9 @@ void CPlayer::Disconnect()
 	m_bIsReplay = false;
 	m_Serial.value = -1;
 	m_SteamAccountID = 0;
+#if SOURCE_ENGINE == SE_CSGO
+	m_LanguageCookie = InvalidQueryCvarCookie;
+#endif
 }
 
 void CPlayer::SetName(const char *name)

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -131,6 +131,9 @@ private:
 	bool m_bIsReplay;
 	serial_t m_Serial;
 	unsigned int m_SteamAccountID;
+#if SOURCE_ENGINE == SE_CSGO
+	QueryCvarCookie_t m_LanguageCookie;
+#endif
 };
 
 class PlayerManager : 
@@ -211,6 +214,9 @@ public:
 	unsigned int GetReplyTo();
 	unsigned int SetReplyTo(unsigned int reply);
 	void MaxPlayersChanged(int newvalue = -1);
+#if SOURCE_ENGINE == SE_CSGO
+	bool HandleConVarQuery(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue);
+#endif
 private:
 #if SOURCE_ENGINE == SE_DOTA
 	void OnServerActivate();


### PR DESCRIPTION
As noted in [bug 6163](https://bugs.alliedmods.net/show_bug.cgi?id=6163), cl_language is no longer available as a userinfo var in CS:GO, breaking our automatic client language detection.

However, it does still exist, albeit hidden on the client. We are able to query the value.

There are some drawbacks to this compared to getting it from userinfo (inconsistent behavior across games, language not being available until shortly after PutInServer rather than Connect on CS:GO, extra logic running for every convar query in CS:GO), but I think that it's still better than nothing. 
