### PR TITLE
Don't unpack mysql verbosely in checkout-deps.sh

### DIFF
--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -7,7 +7,7 @@ ismac=0
 iswin=0
 
 archive_ext=tar.gz
-decomp="tar zxvf"
+decomp="tar zxf"
 
 if [ `uname` = "Darwin" ]; then
   ismac=1


### PR DESCRIPTION
I doubt we're interested in the filename of every single file
contained in the mysql archive when it's decompressed.

It bloats up the travis build log.
