### PR TITLE
Port TopMenus to transitional syntax.

### DIFF
--- a/extensions/topmenus/smn_topmenus.cpp
+++ b/extensions/topmenus/smn_topmenus.cpp
@@ -417,6 +417,38 @@ static cell_t SetTopMenuTitleCaching(IPluginContext *pContext, const cell_t *par
 	return 0;
 }
 
+static cell_t TopMenu_AddItem(IPluginContext *pContext, const cell_t *params)
+{
+	cell_t new_params[] = {
+		8,
+		params[1],				// this
+		params[2],				// name
+		TopMenuObject_Item,		// type
+		params[3],				// handler
+		params[4],				// parent
+		params[5],				// cmdname
+		params[6],				// flags
+		params[7],				// info_string
+	};
+	return AddToTopMenu(pContext, new_params);
+}
+
+static cell_t TopMenu_AddCategory(IPluginContext *pContext, const cell_t *params)
+{
+	cell_t new_params[] = {
+		8,
+		params[1],				// this
+		params[2],				// name
+		TopMenuObject_Category,	// type
+		params[3],				// handler
+		0,						// parent
+		params[4],				// cmdname
+		params[5],				// flags
+		params[6],				// info_string
+	};
+	return AddToTopMenu(pContext, new_params);
+}
+
 sp_nativeinfo_t g_TopMenuNatives[] = 
 {
 	{"AddToTopMenu",			AddToTopMenu},
@@ -429,5 +461,19 @@ sp_nativeinfo_t g_TopMenuNatives[] =
 	{"GetTopMenuInfoString",	GetTopMenuInfoString},
 	{"GetTopMenuObjName",		GetTopMenuName},
 	{"SetTopMenuTitleCaching",		SetTopMenuTitleCaching},
+
+	// Transitional variants.
+	{"TopMenu.TopMenu",			CreateTopMenu},
+	{"TopMenu.AddItem",			TopMenu_AddItem},
+	{"TopMenu.AddCategory",		TopMenu_AddCategory},
+	{"TopMenu.Display",			DisplayTopMenu},
+	{"TopMenu.DisplayCategory",	DisplayTopMenuCategory},
+	{"TopMenu.LoadConfig",		LoadTopMenuConfig},
+	{"TopMenu.Remove",			RemoveFromTopMenu},
+	{"TopMenu.FindCategory",	FindTopMenuCategory},
+	{"TopMenu.GetInfoString",	GetTopMenuInfoString},
+	{"TopMenu.GetObjName",		GetTopMenuName},
+	{"TopMenu.CacheTitles.set",	SetTopMenuTitleCaching},
+
 	{NULL,					NULL},
 };

--- a/plugins/adminmenu.sp
+++ b/plugins/adminmenu.sp
@@ -50,12 +50,12 @@ new Handle:hOnAdminMenuReady = INVALID_HANDLE;
 new Handle:hOnAdminMenuCreated = INVALID_HANDLE;
 
 /* Menus */
-new Handle:hAdminMenu = INVALID_HANDLE;
+TopMenu hAdminMenu;
 
 /* Top menu objects */
-new TopMenuObject:obj_playercmds = INVALID_TOPMENUOBJECT;
-new TopMenuObject:obj_servercmds = INVALID_TOPMENUOBJECT;
-new TopMenuObject:obj_votingcmds = INVALID_TOPMENUOBJECT;
+TopMenuObject obj_playercmds = INVALID_TOPMENUOBJECT;
+TopMenuObject obj_servercmds = INVALID_TOPMENUOBJECT;
+TopMenuObject obj_votingcmds = INVALID_TOPMENUOBJECT;
 
 #include "adminmenu/dynamicmenu.sp"
 
@@ -86,7 +86,7 @@ public OnConfigsExecuted()
 	
 	BuildPath(Path_SM, path, sizeof(path), "configs/adminmenu_sorting.txt");
 	
-	if (!LoadTopMenuConfig(hAdminMenu, path, error, sizeof(error)))
+	if (!hAdminMenu.LoadConfig(path, error, sizeof(error)))
 	{
 		LogError("Could not load admin menu config (file \"%s\": %s)", path, error);
 		return;
@@ -100,25 +100,11 @@ public OnMapStart()
 
 public OnAllPluginsLoaded()
 {
-	hAdminMenu = CreateTopMenu(DefaultCategoryHandler);
+	hAdminMenu = TopMenu(DefaultCategoryHandler);
 	
-	obj_playercmds = AddToTopMenu(hAdminMenu, 
-		"PlayerCommands",
-		TopMenuObject_Category,
-		DefaultCategoryHandler,
-		INVALID_TOPMENUOBJECT);
-
-	obj_servercmds = AddToTopMenu(hAdminMenu,
-		"ServerCommands",
-		TopMenuObject_Category,
-		DefaultCategoryHandler,
-		INVALID_TOPMENUOBJECT);
-
-	obj_votingcmds = AddToTopMenu(hAdminMenu,
-		"VotingCommands",
-		TopMenuObject_Category,
-		DefaultCategoryHandler,
-		INVALID_TOPMENUOBJECT);
+	obj_playercmds = hAdminMenu.AddCategory("PlayerCommands", DefaultCategoryHandler);
+	obj_servercmds = hAdminMenu.AddCategory("ServerCommands", DefaultCategoryHandler);
+	obj_votingcmds = hAdminMenu.AddCategory("VotingCommands", DefaultCategoryHandler);
 		
 	BuildDynamicMenu();
 	
@@ -204,8 +190,7 @@ public Action:Command_DisplayMenu(client, args)
 		return Plugin_Handled;
 	}
 	
-	DisplayTopMenu(hAdminMenu, client, TopMenuPosition_Start);
-	
+	hAdminMenu.Display(client, TopMenuPosition_Start);
 	return Plugin_Handled;
 }
 

--- a/plugins/adminmenu/dynamicmenu.sp
+++ b/plugins/adminmenu/dynamicmenu.sp
@@ -117,13 +117,10 @@ BuildDynamicMenu()
 
 		KvGetString(kvMenu, "admin", admin, sizeof(admin),"sm_admin");
 				
-		if ((categoryId =FindTopMenuCategory(hAdminMenu, buffer)) == INVALID_TOPMENUOBJECT)
+		if ((categoryId = hAdminMenu.FindCategory(buffer)) == INVALID_TOPMENUOBJECT)
 		{
-			categoryId = AddToTopMenu(hAdminMenu,
-							buffer,
-							TopMenuObject_Category,
+			categoryId = hAdminMenu.AddCategory(buffer,
 							DynamicMenuCategoryHandler,
-							INVALID_TOPMENUOBJECT,
 							admin,
 							ADMFLAG_GENERIC,
 							name);
@@ -309,9 +306,7 @@ BuildDynamicMenu()
 			decl String:locString[10];
 			IntToString(location, locString, sizeof(locString));
 
-			if (AddToTopMenu(hAdminMenu,
-				buffer,
-				TopMenuObject_Item,
+			if (hAdminMenu.AddItem(buffer,
 				DynamicMenuItemHandler,
   				categoryId,
   				admin,
@@ -590,7 +585,7 @@ public ParamCheck(client)
 	{	
 		//nothing else need to be done. Run teh command.
 		
-		DisplayTopMenu(hAdminMenu, client, TopMenuPosition_LastCategory);
+		hAdminMenu.Display(client, TopMenuPosition_LastCategory);
 		
 		decl String:unquotedCommand[CMD_LENGTH];
 		UnQuoteString(g_command[client], unquotedCommand, sizeof(unquotedCommand), "#@");
@@ -654,7 +649,7 @@ public Menu_Selection(Handle:menu, MenuAction:action, param1, param2)
 	if (action == MenuAction_Cancel && param2 == MenuCancel_ExitBack)
 	{
 		//client exited we should go back to submenu i think
-		DisplayTopMenu(hAdminMenu, param1, TopMenuPosition_LastCategory);
+		hAdminMenu.Display(param1, TopMenuPosition_LastCategory);
 	}
 }
 

--- a/plugins/basebans.sp
+++ b/plugins/basebans.sp
@@ -46,7 +46,7 @@ public Plugin:myinfo =
 	url = "http://www.sourcemod.net/"
 };
 
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 new g_BanTarget[MAXPLAYERS+1];
 new g_BanTargetUserId[MAXPLAYERS+1];
@@ -77,8 +77,8 @@ public OnPluginStart()
 	RegConsoleCmd("sm_abortban", Command_AbortBan, "sm_abortban");
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
@@ -136,7 +136,7 @@ LoadBanReasons()
 	}
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -148,18 +148,11 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Find the "Player Commands" category */
-	new TopMenuObject:player_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_PLAYERCOMMANDS);
+	new TopMenuObject:player_commands = hTopMenu.FindCategory(ADMINMENU_PLAYERCOMMANDS);
 
 	if (player_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_ban",
-			TopMenuObject_Item,
-			AdminMenu_Ban,
-			player_commands,
-			"sm_ban",
-			ADMFLAG_BAN);
-			
+		hTopMenu.AddItem("sm_ban", AdminMenu_Ban, player_commands, "sm_ban", ADMFLAG_BAN);
 	}
 }
 

--- a/plugins/basebans/ban.sp
+++ b/plugins/basebans/ban.sp
@@ -177,9 +177,9 @@ public MenuHandler_BanReasonList(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -209,9 +209,9 @@ public MenuHandler_BanPlayerList(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -247,9 +247,9 @@ public MenuHandler_BanTimeList(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basecomm.sp
+++ b/plugins/basecomm.sp
@@ -54,7 +54,7 @@ new Handle:g_Cvar_Deadtalk = INVALID_HANDLE;	// Holds the handle for sm_deadtalk
 new Handle:g_Cvar_Alltalk = INVALID_HANDLE;	// Holds the handle for sv_alltalk
 new bool:g_Hooked = false;			// Tracks if we've hooked events for deadtalk
 
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 new g_GagTarget[MAXPLAYERS+1];
 
@@ -93,14 +93,14 @@ public OnPluginStart()
 	HookConVarChange(g_Cvar_Alltalk, ConVarChange_Alltalk);
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -112,17 +112,11 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Build the "Player Commands" category */
-	new TopMenuObject:player_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_PLAYERCOMMANDS);
+	TopMenuObject player_commands = hTopMenu.FindCategory(ADMINMENU_PLAYERCOMMANDS);
 	
 	if (player_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu, 
-			"sm_gag",
-			TopMenuObject_Item,
-			AdminMenu_Gag,
-			player_commands,
-			"sm_gag",
-			ADMFLAG_CHAT);
+		hTopMenu.AddItem("sm_gag", AdminMenu_Gag, player_commands, "sm_gag", ADMFLAG_CHAT);
 	}
 }
 

--- a/plugins/basecomm/gag.sp
+++ b/plugins/basecomm/gag.sp
@@ -128,9 +128,9 @@ public MenuHandler_GagPlayer(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -165,9 +165,9 @@ public MenuHandler_GagTypes(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basecommands.sp
+++ b/plugins/basecommands.sp
@@ -46,7 +46,7 @@ public Plugin:myinfo =
 	url = "http://www.sourcemod.net/"
 };
 
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 new Handle:g_MapList;
 new Handle:g_ProtectedVars;
@@ -75,8 +75,8 @@ public OnPluginStart()
 	RegConsoleCmd("sm_revote", Command_ReVote);
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
@@ -146,7 +146,7 @@ bool:IsClientAllowedToChangeCvar(client, const String:cvarname[])
 	return allowed;
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -158,67 +158,28 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Build the "Player Commands" category */
-	new TopMenuObject:player_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_PLAYERCOMMANDS);
+	TopMenuObject player_commands = hTopMenu.FindCategory(ADMINMENU_PLAYERCOMMANDS);
 	
 	if (player_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu, 
-			"sm_kick",
-			TopMenuObject_Item,
-			AdminMenu_Kick,
-			player_commands,
-			"sm_kick",
-			ADMFLAG_KICK);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_who",
-			TopMenuObject_Item,
-			AdminMenu_Who,
-			player_commands,
-			"sm_who",
-			ADMFLAG_GENERIC);
+		hTopMenu.AddItem("sm_kick", AdminMenu_Kick, player_commands, "sm_kick", ADMFLAG_KICK);
+		hTopMenu.AddItem("sm_who", AdminMenu_Who, player_commands, "sm_who", ADMFLAG_GENERIC);
 	}
 
-	new TopMenuObject:server_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_SERVERCOMMANDS);
+	TopMenuObject server_commands = hTopMenu.FindCategory(ADMINMENU_SERVERCOMMANDS);
 
 	if (server_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_reloadadmins",
-			TopMenuObject_Item,
-			AdminMenu_ReloadAdmins,
-			server_commands,
-			"sm_reloadadmins",
-			ADMFLAG_BAN);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_map",
-			TopMenuObject_Item,
-			AdminMenu_Map,
-			server_commands,
-			"sm_map",
-			ADMFLAG_CHANGEMAP);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_execcfg",
-			TopMenuObject_Item,
-			AdminMenu_ExecCFG,
-			server_commands,
-			"sm_execcfg",
-			ADMFLAG_CONFIG);		
+		hTopMenu.AddItem("sm_reloadadmins", AdminMenu_ReloadAdmins, server_commands, "sm_reloadadmins", ADMFLAG_BAN);
+		hTopMenu.AddItem("sm_map", AdminMenu_Map, server_commands, "sm_map", ADMFLAG_CHANGEMAP);
+		hTopMenu.AddItem("sm_execcfg", AdminMenu_ExecCFG, server_commands, "sm_execcfg", ADMFLAG_CONFIG);		
 	}
 
-	new TopMenuObject:voting_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_VOTINGCOMMANDS);
+	TopMenuObject voting_commands = hTopMenu.FindCategory(ADMINMENU_VOTINGCOMMANDS);
 
 	if (voting_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_cancelvote",
-			TopMenuObject_Item,
-			AdminMenu_CancelVote,
-			voting_commands,
-			"sm_cancelvote",
-			ADMFLAG_VOTE);
+		hTopMenu.AddItem("sm_cancelvote", AdminMenu_CancelVote, voting_commands, "sm_cancelvote", ADMFLAG_VOTE);
 	}
 }
 
@@ -226,7 +187,7 @@ public OnLibraryRemoved(const String:name[])
 {
 	if (strcmp(name, "adminmenu") == 0)
 	{
-		hTopMenu = INVALID_HANDLE;
+		hTopMenu = null;
 	}
 }
 

--- a/plugins/basecommands/execcfg.sp
+++ b/plugins/basecommands/execcfg.sp
@@ -69,9 +69,9 @@ public MenuHandler_ExecCFG(Handle:menu, MenuAction:action, param1, param2)
 {
 	if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basecommands/kick.sp
+++ b/plugins/basecommands/kick.sp
@@ -84,9 +84,9 @@ public MenuHandler_Kick(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basecommands/map.sp
+++ b/plugins/basecommands/map.sp
@@ -35,9 +35,9 @@ public MenuHandler_ChangeMap(Handle:menu, MenuAction:action, param1, param2)
 {
 	if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basecommands/who.sp
+++ b/plugins/basecommands/who.sp
@@ -126,9 +126,9 @@ public MenuHandler_Who(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -79,7 +79,7 @@ new String:g_voteInfo[3][65];	/* Holds the target's name, authid, and IP */
 new String:g_voteArg[256];	/* Used to hold ban/kick reasons or vote questions */
 
 
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 #include "basevotes/votekick.sp"
 #include "basevotes/voteban.sp"
@@ -110,8 +110,8 @@ public OnPluginStart()
 	g_Cvar_Limits[2] = CreateConVar("sm_vote_ban", "0.60", "percent required for successful ban vote.", 0, true, 0.05, true, 1.0);		
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
@@ -132,7 +132,7 @@ public OnConfigsExecuted()
 	g_mapCount = LoadMapList(g_MapList);
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -144,33 +144,13 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Build the "Voting Commands" category */
-	new TopMenuObject:voting_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_VOTINGCOMMANDS);
+	new TopMenuObject:voting_commands = hTopMenu.FindCategory(ADMINMENU_VOTINGCOMMANDS);
 
 	if (voting_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_votekick",
-			TopMenuObject_Item,
-			AdminMenu_VoteKick,
-			voting_commands,
-			"sm_votekick",
-			ADMFLAG_VOTE|ADMFLAG_KICK);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_voteban",
-			TopMenuObject_Item,
-			AdminMenu_VoteBan,
-			voting_commands,
-			"sm_voteban",
-			ADMFLAG_VOTE|ADMFLAG_BAN);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_votemap",
-			TopMenuObject_Item,
-			AdminMenu_VoteMap,
-			voting_commands,
-			"sm_votemap",
-			ADMFLAG_VOTE|ADMFLAG_CHANGEMAP);
+		hTopMenu.AddItem("sm_votekick", AdminMenu_VoteKick, voting_commands, "sm_votekick", ADMFLAG_VOTE|ADMFLAG_KICK);
+		hTopMenu.AddItem("sm_voteban", AdminMenu_VoteBan, voting_commands, "sm_voteban", ADMFLAG_VOTE|ADMFLAG_BAN);
+		hTopMenu.AddItem("sm_votemap", AdminMenu_VoteMap, voting_commands, "sm_votemap", ADMFLAG_VOTE|ADMFLAG_CHANGEMAP);
 	}
 }
 

--- a/plugins/basevotes/voteban.sp
+++ b/plugins/basevotes/voteban.sp
@@ -96,9 +96,9 @@ public MenuHandler_Ban(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basevotes/votekick.sp
+++ b/plugins/basevotes/votekick.sp
@@ -97,9 +97,9 @@ public MenuHandler_Kick(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/basevotes/votemap.sp
+++ b/plugins/basevotes/votemap.sp
@@ -102,9 +102,9 @@ public MenuHandler_Confirm(Handle:menu, MenuAction:action, param1, param2)
 	{
 		ResetMenu();
 		
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -127,7 +127,7 @@ public MenuHandler_Map(Handle:menu, MenuAction:action, param1, param2)
 {
 	if (action == MenuAction_Cancel)
 	{		
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
 			ConfirmVote(param1);
 		}

--- a/plugins/funcommands.sp
+++ b/plugins/funcommands.sp
@@ -48,7 +48,7 @@ public Plugin:myinfo =
 };
 
 // Admin Menu
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 // Sounds
 new String:g_BlipSound[PLATFORM_MAX_PATH];
@@ -110,8 +110,8 @@ public OnPluginStart()
 	HookEvents( );
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
@@ -258,7 +258,7 @@ public Action:Event_RoundEnd(Handle:event,const String:name[],bool:dontBroadcast
 	KillAllDrugs();
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -270,89 +270,20 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Find the "Player Commands" category */
-	new TopMenuObject:player_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_PLAYERCOMMANDS);
+	TopMenuObject player_commands = hTopMenu.FindCategory(ADMINMENU_PLAYERCOMMANDS);
 
 	if (player_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_beacon",
-			TopMenuObject_Item,
-			AdminMenu_Beacon,
-			player_commands,
-			"sm_beacon",
-			ADMFLAG_SLAY);
-	
-		AddToTopMenu(hTopMenu,
-			"sm_timebomb",
-			TopMenuObject_Item,
-			AdminMenu_TimeBomb,
-			player_commands,
-			"sm_timebomb",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_burn",
-			TopMenuObject_Item,
-			AdminMenu_Burn,
-			player_commands,
-			"sm_burn",
-			ADMFLAG_SLAY);
-		
-		AddToTopMenu(hTopMenu,
-			"sm_firebomb",
-			TopMenuObject_Item,
-			AdminMenu_FireBomb,
-			player_commands,
-			"sm_firebomb",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_freeze",
-			TopMenuObject_Item,
-			AdminMenu_Freeze,
-			player_commands,
-			"sm_freeze",
-			ADMFLAG_SLAY);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_freezebomb",
-			TopMenuObject_Item,
-			AdminMenu_FreezeBomb,
-			player_commands,
-			"sm_freezebomb",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_gravity",
-			TopMenuObject_Item,
-			AdminMenu_Gravity,
-			player_commands,
-			"sm_gravity",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_blind",
-			TopMenuObject_Item,
-			AdminMenu_Blind,
-			player_commands,
-			"sm_blind",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_noclip",
-			TopMenuObject_Item,
-			AdminMenu_NoClip,
-			player_commands,
-			"sm_noclip",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_drug",
-			TopMenuObject_Item,
-			AdminMenu_Drug,
-			player_commands,
-			"sm_drug",
-			ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_beacon", AdminMenu_Beacon, player_commands, "sm_beacon", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_timebomb", AdminMenu_TimeBomb, player_commands, "sm_timebomb", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_burn", AdminMenu_Burn, player_commands, "sm_burn", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_firebomb", AdminMenu_FireBomb, player_commands, "sm_firebomb", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_freeze", AdminMenu_Freeze, player_commands, "sm_freeze", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_freezebomb", AdminMenu_FreezeBomb, player_commands, "sm_freezebomb", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_gravity", AdminMenu_Gravity, player_commands, "sm_gravity", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_blind", AdminMenu_Blind, player_commands, "sm_blind", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_noclip", AdminMenu_NoClip, player_commands, "sm_noclip", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_drug", AdminMenu_Drug, player_commands, "sm_drug", ADMFLAG_SLAY);
 	}
 }
 

--- a/plugins/funcommands/beacon.sp
+++ b/plugins/funcommands/beacon.sp
@@ -161,9 +161,9 @@ public MenuHandler_Beacon(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/blind.sp
+++ b/plugins/funcommands/blind.sp
@@ -137,9 +137,9 @@ public MenuHandler_Blind(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -183,9 +183,9 @@ public MenuHandler_Amount(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/drug.sp
+++ b/plugins/funcommands/drug.sp
@@ -241,9 +241,9 @@ public MenuHandler_Drug(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/fire.sp
+++ b/plugins/funcommands/fire.sp
@@ -281,9 +281,9 @@ public MenuHandler_Burn(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -326,9 +326,9 @@ public MenuHandler_FireBomb(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/gravity.sp
+++ b/plugins/funcommands/gravity.sp
@@ -96,9 +96,9 @@ public MenuHandler_Gravity(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -142,9 +142,9 @@ public MenuHandler_GravityAmount(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/ice.sp
+++ b/plugins/funcommands/ice.sp
@@ -395,9 +395,9 @@ public MenuHandler_Freeze(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -441,9 +441,9 @@ public MenuHandler_FreezeBomb(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/noclip.sp
+++ b/plugins/funcommands/noclip.sp
@@ -86,9 +86,9 @@ public MenuHandler_NoClip(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funcommands/timebomb.sp
+++ b/plugins/funcommands/timebomb.sp
@@ -252,9 +252,9 @@ public MenuHandler_TimeBomb(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -83,7 +83,7 @@ new g_voteClient[2];		/* Holds the target's client id and user id */
 #define	VOTE_IP		2
 new String:g_voteInfo[3][65];	/* Holds the target's name, authid, and IP */
 
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 #include "funvotes/votegravity.sp"
 #include "funvotes/voteburn.sp"
@@ -128,14 +128,14 @@ public OnPluginStart()
 	*/
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -147,49 +147,15 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Build the "Voting Commands" category */
-	new TopMenuObject:voting_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_VOTINGCOMMANDS);
+	new TopMenuObject:voting_commands = hTopMenu.FindCategory(ADMINMENU_VOTINGCOMMANDS);
 
 	if (voting_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_votegravity",
-			TopMenuObject_Item,
-			AdminMenu_VoteGravity,
-			voting_commands,
-			"sm_votegravity",
-			ADMFLAG_VOTE);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_voteburn",
-			TopMenuObject_Item,
-			AdminMenu_VoteBurn,
-			voting_commands,
-			"sm_voteburn",
-			ADMFLAG_VOTE|ADMFLAG_SLAY);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_voteslay",
-			TopMenuObject_Item,
-			AdminMenu_VoteSlay,
-			voting_commands,
-			"sm_voteslay",
-			ADMFLAG_VOTE|ADMFLAG_SLAY);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_votealltalk",
-			TopMenuObject_Item,
-			AdminMenu_VoteAllTalk,
-			voting_commands,
-			"sm_votealltalk",
-			ADMFLAG_VOTE);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_voteff",
-			TopMenuObject_Item,
-			AdminMenu_VoteFF,
-			voting_commands,
-			"sm_voteff",
-			ADMFLAG_VOTE);
+		hTopMenu.AddItem("sm_votegravity", AdminMenu_VoteGravity, voting_commands, "sm_votegravity", ADMFLAG_VOTE);
+		hTopMenu.AddItem("sm_voteburn", AdminMenu_VoteBurn, voting_commands, "sm_voteburn", ADMFLAG_VOTE|ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_voteslay", AdminMenu_VoteSlay, voting_commands, "sm_voteslay", ADMFLAG_VOTE|ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_votealltalk", AdminMenu_VoteAllTalk, voting_commands, "sm_votealltalk", ADMFLAG_VOTE);
+		hTopMenu.AddItem("sm_voteff", AdminMenu_VoteFF, voting_commands, "sm_voteff", ADMFLAG_VOTE);
 	}
 }
 

--- a/plugins/funvotes/voteburn.sp
+++ b/plugins/funvotes/voteburn.sp
@@ -99,9 +99,9 @@ public MenuHandler_Burn(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/funvotes/voteslay.sp
+++ b/plugins/funvotes/voteslay.sp
@@ -100,9 +100,9 @@ public MenuHandler_Slay(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/include/adminmenu.inc
+++ b/plugins/include/adminmenu.inc
@@ -65,7 +65,7 @@
  * @param topmenu		Handle to the admin menu's TopMenu.
  * @noreturn
  */
-forward OnAdminMenuCreated(Handle:topmenu);
+forward OnAdminMenuCreated(TopMenu topmenu);
 
 /**
  * Called when the admin menu is ready to have items added.
@@ -73,7 +73,7 @@ forward OnAdminMenuCreated(Handle:topmenu);
  * @param topmenu		Handle to the admin menu's TopMenu.
  * @noreturn
  */
-forward OnAdminMenuReady(Handle:topmenu);
+forward OnAdminMenuReady(TopMenu topmenu);
 
 /**
  * Retrieves the Handle to the admin top menu.
@@ -81,7 +81,7 @@ forward OnAdminMenuReady(Handle:topmenu);
  * @return				Handle to the admin menu's TopMenu,
  *						or INVALID_HANDLE if not created yet.
  */
-native Handle:GetAdminTopMenu();
+native TopMenu GetAdminTopMenu();
 
 /**
  * Adds targets to an admin menu.

--- a/plugins/include/topmenus.inc
+++ b/plugins/include/topmenus.inc
@@ -1,5 +1,5 @@
 /**
- * vim: set ts=4 :
+ * vim: set ts=4 sw=4 tw=99 noet:
  * =============================================================================
  * SourceMod (C)2004-2008 AlliedModders LLC.  All rights reserved.
  * =============================================================================
@@ -40,7 +40,7 @@
 /**
  * Actions a top menu will take on an topobj.
  */
-enum TopMenuAction
+enum TopMenuAction:
 {
 	/**
 	 * An option is being drawn for a menu (or for sorting purposes).
@@ -92,7 +92,7 @@ enum TopMenuAction
 /**
  * Top menu topobj types.
  */
-enum TopMenuObjectType
+enum TopMenuObjectType:
 {
 	TopMenuObject_Category = 0,			/**< Category (sub-menu branching from root) */
 	TopMenuObject_Item = 1				/**< Item on a sub-menu */
@@ -101,7 +101,7 @@ enum TopMenuObjectType
 /**
  * Top menu starting positions for display.
  */
-enum TopMenuPosition
+enum TopMenuPosition:
 {
 	TopMenuPosition_Start = 0,			/**< Start/root of the menu */
 	TopMenuPosition_LastRoot = 1,		/**< Last position in the root menu */
@@ -111,7 +111,7 @@ enum TopMenuPosition
 /**
  * Top menu topobj tag for type checking.
  */
-enum TopMenuObject
+enum TopMenuObject:
 {
 	INVALID_TOPMENUOBJECT = 0,
 };
@@ -136,13 +136,126 @@ typedef TopMenuHandler = function void (
   int maxlength
 );
 
+// TopMenu objects are used for constructing multi-layer menus. Currently, they
+// support at most two levels. The first level of items are called "categories".
+methodmap TopMenu < Handle
+{
+	// Creates a new TopMenu.
+	//
+	// @param handler       Handler to use for drawing the root title.
+	// @return              A new TopMenu.
+	public native TopMenu(TopMenuHandler handler);
+
+	// Re-sorts the items in a TopMenu via a configuration file.
+	//
+	// The format of the configuration file should be a Valve Key-Values 
+	// formatted file that SourceMod can parse.  There should be one root 
+	// section, and one sub-section for each category.  Each sub-section's 
+	// name should match the category name.
+	//
+	// Each sub-section may only contain key/value pairs in the form of:
+	// key: "item"
+	// value: Name of the item as passed to AddToTopMenu().
+	//
+	// The TopMenu will draw items in the order declared in the configuration 
+	// file.  If items do not appear in the configuration file, they are sorted 
+	// per-player based on how the handler function renders for that player.  
+	// These items appear after the configuration sorted items.
+	//
+	// @param topmenu      TopMenu Handle.
+	// @param file         File path.
+	// @param error        Error buffer.
+	// @param maxlength    Maximum size of the error buffer. Error buffer
+	//                     will be filled with a zero-terminated string if
+	//                     false is returned.
+	// @return             True on success, false on failure.
+	public native bool LoadConfig(const char[] file, char[] error, int maxlength);
+
+	// Adds a category to a TopMenu.
+	// 
+	// @param name         Object name (MUST be unique).
+	// @param handler      Handler for topobj.
+	// @param cmdname      Command name (for access overrides).
+	// @param flags        Default access flags.
+	// @param info_string  Arbitrary storage (max 255 bytes).
+	// @return             A new TopMenuObject ID, or INVALID_TOPMENUOBJECT on failure.
+	public native TopMenuObject AddCategory(const char[] name, TopMenuHandler handler,
+	                                        const char[] cmdname = "", int flags = 0,
+	                                        const char[] info_string = "");
+
+	// Adds an item to a TopMenu category.
+	// 
+	// @param name         Object name (MUST be unique).
+	// @param handler      Handler for topobj.
+	// @param category     The object of the parent category for the item.
+	// @param cmdname      Command name (for access overrides).
+	// @param flags        Default access flags.
+	// @param info_string  Arbitrary storage (max 255 bytes).
+	// @return             A new TopMenuObject ID, or INVALID_TOPMENUOBJECT on failure.
+	public native TopMenuObject AddItem(const char[] name, TopMenuHandler handler,
+	                                    TopMenuObject parent, const char[] cmdname = "",
+	                                    int flags = 0, const char[] info_string = "");
+
+	// Retrieves the info string of a top menu item.
+	// 
+	// @param parent       TopMenuObject ID.
+	// @param buffer       Buffer to store info string.
+	// @param maxlength    Maximum size of info string.
+	// @return             Number of bytes written, not including the  null terminator.
+	public native int GetInfoString(TopMenuObject parent, char[] buffer, int maxlength);
+
+	// Retrieves the name string of a top menu item.
+	// 
+	// @param topobj       TopMenuObject ID.
+	// @param buffer       Buffer to store info string.
+	// @param maxlength    Maximum size of info string.
+	// @return             Number of bytes written, not including the null terminator.
+	public native int GetObjName(TopMenuObject topobj, char[] buffer, int maxlength);
+
+	// Removes an topobj from a TopMenu.
+	// 
+	// Plugins' topobjs are automatically removed all TopMenus when the given 
+	// plugin unloads or pauses.  In the case of unpausing, all items are restored.
+	// 
+	// @param topobj       TopMenuObject ID.
+	public native void Remove(TopMenuObject topobj);
+
+	// Displays a TopMenu to a client.
+	// 
+	// @param client       Client index.
+	// @param position     Position to display from.
+	// @return             True on success, false on failure.
+	public native bool Display(int client, TopMenuPosition position);
+
+	// Displays a TopMenu category to a client.
+	// 
+	// @param category     Category topobj id.
+	// @param client       Client index.
+	// @return             True on success, false on failure.
+	public native bool DisplayCategory(TopMenuObject category, int client);
+
+	// Finds a category's topobj ID in a TopMenu.
+	// 
+	// @param name         Object's unique name.
+	// @return             TopMenuObject ID on success, or 
+	//                     INVALID_TOPMENUOBJECT on failure.
+	public native TopMenuObject FindCategory(const char[] name);
+	
+	// Set the menu title caching behaviour of the TopMenu. By default titles
+	// are cached to reduce overhead. If you need dynamic menu titles which
+	// change each time the menu is displayed to a user, set this to false.
+	property bool CacheTitles {
+		public native set(bool value);
+	}
+};
+
 /**
  * Creates a TopMenu.
  *
  * @param handler			Handler to use for drawing the root title.
  * @return					A new TopMenu Handle, or INVALID_HANDLE on failure.
  */						  
-native Handle:CreateTopMenu(TopMenuHandler:handler);
+native TopMenu CreateTopMenu(TopMenuHandler handler);
 
 /**
  * Re-sorts the items in a TopMenu via a configuration file.
@@ -171,7 +284,7 @@ native Handle:CreateTopMenu(TopMenuHandler:handler);
  * @return					True on success, false on failure.
  * @error					Invalid TopMenu Handle.
  */
-native bool:LoadTopMenuConfig(Handle:topmenu, const String:file[], String:error[], maxlength);
+native bool LoadTopMenuConfig(Handle topmenu, const char[] file, char[] error, int maxlength);
 
 /**
  * Adds an topobj to a TopMenu.
@@ -190,14 +303,14 @@ native bool:LoadTopMenuConfig(Handle:topmenu, const String:file[], String:error[
  *							failure.
  * @error					Invalid TopMenu Handle.
  */
-native TopMenuObject:AddToTopMenu(Handle:topmenu,
-								  const String:name[],
-								  TopMenuObjectType:type,
-								  TopMenuHandler:handler,
-								  TopMenuObject:parent,
-								  const String:cmdname[]="",
-								  flags=0,
-								  const String:info_string[]="");
+native TopMenuObject AddToTopMenu(Handle topmenu,
+								  const char[] name,
+								  TopMenuObjectType type,
+								  TopMenuHandler handler,
+								  TopMenuObject parent,
+								  const char[] cmdname="",
+								  int flags=0,
+								  const char[] info_string="");
 								  
 /**
  * Retrieves the info string of a top menu item.
@@ -210,7 +323,7 @@ native TopMenuObject:AddToTopMenu(Handle:topmenu,
  *							null terminator.
  * @error					Invalid TopMenu Handle or TopMenuObject ID.
  */
-native GetTopMenuInfoString(Handle:topmenu, TopMenuObject:parent, String:buffer[], maxlength);
+native int GetTopMenuInfoString(Handle topmenu, TopMenuObject parent, char[] buffer, int maxlength);
 
 /**
  * Retrieves the name string of a top menu item.
@@ -223,7 +336,7 @@ native GetTopMenuInfoString(Handle:topmenu, TopMenuObject:parent, String:buffer[
  *							null terminator.
  * @error					Invalid TopMenu Handle or TopMenuObject ID.
  */
-native GetTopMenuObjName(Handle:topmenu, TopMenuObject:topobj, String:buffer[], maxlength);
+native int GetTopMenuObjName(Handle topmenu, TopMenuObject topobj, char[] buffer, int maxlength);
 
 /**
  * Removes an topobj from a TopMenu.
@@ -236,7 +349,7 @@ native GetTopMenuObjName(Handle:topmenu, TopMenuObject:topobj, String:buffer[], 
  * @noreturn
  * @error					Invalid TopMenu Handle.
  */
-native RemoveFromTopMenu(Handle:topmenu, TopMenuObject:topobj);
+native void RemoveFromTopMenu(Handle topmenu, TopMenuObject topobj);
 
 /**
  * Displays a TopMenu to a client.
@@ -247,7 +360,7 @@ native RemoveFromTopMenu(Handle:topmenu, TopMenuObject:topobj);
  * @return					True on success, false on failure.
  * @error					Invalid TopMenu Handle or client not in game.
  */
-native bool:DisplayTopMenu(Handle:topmenu, client, TopMenuPosition:position);
+native bool DisplayTopMenu(Handle topmenu, int client, TopMenuPosition position);
 
 /**
  * Displays a TopMenu category to a client.
@@ -258,7 +371,7 @@ native bool:DisplayTopMenu(Handle:topmenu, client, TopMenuPosition:position);
  * @return					True on success, false on failure.
  * @error					Invalid TopMenu Handle or client not in game.
  */
-native bool:DisplayTopMenuCategory(Handle:topmenu, TopMenuObject:category, client);
+native bool DisplayTopMenuCategory(Handle topmenu, TopMenuObject category, int client);
 
 /**
  * Finds a category's topobj ID in a TopMenu.
@@ -269,18 +382,21 @@ native bool:DisplayTopMenuCategory(Handle:topmenu, TopMenuObject:category, clien
  *							INVALID_TOPMENUOBJECT on failure.
  * @error					Invalid TopMenu Handle.
  */
-native TopMenuObject:FindTopMenuCategory(Handle:topmenu, const String:name[]);
+native TopMenuObject FindTopMenuCategory(Handle topmenu, const char[] name);
 
 /**
- * Change the menu title caching behaviour of the TopMenu. By default the titles are cached to reduce overhead.
- * If you need dynamic menu titles, which can change everytime the menu is displayed to a user, set this to false.
+ * Change the menu title caching behaviour of the TopMenu. By default the
+ * titles are cached to reduce overhead. If you need dynamic menu titles, which
+ * can change everytime the menu is displayed to a user, set this to false.
  *
  * @param topmenu       TopMenu Handle.
- * @param cache_titles  Cache the menu titles and don't call the handler with TopMenuAction_DisplayTitle everytime the menu is drawn?
+ * @param cache_titles  Cache the menu titles and don't call the handler with
+ *                      TopMenuAction_DisplayTitle everytime the menu is drawn?
  * @noreturn
  * @error               Invalid TopMenu Handle
  */
-native SetTopMenuTitleCaching(Handle:topmenu, bool:cache_titles);
+native void SetTopMenuTitleCaching(Handle topmenu, bool cache_titles);
+
 
 /**
  * Do not edit below this line!

--- a/plugins/playercommands.sp
+++ b/plugins/playercommands.sp
@@ -47,7 +47,7 @@ public Plugin:myinfo =
 	url = "http://www.sourcemod.net/"
 };
 
-new Handle:hTopMenu = INVALID_HANDLE;
+TopMenu hTopMenu;
 
 /* Used to get the SDK / Engine version. */
 /* This is used in sm_rename and sm_changeteam */
@@ -69,14 +69,14 @@ public OnPluginStart()
 	g_ModVersion = GetEngineVersion();
 	
 	/* Account for late loading */
-	new Handle:topmenu;
-	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != INVALID_HANDLE))
+	TopMenu topmenu;
+	if (LibraryExists("adminmenu") && ((topmenu = GetAdminTopMenu()) != null))
 	{
 		OnAdminMenuReady(topmenu);
 	}
 }
 
-public OnAdminMenuReady(Handle:topmenu)
+public OnAdminMenuReady(TopMenu topmenu)
 {
 	/* Block us from being called twice */
 	if (topmenu == hTopMenu)
@@ -88,32 +88,12 @@ public OnAdminMenuReady(Handle:topmenu)
 	hTopMenu = topmenu;
 	
 	/* Find the "Player Commands" category */
-	new TopMenuObject:player_commands = FindTopMenuCategory(hTopMenu, ADMINMENU_PLAYERCOMMANDS);
+	TopMenuObject player_commands = hTopMenu.FindCategory(ADMINMENU_PLAYERCOMMANDS);
 
 	if (player_commands != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(hTopMenu,
-			"sm_slay",
-			TopMenuObject_Item,
-			AdminMenu_Slay,
-			player_commands,
-			"sm_slay",
-			ADMFLAG_SLAY);
-			
-		AddToTopMenu(hTopMenu,
-			"sm_slap",
-			TopMenuObject_Item,
-			AdminMenu_Slap,
-			player_commands,
-			"sm_slap",
-			ADMFLAG_SLAY);
-
-		AddToTopMenu(hTopMenu,
-			"sm_rename",
-			TopMenuObject_Item,
-			AdminMenu_Rename,
-			player_commands,
-			"sm_rename",
-			ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_slay", AdminMenu_Slay, player_commands, "sm_slay", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_slap", AdminMenu_Slap, player_commands, "sm_slap", ADMFLAG_SLAY);
+		hTopMenu.AddItem("sm_rename", AdminMenu_Rename, player_commands, "sm_rename", ADMFLAG_SLAY);
 	}
 }

--- a/plugins/playercommands/rename.sp
+++ b/plugins/playercommands/rename.sp
@@ -95,9 +95,9 @@ public MenuHandler_Rename(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/playercommands/slap.sp
+++ b/plugins/playercommands/slap.sp
@@ -98,9 +98,9 @@ public MenuHandler_SlapDamage(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)
@@ -122,9 +122,9 @@ public MenuHandler_Slap(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)

--- a/plugins/playercommands/slay.sp
+++ b/plugins/playercommands/slay.sp
@@ -76,9 +76,9 @@ public MenuHandler_Slay(Handle:menu, MenuAction:action, param1, param2)
 	}
 	else if (action == MenuAction_Cancel)
 	{
-		if (param2 == MenuCancel_ExitBack && hTopMenu != INVALID_HANDLE)
+		if (param2 == MenuCancel_ExitBack && hTopMenu != null)
 		{
-			DisplayTopMenu(hTopMenu, param1, TopMenuPosition_LastCategory);
+			hTopMenu.Display(param1, TopMenuPosition_LastCategory);
 		}
 	}
 	else if (action == MenuAction_Select)


### PR DESCRIPTION
Mostly a syntactic refactoring. For this patch (and going forward, I think) I'm going to try and not use the `X() = Y` syntax, since it makes documentation more confusing. The downside is the comments get duplicated, but oh well. With this method we can stick classes at the top of the file anyway.
