### PR TITLE
Remove weird tag flags.

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -524,16 +524,15 @@ typedef enum s_optmark {
 
 #define suSLEEP_INSTR 0x01      /* the "sleep" instruction was used */
 
-#define PUBLICTAG    0x80000000Lu
 #define FIXEDTAG     0x40000000Lu
 #define FUNCTAG      0x20000000Lu
 #define OBJECTTAG    0x10000000Lu
 #define ENUMTAG      0x08000000Lu
 #define METHODMAPTAG 0x04000000Lu
 #define STRUCTTAG    0x02000000Lu
-#define TAGMASK       (~PUBLICTAG)
 #define TAGTYPEMASK   (FUNCTAG | OBJECTTAG | ENUMTAG | METHODMAPTAG | STRUCTTAG)
 #define TAGFLAGMASK   (FIXEDTAG | TAGTYPEMASK)
+#define TAGID(tag)    ((tag) & ~(TAGFLAGMASK))
 #define CELL_MAX      (((ucell)1 << (sizeof(cell)*8-1)) - 1)
 
 
@@ -591,7 +590,6 @@ constvalue *append_constval(constvalue *table,const char *name,cell val,int inde
 constvalue *find_constval(constvalue *table,char *name,int index);
 void delete_consttable(constvalue *table);
 symbol *add_constant(const char *name,cell val,int vclass,int tag);
-void exporttag(int tag);
 void sc_attachdocumentation(symbol *sym);
 constvalue *find_tag_byval(int tag);
 int get_actual_compound(symbol *sym);

--- a/sourcepawn/compiler/sc2.cpp
+++ b/sourcepawn/compiler/sc2.cpp
@@ -1135,7 +1135,6 @@ static int command(void)
           } /* if */
           /* add the tag (make it public) and check the values */
           i=pc_addtag(name);
-          exporttag(i);
           if (sc_rationaltag==0 || (sc_rationaltag==i && rational_digits==(int)digits)) {
             sc_rationaltag=i;
             rational_digits=(int)digits;

--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -1806,10 +1806,9 @@ static int hier2(value *lval)
       else if (level==sym->dim.array.level+1 && idxsym!=NULL)
         tag= idxsym->x.tags.index;
     } /* if */
-    exporttag(tag);
     clear_value(lval);
     lval->ident=iCONSTEXPR;
-    lval->constval=tag | PUBLICTAG;
+    lval->constval=tag;
     ldconst(lval->constval,sPRI);
     while (paranthese--)
       needtoken(')');
@@ -2899,8 +2898,7 @@ static int nesting=0;
       asz=find_constval(&taglst,arg[argidx].defvalue.size.symname,
                         arg[argidx].defvalue.size.level);
       if (asz != NULL) {
-        exporttag(asz->value);
-        array_sz=asz->value | PUBLICTAG;  /* must be set, because it just was exported */
+        array_sz=asz->value;  /* must be set, because it just was exported */
       } else {
         array_sz=0;
       } /* if */


### PR DESCRIPTION
In random cases the compiler adds a flag called "PUBLICTAG" to tag ids, and takes great pains to strip it out under mysterious circumstances. It seems to be pointless and we publicly export all tags anyway.

This patch just removes the entire concept, and that simplifies how tags are masked as a bonus.
