### PR TITLE
Change /d2Zi+ flag on msvc builds to /Zo.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -249,14 +249,14 @@ class SMConfig(object):
       if cxx.like('gcc'):
         cxx.cflags += ['-O3']
       elif cxx.like('msvc'):
-        cxx.cflags += ['/Ox']
+        cxx.cflags += ['/Ox', '/Zo']
         cxx.linkflags += ['/OPT:ICF', '/OPT:REF']
 
     # Debugging
     if builder.options.debug == '1':
       cxx.defines += ['DEBUG', '_DEBUG']
       if cxx.like('msvc'):
-        cxx.cflags += ['/Od', '/Zo', '/RTC1']
+        cxx.cflags += ['/Od', '/RTC1']
 
     # This needs to be after our optimization flags which could otherwise disable it.
     if cxx.vendor == 'msvc':


### PR DESCRIPTION
In Visual Studio 2013 Update 3, Microsoft removed the undocumented /d2Zi+ flag that wrote extra info to pdb files for optimized functions.

They added a new, documented flag with very similar but improved behavior, /Zo

http://msdn.microsoft.com/en-us/library/dn785163.aspx

(We already require VS2013 / msvc12 to build SM on Windows. The latest version of it at this time Update 4).
