### PR TITLE
Add a command to dump profiling output.

### DIFF
--- a/core/logic/ProfileTools.cpp
+++ b/core/logic/ProfileTools.cpp
@@ -122,6 +122,13 @@ ProfileToolManager::OnRootConsoleCommand2(const char *cmdname, const ICommandArg
 			active_ = nullptr;
 			return;
 		}
+		if (strcmp(cmdname, "dump") == 0) {
+			if (active_) {
+				// if we have an active profiler, dump it
+				active_->Dump();
+				return;
+			}
+		}
 
 		if (args->ArgC() < 4) {
 			if (strcmp(cmdname, "start") == 0) {
@@ -154,6 +161,15 @@ ProfileToolManager::OnRootConsoleCommand2(const char *cmdname, const ICommandArg
 			StartFromConsole(tool);
 			return;
 		}
+		if (strcmp(cmdname, "dump") == 0) {
+			IProfilingTool *tool = FindToolByName(toolname);
+			if (!tool) {
+				rootmenu->ConsolePrint("No tool with the name \"%s\" was found.", toolname);
+				return;
+			}
+			tool->Dump();
+			return;
+		}
 		if (strcmp(cmdname, "help") == 0) {
 			IProfilingTool *tool = FindToolByName(toolname);
 			if (!tool) {
@@ -169,5 +185,6 @@ ProfileToolManager::OnRootConsoleCommand2(const char *cmdname, const ICommandArg
 	rootmenu->DrawGenericOption("list", "List all available profiling tools.");
 	rootmenu->DrawGenericOption("start", "Start a profile with a given tool.");
 	rootmenu->DrawGenericOption("stop", "Stop the current profile session.");
+	rootmenu->DrawGenericOption("dump", "Dumps output from the current profile session.");
 	rootmenu->DrawGenericOption("help", "Display help text for a profiler.");
 }

--- a/core/vprof_tool.cpp
+++ b/core/vprof_tool.cpp
@@ -73,6 +73,14 @@ VProfTool::Stop(void (*render)(const char *fmt, ...))
 	RenderHelp(render);
 }
 
+void
+VProfTool::Dump()
+{
+	g_VProfCurrentProfile.Pause();
+	g_VProfCurrentProfile.OutputReport(VPRT_FULL);
+	g_VProfCurrentProfile.Resume();
+}
+
 bool
 VProfTool::IsActive()
 {
@@ -105,5 +113,5 @@ VProfTool::LeaveScope()
 void
 VProfTool::RenderHelp(void (*render)(const char *fmt, ...))
 {
-	render("Use vprof_generate_report in your console to analyze a profile session.");
+	render("Use 'sm prof dump vprof' or one of the vprof_generate_report commands in your console to analyze a profile session.");
 }

--- a/core/vprof_tool.h
+++ b/core/vprof_tool.h
@@ -44,6 +44,7 @@ public:
 	const char *Description() KE_OVERRIDE;
 	bool Start() KE_OVERRIDE;
 	void Stop(void (*render)(const char *fmt, ...)) KE_OVERRIDE;
+	void Dump() KE_OVERRIDE;
 	bool IsActive() KE_OVERRIDE;
 	bool IsAttached() KE_OVERRIDE;
 	void EnterScope(const char *group, const char *name) KE_OVERRIDE;

--- a/public/sourcepawn/sp_vm_api.h
+++ b/public/sourcepawn/sp_vm_api.h
@@ -1044,6 +1044,15 @@ namespace SourcePawn
 		 * @param render            Function to render any help messages.
 		 */
 		virtual void Stop(void (*render)(const char *fmt, ...)) = 0;
+
+		/**
+		 * @brief Dump profiling information.
+		 *
+		 * Informs the profiling tool to dump any current profiling information
+		 * it has accumulated. The format and location of the output is profiling
+		 * tool specific.
+		 */
+		virtual void Dump() = 0;
 	
 		/**
 		 * @brief Returns whether or not the profiler is currently profiling.


### PR DESCRIPTION
There's a few reasons this is useful:
1. Puts profile dumping into the same group of commands as the ones that start and stop the profiler.
2. None of the vprof_generate_report commands do a FULL dump, that is, a dump that includes the hierarchy output as well as outputs sorted by time, average time, and peak time. Without this you'd need to run multiple vprof_generate_report commands in order to get this entire output.
