### PR TITLE
Don't special case hierarchy-free enumeration constants when used as array indices. (bug 6302)

### DIFF
--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -2227,7 +2227,11 @@ restart:
          * from the field and save the size of the field too.
          */
         assert(lval2.sym==NULL || lval2.sym->dim.array.level==0);
-        if (lval2.sym!=NULL && lval2.sym->dim.array.length>0 && sym->dim.array.level==0) {
+        if (lval2.sym &&
+            lval2.sym->parent &&
+            lval2.sym->dim.array.length > 0 &&
+            sym->dim.array.level==0)
+        {
           lval1->tag=lval2.sym->x.tags.index;
           lval1->constval=lval2.sym->dim.array.length;
         } /* if */
@@ -2280,8 +2284,11 @@ restart:
        * from the field and save the size of the field too. Otherwise, the
        * tag is the one from the array symbol.
        */
-      if (lval2.ident==iCONSTEXPR && lval2.sym!=NULL
-          && lval2.sym->dim.array.length>0 && sym->dim.array.level==0)
+      if (lval2.ident==iCONSTEXPR &&
+          lval2.sym &&
+          lval2.sym->parent &&
+          lval2.sym->dim.array.length > 0 &&
+          sym->dim.array.level == 0)
       {
         lval1->tag=lval2.sym->x.tags.index;
         lval1->constval=lval2.sym->dim.array.length;
@@ -2310,15 +2317,17 @@ restart:
         lval1->constval=0;
       } /* if */
 
+      /* a cell in an array is an lvalue, a character in an array is not
+       * always a *valid* lvalue */
+      lvalue = TRUE;
+
       // If there's a call/fetch coming up, keep parsing.
       if (matchtoken('.')) {
         lexpush();
         goto restart;
       }
 
-      /* a cell in an array is an lvalue, a character in an array is not
-       * always a *valid* lvalue */
-      return TRUE;
+      return lvalue;
     } else {            /* tok=='(' -> function(...) */
       svalue thisval;
       thisval.val = *lval1;


### PR DESCRIPTION
This code is all horseshit, but whatever, the show it must go on. There are two bugs here.

1. The compiler has a special case for `x[y]` where if `y` is a constexpr produced by an enumeration value, the tag of the l-value is the tag specified on the enumeration value. I.e., this is what makes enum structs sort-of work. That means if the enum symbol is free-floating (not part of an enum struct), the tag will always be empty. I fixed this with a `sym->parent` check.
2. When restarting the accessor matching loop after parsing an array access, we don't reset `lvalue` to `true`. Before field accessors that wasn't a problem, since we just immediately returned. Now, however, we must make sure the l-valueness is maintained.

As a special totally unworthy-of-note bonus to (1), the check for enum symbols doesn't even look right to begin with. If you force the enum to have an increment of 0, it will fail.