### PR TITLE
Fix a crash when properties have setters but not getters.

### DIFF
--- a/sourcepawn/compiler/sc1.cpp
+++ b/sourcepawn/compiler/sc1.cpp
@@ -3686,8 +3686,7 @@ int parse_property_accessor(const typeinfo_t *type, methodmap_t *map, methodmap_
 
     // Must have one extra argument taking the return type.
     arginfo *arg = &target->dim.arglist[1];
-    if (arg->ident == 0 ||
-        arg->ident != iVARIABLE ||
+    if (arg->ident != iVARIABLE ||
         arg->hasdefault ||
         arg->numtags != 1 ||
         arg->tags[0] != type->tag)

--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -2174,7 +2174,7 @@ restart:
               rvalue(lval1);
             clear_value(lval1);
             lval1->ident = iACCESSOR;
-            lval1->tag = method->getter->tag;
+            lval1->tag = method->property_tag();
             lval1->accessor = method;
             lvalue = TRUE;
             goto restart;

--- a/sourcepawn/compiler/sctracker.h
+++ b/sourcepawn/compiler/sctracker.h
@@ -85,6 +85,19 @@ typedef struct methodmap_method_s
   symbol *target;
   symbol *getter;
   symbol *setter;
+
+  int property_tag() const {
+    assert(getter || setter);
+    if (getter)
+      return getter->tag;
+    arginfo *thisp = &setter->dim.arglist[0];
+    if (thisp->ident == 0)
+      return pc_tag_void;
+    arginfo *valp = &setter->dim.arglist[1];
+    if (valp->ident != iVARIABLE || valp->numtags != 1)
+      return pc_tag_void;
+    return valp->tags[0];
+  }
 } methodmap_method_t;
 
 typedef struct methodmap_s

--- a/sourcepawn/compiler/tests/ok-setter-no-getter.sp
+++ b/sourcepawn/compiler/tests/ok-setter-no-getter.sp
@@ -1,0 +1,12 @@
+methodmap Crab
+{
+	property int X {
+		public native set(int value);
+	}
+}
+
+public main()
+{
+	Crab crab;
+	crab.X = 12;
+}


### PR DESCRIPTION
The code in sc3.cpp to turn `x.y` into an lvalue assumed that `method->getter` was always null. That's not always the case, so this patch sniffs the property type out of the setter if no getter is found.
