### PR TITLE
Root Menu Handles during Display (Bug 5620).

### DIFF
--- a/core/MenuStyle_Radio.cpp
+++ b/core/MenuStyle_Radio.cpp
@@ -593,6 +593,7 @@ bool CRadioMenu::DisplayAtItem(int client,
 		return false;
 	}
 
+	AutoHandleRooter ahr(this->GetHandle());
 	return g_RadioMenuStyle.DoClientMenu(client,
 		this,
 		start_item,

--- a/core/MenuStyle_Radio.h
+++ b/core/MenuStyle_Radio.h
@@ -41,6 +41,8 @@
 #include "sm_fastlink.h"
 #include <sh_stack.h>
 #include <compat_wrappers.h>
+#include "logic/common_logic.h"
+#include "AutoHandleRooter.h"
 
 using namespace SourceMod;
 

--- a/core/MenuStyle_Valve.cpp
+++ b/core/MenuStyle_Valve.cpp
@@ -408,6 +408,7 @@ bool CValveMenu::DisplayAtItem(int client,
 		return false;
 	}
 
+	AutoHandleRooter ahr(this->GetHandle());
 	return g_ValveMenuStyle.DoClientMenu(client, this, start_item, alt_handler ? alt_handler : m_pHandler, time);
 }
 

--- a/core/MenuStyle_Valve.h
+++ b/core/MenuStyle_Valve.h
@@ -39,6 +39,8 @@
 #include "KeyValues.h"
 #include "sm_fastlink.h"
 #include <compat_wrappers.h>
+#include "logic/common_logic.h"
+#include "AutoHandleRooter.h"
 
 using namespace SourceMod;
 


### PR DESCRIPTION
Totally wrong plugins can crash SourceMod quite easily unfortunately during our menu drawing process. We maintain the pointer to the menu and still use it. During the draw process, pawn plugins can close the handle on us, resulting in a free'd handle. The solution in other areas of SM is to "root" (clone) the handle. To my knowledge, there's at least one bug on BZ related to this, along with a ton of people always hitting this when first using the menu API (including myself, ages ago).

Before:
Segmentation fault

After:
L 02/21/2015 - 20:11:40: [SM] Native "CloseHandle" reported: Handle 63e0357 is invalid (error 3)
L 02/21/2015 - 20:11:40: [SM] Displaying call stack trace for plugin "MenuCrash.smx":
L 02/21/2015 - 20:11:40: [SM]   [0]  Line 53, /groups/sourcemod/upload_tmp/textmf9SIJ.sp::crash1Handler()
L 02/21/2015 - 20:11:40: [SM] Native "CloseHandle" reported: Handle 63e0357 is invalid (error 3)
L 02/21/2015 - 20:11:40: [SM] Displaying call stack trace for plugin "MenuCrash.smx":
L 02/21/2015 - 20:11:40: [SM]   [0]  Line 53, /groups/sourcemod/upload_tmp/textmf9SIJ.sp::crash1Handler()
L 02/21/2015 - 20:11:40: [SM] Native "CloseHandle" reported: Handle 63e0357 is invalid (error 3)
L 02/21/2015 - 20:11:40: [SM] Displaying call stack trace for plugin "MenuCrash.smx":
L 02/21/2015 - 20:11:40: [SM]   [0]  Line 53, /groups/sourcemod/upload_tmp/textmf9SIJ.sp::crash1Handler()