### PR TITLE
Old style retagging should emit a compiler warning when newdecls are required.

### DIFF
--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -334,7 +334,7 @@ const char *type_to_name(int tag)
 
   const char *name = pc_tagname(tag);
   if (name)
-    return "unknown";
+    return name;
 
   if (tag & FUNCTAG)
     return "function";
@@ -1698,6 +1698,10 @@ static int hier2(value *lval)
   }
   case tLABEL:                  /* tagname override */
     tag=pc_addtag(st);
+    if (sc_require_newdecls) {
+      // Warn: old style cast used when newdecls pragma is enabled
+      error(240, st, type_to_name(tag));
+    }
     lval->cmptag=tag;
     lvalue=hier2(lval);
     if ((lval->tag & OBJECTTAG) || (tag & OBJECTTAG)) {

--- a/sourcepawn/compiler/sc5-in.scp
+++ b/sourcepawn/compiler/sc5-in.scp
@@ -462,6 +462,7 @@ static const char *warnmsg[] = {
 /*237*/  "coercing functions to and from primitives is unsupported and will be removed in the future\n",
 /*238*/  "'%s:' is an illegal cast; use view_as<%s>(expression)\n",
 /*239*/  "'%s' is an illegal tag; use %s as a type\n",
+/*240*/  "'%s:' is an old-style tag operation; use view_as<%s>(expression) instead\n",
 #else
   "\327 \275tr\242\231\227\266 %\204\305\206a\306\210\260",
   "\214\343i\215 \330\371\213t/\321cro \365",

--- a/sourcepawn/compiler/tests/warn-oldstyle-cast.sp
+++ b/sourcepawn/compiler/tests/warn-oldstyle-cast.sp
@@ -1,0 +1,18 @@
+
+#pragma newdecls required
+
+enum MyType:{};
+
+native void Print(MyType value);
+native void PrintF(float value);
+
+public void main()
+{
+	int val = 2;
+	MyType otherVal = MyType:val;
+
+	float value2 = Float:val;
+
+	Print(otherVal);
+	PrintF(value2);
+}

--- a/sourcepawn/compiler/tests/warn-oldstyle-cast.txt
+++ b/sourcepawn/compiler/tests/warn-oldstyle-cast.txt
@@ -1,0 +1,2 @@
+(12) : warning 240: 'MyType:' is an old-style tag operation; use view_as<MyType>(expression) instead
+(14) : warning 240: 'Float:' is an old-style tag operation; use view_as<float>(expression) instead


### PR DESCRIPTION
This also fixes what looks to be a bug where `type_to_name` was returning "unknown" for tags that had names.

Also included is a warn test case for posterity's sake, since runtests doesn't seem to check for warnings yet.
