### PR TITLE
Add natives to properly use TFCond_TmpDamageBonus

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -36,6 +36,10 @@
 
 #include <ISDKTools.h>
 
+#ifndef TFCOND_TMPDAMAGEBONUS
+#define TFCOND_TMPDAMAGEBONUS 12
+#endif //TFCOND_TMPDAMAGEBONUS
+
 // native TF2_MakeBleed(client, attacker, Float:duration)
 cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 {
@@ -300,7 +304,7 @@ cell_t TF2_AddCondition(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Provider index %d is not valid", params[4]);
 	}
 
-	bool success = TF2_AddCond(pEntity, params[2], *(float *)&params[3], pProvider);
+	bool success = TF2_AddCond(pEntity, params[2], sp_ctof(params[3]), pProvider);
 	if (!success)
 	{
 		return pContext->ThrowNativeError("Failed to locate function");
@@ -677,13 +681,13 @@ int GetTmpDamageBonusOffset()
 			g_pSM->LogError(myself, "Failed to locate TmpDamageBonusOffset");
 			return -1;
 		}
-		sm_sendprop_info_t prop;
-		if (!gamehelpers->FindSendPropInfo("CTFPlayer", "m_unTauntSourceItemID_High", &prop))
+		int propoffset;
+		if (!g_pGameConf->GetOffset("TmpDamageBonusProp", &propoffset))
 		{
-			g_pSM->LogError(myself, "Failed to find m_unTauntSourceItemID_High prop offset");
+			g_pSM->LogError(myself, "Failed to find TmpDamageBonusProp property offset");
 			return -1;
 		}
-		offset += prop.actual_offset;
+		offset += propoffset;
 		found = true;
 	}
 	return offset;
@@ -709,15 +713,15 @@ cell_t TF2_AddTmpDamageBonus(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Provider index %d is not valid", params[4]);
 	}
 
-	float multiplier = *(float *)&params[2];
-	float duration = *(float *)&params[3]; //AddCond does this too, instead of sp_ctof. Why?
+	float multiplier = sp_ctof(params[2]);
+	float duration = sp_ctof(params[3]);
 
 	float dmgBonus = *(float *)((intptr_t)pEntity + offset);
 
-	bool success = TF2_AddCond(pEntity, 12, duration, pProvider);
+	bool success = TF2_AddCond(pEntity, TFCOND_TMPDAMAGEBONUS, duration, pProvider);
 	if (!success)
 	{
-		return pContext->ThrowNativeError("Failed to locate function");
+		return pContext->ThrowNativeError("Failed to locate function for TF2 AddCondition");
 	}
 	*(float *)((intptr_t)pEntity + offset) = dmgBonus + multiplier;
 	return (cell_t)(dmgBonus + multiplier);
@@ -743,13 +747,13 @@ cell_t TF2_SetTmpDamageBonus(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Provider index %d is not valid", params[4]);
 	}
 
-	float multiplier = *(float *)&params[2];
-	float duration = *(float *)&params[3]; //AddCond does this too, instead of sp_ctof. Why?
+	float multiplier = sp_ctof(params[2]);
+	float duration = sp_ctof(params[3]);
 
-	bool success = TF2_AddCond(pEntity, 12, duration, pProvider);
+	bool success = TF2_AddCond(pEntity, TFCOND_TMPDAMAGEBONUS, duration, pProvider);
 	if (!success)
 	{
-		return pContext->ThrowNativeError("Failed to locate function");
+		return pContext->ThrowNativeError("Failed to locate function for TF2 AddCondition");
 	}
 	*(float *)((intptr_t)pEntity + offset) = multiplier;
 	return 1;

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -36,9 +36,7 @@
 
 #include <ISDKTools.h>
 
-#ifndef TFCOND_TMPDAMAGEBONUS
-#define TFCOND_TMPDAMAGEBONUS 12
-#endif //TFCOND_TMPDAMAGEBONUS
+const int TFCond_TmpDamageBonus = 12;
 
 // native TF2_MakeBleed(client, attacker, Float:duration)
 cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
@@ -718,7 +716,7 @@ cell_t TF2_AddTmpDamageBonus(IPluginContext *pContext, const cell_t *params)
 
 	float dmgBonus = *(float *)((intptr_t)pEntity + offset);
 
-	bool success = TF2_AddCond(pEntity, TFCOND_TMPDAMAGEBONUS, duration, pProvider);
+	bool success = TF2_AddCond(pEntity, TFCond_TmpDamageBonus, duration, pProvider);
 	if (!success)
 	{
 		return pContext->ThrowNativeError("Failed to locate function for TF2 AddCondition");
@@ -750,7 +748,7 @@ cell_t TF2_SetTmpDamageBonus(IPluginContext *pContext, const cell_t *params)
 	float multiplier = sp_ctof(params[2]);
 	float duration = sp_ctof(params[3]);
 
-	bool success = TF2_AddCond(pEntity, TFCOND_TMPDAMAGEBONUS, duration, pProvider);
+	bool success = TF2_AddCond(pEntity, TFCond_TmpDamageBonus, duration, pProvider);
 	if (!success)
 	{
 		return pContext->ThrowNativeError("Failed to locate function for TF2 AddCondition");

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -151,6 +151,12 @@
 				"linux"		"8"
 				"mac"		"8"
 			}
+
+			"TmpDamageBonusProp"
+			{
+				"class"		"CTFPlayer"
+				"prop"		"m_unTauntSourceItemID_High"
+			}
 		}
 	}
 	

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -144,6 +144,13 @@
 				"linux"		"428"
 				"mac"		"428"
 			}
+
+			"TmpDamageBonusOffset"
+			{
+				"windows"	"8"
+				"linux"		"8"
+				"mac"		"8"
+			}
 		}
 	}
 	

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -245,11 +245,11 @@ native TF2_RegeneratePlayer(client);
  * @param condition		Integer identifier of condition to apply.
  * @param duration		Duration of condition (does not apply to all conditions).
  *                      Pass TFCondDuration_Infinite to apply until manually removed.
- * @param inflictor		Condition inflictor's index (0 for no inflictor).
+ * @param provider		Condition provider's index (0 for no provider).
  * @noreturn
  * @error				Invalid client index, client not in game, or no mod support.
  */
-native TF2_AddCondition(client, TFCond:condition, Float:duration=TFCondDuration_Infinite, inflictor=0);
+native TF2_AddCondition(client, TFCond:condition, Float:duration=TFCondDuration_Infinite, provider=0);
 
 /**
  * Removes a condition from a player
@@ -395,6 +395,43 @@ native bool:TF2_IsPlayerInDuel(client);
 native TF2_RemoveWearable(client, wearable);
 
 /**
+ * Adds TFCond_TmpDamageBonus to a player and properly adds to the damage multiplier.
+ * Stacks additively with current multiplier.
+ *
+ * @param client		Player's index.
+ * @param multiplier	Damage multiplier to add to current multiplier.
+ * @param duration		Duration of bonus.
+ *                      Pass TFCondDuration_Infinite to apply until manually removed.
+ * @param provider		Condition provider's index (0 for no provider).
+ * @return				Resulting damage multiplier.
+ * @error				Invalid client index, client not in game, or no mod support.
+ */
+native Float:TF2_AddTmpDamageBonus(client, Float:multiplier, Float:duration=TFCondDuration_Infinite, provider=0);
+
+/**
+ * Adds TFCond_TmpDamageBonus to a player and properly sets the damage multiplier.
+ * Overwrites current multiplier.
+ *
+ * @param client		Player's index.
+ * @param multiplier	Damage multiplier to set (1.0 is normal damage).
+ * @param duration		Duration of bonus.
+ *                      Pass TFCondDuration_Infinite to apply until manually removed.
+ * @param provider		Condition provider's index (0 for no provider).
+ * @noreturn
+ * @error				Invalid client index, client not in game, or no mod support.
+ */
+native TF2_SetTmpDamageBonus(client, Float:multiplier, Float:duration=TFCondDuration_Infinite, provider=0);
+
+/**
+ * Gets current multiplier for TFCond_TmpDamageBonus for a player.
+ *
+ * @param client		Player's index.
+ * @return				Current damage multiplier.
+ * @error				Invalid client index, client not in game, or no mod support.
+ */
+native Float:TF2_GetTmpDamageBonus(client);
+
+/**
  * Called after a condition is added to a player
  *
  * @param client		Index of the client to which the conditon is being added.
@@ -472,5 +509,8 @@ public __ext_tf2_SetNTVOptional()
 	MarkNativeAsOptional("TF2_IsPlayerInDuel");
 	MarkNativeAsOptional("TF2_IsHolidayActive");
 	MarkNativeAsOptional("TF2_RemoveWearable");
+	MarkNativeAsOptional("TF2_AddTmpDamageBonus");
+	MarkNativeAsOptional("TF2_SetTmpDamageBonus");
+	MarkNativeAsOptional("TF2_GetTmpDamageBonus");
 }
 #endif


### PR DESCRIPTION
Relevant changes to TF2_AddCondition included:
"Inflictor" changed to "Provider".
Provider is now allowed to be any entity (for instance, dispensers).
Moved actual call to TF2_AddCond to its own function, called by
TF2_AddCondition native (as well as by the TmpDamageBonus natives).