### PR TITLE
Remove support for multiple tags on an argument.

### DIFF
--- a/plugins/admin-flatfile/admin-flatfile.sp
+++ b/plugins/admin-flatfile/admin-flatfile.sp
@@ -70,7 +70,7 @@ public OnRebuildAdminCache(AdminCachePart:part)
 	}
 }
 
-ParseError(const String:format[], {Handle,String,Float,_}:...)
+ParseError(const String:format[], any:...)
 {
 	decl String:buffer[512];
 	

--- a/sourcepawn/compiler/sc1.cpp
+++ b/sourcepawn/compiler/sc1.cpp
@@ -3192,6 +3192,8 @@ static int parse_old_decl(declinfo_t *decl, int flags)
       }
       needtoken(':');
     }
+    if (type->numtags > 1)
+      error(158);
   }
   
   if (type->numtags == 0) {

--- a/sourcepawn/compiler/sc5-in.scp
+++ b/sourcepawn/compiler/sc5-in.scp
@@ -201,6 +201,7 @@ static const char *errmsg[] = {
 /*155*/  "expected newline, but found '%s'\n",
 /*156*/  "the 'any' type is not allowed in new-style natives\n",
 /*157*/  "'%s' is a reserved keyword\n",
+/*158*/  "multi-tags are no longer supported\n",
 #else
   "\315e\306\227\266k\217:\235\277bu\201fo\220\204\223\012",
   "\202l\224\250s\205g\346\356e\233\201(\243\315\214\267\202) \253 f\255low ea\305 \042c\353e\042\012",


### PR DESCRIPTION
More work to simplify the type system. Multiple tags are extremely rare and are near-useless. They're hard to shim into a real type system without annoying hacks.

I'd like to do this right later on with true tagged unions. For now, let's try to can 'em.
