### PR TITLE
Allow Steam IDs in Steam3 format for sm_addban

### DIFF
--- a/plugins/basebans.sp
+++ b/plugins/basebans.sp
@@ -304,7 +304,7 @@ public Action:Command_AddBan(client, args)
 	new bool:idValid = false;
 	if (!strncmp(authid, "STEAM_", 6) && authid[7] == ':')
 		idValid = true;
-	else if (!strcmp(authid, "[U:", 3))
+	else if (!strncmp(authid, "[U:", 3))
 		idValid = true;
 	
 	if (!idValid)


### PR DESCRIPTION
Exactly what the title says.

sm_addban has some logic to attempt to make sure that the input is a valid Steam Id. (It only supports BANFLAG_AUTHID, not BANFLAG_IP). This makes it support both the Steam3 format now in addition to the legacy Steam2 format.

sm_ban operates on client targetting and already uses the game's network auth string internally. No change is necessary.

sm_unban has a heuristic to detect whether input is an IP address or a Steam Id. This adjusts the heuristic to be more flexible with auth ids, putting the limiting factor on the IP detection.

sm_banip and sm_abortban are (logically) unaffected.
