### PR TITLE
Convert TFHoliday values to pubvars.

### DIFF
--- a/extensions/tf2/holiday.cpp
+++ b/extensions/tf2/holiday.cpp
@@ -126,9 +126,40 @@ void HolidayManager::UnhookIfNecessary()
 	m_iHookID = 0;
 }
 
+static inline void PopulateHolidayVar(IPluginRuntime *pRuntime, const char *pszName)
+{
+	uint32_t idx;
+	if (pRuntime->FindPubvarByName(pszName, &idx) != SP_ERROR_NONE)
+		return;
+
+	int varValue = -1;
+	const char *key = g_pGameConf->GetKeyValue(pszName);
+	if (key)
+	{
+		varValue = atoi(key);
+	}
+
+	sp_pubvar_t *var;
+	pRuntime->GetPubvarByIndex(idx, &var);
+	*var->offs = varValue;
+}
+
 void HolidayManager::OnPluginLoaded(IPlugin *plugin)
 {
 	HookIfNecessary();
+
+	auto *pRuntime = plugin->GetRuntime();
+	PopulateHolidayVar(pRuntime, "TFHoliday_Birthday");
+	PopulateHolidayVar(pRuntime, "TFHoliday_Halloween");
+	PopulateHolidayVar(pRuntime, "TFHoliday_Christmas");
+	PopulateHolidayVar(pRuntime, "TFHoliday_EndOfTheLine");
+	PopulateHolidayVar(pRuntime, "TFHoliday_ValentinesDay");
+	PopulateHolidayVar(pRuntime, "TFHoliday_MeetThePyro");
+	PopulateHolidayVar(pRuntime, "TFHoliday_SpyVsEngyWar");
+	PopulateHolidayVar(pRuntime, "TFHoliday_FullMoon");
+	PopulateHolidayVar(pRuntime, "TFHoliday_HalloweenOrFullMoon");
+	PopulateHolidayVar(pRuntime, "TFHoliday_HalloweenOrFullMoonOrValentines");
+	PopulateHolidayVar(pRuntime, "TFHoliday_AprilFools");
 }
 
 void HolidayManager::OnPluginUnloaded(IPlugin *plugin)

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -146,4 +146,25 @@
 			}
 		}
 	}
+	
+	/*
+	 * TF2 Holiday index values. Formerly SM TFHoliday enum.
+	 */
+	"tf"
+	{
+		"Keys"
+		{
+			"TFHoliday_Birthday"		"1"
+			"TFHoliday_Halloween"		"2"
+			"TFHoliday_Christmas"		"3"
+			"TFHoliday_EndOfTheLine"	"4"
+			"TFHoliday_ValentinesDay"	"5"
+			"TFHoliday_MeetThePyro"		"6"
+			"TFHoliday_SpyVsEngyWar"	"7"
+			"TFHoliday_FullMoon"		"8"
+			"TFHoliday_HalloweenOrFullMoon"				"9"
+			"TFHoliday_HalloweenOrFullMoonOrValentines"	"10"
+			"TFHoliday_AprilFools"		"11"
+		}
+	}
 }

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -170,17 +170,20 @@ const Float:TFCondDuration_Infinite = -1.0;
 
 enum TFHoliday
 {
-	TFHoliday_Birthday = 1,
-	TFHoliday_Halloween,
-	TFHoliday_Christmas,
-	TFHoliday_ValentinesDay,
-	TFHoliday_MeetThePyro,
-	TFHoliday_SpyVsEngyWar,
-	TFHoliday_FullMoon,
-	TFHoliday_HalloweenOrFullMoon,
-	TFHoliday_HalloweenOrFullMoonOrValentines,
-	TFHoliday_AprilFools,
+	TFHoliday_Invalid = -1
 };
+
+public const TFHoliday:TFHoliday_Birthday;
+public const TFHoliday:TFHoliday_Halloween;
+public const TFHoliday:TFHoliday_Christmas;
+public const TFHoliday:TFHoliday_EndOfTheLine;
+public const TFHoliday:TFHoliday_ValentinesDay;
+public const TFHoliday:TFHoliday_MeetThePyro;
+public const TFHoliday:TFHoliday_SpyVsEngyWar;
+public const TFHoliday:TFHoliday_FullMoon;
+public const TFHoliday:TFHoliday_HalloweenOrFullMoon;
+public const TFHoliday:TFHoliday_HalloweenOrFullMoonOrValentines;
+public const TFHoliday:TFHoliday_AprilFools;
 
 enum TFObjectType
 {


### PR DESCRIPTION
As mentioned in #216, this converts the former TFHoliday enum vars into pubvars that get populated at runtime from gamedata. Since these change semi-often, it's undesirable to request plugins to be recompiled against a new inc each time. With this change, we can just ship new gamedata.

As a side effect, these are no longer _real_ constants, so using them as values for switch cases is no longer valid. Very few plugins are affected and the author of the most popular, relevant one, @powerlord, has already been warned of the change.

@asherkin 
@VoiDeD 
@ :japanese_goblin: 
