### PR TITLE
Fix missing params in OnTakeDamagePost typedef

### DIFF
--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -264,7 +264,9 @@ typeset SDKHookCB
 	// OnTakeDamagePost
 	// OnTakeDamageAlivePost
 	function void (int victim, int attacker, int inflictor, float damage, int damagetype);
-	function void (int victim, int attacker, int inflictor, float damage, int damagetype, const float damageForce[3], const float damagePosition[3]);
+	function void (int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3]);
+	function void (int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, 
+		const float damageForce[3], const float damagePosition[3], int damagecustom);
 	
 	// FireBulletsPost
 	function void (int client, int shots, const char[] weaponname);


### PR DESCRIPTION
Looks like the |weapon| parameter went missing during the switch to the
transitional syntax.

There was no -Post typedef including the |damagecustom| bit at all too.