### PR TITLE
De-singleton-ify the watchdog timer.

### DIFF
--- a/sourcepawn/jit/environment.cpp
+++ b/sourcepawn/jit/environment.cpp
@@ -15,6 +15,7 @@
 #include "watchdog_timer.h"
 #include "debug-trace.h"
 #include "api.h"
+#include "watchdog_timer.h"
 
 using namespace sp;
 using namespace SourcePawn;
@@ -26,6 +27,10 @@ Environment::Environment()
    profiler_(nullptr),
    jit_enabled_(true),
    profiling_enabled_(false)
+{
+}
+
+Environment::~Environment()
 {
 }
 
@@ -57,6 +62,7 @@ Environment::Initialize()
 {
   api_v1_ = new SourcePawnEngine();
   api_v2_ = new SourcePawnEngine2();
+  watchdog_timer_ = new WatchdogTimer();
 
   if (!g_Jit.InitializeJIT())
     return false;
@@ -67,7 +73,7 @@ Environment::Initialize()
 void
 Environment::Shutdown()
 {
-  g_WatchdogTimer.Shutdown();
+  watchdog_timer_->Shutdown();
   g_Jit.ShutdownJIT();
 }
 
@@ -86,7 +92,7 @@ Environment::DisableProfiling()
 bool
 Environment::InstallWatchdogTimer(int timeout_ms)
 {
-  return g_WatchdogTimer.Initialize(timeout_ms);
+  return watchdog_timer_->Initialize(timeout_ms);
 }
 
 ISourcePawnEngine *

--- a/sourcepawn/jit/environment.h
+++ b/sourcepawn/jit/environment.h
@@ -22,6 +22,8 @@ namespace sp {
 
 using namespace SourcePawn;
 
+class WatchdogTimer;
+
 // An Environment encapsulates everything that's needed to load and run
 // instances of plugins on a single thread. There can be at most one
 // environment per thread.
@@ -32,6 +34,7 @@ class Environment : public ISourcePawnEnvironment
 {
  public:
   Environment();
+  ~Environment();
 
   static Environment *New();
 
@@ -77,12 +80,17 @@ class Environment : public ISourcePawnEnvironment
     return debugger_;
   }
 
+  WatchdogTimer *watchdog() const {
+    return watchdog_timer_;
+  }
+
  private:
   bool Initialize();
 
  private:
   ke::AutoPtr<ISourcePawnEngine> api_v1_;
   ke::AutoPtr<ISourcePawnEngine2> api_v2_;
+  ke::AutoPtr<WatchdogTimer> watchdog_timer_;
 
   IDebugListener *debugger_;
   IProfilingTool *profiler_;

--- a/sourcepawn/jit/interpreter.cpp
+++ b/sourcepawn/jit/interpreter.cpp
@@ -19,6 +19,7 @@
 #include "interpreter.h"
 #include "opcodes.h"
 #include "watchdog_timer.h"
+#include "environment.h"
 
 #define STACK_MARGIN 64
 
@@ -67,7 +68,7 @@ JumpTarget(const sp_plugin_t *plugin, sp_context_t *ctx, cell_t *cip, bool cond)
   }
 
   cell_t *next = reinterpret_cast<cell_t *>(plugin->pcode + target);
-  if (next < cip && !g_WatchdogTimer.HandleInterrupt()) {
+  if (next < cip && !Environment::get()->watchdog()->HandleInterrupt()) {
     ctx->err = SP_ERROR_TIMEOUT;
     return NULL;
   }

--- a/sourcepawn/jit/sp_vm_basecontext.cpp
+++ b/sourcepawn/jit/sp_vm_basecontext.cpp
@@ -529,7 +529,7 @@ BaseContext::Execute2(IPluginFunction *function, const cell_t *params, unsigned 
 
   EnterProfileScope profileScope("SourcePawn", "EnterJIT");
 
-  if (!g_WatchdogTimer.HandleInterrupt())
+  if (!Environment::get()->watchdog()->HandleInterrupt())
     return SP_ERROR_TIMEOUT;
 
   funcid_t fnid = function->GetFunctionID();
@@ -631,7 +631,7 @@ BaseContext::Execute2(IPluginFunction *function, const cell_t *params, unsigned 
   }
 
   if (ir == SP_ERROR_TIMEOUT)
-    g_WatchdogTimer.NotifyTimeoutReceived();
+    Environment::get()->watchdog()->NotifyTimeoutReceived();
 
   if (ir != SP_ERROR_NONE)
     Environment::get()->ReportError(m_pRuntime, ir, m_MsgCache, save_rp);

--- a/sourcepawn/jit/watchdog_timer.cpp
+++ b/sourcepawn/jit/watchdog_timer.cpp
@@ -18,8 +18,6 @@
 #include "x86/jit_x86.h"
 #include <string.h>
 
-WatchdogTimer g_WatchdogTimer;
-
 WatchdogTimer::WatchdogTimer()
   : terminate_(false),
     mainthread_(ke::GetCurrentThreadId()),

--- a/sourcepawn/jit/watchdog_timer.h
+++ b/sourcepawn/jit/watchdog_timer.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <am-thread-utils.h>
 
+namespace sp {
+
 typedef bool (*WatchdogCallback)();
 
 class WatchdogTimer : public ke::IRunnable
@@ -56,6 +58,6 @@ class WatchdogTimer : public ke::IRunnable
   bool timedout_;
 };
 
-extern WatchdogTimer g_WatchdogTimer;
+} // namespace sp
 
 #endif // _include_sourcepawn_watchdog_timer_posix_h_

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -37,6 +37,7 @@
 #include "../sp_vm_basecontext.h"
 #include "watchdog_timer.h"
 #include "interpreter.h"
+#include "environment.h"
 
 using namespace sp;
 using namespace Knight;
@@ -274,7 +275,7 @@ CompileFromThunk(PluginRuntime *runtime, cell_t pcode_offs, void **addrp, char *
   // If the watchdog timer has declared a timeout, we must process it now,
   // and possibly refuse to compile, since otherwise we will compile a
   // function that is not patched for timeouts.
-  if (!g_WatchdogTimer.HandleInterrupt())
+  if (!Environment::get()->watchdog()->HandleInterrupt())
     return SP_ERROR_TIMEOUT;
 
   CompiledFunction *fn = runtime->GetJittedFunctionByOffset(pcode_offs);


### PR DESCRIPTION
Remove the watchdog singleton and tie it to an Environment instead. There should probably be only one watchdog timer in theory (no matter the number of environments), but right now the environment count is fixed to 1.