### PR TITLE
Allow capturing non-public functions as values.

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -58,7 +58,7 @@
 #define sDEF_LITMAX  500    /* initial size of the literal pool, in "cells" */
 #define sDEF_AMXSTACK 4096  /* default stack size for AMX files */
 #define PREPROC_TERM  '\x7f'/* termination character for preprocessor expressions (the "DEL" code) */
-#define sDEF_PREFIX   "sourcemod.inc" /* default prefix filename */
+#define sDEF_PREFIX   "xsourcemod.inc" /* default prefix filename */
 #define sARGS_MAX		32	/* number of arguments a function can have, max */
 #define sTAGS_MAX		16  /* maximum number of tags on an argument */
 
@@ -149,6 +149,7 @@ typedef struct s_symbol {
   int numrefers;        /* number of entries in the referrer list */
   char *documentation;  /* optional documentation string */
   methodmap_t *methodmap; /* if ident == iMETHODMAP */
+  int funcid;           /* set for functions during codegen */
 } symbol;
 
 /*  Possible entries for "ident". These are used in the "symbol", "value"
@@ -757,6 +758,7 @@ void invoke_setter(struct methodmap_method_s *method, int save);
 void inc_pri();
 void dec_pri();
 void load_hidden_arg();
+void load_glbfn(symbol *sym);
 
 /*  Code generation functions for arithmetic operators.
  *
@@ -981,7 +983,7 @@ typedef struct array_info_s
 } array_info_t;
 
 enum FatalError {
-  FIRST_FATAL_ERROR = 182,
+  FIRST_FATAL_ERROR = 183,
 
   FATAL_ERROR_READ  = FIRST_FATAL_ERROR,
   FATAL_ERROR_WRITE,

--- a/sourcepawn/compiler/sc2.cpp
+++ b/sourcepawn/compiler/sc2.cpp
@@ -3102,6 +3102,7 @@ symbol *addsym(const char *name,cell addr,int ident,int vclass,int tag,int usage
   entry.lnumber=fline;
   entry.numrefers=1;
   entry.refer=refer;
+  entry.funcid=0;
 
   /* then insert it in the list */
   if (vclass==sGLOBAL)

--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -2403,31 +2403,22 @@ restart:
       error(76);
       return FALSE;
     }
-
-    int public_index = 0;
-    symbol *target = NULL;
-    for (symbol *iter = glbtab.next; iter; iter = iter->next) {
-      if (iter->ident != iFUNCTN || iter->vclass != sGLOBAL)
-        continue;
-      if (strcmp(iter->name, lval1->sym->name) == 0) {
-        target = iter;
-        break;
-      }
-      if (iter->usage & uPUBLIC)
-        public_index++;
-    }
-
-    if (!target || !(target->usage & uPUBLIC)) {
-      error(76);
+    if (finddepend(sym)) {
+      error(182);
       return FALSE;
     }
 
-    funcenum_t *fe = funcenum_for_symbol(target);
+    funcenum_t *fe = funcenum_for_symbol(sym);
+
+    // Get address into pri.
+    load_glbfn(sym);
+
+    // New-style "closure".
     lval1->sym = NULL;
-    lval1->ident = iCONSTEXPR;
-    lval1->constval = (public_index << 1) | 1;
+    lval1->ident = iEXPRESSION;
+    lval1->constval = 0;
     lval1->tag = fe->tag;
-    target->usage |= uREAD;
+    return FALSE;
   } /* if */
   return lvalue;
 }

--- a/sourcepawn/compiler/sc4.cpp
+++ b/sourcepawn/compiler/sc4.cpp
@@ -1503,3 +1503,17 @@ void invoke_setter(methodmap_method_t *method, int save)
   if (sc_status != statSKIP)
     markusage(method->setter, uREAD);
 }
+
+// function value -> pri
+void load_glbfn(symbol *sym)
+{
+  assert(sym->ident == iFUNCTN);
+  assert(!(sym->usage & uNATIVE));
+  stgwrite("\tldgfn.pri ");
+  stgwrite(sym->name);
+  stgwrite("\n");
+  code_idx += opcodes(1) + opargs(1);
+
+  if (sc_status != statSKIP)
+    markusage(sym, uREAD);
+}

--- a/sourcepawn/compiler/sc5-in.scp
+++ b/sourcepawn/compiler/sc5-in.scp
@@ -225,6 +225,7 @@ static const char *errmsg[] = {
 /*179*/  "cannot assign %s[] to %s[], storage classes differ\n",
 /*180*/  "function return type differs from prototype. expected '%s', but got '%s'\n",
 /*181*/  "function argument named '%s' differs from prototype\n",
+/*182*/  "functions that return arrays cannot be used as callbacks\n",
 #else
   "\315e\306\227\266k\217:\235\277bu\201fo\220\204\223\012",
   "\202l\224\250s\205g\346\356e\233\201(\243\315\214\267\202) \253 f\255low ea\305 \042c\353e\042\012",

--- a/sourcepawn/compiler/smx-builder.h
+++ b/sourcepawn/compiler/smx-builder.h
@@ -129,6 +129,9 @@ class SmxListSection : public SmxSection
     list_.append(T());
     return list_.back();
   }
+  void add(const T &t) {
+    list_.append(t);
+  }
   bool write(ISmxBuffer *buf) KE_OVERRIDE {
     return buf->write(list_.buffer(), list_.length() * sizeof(T));
   }

--- a/sourcepawn/compiler/tests/fail-callback-returns-array.sp
+++ b/sourcepawn/compiler/tests/fail-callback-returns-array.sp
@@ -1,0 +1,16 @@
+String:MyFunction()
+{
+  new String:egg[10] = "egg";
+  return egg;
+}
+
+public crab()
+{
+  new String:egg[10];
+  egg = MyFunction();
+}
+
+public Function:main()
+{
+  return MyFunction;
+}

--- a/sourcepawn/compiler/tests/fail-callback-returns-array.txt
+++ b/sourcepawn/compiler/tests/fail-callback-returns-array.txt
@@ -1,0 +1,1 @@
+(15) : error 182: functions that return arrays cannot be used as callbacks

--- a/sourcepawn/compiler/tests/fail-newdecls.txt
+++ b/sourcepawn/compiler/tests/fail-newdecls.txt
@@ -2,4 +2,4 @@
 (2) : error 141: natives, forwards, and public functions cannot return arrays
 (3) : error 143: new-style declarations should not have "new"
 (5) : error 121: cannot specify array dimensions on both type and name
-(11) : error 025: function heading differs from prototype
+(11) : error 180: function return type differs from prototype. expected 'void', but got 'int'

--- a/sourcepawn/include/smx/smx-v1-opcodes.h
+++ b/sourcepawn/include/smx/smx-v1-opcodes.h
@@ -235,6 +235,7 @@ namespace sp {
   _(STRADJUST_PRI,  "stradjust.pri")  \
   _(UNGEN_STKADJUST,"stackadjust")    \
   _(ENDPROC,        "endproc")        \
+  _(UNGEN_LDGFN_PRI,"ldgfn.pri")     \
   _(FABS,           "fabs")           \
   _(FLOAT,          "float")          \
   _(FLOATADD,       "float.add")      \


### PR DESCRIPTION
This patch allows using non-public functions as callbacks. The JIT is pretty heavily designed around the public function table as an entry point, so the trick here was to just repurpose that table: it now contains all functions that were generated, regardless of whether or not they're public. Non-public ones get some name decoration so they won't cause name collisions (for example, with `static`).

The tricky part is that Pawn is fairly gross, as usual, and it's hard to tell what the final public index will be during codegen. To make this work I added a pseudo-opcode that references the function by name. During assembly this gets rewritten to a normal `const.pri`, after we've computed all the public indices.

As a result, function values no longer result in constant expressions (which is crazy in the first place).