### PR TITLE
Increased handles to 32k

### DIFF
--- a/core/logic/HandleSys.h
+++ b/core/logic/HandleSys.h
@@ -38,7 +38,7 @@
 #include <am-string.h>
 #include "common_logic.h"
 
-#define HANDLESYS_MAX_HANDLES		(1<<14)
+#define HANDLESYS_MAX_HANDLES		(1<<15)
 #define HANDLESYS_MAX_TYPES			(1<<9)
 #define HANDLESYS_MAX_SUBTYPES		0xF
 #define HANDLESYS_SUBTYPE_MASK		0xF


### PR DESCRIPTION
The tf2itemsinfo plugin uses 10332 handles but does not leak them.

Whenever another plugin leaks handles, sourcemod will kill tf2itemsinfo first because it always takes more than half the current maximum number of handles.

"HANDLESYS_HANDLE_MASK needs to be changed."

Why does it need to be changed? isn't 16 bits correctly masked by 0xFFFF?

"why does this plugin keep so many handles live?"

Because it parses the item schema into ADT data structures for fast access.