### PR TITLE
Port events to transitional syntax, part 2.

### DIFF
--- a/core/smn_events.cpp
+++ b/core/smn_events.cpp
@@ -418,6 +418,21 @@ REGISTER_NATIVES(gameEventNatives)
 	{"SetEventFloat",		sm_SetEventFloat},
 	{"SetEventString",		sm_SetEventString},
 	{"SetEventBroadcast",   sm_SetEventBroadcast},
+
+	// Transitional syntax support.
+	{"Event.Fire",			sm_FireEvent},
+	{"Event.Cancel",		sm_CancelCreatedEvent},
+	{"Event.GetName",		sm_GetEventName},
+	{"Event.GetBool",		sm_GetEventBool},
+	{"Event.GetInt",		sm_GetEventInt},
+	{"Event.GetFloat",		sm_GetEventFloat},
+	{"Event.GetString",		sm_GetEventString},
+	{"Event.SetBool",		sm_SetEventBool},
+	{"Event.SetInt",		sm_SetEventInt},
+	{"Event.SetFloat",		sm_SetEventFloat},
+	{"Event.SetString",		sm_SetEventString},
+	{"Event.BroadcastDisabled.set", sm_SetEventBroadcast},
+
 	{NULL,					NULL}
 };
 

--- a/plugins/basecomm.sp
+++ b/plugins/basecomm.sp
@@ -190,9 +190,9 @@ public void ConVarChange_Alltalk(ConVar convar, const char[] oldValue, const cha
 	}
 }
 
-public Event_PlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast)
+public Event_PlayerSpawn(Event event, const String:name[], bool:dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	new client = GetClientOfUserId(event.GetInt("userid"));
 	
 	if (!client)
 	{
@@ -209,9 +209,9 @@ public Event_PlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast)
 	}
 }
 
-public Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
+public Event_PlayerDeath(Event event, const String:name[], bool:dontBroadcast)
 {
-	int client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	
 	if (!client)
 	{

--- a/plugins/basetriggers.sp
+++ b/plugins/basetriggers.sp
@@ -132,9 +132,9 @@ public Event_GameStart(Handle:event, const String:name[], bool:dontBroadcast)
 	g_TotalRounds = 0;	
 }
 
-public Event_TeamPlayWinPanel(Handle:event, const String:name[], bool:dontBroadcast)
+public Event_TeamPlayWinPanel(Event event, const String:name[], bool:dontBroadcast)
 {
-	if(GetEventInt(event, "round_complete") == 1 || StrEqual(name, "arena_win_panel"))
+	if (event.GetInt("round_complete") == 1 || StrEqual(name, "arena_win_panel"))
 	{
 		g_TotalRounds++;
 	}

--- a/plugins/include/events.inc
+++ b/plugins/include/events.inc
@@ -1,7 +1,7 @@
 /**
- * vim: set ts=4 :
+ * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
- * SourceMod (C)2004-2008 AlliedModders LLC.  All rights reserved.
+ * SourceMod (C)2004-2014 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This file is part of the SourceMod/SourcePawn SDK.
@@ -40,9 +40,9 @@
  */
 enum EventHookMode
 {
-	EventHookMode_Pre,					/**< Hook callback fired before event is fired */
-	EventHookMode_Post,					/**< Hook callback fired after event is fired */
-	EventHookMode_PostNoCopy			/**< Hook callback fired after event is fired, but event data won't be copied */
+	EventHookMode_Pre,					//< Hook callback fired before event is fired */
+	EventHookMode_Post,					//< Hook callback fired after event is fired */
+	EventHookMode_PostNoCopy			//< Hook callback fired after event is fired, but event data won't be copied */
 };
 
 /**
@@ -50,27 +50,112 @@ enum EventHookMode
  */
 typeset EventHook
 {
-	/**
-	 * Called when a game event is fired.
-	 *
-	 * @param event			Handle to event. This could be INVALID_HANDLE if every plugin hooking 
-	 *						this event has set the hook mode EventHookMode_PostNoCopy.
-	 * @param name			String containing the name of the event.
-	 * @param dontBroadcast	True if event was not broadcast to clients, false otherwise.
-	 * @return				Ignored for post hooks. Plugin_Handled will block event if hooked as pre.
-	 */
+	// Called when a game event is fired.
+	//
+	// @param event			Handle to event. This could be INVALID_HANDLE if every plugin hooking 
+	//						this event has set the hook mode EventHookMode_PostNoCopy.
+	// @param name			String containing the name of the event.
+	// @param dontBroadcast	True if event was not broadcast to clients, false otherwise.
+	// @return				Ignored for post hooks. Plugin_Handled will block event if hooked as pre.
+	///
 	function Action (Event event, const char[] name, bool dontBroadcast);
-	/**
-	 * Called when a game event is fired.
-	 *
-	 * @param event			Handle to event. This could be INVALID_HANDLE if every plugin hooking 
-	 *						this event has set the hook mode EventHookMode_PostNoCopy.
-	 * @param name			String containing the name of the event.
-	 * @param dontBroadcast	True if event was not broadcast to clients, false otherwise.
-	 * @noreturn
-	 */
+	//
+	// Called when a game event is fired.
+	//
+	// @param event			Handle to event. This could be INVALID_HANDLE if every plugin hooking 
+	//						this event has set the hook mode EventHookMode_PostNoCopy.
+	// @param name			String containing the name of the event.
+	// @param dontBroadcast	True if event was not broadcast to clients, false otherwise.
+	// @noreturn
+	///
 	function void (Event event, const char[] name, bool dontBroadcast);
 };
+
+methodmap Event < Handle
+{
+	// Fires a game event.
+	//
+	// This function closes the event Handle after completing.
+	//
+	// @param dontBroadcast Optional boolean that determines if event should be broadcast to clients.
+	public native void Fire(bool dontBroadcast=false);
+
+	// Cancels a previously created game event that has not been fired. This
+	// is necessary to avoid leaking memory when an event isn't fired.
+	public native void Cancel();
+
+	// Returns the boolean value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param defValue     Optional default value to use if the key is not found.
+	// @return             The boolean value of the specfied event key.
+	public native bool GetBool(const char[] key, bool defValue=false);
+
+	// Sets the boolean value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param value        New boolean value.
+	public native void SetBool(const char[] key, bool value);
+
+	// Returns the integer value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param defValue     Optional default value to use if the key is not found.
+	// @return             The integer value of the specfied event key.
+	public native int GetInt(const char[] key, int defValue=0);
+
+	// Sets the integer value of a game event's key.
+	//
+	// Integer value refers to anything that can be reduced to an integer.
+	// The various size specifiers, such as "byte" and "short" are still 
+	// integers, and only refer to how much data will actually be sent 
+	// over the network (if applicable).
+	//
+	// @param key          Name of event key.
+	// @param value        New integer value.
+	public native void SetInt(const char[] key, int value);
+
+	// Returns the floating point value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param defValue     Optional default value to use if the key is not found.
+	// @return             The floating point value of the specfied event key.
+	public native float GetFloat(const char[] key, float defValue=0.0);
+
+	// Sets the floating point value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param value        New floating point value.
+	public native void SetFloat(const char[] key, float value);
+
+	// Retrieves the string value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param value        Buffer to store the value of the specified event key.
+	// @param maxlength    Maximum length of string buffer.
+	// @param defValue     Optional default value to use if the key is not found.
+	public native void GetString(const char[] key, char[] value, int maxlength, const char[] defvalue="");
+
+	// Sets the string value of a game event's key.
+	//
+	// @param key          Name of event key.
+	// @param value        New string value.
+	public native void SetString(const char[] key, const char[] value);
+
+	// Retrieves the name of a game event.
+	//
+	// @param name         Buffer to store the name of the event.
+	// @param maxlength    Maximum length of string buffer.
+	public native void GetName(char[] name, int maxlength);
+
+	// Sets whether an event's broadcasting will be disabled or not.
+	//
+	// This has no effect on events Handles that are not from HookEvent
+	// or HookEventEx callbacks.
+	property bool BroadcastDisabled {
+		public native set(bool dontBroadcast);
+	}
+}
 
 /**
  * Creates a hook for when a game event is fired.
@@ -109,7 +194,7 @@ native void UnhookEvent(const char[] name, EventHook callback, EventHookMode mod
  * Creates a game event to be fired later.
  *
  * The Handle should not be closed via CloseHandle().  It must be closed via 
- * FireEvent() or CancelCreatedEvent().
+ * event.Fire() or event.Cancel().
  *
  * @param name			Name of event.
  * @param force			If set to true, this forces the event to be created even if it's not being hooked.
@@ -258,19 +343,3 @@ native void GetEventName(Handle event, char[] name, int maxlength);
  * @error               Invalid Handle.
  */
 native void SetEventBroadcast(Handle event, bool dontBroadcast);
-
-methodmap Event < Handle {
-	public Event() = CreateEvent;
-	public Fire() = FireEvent;
-	public Cancel() = CancelCreatedEvent;
-	public GetBool() = GetEventBool;
-	public SetBool() = SetEventBool;
-	public GetInt() = GetEventInt;
-	public SetInt() = SetEventInt;
-	public GetFloat() = GetEventFloat;
-	public SetFloat() = SetEventFloat;
-	public GetString() = GetEventString;
-	public SetString() = SetEventString;
-	public GetName() = GetEventName;
-	public SetBroadcast() = SetEventBroadcast;
-}

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -370,7 +370,7 @@ public Event_TFRestartRound(Handle:event, const String:name[], bool:dontBroadcas
 	g_TotalRounds = 0;	
 }
 
-public Event_TeamPlayWinPanel(Handle:event, const String:name[], bool:dontBroadcast)
+public Event_TeamPlayWinPanel(Event event, const String:name[], bool:dontBroadcast)
 {
 	if (g_ChangeMapAtRoundEnd)
 	{
@@ -379,10 +379,10 @@ public Event_TeamPlayWinPanel(Handle:event, const String:name[], bool:dontBroadc
 		g_ChangeMapInProgress = true;
 	}
 	
-	new bluescore = GetEventInt(event, "blue_score");
-	new redscore = GetEventInt(event, "red_score");
+	new bluescore = event.GetInt("blue_score");
+	new redscore = event.GetInt("red_score");
 		
-	if(GetEventInt(event, "round_complete") == 1 || StrEqual(name, "arena_win_panel"))
+	if (event.GetInt("round_complete") == 1 || StrEqual(name, "arena_win_panel"))
 	{
 		g_TotalRounds++;
 		
@@ -393,7 +393,7 @@ public Event_TeamPlayWinPanel(Handle:event, const String:name[], bool:dontBroadc
 		
 		CheckMaxRounds(g_TotalRounds);
 		
-		switch(GetEventInt(event, "winning_team"))
+		switch(event.GetInt("winning_team"))
 		{
 			case 3:
 			{
@@ -412,7 +412,7 @@ public Event_TeamPlayWinPanel(Handle:event, const String:name[], bool:dontBroadc
 	}
 }
 /* You ask, why don't you just use team_score event? And I answer... Because CSS doesn't. */
-public Event_RoundEnd(Handle:event, const String:name[], bool:dontBroadcast)
+public Event_RoundEnd(Event event, const String:name[], bool:dontBroadcast)
 {
 	if (g_ChangeMapAtRoundEnd)
 	{
@@ -425,11 +425,11 @@ public Event_RoundEnd(Handle:event, const String:name[], bool:dontBroadcast)
 	if (strcmp(name, "round_win") == 0)
 	{
 		// Nuclear Dawn
-		winner = GetEventInt(event, "team");
+		winner = event.GetInt("team");
 	}
 	else
 	{
-		winner = GetEventInt(event, "winner");
+		winner = event.GetInt("winner");
 	}
 	
 	if (winner == 0 || winner == 1 || !g_Cvar_EndOfMapVote.BoolValue)
@@ -485,7 +485,7 @@ public CheckMaxRounds(roundcount)
 	}
 }
 
-public Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
+public Event_PlayerDeath(Event event, const String:name[], bool:dontBroadcast)
 {
 	if (!GetArraySize(g_MapList) || !g_Cvar_Fraglimit || g_HasVoteStarted)
 	{
@@ -502,7 +502,7 @@ public Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
 		return;
 	}
 
-	new fragger = GetClientOfUserId(GetEventInt(event, "attacker"));
+	new fragger = GetClientOfUserId(event.GetInt("attacker"));
 
 	if (!fragger)
 	{


### PR DESCRIPTION
I removed the constructor for Event - I haven't yet decided whether constructors should be able to return null, and the existing one can return null. I'm leaning toward "no" here, since it would be nice to have a guarantee that a constructor either returns a valid object or throws.
