### PR TITLE
Replace frameloop for player condition checks in TF2 ext with sendproxies

### DIFF
--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -51,6 +51,8 @@ void HandleCondChange(void *pData)
 void PlayerConditionsMgr::ProcessCondChange(CondChangeData_t *pCondData)
 {
 	int client = gamehelpers->EntityToBCompatRef(pCondData->pPlayer);
+	if (!playerhelpers->GetGamePlayer(client)->IsInGame())
+		return;
 
 	int newConds = 0;
 	int prevConds = 0;

--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -31,9 +31,6 @@
 
 #include "extension.h"
 #include "conditions.h"
-#include "util.h"
-
-#include <iplayerinfo.h>
 
 IForward *g_addCondForward = NULL;
 IForward *g_removeCondForward = NULL;
@@ -87,13 +84,13 @@ void PlayerConditionsMgr::ProcessCondChange(CondChangeData_t *pCondData)
 			if (addedConds & (1 << i))
 			{
 				g_addCondForward->PushCell(client);
-				g_addCondForward->PushCell(i);
+				g_addCondForward->PushCell(i + m_CondOffset[var]);
 				g_addCondForward->Execute(NULL);
 			}
 			else if (removedConds & (1 << i))
 			{
 				g_removeCondForward->PushCell(client);
-				g_removeCondForward->PushCell(i);
+				g_removeCondForward->PushCell(i + m_CondOffset[var]);
 				g_removeCondForward->Execute(NULL);
 			}
 		}
@@ -141,6 +138,12 @@ bool PlayerConditionsMgr::SetupProp(const char *varname)
 
 bool PlayerConditionsMgr::Init()
 {
+	m_CondOffset[m_nPlayerCond] = 0;
+	m_CondOffset[_condition_bits] = 0;
+	m_CondOffset[m_nPlayerCondEx] = 32;
+	m_CondOffset[m_nPlayerCondEx2] = 64;
+	m_CondOffset[m_nPlayerCondEx3] = 96;
+
 	memset(m_BackupProxyFns, 0, sizeof(m_BackupProxyFns));
 
 	bool bFoundProps = SetupProp<m_nPlayerCond>("m_nPlayerCond")

--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -136,14 +136,17 @@ bool PlayerConditionsMgr::SetupProp(const char *varname)
 	return true;
 }
 
-bool PlayerConditionsMgr::Init()
+PlayerConditionsMgr::PlayerConditionsMgr()
 {
 	m_CondOffset[m_nPlayerCond] = 0;
 	m_CondOffset[_condition_bits] = 0;
 	m_CondOffset[m_nPlayerCondEx] = 32;
 	m_CondOffset[m_nPlayerCondEx2] = 64;
 	m_CondOffset[m_nPlayerCondEx3] = 96;
+}
 
+bool PlayerConditionsMgr::Init()
+{
 	memset(m_BackupProxyFns, 0, sizeof(m_BackupProxyFns));
 
 	bool bFoundProps = SetupProp<m_nPlayerCond>("m_nPlayerCond")

--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -159,7 +159,7 @@ void PlayerConditionsMgr::Shutdown()
 
 void PlayerConditionsMgr::OnClientPutInServer(int client)
 {
-	memset(&m_OldConds[client], 0, CondVar_Count * sizeof(int));
+	memset(&m_OldConds[client], 0, sizeof(m_OldConds[0]));
 }
 
 PlayerConditionsMgr g_CondMgr;

--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -110,7 +110,7 @@ static void OnPlayerCondChange(const SendProp *pProp, const void *pStructBase, c
 void PlayerConditionsMgr::OnConVarChange(CondVar var, const SendProp *pProp, const void *pStructBase, const void *pData, DVariant *pOut, int iElement, int objectID)
 {
 	auto pCondData = new CondChangeData_t;
-	pCondData->pPlayer = (CBaseEntity *)((intp)pStructBase - GetPropOffs(m_Shared));
+	pCondData->pPlayer = (CBaseEntity *)((intp)pData - GetPropOffs(var));
 	pCondData->var = var;
 	pCondData->newConds = *(int *)pData;
 
@@ -129,11 +129,8 @@ bool PlayerConditionsMgr::SetupProp(const char *varname)
 		return false;
 	}
 
-	if (var != m_Shared)
-	{
-		m_BackupProxyFns[var] = GetProp(var)->GetProxyFn();
-		GetProp(var)->SetProxyFn(OnPlayerCondChange<var>);
-	}
+	m_BackupProxyFns[var] = GetProp(var)->GetProxyFn();
+	GetProp(var)->SetProxyFn(OnPlayerCondChange<var>);
 
 	return true;
 }
@@ -155,8 +152,7 @@ bool PlayerConditionsMgr::Init()
 		&& SetupProp<_condition_bits>("_condition_bits")
 		&& SetupProp<m_nPlayerCondEx>("m_nPlayerCondEx")
 		&& SetupProp<m_nPlayerCondEx2>("m_nPlayerCondEx2")
-		&& SetupProp<m_nPlayerCondEx3>("m_nPlayerCondEx3")
-		&& SetupProp<m_Shared>("m_Shared");
+		&& SetupProp<m_nPlayerCondEx3>("m_nPlayerCondEx3");
 
 	if (!bFoundProps)
 		return false;
@@ -171,7 +167,7 @@ bool PlayerConditionsMgr::Init()
 			continue;
 
 		CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(i);
-		for (size_t j = 0; j < CondVar_LastNotifyProp; ++j)
+		for (size_t j = 0; j < CondVar_Count; ++j)
 		{
 			m_OldConds[i][j] = *(int *)((intp) pEntity + GetPropOffs((CondVar)j));
 		}
@@ -182,7 +178,7 @@ bool PlayerConditionsMgr::Init()
 
 void PlayerConditionsMgr::Shutdown()
 {
-	for (size_t i = 0; i < CondVar_LastNotifyProp; ++i)
+	for (size_t i = 0; i < CondVar_Count; ++i)
 	{
 		GetProp((CondVar)i)->SetProxyFn(m_BackupProxyFns[i]);
 	}

--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -42,10 +42,11 @@ struct CondChangeData_t
 	int newConds;
 };
 
-void HandleCondChange(void *pData)
+static void HandleCondChange(void *pData)
 {
 	auto *pCondData = reinterpret_cast<CondChangeData_t *>(pData);
 	g_CondMgr.ProcessCondChange(pCondData);
+	delete pCondData;
 }
 
 void PlayerConditionsMgr::ProcessCondChange(CondChangeData_t *pCondData)
@@ -97,8 +98,6 @@ void PlayerConditionsMgr::ProcessCondChange(CondChangeData_t *pCondData)
 			}
 		}
 	}
-
-	delete pCondData;
 }
 
 template<PlayerConditionsMgr::CondVar CondVar>

--- a/extensions/tf2/conditions.h
+++ b/extensions/tf2/conditions.h
@@ -34,6 +34,8 @@
 
 #include "extension.h"
 
+struct CondChangeData_t;
+
 class PlayerConditionsMgr : public IClientListener
 {
 public:
@@ -56,6 +58,7 @@ public:
 	};
 
 	void OnConVarChange(CondVar var, const SendProp *pProp, const void *pStructBase, const void *pData, DVariant *pOut, int iElement, int objectID);
+	void ProcessCondChange(CondChangeData_t *pCondData);
 private:
 	inline unsigned int GetPropOffs(CondVar var)
 	{

--- a/extensions/tf2/conditions.h
+++ b/extensions/tf2/conditions.h
@@ -39,6 +39,7 @@ struct CondChangeData_t;
 class PlayerConditionsMgr : public IClientListener
 {
 public:
+	PlayerConditionsMgr();
 	bool Init();
 	void Shutdown();
 public: // IClientListener

--- a/extensions/tf2/conditions.h
+++ b/extensions/tf2/conditions.h
@@ -68,9 +68,9 @@ private:
 	template<CondVar var>
 	bool SetupProp(const char *varname);
 private:
-	int m_OldConds[TF_MAXPLAYERS + 1][CondVar_Count];
+	int m_OldConds[SM_MAXPLAYERS + 1][CondVar_LastNotifyProp];
 	sm_sendprop_info_t m_CondVarProps[CondVar_Count];
-	SendVarProxyFn m_BackupProxyFns[CondVar_Count];
+	SendVarProxyFn m_BackupProxyFns[CondVar_LastNotifyProp];
 };
 
 extern PlayerConditionsMgr g_CondMgr;

--- a/extensions/tf2/conditions.h
+++ b/extensions/tf2/conditions.h
@@ -52,8 +52,6 @@ public:
 		m_nPlayerCondEx,
 		m_nPlayerCondEx2,
 		m_nPlayerCondEx3,
-		m_Shared,
-		CondVar_LastNotifyProp = m_Shared,
 
 		CondVar_Count
 	};
@@ -72,10 +70,10 @@ private:
 	template<CondVar var>
 	bool SetupProp(const char *varname);
 private:
-	int m_OldConds[SM_MAXPLAYERS + 1][CondVar_LastNotifyProp];
+	int m_OldConds[SM_MAXPLAYERS + 1][CondVar_Count];
 	sm_sendprop_info_t m_CondVarProps[CondVar_Count];
-	int m_CondOffset[CondVar_LastNotifyProp];
-	SendVarProxyFn m_BackupProxyFns[CondVar_LastNotifyProp];
+	int m_CondOffset[CondVar_Count];
+	SendVarProxyFn m_BackupProxyFns[CondVar_Count];
 };
 
 extern PlayerConditionsMgr g_CondMgr;

--- a/extensions/tf2/conditions.h
+++ b/extensions/tf2/conditions.h
@@ -73,6 +73,7 @@ private:
 private:
 	int m_OldConds[SM_MAXPLAYERS + 1][CondVar_LastNotifyProp];
 	sm_sendprop_info_t m_CondVarProps[CondVar_Count];
+	int m_CondOffset[CondVar_LastNotifyProp];
 	SendVarProxyFn m_BackupProxyFns[CondVar_LastNotifyProp];
 };
 

--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod Team Fortress 2 Extension
- * Copyright (C) 2004-2011 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -116,7 +116,6 @@ bool TF2Tools::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	plsys->AddPluginsListener(this);
 
 	playerhelpers->RegisterCommandTargetProcessor(this);
-	playerhelpers->AddClientListener(this);
 
 	g_critForward = forwards->CreateForward("TF2_CalcIsAttackCritical", ET_Hook, 4, NULL, Param_Cell, Param_Cell, Param_String, Param_CellByRef);
 	g_addCondForward = forwards->CreateForward("TF2_OnConditionAdded", ET_Ignore, 2, NULL, Param_Cell, Param_Cell);
@@ -172,7 +171,6 @@ void TF2Tools::SDK_OnUnload()
 	g_RegNatives.UnregisterAll();
 	gameconfs->CloseGameConfigFile(g_pGameConf);
 	playerhelpers->UnregisterCommandTargetProcessor(this);
-	playerhelpers->RemoveClientListener(this);
 
 	plsys->RemovePluginsListener(this);
 
@@ -357,7 +355,7 @@ void TF2Tools::OnPluginLoaded(IPlugin *plugin)
 		&& ( g_addCondForward->GetFunctionCount() || g_removeCondForward->GetFunctionCount() )
 		)
 	{
-		m_CondChecksEnabled = InitialiseConditionChecks();
+		m_CondChecksEnabled = g_CondMgr.Init();
 	}
 
 	if (!m_RulesDetoursEnabled
@@ -384,7 +382,7 @@ void TF2Tools::OnPluginUnloaded(IPlugin *plugin)
 	{
 		if (!g_addCondForward->GetFunctionCount() && !g_removeCondForward->GetFunctionCount())
 		{
-			RemoveConditionChecks();
+			g_CondMgr.Shutdown();
 			m_CondChecksEnabled = false;
 		}
 	}
@@ -401,11 +399,6 @@ void TF2Tools::OnPluginUnloaded(IPlugin *plugin)
 		RemoveTeleporterDetour();
 		m_TeleportDetourEnabled = false;
 	}
-}
-
-void TF2Tools::OnClientPutInServer(int client)
-{
-	Conditions_OnClientPutInServer(client);
 }
 
 int FindResourceEntity()

--- a/extensions/tf2/extension.h
+++ b/extensions/tf2/extension.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod Team Fortress 2 Extension
- * Copyright (C) 2004-2011 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -42,6 +42,8 @@
 #include <server_class.h>
 #include <igameevents.h>
 
+const int TF_MAXPLAYERS = 33;
+
 namespace SourceMod {
 	class ISDKTools;
 }
@@ -55,8 +57,7 @@ class TF2Tools :
 	public ICommandTargetProcessor,
 	public IConCommandBaseAccessor,
 	public IGameEventListener2,
-	public IPluginsListener,
-	public IClientListener
+	public IPluginsListener
 {
 public: //SDKExtension
 	/**
@@ -104,8 +105,6 @@ public: //IGameEventManager
 public: //IPluginsListener
 	void OnPluginLoaded(IPlugin *plugin);
 	void OnPluginUnloaded(IPlugin *plugin);
-public: //IClientListener
-	void OnClientPutInServer(int client);
 public:
 #if defined SMEXT_CONF_METAMOD
 	/**

--- a/extensions/tf2/extension.h
+++ b/extensions/tf2/extension.h
@@ -42,8 +42,6 @@
 #include <server_class.h>
 #include <igameevents.h>
 
-const int TF_MAXPLAYERS = 33;
-
 namespace SourceMod {
 	class ISDKTools;
 }


### PR DESCRIPTION
For many TF2-specfiic plugins, it's useful to know when a "player condition" is added or removed. We don't/can't hook the functions for add/removing them directly due to them getting inlined in places. We, instead, currently have a loop over all player condition variables (5 of them any counting) for each player, every frame.

Instead, we can insert ourselves as a sendproxy for these sendprops, letting use know when the variable has changed (as the proxies are called when it serializes the data to send to the client).

This is still pending some final testing, but it's ready to be looked at.

@VoiDeD @asherkin :japanese_goblin: 