### PR TITLE
Actually remove extra wearables.

### DIFF
--- a/plugins/include/tf2_stocks.inc
+++ b/plugins/include/tf2_stocks.inc
@@ -448,7 +448,7 @@ stock TF2_RemoveWeaponSlot(client, slot)
 		{
 			TF2_RemoveWearable(client, extraWearable);
 		}
-		
+
 		RemovePlayerItem(client, weaponIndex);
 		AcceptEntityInput(weaponIndex, "Kill");
 	}


### PR DESCRIPTION
Old logic was to try to get extra wearables on a non-existent entity.
