### PR TITLE
New-style ConVar support

### DIFF
--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -982,13 +982,13 @@ methodmap ConVar < Handle
 	public SetFloat() = SetConVarFloat;
 	public GetString() = GetConVarString;
 	public SetString() = SetConVarString;
-	public Reset() = ResetConVar;
+	public RestoreDefaultValue() = ResetConVar;
 	public GetFlags() = GetConVarFlags;
 	public SetFlags() = SetConVarFlags;
 	public GetBounds() = GetConVarBounds;
 	public SetBounds() = SetConVarBounds;
-	public GetDefault() = GetConVarDefault;
+	public GetDefaultValue() = GetConVarDefault;
 	public GetName() = GetConVarName;
-	public HookChange() = HookConVarChange;
-	public UnhookChange() = UnhookConVarChange;
+	public AddChangeHook() = HookConVarChange;
+	public RemoveChangeHook() = UnhookConVarChange;
 }


### PR DESCRIPTION
OK, so I was going to rewrite one of the core plugins in 1.7's new-style syntax... but it occurred to me that I should probably rewrite the various bits it uses first.

So, here's an updated console.inc that adds a new ConVar methodmap.  It also updates the ConVarChanged callback to allow you to use new-style ConVar syntax there.  The old-style ConVarChanged also seems to work.

All the functions here were only compile-checked (by compiling [this plugin](https://github.com/powerlord/sourcemod-snippets/blob/master/scripting/1.7/convar_test.sp)) and not checked at runtime.

The functions themselves are still defined as taking Handle arguments.  This appears to be the norm, as per menus.inc.  I assumed this was for compatibility reasons and thus left them be.

I should also note that the `Get` and `Set` methods were not made properties for consistency reasons... you can blame GetString / SetString for that.
