### PR TITLE
Clients array in TE_Send should be const.

### DIFF
--- a/plugins/include/sdktools_tempents.inc
+++ b/plugins/include/sdktools_tempents.inc
@@ -171,7 +171,7 @@ native TE_WriteFloatArray(const String:prop[], const Float:array[], arraySize);
  * @noreturn
  * @error		Invalid client index or client not in game.
  */
-native TE_Send(clients[], numClients, Float:delay=0.0);
+native TE_Send(const clients[], numClients, Float:delay=0.0);
 
 /**
  * Sets an encoded entity index in the current temp entity.


### PR DESCRIPTION
This array should be const, as the native doesn't appear to mutate the list of clients the TE is being sent to. This also helps with a pattern where you can re-send a TE within the TE hook.
