### PR TITLE
TF2: Added new End Of The Line holiday between Christmas and Valentines

### DIFF
--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -173,6 +173,7 @@ enum TFHoliday
 	TFHoliday_Birthday = 1,
 	TFHoliday_Halloween,
 	TFHoliday_Christmas,
+	TFHoliday_EndOfTheLine,
 	TFHoliday_ValentinesDay,
 	TFHoliday_MeetThePyro,
 	TFHoliday_SpyVsEngyWar,


### PR DESCRIPTION
Valve added another new holiday to the list in End of the Line.

Here's the current s_HolidayChecks enum:

```
.rodata:0102EB40 _ZL15s_HolidayChecks dd offset _ZL19g_Holiday_NoHoliday, offset _ZL21g_Holiday_TF2Birthday
.rodata:0102EB40                                         ; DATA XREF: _Z28EconHolidays_IsHolidayActiveiRK6CRTime+Br
.rodata:0102EB40                                         ; _Z32EconHolidays_GetHolidayForStringPKc:loc_6269C0r ...
.rodata:0102EB40                 dd offset _ZL19g_Holiday_Halloween, offset _ZL19g_Holiday_Christmas
.rodata:0102EB40                 dd offset _ZL22g_Holiday_EndOfTheLine, offset _ZL23g_Holiday_ValentinesDay
.rodata:0102EB40                 dd offset _ZL21g_Holiday_MeetThePyro, offset _ZL22g_Holiday_SpyVsEngyWar
.rodata:0102EB40                 dd offset _ZL18g_Holiday_FullMoon, offset _ZL29g_Holiday_HalloweenOrFullMoon
.rodata:0102EB40                 dd offset _ZL41g_Holiday_HalloweenOrFullMoonOrValentines
.rodata:0102EB40                 dd offset _ZL20g_Holiday_AprilFools
```
