### PR TITLE
Fix incorrect error line show for incorrect return value on forwards (bug 6226).

### DIFF
--- a/sourcepawn/compiler/sc1.cpp
+++ b/sourcepawn/compiler/sc1.cpp
@@ -5534,7 +5534,7 @@ static int newfunc(declinfo_t *decl, const int *thistag, int fpublic, int fstati
   // Check that return tags match.
   if ((sym->usage & uPROTOTYPED) && !compare_tag(sym->tag, decl->type.tag)) {
     int old_fline = fline;
-    fline = sym->lnumber;
+    fline = funcline;
     error(25);
     fline = old_fline;
   }


### PR DESCRIPTION
As described in [bug 6226](https://bugs.alliedmods.net/show_bug.cgi?id=6226).

When a function implementing a forward has a return type that doesn't match, the line in the error message is the line of the forward declaration, rather than the implementing function. This is a regression in 1.7+.

This seems to fix it.