### PR TITLE
Define 'this' as a keyword.

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -434,6 +434,7 @@ enum TokenKind {
   tSWITCH,
   tTAGOF,
   tTHEN,
+  tTHIS,
   tTYPEDEF,
   tUNION,
   tVOID,

--- a/sourcepawn/compiler/sc1.cpp
+++ b/sourcepawn/compiler/sc1.cpp
@@ -3702,7 +3702,6 @@ int check_this_tag(methodmap_t *map, symbol *target)
   const arginfo *first_arg = &target->dim.arglist[0];
   if (first_arg->ident == 0 ||
       first_arg->ident != iVARIABLE ||
-      (first_arg->usage & uCONST) ||
       first_arg->hasdefault ||
       first_arg->numtags != 1)
   {
@@ -5576,6 +5575,7 @@ static int declargs(symbol *sym, int chkshadow, const int *thistag)
       argptr->tags = (int *)malloc(sizeof(int));
       argptr->tags[0] = *thistag;
       argptr->numtags = 1;
+      argptr->usage = uCONST;
     } else {
       argptr = &sym->dim.arglist[0];
     }
@@ -5591,6 +5591,7 @@ static int declargs(symbol *sym, int chkshadow, const int *thistag)
       argptr->idxtag,
       0
     );
+    sym->usage |= uCONST;
     markusage(sym, uREAD);
 
     argcnt++;

--- a/sourcepawn/compiler/sc2.cpp
+++ b/sourcepawn/compiler/sc2.cpp
@@ -1973,7 +1973,7 @@ const char *sc_tokens[] = {
          "public",
          "return",
          "sizeof", "sleep", "static", "stock", "struct", "switch",
-         "tagof", "*then", "typedef",
+         "tagof", "*then", "this", "typedef",
          "union",
          "void",
          "while",

--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -2304,12 +2304,28 @@ static int primary(value *lval)
 
   clear_value(lval);    /* clear lval */
   tok=lex(&val,&st);
+
+  if (tok == tTHIS) {
+    strcpy(lastsymbol, "this");
+    if ((sym = findloc("this")) == NULL) {
+      error(166);           /* 'this' outside method body */
+      ldconst(0, sPRI);
+      return FALSE;
+    }
+    
+    assert(sym->ident == iVARIABLE);
+    lval->sym = sym;
+    lval->ident = sym->ident;
+    lval->tag = sym->tag;
+    return TRUE;
+  }
+
   if (tok==tSYMBOL) {
     /* lastsymbol is char[sNAMEMAX+1], lex() should have truncated any symbol
      * to sNAMEMAX significant characters */
     assert(strlen(st)<sizeof lastsymbol);
     strcpy(lastsymbol,st);
-  } /* if */
+  }
   if (tok==tSYMBOL && !findconst(st,NULL)) {
     /* first look for a local variable */
     if ((sym=findloc(st))!=0) {

--- a/sourcepawn/compiler/sc5-in.scp
+++ b/sourcepawn/compiler/sc5-in.scp
@@ -209,6 +209,7 @@ static const char *errmsg[] = {
 /*163*/  "indeterminate array size in \"sizeof\" expression (symbol \"%s\")\n",
 /*164*/  "allocated array type '%s' doesn't match original type '%s'\n",
 /*165*/  "cannot create dynamic arrays in static scope - did you mean to create a fixed-length array with brackets after the variable name?\n",
+/*166*/  "cannot use 'this' outside of a methodmap method or property\n",
 #else
   "\315e\306\227\266k\217:\235\277bu\201fo\220\204\223\012",
   "\202l\224\250s\205g\346\356e\233\201(\243\315\214\267\202) \253 f\255low ea\305 \042c\353e\042\012",

--- a/sourcepawn/compiler/tests/fail-array-on-implicit-this.sp
+++ b/sourcepawn/compiler/tests/fail-array-on-implicit-this.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this[]);
+native CloseHandle(Handle:handle[]);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/fail-assign-to-this.sp
+++ b/sourcepawn/compiler/tests/fail-assign-to-this.sp
@@ -1,0 +1,12 @@
+methodmap Egg
+{
+  public void illegal(Egg x) {
+    this = x;
+  }
+};
+
+public main()
+{
+  Egg egg;
+  egg.illegal(egg);
+}

--- a/sourcepawn/compiler/tests/fail-assign-to-this.txt
+++ b/sourcepawn/compiler/tests/fail-assign-to-this.txt
@@ -1,0 +1,1 @@
+(4) : error 022: must be lvalue (non-constant)

--- a/sourcepawn/compiler/tests/fail-dtor-extra-args.sp
+++ b/sourcepawn/compiler/tests/fail-dtor-extra-args.sp
@@ -1,4 +1,4 @@
-native Q(X:this, a);
+native Q(X:handle, a);
 
 methodmap X {
 	public ~X() = Q;

--- a/sourcepawn/compiler/tests/fail-dtor-non-native.sp
+++ b/sourcepawn/compiler/tests/fail-dtor-non-native.sp
@@ -1,4 +1,4 @@
-Q(X:this)
+Q(X:handle)
 {
 }
 

--- a/sourcepawn/compiler/tests/fail-method-on-array.sp
+++ b/sourcepawn/compiler/tests/fail-method-on-array.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/fail-method-on-function.sp
+++ b/sourcepawn/compiler/tests/fail-method-on-function.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/fail-mismatch-on-implicit-this.sp
+++ b/sourcepawn/compiler/tests/fail-mismatch-on-implicit-this.sp
@@ -1,4 +1,4 @@
-native CloseHandle(HandleEgg:this);
+native CloseHandle(HandleEgg:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/fail-multi-tag-on-implicit-this.sp
+++ b/sourcepawn/compiler/tests/fail-multi-tag-on-implicit-this.sp
@@ -1,4 +1,4 @@
-native CloseHandle({Handle, Egg}:this);
+native CloseHandle({Handle, Egg}:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/fail-this-outside-method.sp
+++ b/sourcepawn/compiler/tests/fail-this-outside-method.sp
@@ -1,0 +1,3 @@
+public OnPluginStart() {
+	return this;
+}

--- a/sourcepawn/compiler/tests/fail-this-outside-method.txt
+++ b/sourcepawn/compiler/tests/fail-this-outside-method.txt
@@ -1,0 +1,1 @@
+(2) : error 166: cannot use 'this' outside of a methodmap method or property

--- a/sourcepawn/compiler/tests/ok-base-type-as-thistag.sp
+++ b/sourcepawn/compiler/tests/ok-base-type-as-thistag.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 };

--- a/sourcepawn/compiler/tests/ok-inheritance.sp
+++ b/sourcepawn/compiler/tests/ok-inheritance.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/ok-method-on-const.sp
+++ b/sourcepawn/compiler/tests/ok-method-on-const.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 enum Handle {
 	INVALID_HANDLE = 0,

--- a/sourcepawn/compiler/tests/ok-method-on-constref.sp
+++ b/sourcepawn/compiler/tests/ok-method-on-constref.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/ok-method-on-element.sp
+++ b/sourcepawn/compiler/tests/ok-method-on-element.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/ok-method-on-ref.sp
+++ b/sourcepawn/compiler/tests/ok-method-on-ref.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;

--- a/sourcepawn/compiler/tests/ok-method-on-scalar.sp
+++ b/sourcepawn/compiler/tests/ok-method-on-scalar.sp
@@ -1,5 +1,5 @@
-native CloneHandle(Handle:this);
-native CloseHandle(Handle:this);
+native CloneHandle(Handle:handle);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Clone() = CloneHandle;

--- a/sourcepawn/compiler/tests/warn-bad-upcast.sp
+++ b/sourcepawn/compiler/tests/warn-bad-upcast.sp
@@ -1,4 +1,4 @@
-native CloseHandle(Handle:this);
+native CloseHandle(Handle:handle);
 
 methodmap Handle {
 	public Close() = CloseHandle;


### PR DESCRIPTION
This isn't strictly necessary but it makes 'this' semantics a lot cleaner.
