### PR TITLE
Add block parameter to FindValueInArray native.

### DIFF
--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -8,7 +8,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -35,7 +35,7 @@
 
 HandleType_t htCellArray;
 
-class CellArrayHelpers : 
+class CellArrayHelpers :
 	public SMGlobalClass,
 	public IHandleTypeDispatch
 {
@@ -75,7 +75,7 @@ static cell_t CreateArray(IPluginContext *pContext, const cell_t *params)
 	{
 		array->resize(params[2]);
 	}
-	
+
 	Handle_t hndl = handlesys->CreateHandle(htCellArray, array, pContext->GetIdentity(), g_pCoreIdent, NULL);
 	if (!hndl)
 	{
@@ -91,14 +91,14 @@ static cell_t ClearArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
 	}
 
 	array->clear();
-	
+
 	return 1;
 }
 
@@ -108,7 +108,7 @@ static cell_t ResizeArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -128,7 +128,7 @@ static cell_t GetArraySize(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -143,7 +143,7 @@ static cell_t PushArrayCell(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -166,7 +166,7 @@ static cell_t PushArrayString(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -192,7 +192,7 @@ static cell_t PushArrayArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -224,7 +224,7 @@ static cell_t GetArrayCell(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -263,7 +263,7 @@ static cell_t GetArrayString(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -289,7 +289,7 @@ static cell_t GetArrayArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -322,7 +322,7 @@ static cell_t SetArrayCell(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -361,7 +361,7 @@ static cell_t SetArrayString(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -387,7 +387,7 @@ static cell_t SetArrayArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -420,7 +420,7 @@ static cell_t ShiftArrayUp(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -443,7 +443,7 @@ static cell_t RemoveFromArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -466,7 +466,7 @@ static cell_t SwapArrayItems(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -494,14 +494,14 @@ static cell_t CloneArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&oldArray)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&oldArray))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
 	}
 
 	CellArray *array = oldArray->clone();
-	
+
 	Handle_t hndl = handlesys->CreateHandle(htCellArray, array, pContext->GetIdentity(), g_pCoreIdent, NULL);
 	if (!hndl)
 	{
@@ -517,7 +517,7 @@ static cell_t FindStringInArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
@@ -544,15 +544,22 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array)) 
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
 	}
 
+	size_t blocknumber = (size_t) params[3];
+	if (blocknumber >= array->blocksize())
+	{
+		return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", blocknumber, array->blocksize());
+	}
+
 	for (unsigned int i = 0; i < array->size(); i++)
 	{
-		if (params[2] == *array->at(i))
+		cell_t *blk = array->at(i);
+		if (params[2] == blk[blocknumber])
 		{
 			return (cell_t) i;
 		}

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -550,7 +550,13 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
 	}
 
-	size_t blocknumber = (size_t) params[3];
+	// the blocknumber is not guaranteed to always be passed
+	size_t blocknumber = 0;
+	if (params[0] >= 3)
+	{
+		blocknumber = (size_t) params[3];
+	}
+
 	if (blocknumber >= array->blocksize())
 	{
 		return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", blocknumber, array->blocksize());

--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -9,7 +9,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -29,14 +29,14 @@
  *
  * Version: $Id$
  */
- 
+
 #if defined _adt_array_included
  #endinput
 #endif
 #define _adt_array_included
 
 /**
- * Given a maximum string size (including the null terminator), 
+ * Given a maximum string size (including the null terminator),
  * returns the number of cells required to fit that string.
  *
  * @param size			Number of bytes.
@@ -52,16 +52,16 @@ stock ByteCountToCells(size)
 methodmap ArrayList < Handle {
 	// Creates a dynamic global cell array.  While slower than a normal array,
 	// it can be used globally AND dynamically, which is otherwise impossible.
-	// 
-	// The contents of the array are uniform; i.e. storing a string at index X 
+	//
+	// The contents of the array are uniform; i.e. storing a string at index X
 	// and then retrieving it as an integer is NOT the same as StringToInt()!
 	// The "blocksize" determines how many cells each array slot has; it cannot
 	// be changed after creation.
 	//
-	// @param blocksize     The number of cells each member of the array can 
+	// @param blocksize     The number of cells each member of the array can
 	//                      hold.  For example, 32 cells is equivalent to:
 	//                      new Array[X][32]
-	// @param startsize     Initial size of the array.  Note that data will 
+	// @param startsize     Initial size of the array.  Note that data will
 	//                      NOT be auto-intialized.
 	// @return              New Handle to the array object.
 	public native ArrayList(int blocksize=1, int startsize=0);
@@ -106,7 +106,7 @@ methodmap ArrayList < Handle {
 	//
 	// @param values        Block of values to copy.
 	// @param size          If not set, the number of elements copied from the array
-	//                      will be equal to the blocksize.  If set higher than the 
+	//                      will be equal to the blocksize.  If set higher than the
 	//                      blocksize, the operation will be truncated.
 	// @return              Index of the new entry.
 	public native int PushArray(const any[] values, int size=-1);
@@ -168,15 +168,15 @@ methodmap ArrayList < Handle {
 	// @error               Invalid index.
 	public native void SetArray(int index, const any[] values, int size=-1);
 
-	// Shifts an array up.  All array contents after and including the given 
-	// index are shifted up by one, and the given index is then "free."  
+	// Shifts an array up.  All array contents after and including the given
+	// index are shifted up by one, and the given index is then "free."
 	// After shifting, the contents of the given index is undefined.
 	//
 	// @param index         Index in the array to shift up from.
 	// @error               Invalid index.
 	public native void ShiftUp(int index);
 
-	// Removes an array index, shifting the entire array down from that position 
+	// Removes an array index, shifting the entire array down from that position
 	// on.  For example, if item 8 of 10 is removed, the last 3 items will then be
 	// (6,7,8) instead of (7,8,9), and all indexes before 8 will remain unchanged.
 	//
@@ -197,13 +197,15 @@ methodmap ArrayList < Handle {
 	// @param item          String to search for
 	// @return              Array index, or -1 on failure
 	public native int FindString(const char[] item);
-	 
+
 	// Returns the index for the first occurance of the provided value. If the
 	// value cannot be located, -1 will be returned.
 	//
 	// @param item          Value to search for
+    // @param block         Optionally which block to search in
 	// @return              Array index, or -1 on failure
-	public native int FindValue(any item); 
+	// @error               Invalid block index
+	public native int FindValue(any item, int block=0);
 
 	// Retrieve the size of the array.
 	property int Length {
@@ -214,16 +216,16 @@ methodmap ArrayList < Handle {
 /**
  * Creates a dynamic global cell array.  While slower than a normal array,
  * it can be used globally AND dynamically, which is otherwise impossible.
- * 
- * The contents of the array are uniform; i.e. storing a string at index X 
+ *
+ * The contents of the array are uniform; i.e. storing a string at index X
  * and then retrieving it as an integer is NOT the same as StringToInt()!
  * The "blocksize" determines how many cells each array slot has; it cannot
  * be changed after creation.
  *
- * @param blocksize		The number of cells each member of the array can 
+ * @param blocksize		The number of cells each member of the array can
  *						hold.  For example, 32 cells is equivalent to:
  *						new Array[X][32]
- * @param startsize		Initial size of the array.  Note that data will 
+ * @param startsize		Initial size of the array.  Note that data will
  *						NOT be auto-intialized.
  * @return				New Handle to the array object.
  */
@@ -300,7 +302,7 @@ native int PushArrayString(Handle array, const char[] value);
  * @param array			Array Handle.
  * @param values		Block of values to copy.
  * @param size			If not set, the number of elements copied from the array
- *						will be equal to the blocksize.  If set higher than the 
+ *						will be equal to the blocksize.  If set higher than the
  *						blocksize, the operation will be truncated.
  * @return				Index of the new entry.
  * @error				Invalid Handle or out of memory.
@@ -383,8 +385,8 @@ native int SetArrayString(Handle array, int index, const char[] value);
 native int SetArrayArray(Handle array, int index, const any[] values, int size=-1);
 
 /**
- * Shifts an array up.  All array contents after and including the given 
- * index are shifted up by one, and the given index is then "free."  
+ * Shifts an array up.  All array contents after and including the given
+ * index are shifted up by one, and the given index is then "free."
  * After shifting, the contents of the given index is undefined.
  *
  * @param array			Array Handle.
@@ -394,7 +396,7 @@ native int SetArrayArray(Handle array, int index, const any[] values, int size=-
 native void ShiftArrayUp(Handle array, int index);
 
 /**
- * Removes an array index, shifting the entire array down from that position 
+ * Removes an array index, shifting the entire array down from that position
  * on.  For example, if item 8 of 10 is removed, the last 3 items will then be
  * (6,7,8) instead of (7,8,9), and all indexes before 8 will remain unchanged.
  *
@@ -424,14 +426,15 @@ native void SwapArrayItems(Handle array, int index1, int index2);
  * @error				Invalid Handle
  */
 native int FindStringInArray(Handle array, const char[] item);
- 
+
 /**
  * Returns the index for the first occurance of the provided value. If the value
  * cannot be located, -1 will be returned.
  *
  * @param array			Array Handle.
  * @param item			Value to search for
+ * @param block			Optionally which block to search in
  * @return				Array index, or -1 on failure
- * @error				Invalid Handle
+ * @error				Invalid Handle or invalid block
  */
-native int FindValueInArray(Handle array, any item); 
+native int FindValueInArray(Handle array, any item, int block=0);


### PR DESCRIPTION
I'm not sure what is going on with trailing whitespace/line endings in this file, my apologies for making that diff crazy.

I guess there's no easy way to test, but I did a small test myself:

```
#include <sourcemod>
public OnPluginStart()
{
	Handle arr = CreateArray(2);

	PushArrayCell(arr, 10);
	PushArrayCell(arr, 20);
	PushArrayCell(arr, 30);
	PushArrayCell(arr, 40);
	SetArrayCell(arr, 0, -10, 1);
	SetArrayCell(arr, 1, -20, 1);
	SetArrayCell(arr, 2, -30, 1);
	SetArrayCell(arr, 3, -40, 1);

	LogMessage("result = %d", FindValueInArray(arr, -999));    // should be -1
	LogMessage("result = %d", FindValueInArray(arr, -999, 0)); // should be -1
	LogMessage("result = %d", FindValueInArray(arr, -999, 1)); // should be -1

	LogMessage("result = %d", FindValueInArray(arr, -30));    // should be -1
	LogMessage("result = %d", FindValueInArray(arr, -30, 0)); // should be -1
	LogMessage("result = %d", FindValueInArray(arr, 10, 1)); // should be -1
	LogMessage("result = %d", FindValueInArray(arr, -10, 1)); // should be 0
	LogMessage("result = %d", FindValueInArray(arr, -30, 1)); // should be 2
	LogMessage("result = %d", FindValueInArray(arr, -40, 1)); // should be 3

	CloseHandle(arr);
}
```
```
L 12/06/2014 - 09:12:37: SourceMod log file session started (file "L20141206.log") (Version "1.7.0-dev+5061")
L 12/06/2014 - 09:12:37: -------- Mapchange to de_dust --------
L 12/06/2014 - 09:12:37: [test.smx] result = -1
L 12/06/2014 - 09:12:37: [test.smx] result = -1
L 12/06/2014 - 09:12:37: [test.smx] result = -1
L 12/06/2014 - 09:12:37: [test.smx] result = -1
L 12/06/2014 - 09:12:37: [test.smx] result = -1
L 12/06/2014 - 09:12:37: [test.smx] result = -1
L 12/06/2014 - 09:12:37: [test.smx] result = 0
L 12/06/2014 - 09:12:37: [test.smx] result = 2
L 12/06/2014 - 09:12:37: [test.smx] result = 3
L 12/06/2014 - 04:12:39: -------- Mapchange to workshop/122443683/aim_map --------
```