### PR TITLE
Add missing impl for File.ReadUint16.

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -1176,6 +1176,7 @@ REGISTER_NATIVES(filesystem)
 	{"File.ReadInt8",			File_ReadTyped<int8_t>},
 	{"File.ReadUint8",			File_ReadTyped<uint8_t>},
 	{"File.ReadInt16",			File_ReadTyped<int16_t>},
+	{"File.ReadUint16",			File_ReadTyped<uint16_t>},
 	{"File.ReadInt32",			File_ReadTyped<int32_t>},
 	{"File.WriteInt8",			File_WriteTyped<int8_t>},
 	{"File.WriteInt16",			File_WriteTyped<int16_t>},


### PR DESCRIPTION
This exists in the File methodmap, but there is no implementation for it.