### PR TITLE
Fix some syntax errors in include files.

### DIFF
--- a/plugins/include/core.inc
+++ b/plugins/include/core.inc
@@ -95,7 +95,19 @@ enum PluginStatus
 };
 
 /**
- * Plugin information properties.
+ * Plugin information properties. Plugins can declare a global variable with
+ * their info. Example,
+ *
+ *   public Plugin:myinfo = {
+ *   	name = "Admin Help",
+ *   	author = "AlliedModders LLC",
+ *   	description = "Display command information",
+ *   	version = "1.0",
+ *   	url = "http://www.sourcemod.net/"
+ *   };
+ *
+ * SourceMod will display this information when a user inspects plugins in the
+ * console.
  */
 enum PluginInfo
 {

--- a/plugins/include/entity.inc
+++ b/plugins/include/entity.inc
@@ -682,15 +682,12 @@ native GetEntPropArraySize(entity, PropType:type, const String:prop[]);
  * @param array			Array to read into.
  * @param arraySize		Number of values to read.
  * @param dataSize		Size of each value in bytes (1, 2, or 4).
- * @noreturn
  * @error				Invalid entity or offset out of reasonable bounds.
  */
-stock GetEntDataArray(entity, offset, array[], arraySize, dataSize=4)
+stock void GetEntDataArray(int entity, int offset, int[] array, int arraySize, int dataSize=4)
 {
-	for (new i=0; i<arraySize; i++)
-	{
-		array[i] = GetEntData(entity, offset + i*dataSize, dataSize)
-	}
+	for (int i=0; i<arraySize; i++)
+		array[i] = GetEntData(entity, offset + i*dataSize, dataSize);
 }
 
 /**

--- a/plugins/include/helpers.inc
+++ b/plugins/include/helpers.inc
@@ -97,59 +97,45 @@ stock Handle:FindPluginByFile(const String:filename[])
  * @deprecated Use FindTarget() or ProcessTargetString().
  */
 #pragma deprecated Use FindTarget() or ProcessTargetString()
-stock SearchForClients(const String:pattern[], clients[], maxClients)
+stock int SearchForClients(const char[] pattern, int[] clients, int maxClients)
 {
-	new total = 0;
+	int total = 0;
 	
 	if (maxClients == 0)
-	{
 		return 0;
-	}
 	
-	if (pattern[0] == '#')
-	{
-		new input = StringToInt(pattern[1]);
-		if (!input)
-		{
-			decl String:name[65]
-			for (new i=1; i<=MaxClients; i++)
-			{
+	if (pattern[0] == '#') {
+		int input = StringToInt(pattern[1]);
+		if (!input) {
+			char name[65];
+			for (int i=1; i<=MaxClients; i++) {
 				if (!IsClientInGame(i))
-				{
 					continue;
-				}
 				GetClientName(i, name, sizeof(name));
-				if (strcmp(name, pattern, false) == 0)
-				{
+				if (strcmp(name, pattern, false) == 0) {
 					clients[0] = i;
 					return 1;
 				}
 			}
 		} else {
-			new client = GetClientOfUserId(input);
-			if (client)
-			{
+			int client = GetClientOfUserId(input);
+			if (client) {
 				clients[0] = client;
 				return 1;
 			}
 		}
 	}
 	
-	decl String:name[65]
-	for (new i=1; i<=MaxClients; i++)
+	char name[65];
+	for (int i=1; i<=MaxClients; i++)
 	{
 		if (!IsClientInGame(i))
-		{
 			continue;
-		}
 		GetClientName(i, name, sizeof(name));
-		if (StrContains(name, pattern, false) != -1)
-		{
+		if (StrContains(name, pattern, false) != -1) {
 			clients[total++] = i;
 			if (total >= maxClients)
-			{
 				break;
-			}
 		}
 	}
 	

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -84,18 +84,6 @@ enum APLRes
 };
 
 /**
- * Declare this as a struct in your plugin to expose its information.
- * Example:
- *
- * public Plugin:myinfo =
- * {
- *    name = "My Plugin",
- *    //etc
- * };
- */
-public Plugin:myinfo;
- 
-/**
  * Called when the plugin is fully initialized and all known external references 
  * are resolved. This is only called once in the lifetime of the plugin, and is 
  * paired with OnPluginEnd().

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -433,30 +433,19 @@ stock CharToLower(chr)
  * @return				The index of the first occurrence of the character 
  * 						in the string, or -1 if the character was not found.
  */
-stock FindCharInString(const String:str[], c, bool:reverse = false)
+stock int FindCharInString(const char[] str, char c, bool reverse = false)
 {
-	new i, len
-
-	len = strlen(str);
+	int len = strlen(str);
 	
-	if (!reverse)
-	{
-		for (i = 0; i < len; i++)
-		{
+	if (!reverse) {
+		for (int i = 0; i < len; i++) {
 			if (str[i] == c)
-			{
 				return i;
-			}
 		}
-	}
-	else
-	{
-		for (i = len - 1; i >= 0; i--)
-		{
+	} else {
+		for (int i = len - 1; i >= 0; i--) {
 			if (str[i] == c)
-			{
 				return i;
-			}
 		}
 	}
 


### PR DESCRIPTION
A few functions were missing semicolons. While I was there I ported them to new-style syntax.

The really problematic thing was the forward declaration of `public PluginInfo:myinfo`. I think it was there for documentation. Anyway, forward declaring variables doesn't make sense, so this is just a duplicate definition.
