### PR TITLE
Fix chained field expressions losing lvalue-ness. (bug 6298)

### DIFF
--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -2334,6 +2334,7 @@ restart:
             implicitthis = &thisval;
             break;
           case FER_Accessor:
+            lvalue = TRUE;
             goto restart;
           default:
             assert(false);


### PR DESCRIPTION
Silly bug caused by SP1's decoupling of value state and l-value state. When we encounter an accessor, we must set the l-value bit back to `true` since if we resolved the `this` from an expression it will be `false`.