### PR TITLE
Fix UserMessageToBfWrite and UserMessageToBfRead

### DIFF
--- a/plugins/include/usermessages.inc
+++ b/plugins/include/usermessages.inc
@@ -80,7 +80,7 @@ stock Protobuf UserMessageToProtobuf(Handle msg)
 // Make sure to only call this on writable buffers (eg from StartMessage).
 stock BfWrite UserMessageToBfWrite(Handle msg)
 {
-	if (GetUserMessageType() != UM_Protobuf)
+	if (GetUserMessageType() == UM_Protobuf)
 		return null;
 	return BfWrite:msg;
 }
@@ -88,7 +88,7 @@ stock BfWrite UserMessageToBfWrite(Handle msg)
 // Make sure to only call this on readable buffers (eg from a message hook).
 stock BfWrite UserMessageToBfRead(Handle msg)
 {
-	if (GetUserMessageType() != UM_Protobuf)
+	if (GetUserMessageType() == UM_Protobuf)
 		return null;
 	return BfRead:msg;
 }


### PR DESCRIPTION
These two stocks have their behavior reversed, they currently return `null` on non-protobuf messages, but it should be the other way around.

This currently causes an issue in [funcommands blind/drugs](https://mxr.alliedmods.net/sourcemod/source/plugins/funcommands/blind.sp#67) where a TNE gets thrown during usermessage creation, which then later brings down the entire server process since the usermessage is never completed.
