### PR TITLE
Support long key names for languages (bug 6282)

### DIFF
--- a/core/logic/Translator.cpp
+++ b/core/logic/Translator.cpp
@@ -887,6 +887,14 @@ SMCResult Translator::ReadSMC_LeavingSection(const SMCStates *states)
 
 SMCResult Translator::ReadSMC_KeyValue(const SMCStates *states, const char *key, const char *value)
 {
+	size_t len = strlen(key);
+
+	if (len >= sizeof(((Language *)0)->m_code2))
+	{
+		logger->LogError("[SM] Warning encountered parsing languages.cfg file.");
+		logger->LogError("[SM] Invalid language code \"%s\" is too long.", key);
+	}
+
 	AddLanguage(key, value);
 
 	return SMCResult_Continue;

--- a/core/logic/Translator.h
+++ b/core/logic/Translator.h
@@ -54,7 +54,7 @@ enum PhraseParseState
 
 struct Language
 {
-	char m_code2[4];
+	char m_code2[32];
 	int m_CanonicalName;
 };
 


### PR DESCRIPTION
Also brought back the length check warning, _not tested_.

@psychonic
