### PR TITLE
New Holiday as per Halloween update.

### DIFF
--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -168,6 +168,7 @@ enum TFHoliday
 	TFHoliday_Christmas,
 	TFHoliday_ValentinesDay,
 	TFHoliday_MeetThePyro,
+	TFHoliday_SpyVsEngyWar,
 	TFHoliday_FullMoon,
 	TFHoliday_HalloweenOrFullMoon,
 	TFHoliday_HalloweenOrFullMoonOrValentines,


### PR DESCRIPTION
New Holiday was added in Halloween update.

```
.rodata:0102A260 _ZL15s_HolidayChecks dd offset _ZL19g_Holiday_NoHoliday, offset _ZL21g_Holiday_TF2Birthday
.rodata:0102A260                                         ; DATA XREF: _Z28EconHolidays_IsHolidayActiveiRK6CRTime+Br
.rodata:0102A260                                         ; _Z32EconHolidays_GetHolidayForStringPKc:loc_6228A0r ...
.rodata:0102A260                 dd offset _ZL19g_Holiday_Halloween, offset _ZL19g_Holiday_Christmas
.rodata:0102A260                 dd offset _ZL23g_Holiday_ValentinesDay, offset _ZL21g_Holiday_MeetThePyro
.rodata:0102A260                 dd offset _ZL22g_Holiday_SpyVsEngyWar, offset _ZL18g_Holiday_FullMoon
.rodata:0102A260                 dd offset _ZL29g_Holiday_HalloweenOrFullMoon, offset _ZL41g_Holiday_HalloweenOrFullMoonOrValentines
.rodata:0102A260                 dd offset _ZL20g_Holiday_AprilFools
```
