### PR TITLE
Fix crash when creating and destroying a TopMenu before map start (bug 6303).

### DIFF
--- a/extensions/topmenus/TopMenu.cpp
+++ b/extensions/topmenus/TopMenu.cpp
@@ -80,12 +80,15 @@ TopMenu::~TopMenu()
 		delete m_Config.cats[i];
 	}
 
-	/* Sweep players */
-	for (size_t i = 0; i <= (size_t)m_max_clients; i++)
+	if (m_clients != NULL)
 	{
-		TearDownClient(&m_clients[i]);
+		/* Sweep players */
+		for (size_t i = 0; i <= (size_t)m_max_clients; i++)
+		{
+			TearDownClient(&m_clients[i]);
+		}
+		free(m_clients);
 	}
-	free(m_clients);
 }
 
 unsigned int TopMenu::CalcMemUsage()


### PR DESCRIPTION
Added NULL check on m_Clients like exists elsewhere in the class due to it only being initialized in ctor if ServerActivated or upon ServerActivate.