### PR TITLE
Treat SourcePawn warnings as errors when building

### DIFF
--- a/plugins/AMBuilder
+++ b/plugins/AMBuilder
@@ -35,6 +35,7 @@ spcomp_argv = [
   '-i' + os.path.relpath(os.path.join(builder.sourcePath, 'plugins', 'include'),
                          os.path.join(builder.buildPath, builder.buildFolder)),
   '-h',
+  '-E',
 ]
 
 def build_plugin(script_path, smx_file):


### PR DESCRIPTION
Note that this will currently, rightfully cause the build to fail until the [auth-fixups](https://github.com/alliedmodders/sourcemod/tree/auth-fixups) branch is merged.
