### PR TITLE
Enable SDK independence with MM:S enabled extensions.

### DIFF
--- a/public/asm/asm.c
+++ b/public/asm/asm.c
@@ -13,8 +13,6 @@
 #define IA32_MOV_REG_IMM		0xB8	// encoding is +r <imm32>
 #endif
 
-extern void Msg( const char *, ... );
-
 /**
 * Checks if a call to a fpic thunk has just been written into dest.
 * If found replaces it with a direct mov that sets the required register to the value of pc.
@@ -64,7 +62,6 @@ void check_thunks(unsigned char *dest, unsigned char *pc)
 			}
 		default:
 			{
-				Msg("Unknown thunk: %c\n", *(calladdr+1));
 				break;
 			}
 		}

--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -307,8 +307,10 @@ ISmmPlugin *g_PLAPI = NULL;					/**< Metamod plugin API */
 SourceHook::ISourceHook *g_SHPtr = NULL;	/**< SourceHook pointer */
 ISmmAPI *g_SMAPI = NULL;					/**< SourceMM API pointer */
 
+#ifndef META_NO_HL2SDK
 IVEngineServer *engine = NULL;				/**< IVEngineServer pointer */
 IServerGameDLL *gamedll = NULL;				/**< IServerGameDLL pointer */
+#endif
 
 /** Exposes the extension to Metamod */
 SMM_API void *PL_EXPOSURE(const char *name, int *code)
@@ -321,14 +323,14 @@ SMM_API void *PL_EXPOSURE(const char *name, int *code)
 	{
 		if (code)
 		{
-			*code = IFACE_OK;
+			*code = META_IFACE_OK;
 		}
 		return static_cast<void *>(g_pExtensionIface);
 	}
 
 	if (code)
 	{
-		*code = IFACE_FAILED;
+		*code = META_IFACE_FAILED;
 	}
 
 	return NULL;
@@ -338,6 +340,7 @@ bool SDKExtension::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, 
 {
 	PLUGIN_SAVEVARS();
 
+#ifndef META_NO_HL2SDK
 #if !defined METAMOD_PLAPI_VERSION
 	GET_V_IFACE_ANY(serverFactory, gamedll, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL);
 	GET_V_IFACE_CURRENT(engineFactory, engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
@@ -345,6 +348,7 @@ bool SDKExtension::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, 
 	GET_V_IFACE_ANY(GetServerFactory, gamedll, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL);
 	GET_V_IFACE_CURRENT(GetEngineFactory, engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
 #endif
+#endif //META_NO_HL2SDK
 
 	m_SourceMMLoaded = true;
 

--- a/public/smsdk_ext.h
+++ b/public/smsdk_ext.h
@@ -100,7 +100,9 @@
 
 #if defined SMEXT_CONF_METAMOD
 #include <ISmmPlugin.h>
+#ifndef META_NO_HL2SDK
 #include <eiface.h>
+#endif //META_NO_HL2SDK
 #endif
 
 #if !defined METAMOD_PLAPI_VERSION
@@ -317,8 +319,10 @@ extern IRootConsole *rootconsole;
 
 #if defined SMEXT_CONF_METAMOD
 PLUGIN_GLOBALVARS();
+#ifndef META_NO_HL2SDK
 extern IVEngineServer *engine;
 extern IServerGameDLL *gamedll;
+#endif //META_NO_HL2SDK
 #endif
 
 /** Creates a SourceMod interface macro pair */


### PR DESCRIPTION
I had to do this for SteamWorks, Drifter hit it with enabling SDK independence with DHooks2.