### PR TITLE
Use directly-exported random functions on vstdlib rather than IUniformRandomStream

### DIFF
--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -35,9 +35,11 @@
 #include "PlayerManager.h"
 #include "HalfLife2.h"
 
+#include <vstdlib/random.h>
+
 static cell_t SetRandomSeed(IPluginContext *pContext, const cell_t *params)
 {
-	engrandom->SetSeed(params[1]);
+	::RandomSeed(params[1]);
 
 	return 1;
 }
@@ -47,14 +49,14 @@ static cell_t GetRandomFloat(IPluginContext *pContext, const cell_t *params)
 	float fMin = sp_ctof(params[1]);
 	float fMax = sp_ctof(params[2]);
 
-	float fRandom = engrandom->RandomFloat(fMin, fMax);
+	float fRandom = ::RandomFloat(fMin, fMax);
 
 	return sp_ftoc(fRandom);
 }
 
 static cell_t GetRandomInt(IPluginContext *pContext, const cell_t *params)
 {
-	return engrandom->RandomInt(params[1], params[2]);
+	return ::RandomInt(params[1], params[2]);
 }
 
 static cell_t IsMapValid(IPluginContext *pContext, const cell_t *params)

--- a/core/sourcemm_api.cpp
+++ b/core/sourcemm_api.cpp
@@ -45,7 +45,6 @@ ISmmPluginManager *g_pMMPlugins = NULL;
 CGlobalVars *gpGlobals = NULL;
 ICvar *icvar = NULL;
 IGameEventManager2 *gameevents = NULL;
-IUniformRandomStream *engrandom = NULL;
 CallClass<IVEngineServer> *enginePatch = NULL;
 CallClass<IServerGameDLL> *gamedllPatch = NULL;
 IPlayerInfoManager *playerinfo = NULL;
@@ -68,7 +67,6 @@ bool SourceMod_Core::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen
 	GET_V_IFACE_CURRENT(GetServerFactory, serverClients, IServerGameClients, INTERFACEVERSION_SERVERGAMECLIENTS);
 	GET_V_IFACE_CURRENT(GetEngineFactory, icvar, ICvar, CVAR_INTERFACE_VERSION);
 	GET_V_IFACE_CURRENT(GetEngineFactory, gameevents, IGameEventManager2, INTERFACEVERSION_GAMEEVENTSMANAGER2);
-	GET_V_IFACE_CURRENT(GetEngineFactory, engrandom, IUniformRandomStream, VENGINE_SERVER_RANDOM_INTERFACE_VERSION);
 	GET_V_IFACE_CURRENT(GetFileSystemFactory, basefilesystem, IBaseFileSystem, BASEFILESYSTEM_INTERFACE_VERSION);
 	GET_V_IFACE_CURRENT(GetFileSystemFactory, filesystem, IFileSystem, FILESYSTEM_INTERFACE_VERSION);
 	GET_V_IFACE_CURRENT(GetEngineFactory, enginesound, IEngineSound, IENGINESOUND_SERVER_INTERFACE_VERSION);

--- a/core/sourcemm_api.h
+++ b/core/sourcemm_api.h
@@ -47,7 +47,6 @@
 #include <eiface.h>
 #include <igameevents.h>
 #include <iplayerinfo.h>
-#include <random.h>
 #include <filesystem.h>
 #include <IEngineSound.h>
 #include <toolframework/itoolentity.h>
@@ -99,7 +98,6 @@ extern CGlobalVars *gpGlobals;
 extern IGameEventManager2 *gameevents;
 extern SourceHook::CallClass<IVEngineServer> *enginePatch;
 extern SourceHook::CallClass<IServerGameDLL> *gamedllPatch;
-extern IUniformRandomStream *engrandom;
 extern IPlayerInfoManager *playerinfo;
 extern IBaseFileSystem *basefilesystem;
 extern IFileSystem *filesystem;


### PR DESCRIPTION
This will fix a known, upcoming breakage when HL2:DM, CS:S, DOD:S, and SDK2013 are next synced from TF2.
