### PR TITLE
Add Wno-error=sign-compare for gcc to Compiler.

### DIFF
--- a/sourcepawn/compiler/AMBuilder
+++ b/sourcepawn/compiler/AMBuilder
@@ -53,6 +53,7 @@ compiler.sourcedeps += packed_includes
  
 if compiler.cc.behavior == 'gcc':
   compiler.cflags += ['-Wno-format']
+  compiler.cflags += ['-Wno-error=sign-compare']
   compiler.c_only_flags += ['-std=c99']
   if builder.target_platform == 'linux':
     compiler.postlink += ['-lm']


### PR DESCRIPTION
Obviously this isn't ideal, but this should allow newer versions of g++ to successfully compile the SourceMod compiler once again.