### PR TITLE
Add a "union" keyword to replace funcenum.

### DIFF
--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -669,7 +669,7 @@ native SetConVarBounds(Handle:convar, ConVarBounds:type, bool:set, Float:value=0
  */
 native GetConVarName(Handle:convar, String:name[], maxlength);
 
-funcenum ConVarQueryFinished
+union ConVarQueryFinished
 {	
 	/**
 	 * Called when a query to retrieve a client's console variable has finished.
@@ -683,7 +683,7 @@ funcenum ConVarQueryFinished
 	 * @param value			Value that was passed when query was started.
 	 * @noreturn
 	 */
-	public(QueryCookie:cookie, client, ConVarQueryResult:result, const String:cvarName[], const String:cvarValue[], any:value),
+	function void (QueryCookie cookie, int client, ConVarQueryResult result, const char[] cvarName, const char[] cvarValue, any value);
 	
 	/**
 	 * Called when a query to retrieve a client's console variable has finished.
@@ -696,7 +696,7 @@ funcenum ConVarQueryFinished
 	 * @param convarValue	Value of client convar that was queried if successful. This will be "" if it was not.
 	 * @noreturn
 	 */
-	public(QueryCookie:cookie, client, ConVarQueryResult:result, const String:cvarName[], const String:cvarValue[])
+	function void (QueryCookie cookie, int client, ConVarQueryResult result, const char[] cvarName, const char[] cvarValue);
 };
 
 /**

--- a/plugins/include/events.inc
+++ b/plugins/include/events.inc
@@ -48,7 +48,7 @@ enum EventHookMode
 /**
  * Hook function types for events.
  */
-funcenum EventHook
+union EventHook
 {
 	/**
 	 * Called when a game event is fired.
@@ -59,7 +59,7 @@ funcenum EventHook
 	 * @param dontBroadcast	True if event was not broadcast to clients, false otherwise.
 	 * @return				Ignored for post hooks. Plugin_Handled will block event if hooked as pre.
 	 */
-	Action:public(Handle:event, const String:name[], bool:dontBroadcast),
+	function Action (Handle event, const char[] name, bool dontBroadcast);
 	/**
 	 * Called when a game event is fired.
 	 *
@@ -69,7 +69,7 @@ funcenum EventHook
 	 * @param dontBroadcast	True if event was not broadcast to clients, false otherwise.
 	 * @noreturn
 	 */
-	public(Handle:event, const String:name[], bool:dontBroadcast),
+	function void (Handle event, const char[] name, bool dontBroadcast);
 };
 
 /**

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -192,90 +192,90 @@ enum UseType
 	Use_Toggle
 };
 
-funcenum SDKHookCB
+union SDKHookCB
 {
 	// PreThink/Post
 	// PostThink/Post
-	public(client),
+	function void (int client);
 	
 	// Spawn
-	Action:public(entity),
+	function Action (int entity);
 	
 	// GroundEntChanged
 	// SpawnPost
 	// Think/Post
 	// VPhysicsUpdate/Post
-	public(entity),
+	function void (int entity);
 	
 	// EndTouch
 	// StartTouch
 	// Touch
-	Action:public(entity, other),
+	function Action (int entity, int other);
 	
 	// EndTouchPost
 	// StartTouchPost
 	// TouchPost
-	public(entity, other),
+	function void (int entity, int other);
 	
 	// SetTransmit
-	Action:public(entity, client),
+	function Action (int entity, int client);
 	
 	// WeaponCanSwitchTo
 	// WeaponCanUse
 	// WeaponDrop
 	// WeaponEquip
 	// WeaponSwitch
-	Action:public(client, weapon),
+	function Action (int client, int weapon);
 	
 	// WeaponCanSwitchToPost
 	// WeaponCanUsePost
 	// WeaponDropPost
 	// WeaponEquipPost
 	// WeaponSwitchPost
-	public(client, weapon),
+	function void (int client, int weapon);
 	
 	// GetMaxHealth (ep2v and later)
-	Action:public(entity, &maxhealth),
+	function Action (int entity, int &maxhealth);
 	
 	// OnTakeDamage
 	// Note: The weapon parameter is not used by all games and damage sources.
 	// Note: Force application is dependent on game and damage type(s)
 	// SDKHooks 1.0+
-	Action:public(victim, &attacker, &inflictor, &Float:damage, &damagetype),
+	function Action (int victim, int &attacker, int &inflictor, float &damage, int &damagetype),
 	// SDKHooks 2.0+
-	Action:public(victim, &attacker, &inflictor, &Float:damage, &damagetype, &weapon, Float:damageForce[3], Float:damagePosition[3]),
+	function Action (int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float[3] damageForce, float[3] damagePosition);
 	// SDKHooks 2.1+  (can check for support at runtime using GetFeatureStatus on SDKHook_DmgCustomInOTD capability.
 	// DON'T attempt to access 'damagecustom' var if feature status != available
-	Action:public(victim, &attacker, &inflictor, &Float:damage, &damagetype, &weapon,
-		Float:damageForce[3], Float:damagePosition[3], damagecustom),
+	function Action (int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon,
+		float[3] damageForce, float[3] damagePosition, int damagecustom);
 	
 	// OnTakeDamagePost
-	public(victim, attacker, inflictor, Float:damage, damagetype),
-	public(victim, attacker, inflictor, Float:damage, damagetype, weapon, const Float:damageForce[3], const Float:damagePosition[3]),
+	function void (int victim, int attacker, int inflictor, float damage, int damagetype);
+	function void (int victim, int attacker, int inflictor, float damage, int damagetype, const float[3] damageForce, const float[3] damagePosition);
 	
 	// FireBulletsPost
-	public(client, shots, const String:weaponname[]),
+	function void (int client, int shots, const char[] weaponname);
 	
 	// TraceAttack
-	Action:public(victim, &attacker, &inflictor, &Float:damage, &damagetype, &ammotype, hitbox, hitgroup),
+	function Action (int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &ammotype, int hitbox, int hitgroup);
 	
 	// TraceAttackPost
-	public(victim, attacker, inflictor, Float:damage, damagetype, ammotype, hitbox, hitgroup),
+	function void (int victim, int attacker, int inflictor, float damage, int damagetype, int ammotype, int hitbox, int hitgroup);
 	
 	// ShouldCollide
-	bool:public(entity, collisiongroup, contentsmask, bool:originalResult),
+	function bool (int entity, int collisiongroup, int contentsmask, bool originalResult);
 	
 	// Use
-	Action:public(entity, activator, caller, UseType:type, Float:value),
+	function Action (int entity, int activator, int caller, UseType type, float value);
 	
 	// UsePost
-	public(entity, activator, caller, UseType:type, Float:value),
+	function void (int entity, int activator, int caller, UseType type, float value);
 	
 	// Reload
-	Action:public(weapon),
+	function Action (int weapon);
 	
 	// Reload post
-	public(weapon, bool:bSuccessful)
+	function void (int weapon, bool bSuccessful);
 };
 
 

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -110,7 +110,7 @@ enum RayType
 	RayType_Infinite	/**< The trace ray will go from the start position to infinity using a direction vector. */
 };
 
-funcenum TraceEntityFilter
+union TraceEntityFilter
 {
 	/**
 	 * Called on entity filtering.
@@ -119,7 +119,7 @@ funcenum TraceEntityFilter
  	 * @param contentsMask	Contents Mask.
  	 * @return				True to allow the current entity to be hit, otherwise false.
  	 */
-	bool:public(entity, contentsMask),
+	function bool (int entity, int contentsMask);
 	
 	/**
 	 * Called on entity filtering.
@@ -129,7 +129,7 @@ funcenum TraceEntityFilter
  	 * @param data			Data value, if used.
  	 * @return				True to allow the current entity to be hit, otherwise false.
  	 */
-	bool:public(entity, contentsMask, any:data),
+	function bool (int entity, int contentsMask, any data);
 };
 
 /**

--- a/plugins/include/sorting.inc
+++ b/plugins/include/sorting.inc
@@ -123,10 +123,10 @@ native SortCustom1D(array[], array_size, SortFunc1D:sortfunc, Handle:hndl=INVALI
  *						0 if first is equal to second
  *						1 if first should go after second
  */
-funcenum SortFunc2D
+union SortFunc2D
 {
-	public(elem1[], elem2[], const array[][], Handle:hndl),
-	public(String:elem1[], String:elem2[], const String:array[][], Handle:hndl),
+	function int (int[] elem1, int[] elem2, const int[][] array, Handle hndl);
+	function int (char[] elem1, char[] elem2, const char[][] array, Handle hndl);
 };
 
 /** 

--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -45,7 +45,7 @@
 /**
  * Any of the following prototypes will work for a timed function.
  */
-funcenum Timer
+union Timer
 {
 	/**
  	 * Called when the timer interval has elapsed.
@@ -55,7 +55,7 @@ funcenum Timer
  	 * @return				Plugin_Stop to stop a repeating timer, any other value for
  	 *						default behavior.
  	 */
-	Action:public(Handle:timer, Handle:hndl),
+	function Action(Handle timer, Handle hndl);
 	
 	/**
  	 * Called when the timer interval has elapsed.
@@ -65,7 +65,7 @@ funcenum Timer
  	 * @return				Plugin_Stop to stop a repeating timer, any other value for
  	 *						default behavior.
  	 */
-	Action:public(Handle:timer, any:data),
+	function Action(Handle timer, any data);
 	
 	/**
  	 * Called when the timer interval has elapsed.
@@ -74,7 +74,7 @@ funcenum Timer
  	 * @return				Plugin_Stop to stop a repeating timer, any other value for
  	 *						default behavior.
  	 */
-	Action:public(Handle:timer),
+	function Action(Handle timer);
 };
 
 /**

--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -432,6 +432,7 @@ enum TokenKind {
   tTAGOF,
   tTHEN,
   tTYPEDEF,
+  tUNION,
   tVOID,
   tWHILE,
   /* compiler directives */

--- a/sourcepawn/compiler/sc2.cpp
+++ b/sourcepawn/compiler/sc2.cpp
@@ -1963,6 +1963,7 @@ const char *sc_tokens[] = {
          "return",
          "sizeof", "sleep", "static", "stock", "struct", "switch",
          "tagof", "*then", "typedef",
+         "union",
          "void",
          "while",
          "#assert", "#define", "#else", "#elseif", "#emit", "#endif", "#endinput",


### PR DESCRIPTION
funcenums are probably my biggest mistake in SourcePawn. Oh well. For future compilers, it makes much more sense to parse these as a discriminated union type rather than some hack for functags. In the meantime, spcomp1 can just compile it to a funcenum.

Since no tag -> void|int in old sytnax, someone should make sure these sdkhooks tags are supposed to be "void" and not "int".
