### PR TITLE
Fix un-joined threads leaking. (bug 3460)

### DIFF
--- a/public/amtl/am-thread-posix.h
+++ b/public/amtl/am-thread-posix.h
@@ -174,6 +174,11 @@ class Thread
     if (!initialized_)
       delete data;
   }
+  ~Thread() {
+    if (!Succeeded())
+      return;
+    pthread_detach(thread_);
+  }
 
   bool Succeeded() const {
     return initialized_;

--- a/public/amtl/am-thread-posix.h
+++ b/public/amtl/am-thread-posix.h
@@ -188,6 +188,7 @@ class Thread
     if (!Succeeded())
       return;
     pthread_join(thread_, NULL);
+    initialized_ = false;
   }
 
  private:


### PR DESCRIPTION
We currently leak threads if Join() is never called (such as IThreader threads using Thread_AutoRelease or the simple MakeThread overload). Also, calling Join() more than once could cause a crash / the wrong thread to be joined. This changes the POSIX thread implementation to match the behaviour of the Windows one and let the OS clean up resources if the Thread instance is released.

@dvander