### PR TITLE
Use BfRead or Protobuf tags in umsg hook callbacks, rather than a generic Handle.

### DIFF
--- a/plugins/include/usermessages.inc
+++ b/plugins/include/usermessages.inc
@@ -163,7 +163,7 @@ native EndMessage();
  *						blocks the message from being sent, and Plugin_Continue 
  *						resumes normal functionality.
  */
-typedef MsgHook = function Action (UserMsg msg_id, BfRead msg, const int[] players, int playersNum, bool reliable, bool init);
+typedef MsgHook = function Action (UserMsg msg_id, Handle msg, const int[] players, int playersNum, bool reliable, bool init);
 
 /**
  * Called when a message hook has completed.

--- a/plugins/include/usermessages.inc
+++ b/plugins/include/usermessages.inc
@@ -151,19 +151,39 @@ native Handle:StartMessageEx(UserMsg:msg, clients[], numClients, flags=0);
 native EndMessage();
 
 /**
- * Called when a message is hooked
- *
- * @param msg_id		Message index.
- * @param msg			Handle to the input bit buffer or protobuf.
- * @param players		Array containing player indexes.
- * @param playersNum	Number of players in the array.
- * @param reliable		True if message is reliable, false otherwise.
- * @param init			True if message is an initmsg, false otherwise.
- * @return				Ignored for normal hooks.  For intercept hooks, Plugin_Handled 
- *						blocks the message from being sent, and Plugin_Continue 
- *						resumes normal functionality.
- */
-typedef MsgHook = function Action (UserMsg msg_id, Handle msg, const int[] players, int playersNum, bool reliable, bool init);
+ * Hook function types for user messages.
+*/
+typeset MsgHook
+{
+	/**
+	 * Called when a bit buffer based usermessage is hooked
+	 *
+	 * @param msg_id		Message index.
+	 * @param msg			Handle to the input bit buffer.
+	 * @param players		Array containing player indexes.
+	 * @param playersNum	Number of players in the array.
+	 * @param reliable		True if message is reliable, false otherwise.
+	 * @param init			True if message is an initmsg, false otherwise.
+	 * @return				Ignored for normal hooks.  For intercept hooks, Plugin_Handled 
+	 *						blocks the message from being sent, and Plugin_Continue 
+	 *						resumes normal functionality.
+	 */
+	function Action (UserMsg msg_id, BfRead msg, const int[] players, int playersNum, bool reliable, bool init);
+	/**
+	 * Called when a protobuf based usermessage is hooked
+	 *
+	 * @param msg_id		Message index.
+	 * @param msg			Handle to the input protobuf.
+	 * @param players		Array containing player indexes.
+	 * @param playersNum	Number of players in the array.
+	 * @param reliable		True if message is reliable, false otherwise.
+	 * @param init			True if message is an initmsg, false otherwise.
+	 * @return				Ignored for normal hooks.  For intercept hooks, Plugin_Handled 
+	 *						blocks the message from being sent, and Plugin_Continue 
+	 *						resumes normal functionality.
+	 */
+	function Action (UserMsg msg_id, Protobuf msg, const int[] players, int playersNum, bool reliable, bool init);
+};
 
 /**
  * Called when a message hook has completed.


### PR DESCRIPTION
Alright, take 2. It's surprisingly easy to forget that CS:GO exists.

Two separate commits to make cherrypicking to 1.7 easier.