### PR TITLE
Replace use of netprops with an sdkcall to remove extra wearables.

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -648,6 +648,44 @@ cell_t TF2_RemoveWearable(IPluginContext *pContext, const cell_t *params)
 	return 1;
 }
 
+cell_t TF2_RemoveExtraWearables(IPluginContext *pContext, const cell_t *params)
+{
+	static ICallWrapper *pWrapper = NULL;
+
+	//CTFWeaponBase::RemoveExtraWearables(void)
+
+	if (!pWrapper)
+	{
+		int offset;
+
+		if (!g_pGameConf->GetOffset("RemoveExtraWearables", &offset))
+		{
+			return pContext->ThrowNativeError("Failed to locate function");
+		}
+
+		PassInfo pass[1];
+
+		pWrapper = g_pBinTools->CreateVCall(offset, 0, 0, NULL, pass, 0);
+
+		g_RegNatives.Register(pWrapper);
+	}
+
+	CBaseEntity *pEntity;
+	if (!(pEntity = UTIL_GetCBaseEntity(params[1], true)))
+	{
+		return pContext->ThrowNativeError("Weapon index %d is not valid", params[1]);
+	}
+
+	unsigned char vstk[sizeof(void *)];
+	unsigned char *vptr = vstk;
+
+	*(void **)vptr = (void *)pEntity;
+
+	pWrapper->Execute(vstk, NULL);
+
+	return 1;
+}
+
 sp_nativeinfo_t g_TFNatives[] = 
 {
 	{"TF2_IgnitePlayer",			TF2_Burn},
@@ -666,5 +704,6 @@ sp_nativeinfo_t g_TFNatives[] =
 	{"TF2_IsPlayerInDuel",				TF2_IsPlayerInDuel},
 	{"TF2_IsHolidayActive",				TF2_IsHolidayActive},
 	{"TF2_RemoveWearable",			TF2_RemoveWearable},
+	{"TF2_RemoveExtraWearables",	TF2_RemoveExtraWearables},
 	{NULL,							NULL}
 };

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -111,6 +111,12 @@
 		}
 		"Offsets"
 		{
+			"RemoveExtraWearables"
+			{
+				"windows"	"386"
+				"linux"		"387"
+				"mac"		"387"
+			}
 			"ForceRespawn"
 			{
 				"windows"	"324"

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -371,6 +371,15 @@ native bool:TF2_IsPlayerInDuel(client);
 native TF2_RemoveWearable(client, wearable);
 
 /**
+ * Removes extra wearables from a weapon(if any)
+ *
+ * @param weapon	Weapon to remove extra wearables from(if any)
+ * @noreturn
+ * @error			Invalid weapon index or no mod support.
+*/
+native TF2_RemoveExtraWearables(weapon);
+
+/**
  * Called after a condition is added to a player
  *
  * @param client		Index of the client to which the conditon is being added.

--- a/plugins/include/tf2_stocks.inc
+++ b/plugins/include/tf2_stocks.inc
@@ -437,18 +437,7 @@ stock TF2_RemoveWeaponSlot(client, slot)
 	{
 		// bug #6206
 		// papering over a valve bug where a weapon's extra wearables aren't properly removed from the weapon's owner
-		new extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearable");
-		if (extraWearable != -1)
-		{
-			TF2_RemoveWearable(client, extraWearable);
-		}
-
-		extraWearable = GetEntPropEnt(weaponIndex, Prop_Send, "m_hExtraWearableViewModel");
-		if (extraWearable != -1)
-		{
-			TF2_RemoveWearable(client, extraWearable);
-		}
-
+		TF2_RemoveExtraWearables(weaponIndex);
 		RemovePlayerItem(client, weaponIndex);
 		AcceptEntityInput(weaponIndex, "Kill");
 	}


### PR DESCRIPTION
Ok, while I was poking around tf2's server_srv.so binary with ida 6.6 demo, I came accross this SDK function called RemoveExtraWearables, testing it with the call in tf2_stocks revealed that it looks VERY promising as an alternative to using netprops.  
I need to know if I setup extension's call right.
