### PR TITLE
Fix "sm plugins refresh" not refreshing changed plugins.

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -2312,6 +2312,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const CCommand &c
 		}
 		else if (strcmp(cmd, "refresh") == 0)
 		{
+			RefreshAll();
 			smcore.DoGlobalPluginLoads();
 			rootmenu->ConsolePrint("[SM] The plugin list has been refreshed and reloaded.");
 			return;


### PR DESCRIPTION
RefreshAll is normally only called in LevelShutdown to unload any plugins loaded for that map only (obsolete) or any that have been change since load. LevelInit then calls DoGlobalPluginLoads.

By adding the RefreshAll call in "sm plugins refresh", we replicate this. Tested and it seems to work as documented now.