### PR TITLE
Add OnTakeDamage_Alive hook support to SDKHooks (bug=6249).

### DIFF
--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -90,6 +90,8 @@ enum SDKHookType
 	SDKHook_GetMaxHealth,
 	SDKHook_Blocked,
 	SDKHook_BlockedPost,
+	SDKHook_OnTakeDamageAlive,
+	SDKHook_OnTakeDamageAlivePost,
 	SDKHook_MAXHOOKS
 };
 
@@ -288,6 +290,8 @@ public:
 	void Hook_GroundEntChangedPost(void *pVar);
 	int Hook_OnTakeDamage(CTakeDamageInfoHack &info);
 	int Hook_OnTakeDamagePost(CTakeDamageInfoHack &info);
+	int Hook_OnTakeDamageAlive(CTakeDamageInfoHack &info);
+	int Hook_OnTakeDamageAlivePost(CTakeDamageInfoHack &info);
 	void Hook_PreThink();
 	void Hook_PreThinkPost();
 	void Hook_PostThink();
@@ -339,6 +343,10 @@ private:
 	void HandleEntityDeleted(CBaseEntity *pEntity, int ref);
 	void Unhook(CBaseEntity *pEntity);
 	void Unhook(IPluginContext *pContext);
+
+private:
+	int HandleOnTakeDamageHook(CTakeDamageInfoHack &info, SDKHookType hookType);
+	int HandleOnTakeDamageHookPost(CTakeDamageInfoHack &info, SDKHookType hookType);
 };
 
 extern CGlobalVars *gpGlobals;

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -119,6 +119,8 @@ enum SDKHookType
 	SDKHook_GetMaxHealth,  /**< ep2v and later */
 	SDKHook_Blocked,
 	SDKHook_BlockedPost,
+	SDKHook_OnTakeDamageAlive,
+	SDKHook_OnTakeDamageAlivePost,
 };
 
 /*
@@ -138,6 +140,9 @@ enum SDKHookType
 	
 	SDKHook_OnTakeDamage,
 	SDKHook_OnTakeDamagePost,
+	
+	SDKHook_OnTakeDamageAlive,
+	SDKHook_OnTakeDamageAlivePost,
 	
 	SDKHook_PreThink,
 	SDKHook_PreThinkPost,
@@ -244,6 +249,7 @@ union SDKHookCB
 	function Action (int entity, int &maxhealth);
 	
 	// OnTakeDamage
+	// OnTakeDamagAlive
 	// Note: The weapon parameter is not used by all games and damage sources.
 	// Note: Force application is dependent on game and damage type(s)
 	// SDKHooks 1.0+
@@ -256,6 +262,7 @@ union SDKHookCB
 		float[3] damageForce, float[3] damagePosition, int damagecustom);
 	
 	// OnTakeDamagePost
+	// OnTakeDamageAlivePost
 	function void (int victim, int attacker, int inflictor, float damage, int damagetype);
 	function void (int victim, int attacker, int inflictor, float damage, int damagetype, const float[3] damageForce, const float[3] damagePosition);
 	


### PR DESCRIPTION
Gamedata is omitted for now. I will add gamedata to multiple games for both this and the new Blocked hook after it's in master.

This is fairly straightforward is it just shared the logic for the existing OnTakeDamage hooks since the params and return types are the same. Justification for the hook is on [bug 6249](https://bugs.alliedmods.net/show_bug.cgi?id=6249).
