### PR TITLE
Stop MENU_ACTIONS_ALL from tossing warnings with #pragma newdecls required

### DIFF
--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -72,7 +72,7 @@ enum MenuAction
 /** Default menu actions */
 #define MENU_ACTIONS_DEFAULT	MenuAction_Select|MenuAction_Cancel|MenuAction_End
 /** All menu actions */
-#define MENU_ACTIONS_ALL		MenuAction:0xFFFFFFFF
+#define MENU_ACTIONS_ALL		view_as<MenuAction>(0xFFFFFFFF)
 
 #define MENU_NO_PAGINATION		0		/**< Menu should not be paginated (10 items max) */
 #define MENU_TIME_FOREVER		0		/**< Menu should be displayed as long as possible */


### PR DESCRIPTION
Basically, this fixes a warning with the `MENU_ACTIONS_ALL` define triggered by commit 154d846.