### PR TITLE
Remove sizeof() as a special-case default argument value.

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -80,10 +80,6 @@ typedef struct s_arginfo {  /* function argument info */
   union {
     cell val;           /* default value */
     struct {
-      char *symname;    /* name of another symbol */
-      short level;      /* indirection level for that symbol */
-    } size;             /* used for "sizeof" default value */
-    struct {
       cell *data;       /* values of default array */
       int size;         /* complete length of default array */
       int arraysize;    /* size to reserve on the heap */
@@ -229,10 +225,6 @@ typedef struct s_symbol {
 #define uRETNONE  0x10
 
 #define flgDEPRECATED 0x01  /* symbol is deprecated (avoid use) */
-
-#define uCOUNTOF  0x20  /* set in the "hasdefault" field of the arginfo struct */
-#define uTAGOF    0x40  /* set in the "hasdefault" field of the arginfo struct */
-#define uSIZEOF   0x80  /* set in the "hasdefault" field of the arginfo struct */
 
 #define uMAINFUNC "main"
 #define uENTRYFUNC "entry"

--- a/sourcepawn/compiler/sc2.cpp
+++ b/sourcepawn/compiler/sc2.cpp
@@ -2734,9 +2734,6 @@ static void free_symbol(symbol *sym)
     for (arg=sym->dim.arglist; arg->ident!=0; arg++) {
       if (arg->ident==iREFARRAY && arg->hasdefault)
         free(arg->defvalue.array.data);
-      else if (arg->ident==iVARIABLE
-               && ((arg->hasdefault & uSIZEOF)!=0 || (arg->hasdefault & uTAGOF)!=0))
-        free(arg->defvalue.size.symname);
       assert(arg->tags!=NULL);
       free(arg->tags);
     } /* for */

--- a/sourcepawn/compiler/sc3.cpp
+++ b/sourcepawn/compiler/sc3.cpp
@@ -3009,13 +3009,6 @@ static int nesting=0;
   for (argidx=0; arg[argidx].ident!=0 && arg[argidx].ident!=iVARARGS; argidx++) {
     if (arglist[argidx]==ARG_DONE)
       continue;                 /* already seen and handled this argument */
-    /* in this first stage, we also skip the arguments with uSIZEOF and uTAGOF;
-     * these are handled last
-     */
-    if ((arg[argidx].hasdefault & uSIZEOF)!=0 || (arg[argidx].hasdefault & uTAGOF)!=0) {
-      assert(arg[argidx].ident==iVARIABLE);
-      continue;
-    } /* if */
     stgmark((char)(sEXPRSTART+argidx));/* mark beginning of new expression in stage */
     if (arg[argidx].hasdefault) {
       if (arg[argidx].ident==iREFARRAY) {
@@ -3059,49 +3052,6 @@ static int nesting=0;
     } else {
       error(92,argidx);        /* argument count mismatch */
     } /* if */
-    if (arglist[argidx]==ARG_UNHANDLED)
-      nargs++;
-    arglist[argidx]=ARG_DONE;
-  } /* for */
-  /* now a second loop to catch the arguments with default values that are
-   * the "sizeof" or "tagof" of other arguments
-   */
-  for (argidx=0; arg[argidx].ident!=0 && arg[argidx].ident!=iVARARGS; argidx++) {
-    constvalue *asz;
-    cell array_sz;
-    if (arglist[argidx]==ARG_DONE)
-      continue;                 /* already seen and handled this argument */
-    stgmark((char)(sEXPRSTART+argidx));/* mark beginning of new expression in stage */
-    assert(arg[argidx].ident==iVARIABLE);           /* if "sizeof", must be single cell */
-    /* if unseen, must be "sizeof" or "tagof" */
-    assert((arg[argidx].hasdefault & uSIZEOF)!=0 || (arg[argidx].hasdefault & uTAGOF)!=0);
-    if ((arg[argidx].hasdefault & uSIZEOF)!=0) {
-      /* find the argument; if it isn't found, the argument's default value
-       * was a "sizeof" of a non-array (a warning for this was already given
-       * when declaring the function)
-       */
-      asz=find_constval(&arrayszlst,arg[argidx].defvalue.size.symname,
-                        arg[argidx].defvalue.size.level);
-      if (asz!=NULL) {
-        array_sz=asz->value;
-        if (array_sz==0)
-          error(163,arg[argidx].name);    /* indeterminate array size in "sizeof" expression */
-      } else {
-        array_sz=1;
-      } /* if */
-    } else {
-      asz=find_constval(&taglst,arg[argidx].defvalue.size.symname,
-                        arg[argidx].defvalue.size.level);
-      if (asz != NULL) {
-        array_sz=asz->value;  /* must be set, because it just was exported */
-      } else {
-        array_sz=0;
-      } /* if */
-    } /* if */
-    ldconst(array_sz,sPRI);
-    pushreg(sPRI);              /* store the function argument on the stack */
-    markexpr(sPARM,NULL,0);
-    nest_stkusage++;
     if (arglist[argidx]==ARG_UNHANDLED)
       nargs++;
     arglist[argidx]=ARG_DONE;

--- a/sourcepawn/compiler/tests/fail-newdecls.txt
+++ b/sourcepawn/compiler/tests/fail-newdecls.txt
@@ -2,4 +2,4 @@
 (2) : error 141: natives, forwards, and public functions cannot return arrays
 (3) : error 143: new-style declarations should not have "new"
 (5) : error 121: cannot specify array dimensions on both type and name
-(9) : error 025: function heading differs from prototype
+(11) : error 025: function heading differs from prototype

--- a/sourcepawn/compiler/tests/fail-sizeof-default-arg.sp
+++ b/sourcepawn/compiler/tests/fail-sizeof-default-arg.sp
@@ -1,0 +1,9 @@
+stock void crab(int[] eggs, int numEggs = sizeof(eggs))
+{
+}
+
+public main()
+{
+  int eggs[12];
+  crab(eggs);
+}

--- a/sourcepawn/compiler/tests/fail-sizeof-default-arg.txt
+++ b/sourcepawn/compiler/tests/fail-sizeof-default-arg.txt
@@ -1,0 +1,1 @@
+(1) : error 163: indeterminate array size in "sizeof" expression (symbol "eggs")


### PR DESCRIPTION
This craptacular feature has been a minor thorn in my side. I don't like it, it doesn't reflect where we want the API to be, and it's not usable in situations where the array size is indeterminate or controlled by a dynamic value. It also computes its value wrong for character arrays.

From a language design perspective, it's very odd that the `sizeof` in this context is magic and binds to the callsite rather than the in-scope argument. 

As far as I know, it's rare for SourceMod code to use this, so let's try removing it. Other special cases removed as well are `tagof` and `countof` - the former being particularly useless, and we can get rid of a bunch of code as a result.