### PR TITLE
Remove sp_context_t.

### DIFF
--- a/sourcepawn/jit/AMBuilder
+++ b/sourcepawn/jit/AMBuilder
@@ -18,7 +18,10 @@ def setup(binary):
   compiler = binary.compiler
   compiler.includes += Includes
   if compiler.vendor == 'gcc' or compiler.vendor == 'clang':
-    compiler.cxxflags += ['-fno-rtti']
+    compiler.cxxflags += [
+      '-fno-rtti',
+      '-Wno-invalid-offsetof',
+    ]
   elif binary.compiler.vendor == 'msvc':
     compiler.cxxflags += ['/GR-']
  

--- a/sourcepawn/jit/code-stubs.h
+++ b/sourcepawn/jit/code-stubs.h
@@ -16,13 +16,13 @@
 #include <stdint.h>
 #include <sp_vm_api.h>
 
-typedef struct sp_context_s sp_context_t;
+class PluginContext;
 
 namespace sp {
 
 class Environment;
 
-typedef int (*InvokeStubFn)(sp_context_t *ctx, uint8_t *memory, void *code);
+typedef int (*InvokeStubFn)(PluginContext *cx, void *code, cell_t *rval);
 
 class CodeStubs
 {

--- a/sourcepawn/jit/debug-trace.cpp
+++ b/sourcepawn/jit/debug-trace.cpp
@@ -105,7 +105,7 @@ CContextTrace::GetTraceInfo(CallStackInfo *trace)
 const char *
 CContextTrace::GetLastNative(uint32_t *index)
 {
-  if (m_ctx->n_err == SP_ERROR_NONE)
+  if (context_->GetLastNativeError() == SP_ERROR_NONE)
     return NULL;
 
   int lastNative = context_->lastNative();

--- a/sourcepawn/jit/debug-trace.cpp
+++ b/sourcepawn/jit/debug-trace.cpp
@@ -20,6 +20,7 @@ using namespace SourcePawn;
 
 CContextTrace::CContextTrace(PluginRuntime *pRuntime, int err, const char *errstr, cell_t start_rp) 
  : m_pRuntime(pRuntime),
+   context_(pRuntime->GetBaseContext()),
    m_Error(err),
    m_pMsg(errstr),
    m_StartRp(start_rp),
@@ -66,20 +67,18 @@ CContextTrace::GetTraceInfo(CallStackInfo *trace)
 
   if (m_Level == 0) {
     cip = m_ctx->cip;
-  } else if (m_ctx->rp > 0) {
+  } else if (context_->rp() > 0) {
     /* Entries go from ctx.rp - 1 to m_StartRp */
     cell_t offs, start, end;
 
     offs = m_Level - 1;
-    start = m_ctx->rp - 1;
+    start = context_->rp() - 1;
     end = m_StartRp;
 
     if (start - offs < end)
-    {
       return false;
-    }
 
-    cip = m_ctx->rstk_cips[start - offs];
+    cip = context_->getReturnStackCip(start - offs);
   } else {
     return false;
   }

--- a/sourcepawn/jit/debug-trace.cpp
+++ b/sourcepawn/jit/debug-trace.cpp
@@ -108,12 +108,16 @@ CContextTrace::GetLastNative(uint32_t *index)
   if (m_ctx->n_err == SP_ERROR_NONE)
     return NULL;
 
+  int lastNative = context_->lastNative();
+  if (lastNative < 0)
+    return NULL;
+
   sp_native_t *native;
-  if (m_pRuntime->GetNativeByIndex(m_ctx->n_idx, &native) != SP_ERROR_NONE)
+  if (m_pRuntime->GetNativeByIndex(lastNative, &native) != SP_ERROR_NONE)
     return NULL;
 
   if (index)
-    *index = m_ctx->n_idx;
+    *index = lastNative;
 
   return native->name;
 }

--- a/sourcepawn/jit/debug-trace.cpp
+++ b/sourcepawn/jit/debug-trace.cpp
@@ -66,7 +66,7 @@ CContextTrace::GetTraceInfo(CallStackInfo *trace)
   cell_t cip;
 
   if (m_Level == 0) {
-    cip = m_ctx->cip;
+    cip = context_->cip();
   } else if (context_->rp() > 0) {
     /* Entries go from ctx.rp - 1 to m_StartRp */
     cell_t offs, start, end;

--- a/sourcepawn/jit/debug-trace.cpp
+++ b/sourcepawn/jit/debug-trace.cpp
@@ -26,7 +26,6 @@ CContextTrace::CContextTrace(PluginRuntime *pRuntime, int err, const char *errst
    m_StartRp(start_rp),
    m_Level(0)
 {
-  m_ctx = pRuntime->m_pCtx->GetCtx();
   m_pDebug = m_pRuntime->GetDebugInfo();
 }
 

--- a/sourcepawn/jit/debug-trace.h
+++ b/sourcepawn/jit/debug-trace.h
@@ -16,6 +16,7 @@
 #include <sp_vm_api.h>
 
 class PluginRuntime;
+class PluginContext;
 
 namespace sp {
 
@@ -37,6 +38,7 @@ class CContextTrace : public IContextTrace
 
  private:
   PluginRuntime *m_pRuntime;
+  PluginContext *context_;
   sp_context_t *m_ctx;
   int m_Error;
   const char *m_pMsg;

--- a/sourcepawn/jit/debug-trace.h
+++ b/sourcepawn/jit/debug-trace.h
@@ -39,7 +39,6 @@ class CContextTrace : public IContextTrace
  private:
   PluginRuntime *m_pRuntime;
   PluginContext *context_;
-  sp_context_t *m_ctx;
   int m_Error;
   const char *m_pMsg;
   cell_t m_StartRp;

--- a/sourcepawn/jit/environment.cpp
+++ b/sourcepawn/jit/environment.cpp
@@ -238,10 +238,11 @@ Environment::UnpatchAllJumpsFromTimeout()
 int
 Environment::Invoke(PluginRuntime *runtime, CompiledFunction *fn, cell_t *result)
 {
-  sp_context_t *ctx = runtime->GetBaseContext()->GetCtx();
+  PluginContext *cx = runtime->GetBaseContext();
+  sp_context_t *ctx = cx->GetCtx();
 
   // Note that cip, hp, sp are saved and restored by Execute2().
-  ctx->cip = fn->GetCodeOffset();
+  *cx->addressOfCip() = fn->GetCodeOffset();
 
   InvokeStubFn invoke = code_stubs_->InvokeStub();
 

--- a/sourcepawn/jit/environment.cpp
+++ b/sourcepawn/jit/environment.cpp
@@ -239,7 +239,6 @@ int
 Environment::Invoke(PluginRuntime *runtime, CompiledFunction *fn, cell_t *result)
 {
   PluginContext *cx = runtime->GetBaseContext();
-  sp_context_t *ctx = cx->GetCtx();
 
   // Note that cip, hp, sp are saved and restored by Execute2().
   *cx->addressOfCip() = fn->GetCodeOffset();
@@ -247,9 +246,8 @@ Environment::Invoke(PluginRuntime *runtime, CompiledFunction *fn, cell_t *result
   InvokeStubFn invoke = code_stubs_->InvokeStub();
 
   EnterInvoke();
-  int err = invoke(ctx, runtime->plugin()->memory, fn->GetEntryAddress());
+  int err = invoke(cx, fn->GetEntryAddress(), result);
   LeaveInvoke();
 
-  *result = ctx->rval;
   return err;
 }

--- a/sourcepawn/jit/interpreter.cpp
+++ b/sourcepawn/jit/interpreter.cpp
@@ -137,12 +137,13 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
   // the stack unwinding code.
   cell_t orig_frm = cx->frm();
 
+  cell_t &frm = *cx->addressOfFrm();
+  cell_t &sp = *cx->addressOfSp();
+
   cell_t pri = 0;
   cell_t alt = 0;
   cell_t *cip = code + (aCodeStart / 4);
-  cell_t *stk = reinterpret_cast<cell_t *>(plugin->memory + ctx->sp);
-
-  cell_t &frm = *cx->addressOfFrm();
+  cell_t *stk = reinterpret_cast<cell_t *>(plugin->memory + sp);
 
   for (;;) {
     if (cip >= codeend) {
@@ -808,11 +809,11 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
           goto error;
         }
         *cx->addressOfCip() = offset;
-        ctx->sp = uintptr_t(stk) - uintptr_t(plugin->memory);
+        sp = uintptr_t(stk) - uintptr_t(plugin->memory);
 
         int err = Interpret(rt, offset, &pri);
 
-        stk = reinterpret_cast<cell_t *>(plugin->memory + ctx->sp);
+        stk = reinterpret_cast<cell_t *>(plugin->memory + sp);
         *cx->addressOfCip() = rcip;
         cx->popReturnCip();
 
@@ -848,7 +849,7 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
           *--stk = num_params;
         }
 
-        ctx->sp = uintptr_t(stk) - uintptr_t(plugin->memory);
+        sp = uintptr_t(stk) - uintptr_t(plugin->memory);
         pri = cx->invokeNative(native_index, stk);
         if (cx->GetLastNativeError() != SP_ERROR_NONE) {
           err = cx->GetLastNativeError();
@@ -892,7 +893,7 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
 
  done:
   assert(orig_frm == frm);
-  ctx->sp = uintptr_t(stk) - uintptr_t(plugin->memory);
+  sp = uintptr_t(stk) - uintptr_t(plugin->memory);
   return err;
 
  error:

--- a/sourcepawn/jit/interpreter.cpp
+++ b/sourcepawn/jit/interpreter.cpp
@@ -45,7 +45,7 @@ Write(const sp_plugin_t *plugin, cell_t offset, cell_t value)
 }
 
 static inline cell_t *
-Jump(const sp_plugin_t *plugin, sp_context_t *ctx, cell_t target)
+Jump(const sp_plugin_t *plugin, cell_t target)
 {
   if (!IsValidOffset(target) || uint32_t(target) >= plugin->pcode_size)
     return NULL;
@@ -53,7 +53,7 @@ Jump(const sp_plugin_t *plugin, sp_context_t *ctx, cell_t target)
 }
 
 static inline cell_t *
-JumpTarget(const sp_plugin_t *plugin, sp_context_t *ctx, cell_t *cip, bool cond, int *errp)
+JumpTarget(const sp_plugin_t *plugin, cell_t *cip, bool cond, int *errp)
 {
   if (!cond)
     return cip + 1;
@@ -84,7 +84,6 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
     return SP_ERROR_INVALID_INSTRUCTION;
 
   PluginContext *cx = rt->GetBaseContext();
-  sp_context_t *ctx = cx->GetCtx();
 
   int err = SP_ERROR_NONE;
 
@@ -675,41 +674,41 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
       }
 
       case OP_JUMP:
-        if ((cip = JumpTarget(plugin, ctx, cip, true, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, true, &err)) == NULL)
           goto error;
         break;
 
       case OP_JZER:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri == 0, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri == 0, &err)) == NULL)
           goto error;
         break;
       case OP_JNZ:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri != 0, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri != 0, &err)) == NULL)
           goto error;
         break;
 
       case OP_JEQ:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri == alt, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri == alt, &err)) == NULL)
           goto error;
         break;
       case OP_JNEQ:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri != alt, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri != alt, &err)) == NULL)
           goto error;
         break;
       case OP_JSLESS:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri < alt, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri < alt, &err)) == NULL)
           goto error;
         break;
       case OP_JSLEQ:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri <= alt, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri <= alt, &err)) == NULL)
           goto error;
         break;
       case OP_JSGRTR:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri > alt, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri > alt, &err)) == NULL)
           goto error;
         break;
       case OP_JSGEQ:
-        if ((cip = JumpTarget(plugin, ctx, cip, pri >= alt, &err)) == NULL)
+        if ((cip = JumpTarget(plugin, cip, pri >= alt, &err)) == NULL)
           goto error;
         break;
 
@@ -831,7 +830,7 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
           }
         }
 
-        if ((cip = Jump(plugin, ctx, target)) == NULL) {
+        if ((cip = Jump(plugin, target)) == NULL) {
           err = SP_ERROR_INVALID_INSTRUCTION;
           goto error;
         }

--- a/sourcepawn/jit/interpreter.cpp
+++ b/sourcepawn/jit/interpreter.cpp
@@ -777,7 +777,7 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
       }
 
       case OP_BREAK:
-        ctx->cip = uintptr_t(cip - 1) - uintptr_t(plugin->pcode);
+        *cx->addressOfCip() = uintptr_t(cip - 1) - uintptr_t(plugin->pcode);
         break;
 
       case OP_BOUNDS:
@@ -805,13 +805,13 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
           err = SP_ERROR_STACKLOW;
           goto error;
         }
-        ctx->cip = offset;
+        *cx->addressOfCip() = offset;
         ctx->sp = uintptr_t(stk) - uintptr_t(plugin->memory);
 
         int err = Interpret(rt, offset, &pri);
 
         stk = reinterpret_cast<cell_t *>(plugin->memory + ctx->sp);
-        ctx->cip = rcip;
+        *cx->addressOfCip() = rcip;
         cx->popReturnCip();
 
         if (err != SP_ERROR_NONE)

--- a/sourcepawn/jit/interpreter.cpp
+++ b/sourcepawn/jit/interpreter.cpp
@@ -842,8 +842,8 @@ Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval)
 
         ctx->sp = uintptr_t(stk) - uintptr_t(plugin->memory);
         pri = cx->invokeNative(native_index, stk);
-        if (ctx->n_err != SP_ERROR_NONE) {
-          ctx->err = ctx->n_err;
+        if (cx->GetLastNativeError() != SP_ERROR_NONE) {
+          ctx->err = cx->GetLastNativeError();
           goto error;
         }
 

--- a/sourcepawn/jit/interpreter.h
+++ b/sourcepawn/jit/interpreter.h
@@ -22,19 +22,10 @@
 #include "plugin-runtime.h"
 #include "plugin-context.h"
 
-struct tracker_t
-{
-  size_t size; 
-  ucell_t *pBase; 
-  ucell_t *pCur;
-};
-
 int Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval);
 
 int GenerateFullArray(PluginRuntime *rt, uint32_t argc, cell_t *argv, int autozero);
 cell_t NativeCallback(sp_context_t *ctx, ucell_t native_idx, cell_t *params);
 cell_t BoundNativeCallback(sp_context_t *ctx, SPVM_NATIVE_FUNC pfn, cell_t *params);
-int PopTrackerAndSetHeap(PluginRuntime *rt);
-int PushTracker(sp_context_t *ctx, size_t amount);
 
 #endif // _include_sourcepawn_interpreter_h_

--- a/sourcepawn/jit/interpreter.h
+++ b/sourcepawn/jit/interpreter.h
@@ -25,7 +25,6 @@
 int Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval);
 
 int GenerateFullArray(PluginRuntime *rt, uint32_t argc, cell_t *argv, int autozero);
-cell_t NativeCallback(sp_context_t *ctx, ucell_t native_idx, cell_t *params);
 cell_t BoundNativeCallback(sp_context_t *ctx, SPVM_NATIVE_FUNC pfn, cell_t *params);
 
 #endif // _include_sourcepawn_interpreter_h_

--- a/sourcepawn/jit/interpreter.h
+++ b/sourcepawn/jit/interpreter.h
@@ -24,7 +24,4 @@
 
 int Interpret(PluginRuntime *rt, uint32_t aCodeStart, cell_t *rval);
 
-int GenerateFullArray(PluginRuntime *rt, uint32_t argc, cell_t *argv, int autozero);
-cell_t BoundNativeCallback(sp_context_t *ctx, SPVM_NATIVE_FUNC pfn, cell_t *params);
-
 #endif // _include_sourcepawn_interpreter_h_

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -76,7 +76,6 @@ typedef struct sp_context_s
 	cell_t			sp;				/**< Stack pointer */
 	cell_t			frm;			/**< Frame pointer */
 	cell_t			rval;			/**< Return value from InvokeFunction() */
-	int32_t			cip;			/**< Code pointer last error occurred in */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;
 } sp_context_t;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -72,7 +72,6 @@ class PluginContext;
 
 typedef struct sp_context_s
 {
-	cell_t			rval;			/**< Return value from InvokeFunction() */
 	sp_plugin_t     *plugin;
 } sp_context_t;
 

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -85,8 +85,6 @@ typedef struct sp_context_s
 	sp_plugin_t 	*plugin;
 	PluginContext	*basecx;
 	void *			vm[8];			/**< VM-specific pointers */
-	cell_t			rp;				/**< Return stack pointer */
-	cell_t			rstk_cips[SP_MAX_RETURN_STACK];
 } sp_context_t;
 
 //#define SPFLAG_PLUGIN_DEBUG			(1<<0)

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -79,7 +79,6 @@ typedef struct sp_context_s
 	int32_t			cip;			/**< Code pointer last error occurred in */
 	int32_t			err;			/**< Error last set by interpreter */
 	int32_t			n_err;			/**< Error code set by a native */
-	uint32_t		n_idx;			/**< Current native index being executed */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;
 } sp_context_t;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -73,7 +73,6 @@ class PluginContext;
 typedef struct sp_context_s
 {
 	cell_t			hp;				/**< Heap pointer */
-	cell_t			sp;				/**< Stack pointer */
 	cell_t			rval;			/**< Return value from InvokeFunction() */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -70,10 +70,6 @@ namespace SourcePawn
 
 class PluginContext;
 
-typedef struct sp_context_s
-{
-} sp_context_t;
-
 //#define SPFLAG_PLUGIN_DEBUG			(1<<0)
 #define SPFLAG_PLUGIN_PAUSED		(1<<1)
 

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -74,7 +74,6 @@ typedef struct sp_context_s
 {
 	cell_t			rval;			/**< Return value from InvokeFunction() */
 	sp_plugin_t     *plugin;
-	PluginContext   *basecx;
 } sp_context_t;
 
 //#define SPFLAG_PLUGIN_DEBUG			(1<<0)

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -74,7 +74,6 @@ typedef struct sp_context_s
 {
 	cell_t			hp;				/**< Heap pointer */
 	cell_t			sp;				/**< Stack pointer */
-	cell_t			frm;			/**< Frame pointer */
 	cell_t			rval;			/**< Return value from InvokeFunction() */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -68,7 +68,6 @@ namespace SourcePawn
 	} sp_plugin_t;
 }
 
-struct tracker_t;
 class PluginContext;
 
 typedef struct sp_context_s
@@ -81,7 +80,6 @@ typedef struct sp_context_s
 	int32_t			err;			/**< Error last set by interpreter */
 	int32_t			n_err;			/**< Error code set by a native */
 	uint32_t		n_idx;			/**< Current native index being executed */
-	tracker_t 		*tracker;
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;
 } sp_context_t;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -72,7 +72,6 @@ class PluginContext;
 
 typedef struct sp_context_s
 {
-	cell_t			hp;				/**< Heap pointer */
 	cell_t			rval;			/**< Return value from InvokeFunction() */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -77,7 +77,6 @@ typedef struct sp_context_s
 	cell_t			frm;			/**< Frame pointer */
 	cell_t			rval;			/**< Return value from InvokeFunction() */
 	int32_t			cip;			/**< Code pointer last error occurred in */
-	int32_t			err;			/**< Error last set by interpreter */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;
 } sp_context_t;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -78,7 +78,6 @@ typedef struct sp_context_s
 	cell_t			rval;			/**< Return value from InvokeFunction() */
 	int32_t			cip;			/**< Code pointer last error occurred in */
 	int32_t			err;			/**< Error last set by interpreter */
-	int32_t			n_err;			/**< Error code set by a native */
 	sp_plugin_t     *plugin;
 	PluginContext   *basecx;
 } sp_context_t;

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -72,7 +72,6 @@ class PluginContext;
 
 typedef struct sp_context_s
 {
-	sp_plugin_t     *plugin;
 } sp_context_t;
 
 //#define SPFLAG_PLUGIN_DEBUG			(1<<0)

--- a/sourcepawn/jit/jit_shared.h
+++ b/sourcepawn/jit/jit_shared.h
@@ -82,9 +82,8 @@ typedef struct sp_context_s
 	int32_t			n_err;			/**< Error code set by a native */
 	uint32_t		n_idx;			/**< Current native index being executed */
 	tracker_t 		*tracker;
-	sp_plugin_t 	*plugin;
-	PluginContext	*basecx;
-	void *			vm[8];			/**< VM-specific pointers */
+	sp_plugin_t     *plugin;
+	PluginContext   *basecx;
 } sp_context_t;
 
 //#define SPFLAG_PLUGIN_DEBUG			(1<<0)

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -80,12 +80,6 @@ PluginContext::GetContext()
   return reinterpret_cast<sp_context_t *>((IPluginContext * )this);
 }
 
-sp_context_t *
-PluginContext::GetCtx()
-{
-  return &m_ctx;
-}
-
 bool
 PluginContext::IsDebugging()
 {

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -56,7 +56,7 @@ PluginContext::PluginContext(PluginRuntime *pRuntime)
   m_ctx.frm = m_ctx.sp;
   m_ctx.n_err = SP_ERROR_NONE;
   m_ctx.n_idx = SP_ERROR_NONE;
-  m_ctx.rp = 0;
+  rp_ = 0;
 
   m_ctx.tracker = new tracker_t;
   m_ctx.tracker->pBase = (ucell_t *)malloc(1024);
@@ -584,7 +584,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
   save_hp = m_ctx.hp;
   save_exec = m_InExec;
   save_n_idx = m_ctx.n_idx;
-  save_rp = m_ctx.rp;
+  save_rp = rp_;
   save_cip = m_ctx.cip;
 
   /* Push parameters */
@@ -628,10 +628,10 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
         m_ctx.hp, 
         save_hp);
     }
-    if (m_ctx.rp != save_rp) {
+    if (rp_ != save_rp) {
       ir = SP_ERROR_STACKLEAK;
       _SetErrorMessage("Return stack leak detected: rp:%d should be %d!",
-        m_ctx.rp,
+        rp_,
         save_rp);
     }
   }
@@ -644,7 +644,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
 
   m_ctx.sp = save_sp;
   m_ctx.hp = save_hp;
-  m_ctx.rp = save_rp;
+  rp_ = save_rp;
   
   m_ctx.cip = save_cip;
   m_ctx.n_idx = save_n_idx;

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -61,7 +61,6 @@ PluginContext::PluginContext(PluginRuntime *pRuntime)
   tracker_.pBase = (ucell_t *)malloc(1024);
   tracker_.pCur = tracker_.pBase;
   tracker_.size = 1024 / sizeof(cell_t);
-  m_ctx.plugin = const_cast<sp_plugin_t *>(pRuntime->plugin());
 }
 
 PluginContext::~PluginContext()

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -61,7 +61,6 @@ PluginContext::PluginContext(PluginRuntime *pRuntime)
   tracker_.pBase = (ucell_t *)malloc(1024);
   tracker_.pCur = tracker_.pBase;
   tracker_.size = 1024 / sizeof(cell_t);
-  m_ctx.basecx = this;
   m_ctx.plugin = const_cast<sp_plugin_t *>(pRuntime->plugin());
 }
 
@@ -867,7 +866,7 @@ PluginContext::invokeNative(ucell_t native_idx, cell_t *params)
     return 0;
   }
 
-  cell_t result = native->pfn(m_ctx.basecx, params);
+  cell_t result = native->pfn(this, params);
 
   if (native_error_ != SP_ERROR_NONE)
     return result;

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -583,7 +583,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
   save_exec = m_InExec;
   save_n_idx = last_native_;
   save_rp = rp_;
-  save_cip = m_ctx.cip;
+  save_cip = cip_;
 
   /* Push parameters */
 
@@ -644,7 +644,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
   m_ctx.hp = save_hp;
   rp_ = save_rp;
   
-  m_ctx.cip = save_cip;
+  cip_ = save_cip;
   last_native_ = save_n_idx;
   native_error_ = SP_ERROR_NONE;
   m_MsgCache[0] = '\0';

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -53,7 +53,7 @@ PluginContext::PluginContext(PluginRuntime *pRuntime)
 
   m_ctx.hp = m_pRuntime->plugin()->data_size;
   m_ctx.sp = m_pRuntime->plugin()->mem_size - sizeof(cell_t);
-  m_ctx.frm = m_ctx.sp;
+  frm_ = m_ctx.sp;
   rp_ = 0;
   last_native_ = -1;
   native_error_ = SP_ERROR_NONE;
@@ -784,7 +784,7 @@ PluginContext::GetLastNativeError()
 cell_t *
 PluginContext::GetLocalParams()
 {
-  return (cell_t *)(m_pRuntime->plugin()->memory + m_ctx.frm + (2 * sizeof(cell_t)));
+  return (cell_t *)(m_pRuntime->plugin()->memory + frm_ + (2 * sizeof(cell_t)));
 }
 
 void

--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -51,7 +51,7 @@ PluginContext::PluginContext(PluginRuntime *pRuntime)
     m_pNullString = NULL;
   }
 
-  m_ctx.hp = m_pRuntime->plugin()->data_size;
+  hp_ = m_pRuntime->plugin()->data_size;
   sp_ = m_pRuntime->plugin()->mem_size - sizeof(cell_t);
   frm_ = sp_;
   rp_ = 0;
@@ -185,21 +185,21 @@ PluginContext::HeapAlloc(unsigned int cells, cell_t *local_addr, cell_t **phys_a
   /**
    * Check if the space between the heap and stack is sufficient.
    */
-  if ((cell_t)(sp_ - m_ctx.hp - realmem) < STACKMARGIN)
+  if ((cell_t)(sp_ - hp_ - realmem) < STACKMARGIN)
     return SP_ERROR_HEAPLOW;
 
-  addr = (cell_t *)(m_pRuntime->plugin()->memory + m_ctx.hp);
+  addr = (cell_t *)(m_pRuntime->plugin()->memory + hp_);
   /* store size of allocation in cells */
   *addr = (cell_t)cells;
   addr++;
-  m_ctx.hp += sizeof(cell_t);
+  hp_ += sizeof(cell_t);
 
-  *local_addr = m_ctx.hp;
+  *local_addr = hp_;
 
   if (phys_addr)
     *phys_addr = addr;
 
-  m_ctx.hp += realmem;
+  hp_ += realmem;
 
   return SP_ERROR_NONE;
 }
@@ -218,10 +218,10 @@ PluginContext::HeapPop(cell_t local_addr)
   addr = (cell_t *)(m_pRuntime->plugin()->memory + local_addr);
   cellcount = (*addr) * sizeof(cell_t);
   /* check if this memory count looks valid */
-  if ((signed)(m_ctx.hp - cellcount - sizeof(cell_t)) != local_addr)
+  if ((signed)(hp_ - cellcount - sizeof(cell_t)) != local_addr)
     return SP_ERROR_INVALID_ADDRESS;
 
-  m_ctx.hp = local_addr;
+  hp_ = local_addr;
 
   return SP_ERROR_NONE;
 }
@@ -233,7 +233,7 @@ PluginContext::HeapRelease(cell_t local_addr)
   if (local_addr < (cell_t)m_pRuntime->plugin()->data_size)
     return SP_ERROR_INVALID_ADDRESS;
 
-  m_ctx.hp = local_addr - sizeof(cell_t);
+  hp_ = local_addr - sizeof(cell_t);
 
   return SP_ERROR_NONE;
 }
@@ -325,7 +325,7 @@ PluginContext::BindNativeToAny(SPVM_NATIVE_FUNC native)
 int
 PluginContext::LocalToPhysAddr(cell_t local_addr, cell_t **phys_addr)
 {
-  if (((local_addr >= m_ctx.hp) && (local_addr < sp_)) ||
+  if (((local_addr >= hp_) && (local_addr < sp_)) ||
       (local_addr < 0) || ((ucell_t)local_addr >= m_pRuntime->plugin()->mem_size))
   {
     return SP_ERROR_INVALID_ADDRESS;
@@ -358,7 +358,7 @@ PluginContext::PushCellArray(cell_t *local_addr, cell_t **phys_addr, cell_t arra
 int
 PluginContext::LocalToString(cell_t local_addr, char **addr)
 {
-  if (((local_addr >= m_ctx.hp) && (local_addr < sp_)) ||
+  if (((local_addr >= hp_) && (local_addr < sp_)) ||
       (local_addr < 0) || ((ucell_t)local_addr >= m_pRuntime->plugin()->mem_size))
   {
     return SP_ERROR_INVALID_ADDRESS;
@@ -380,7 +380,7 @@ PluginContext::StringToLocal(cell_t local_addr, size_t bytes, const char *source
   char *dest;
   size_t len;
 
-  if (((local_addr >= m_ctx.hp) && (local_addr < sp_)) ||
+  if (((local_addr >= hp_) && (local_addr < sp_)) ||
       (local_addr < 0) || ((ucell_t)local_addr >= m_pRuntime->plugin()->mem_size))
   {
     return SP_ERROR_INVALID_ADDRESS;
@@ -443,7 +443,7 @@ PluginContext::StringToLocalUTF8(cell_t local_addr, size_t maxbytes, const char 
   size_t len;
   bool needtocheck = false;
 
-  if (((local_addr >= m_ctx.hp) && (local_addr < sp_)) ||
+  if (((local_addr >= hp_) && (local_addr < sp_)) ||
       (local_addr < 0) ||
       ((ucell_t)local_addr >= m_pRuntime->plugin()->mem_size))
   {
@@ -548,7 +548,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
   if (m_pRuntime->IsPaused())
     return SP_ERROR_NOT_RUNNABLE;
 
-  if ((cell_t)(m_ctx.hp + 16*sizeof(cell_t)) > (cell_t)(sp_ - (sizeof(cell_t) * (num_params + 1))))
+  if ((cell_t)(hp_ + 16*sizeof(cell_t)) > (cell_t)(sp_ - (sizeof(cell_t) * (num_params + 1))))
     return SP_ERROR_STACKLOW;
 
   if (result == NULL)
@@ -579,7 +579,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
   cell_t save_sp, save_hp, save_rp, save_cip;
 
   save_sp = sp_;
-  save_hp = m_ctx.hp;
+  save_hp = hp_;
   save_exec = m_InExec;
   save_n_idx = last_native_;
   save_rp = rp_;
@@ -620,10 +620,10 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
         sp_, 
         save_sp);
     }
-    if (m_ctx.hp != save_hp) {
+    if (hp_ != save_hp) {
       ir = SP_ERROR_HEAPLEAK;
       _SetErrorMessage("Heap leak detected: hp:%d should be %d!", 
-        m_ctx.hp, 
+        hp_, 
         save_hp);
     }
     if (rp_ != save_rp) {
@@ -641,7 +641,7 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
     Environment::get()->ReportError(m_pRuntime, ir, m_MsgCache, save_rp);
 
   sp_ = save_sp;
-  m_ctx.hp = save_hp;
+  hp_ = save_hp;
   rp_ = save_rp;
   
   cip_ = save_cip;
@@ -823,10 +823,10 @@ PluginContext::popTrackerAndSetHeap()
     return SP_ERROR_TRACKER_BOUNDS;
 
   ucell_t amt = *tracker_.pCur;
-  if (amt > (m_ctx.hp - m_pRuntime->plugin()->data_size))
+  if (amt > (hp_ - m_pRuntime->plugin()->data_size))
     return SP_ERROR_HEAPMIN;
 
-  m_ctx.hp -= amt;
+  hp_ -= amt;
   return SP_ERROR_NONE;
 }
 
@@ -855,7 +855,7 @@ cell_t
 PluginContext::invokeNative(ucell_t native_idx, cell_t *params)
 {
   cell_t save_sp = sp_;
-  cell_t save_hp = m_ctx.hp;
+  cell_t save_hp = hp_;
 
   // Note: Invoke() saves the last native, so we don't need to here.
   last_native_ = native_idx;
@@ -876,7 +876,7 @@ PluginContext::invokeNative(ucell_t native_idx, cell_t *params)
     native_error_ = SP_ERROR_STACKLEAK;
     return result;
   }
-  if (save_hp != m_ctx.hp) {
+  if (save_hp != hp_) {
     native_error_ = SP_ERROR_HEAPLEAK;
     return result;
   }
@@ -888,7 +888,7 @@ cell_t
 PluginContext::invokeBoundNative(SPVM_NATIVE_FUNC pfn, cell_t *params)
 {
   cell_t save_sp = sp_;
-  cell_t save_hp = m_ctx.hp;
+  cell_t save_hp = hp_;
 
   cell_t result = pfn(this, params);
 
@@ -899,10 +899,161 @@ PluginContext::invokeBoundNative(SPVM_NATIVE_FUNC pfn, cell_t *params)
     native_error_ = SP_ERROR_STACKLEAK;
     return result;
   }
-  if (save_hp != m_ctx.hp) {
+  if (save_hp != hp_) {
     native_error_ = SP_ERROR_HEAPLEAK;
     return result;
   }
 
   return result;
 }
+
+struct array_creation_t
+{
+  const cell_t *dim_list;     /* Dimension sizes */
+  cell_t dim_count;           /* Number of dimensions */
+  cell_t *data_offs;          /* Current offset AFTER the indirection vectors (data) */
+  cell_t *base;               /* array base */
+};
+
+static cell_t
+GenerateInnerArrayIndirectionVectors(array_creation_t *ar, int dim, cell_t cur_offs)
+{
+  cell_t write_offs = cur_offs;
+  cell_t *data_offs = ar->data_offs;
+
+  cur_offs += ar->dim_list[dim];
+
+  // Dimension n-x where x > 2 will have sub-vectors.  
+  // Otherwise, we just need to reference the data section.
+  if (ar->dim_count > 2 && dim < ar->dim_count - 2) {
+    // For each index at this dimension, write offstes to our sub-vectors.
+    // After we write one sub-vector, we generate its sub-vectors recursively.
+    // At the end, we're given the next offset we can use.
+    for (int i = 0; i < ar->dim_list[dim]; i++) {
+      ar->base[write_offs] = (cur_offs - write_offs) * sizeof(cell_t);
+      write_offs++;
+      cur_offs = GenerateInnerArrayIndirectionVectors(ar, dim + 1, cur_offs);
+    }
+  } else {
+    // In this section, there are no sub-vectors, we need to write offsets 
+    // to the data.  This is separate so the data stays in one big chunk.
+    // The data offset will increment by the size of the last dimension, 
+    // because that is where the data is finally computed as. 
+    for (int i = 0; i < ar->dim_list[dim]; i++) {
+      ar->base[write_offs] = (*data_offs - write_offs) * sizeof(cell_t);
+      write_offs++;
+      *data_offs = *data_offs + ar->dim_list[dim + 1];
+    }
+  }
+
+  return cur_offs;
+}
+
+static cell_t
+calc_indirection(const array_creation_t *ar, cell_t dim)
+{
+  cell_t size = ar->dim_list[dim];
+  if (dim < ar->dim_count - 2)
+    size += ar->dim_list[dim] * calc_indirection(ar, dim + 1);
+  return size;
+}
+
+static cell_t
+GenerateArrayIndirectionVectors(cell_t *arraybase, cell_t dims[], cell_t _dimcount, bool autozero)
+{
+  array_creation_t ar;
+  cell_t data_offs;
+
+  /* Reverse the dimensions */
+  cell_t dim_list[sDIMEN_MAX];
+  int cur_dim = 0;
+  for (int i = _dimcount - 1; i >= 0; i--)
+    dim_list[cur_dim++] = dims[i];
+  
+  ar.base = arraybase;
+  ar.dim_list = dim_list;
+  ar.dim_count = _dimcount;
+  ar.data_offs = &data_offs;
+
+  data_offs = calc_indirection(&ar, 0);
+  GenerateInnerArrayIndirectionVectors(&ar, 0, 0);
+  return data_offs;
+}
+
+int
+PluginContext::generateFullArray(uint32_t argc, cell_t *argv, int autozero)
+{
+  // Calculate how many cells are needed.
+  if (argv[0] <= 0)
+    return SP_ERROR_ARRAY_TOO_BIG;
+
+  uint32_t cells = argv[0];
+
+  for (uint32_t dim = 1; dim < argc; dim++) {
+    cell_t dimsize = argv[dim];
+    if (dimsize <= 0)
+      return SP_ERROR_ARRAY_TOO_BIG;
+    if (!ke::IsUint32MultiplySafe(cells, dimsize))
+      return SP_ERROR_ARRAY_TOO_BIG;
+    cells *= uint32_t(dimsize);
+    if (!ke::IsUint32AddSafe(cells, dimsize))
+      return SP_ERROR_ARRAY_TOO_BIG;
+    cells += uint32_t(dimsize);
+  }
+
+  if (!ke::IsUint32MultiplySafe(cells, 4))
+    return SP_ERROR_ARRAY_TOO_BIG;
+
+  uint32_t bytes = cells * 4;
+  if (!ke::IsUint32AddSafe(hp_, bytes))
+    return SP_ERROR_ARRAY_TOO_BIG;
+
+  uint32_t new_hp = hp_ + bytes;
+  cell_t *dat_hp = reinterpret_cast<cell_t *>(m_pRuntime->plugin()->memory + new_hp);
+
+  // argv, coincidentally, is STK.
+  if (dat_hp >= argv - STACK_MARGIN)
+    return SP_ERROR_HEAPLOW;
+
+  if (int err = pushTracker(bytes))
+    return err;
+
+  cell_t *base = reinterpret_cast<cell_t *>(m_pRuntime->plugin()->memory + hp_);
+  cell_t offs = GenerateArrayIndirectionVectors(base, argv, argc, !!autozero);
+  assert(size_t(offs) == cells);
+
+  argv[argc - 1] = hp_;
+  hp_ = new_hp;
+  return SP_ERROR_NONE;
+}
+
+int
+PluginContext::generateArray(cell_t dims, cell_t *stk, bool autozero)
+{
+  if (dims == 1) {
+    uint32_t size = *stk;
+    if (size == 0 || !ke::IsUint32MultiplySafe(size, 4))
+      return SP_ERROR_ARRAY_TOO_BIG;
+    *stk = hp_;
+
+    uint32_t bytes = size * 4;
+
+    hp_ += bytes;
+    if (uintptr_t(m_pRuntime->plugin()->memory + hp_) >= uintptr_t(stk))
+      return SP_ERROR_HEAPLOW;
+
+    if (int err = pushTracker(bytes))
+      return err;
+
+    if (autozero)
+      memset(m_pRuntime->plugin()->memory + hp_, 0, bytes);
+
+    return SP_ERROR_NONE;
+  }
+
+  if (int err = generateFullArray(dims, stk, autozero))
+    return err;
+
+  return SP_ERROR_NONE;
+}
+

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -97,7 +97,11 @@ class PluginContext : public IPluginContext
   static inline size_t offsetOfTracker() {
     return offsetof(PluginContext, tracker_);
   }
+  static inline size_t offsetOfLastNative() {
+    return offsetof(PluginContext, last_native_);
+  }
 
+  // Return stack logic.
   bool pushReturnCip(cell_t cip) {
     if (rp_ >= SP_MAX_RETURN_STACK)
       return false;
@@ -118,6 +122,12 @@ class PluginContext : public IPluginContext
 
   int popTrackerAndSetHeap();
   int pushTracker(uint32_t amount);
+
+  cell_t invokeNative(ucell_t native_idx, cell_t *params);
+  cell_t invokeBoundNative(SPVM_NATIVE_FUNC pfn, cell_t *params);
+  int lastNative() const {
+    return last_native_;
+  }
 
  private:
   void SetErrorMessage(const char *msg, va_list ap);
@@ -140,6 +150,9 @@ class PluginContext : public IPluginContext
   // Return stack.
   cell_t rp_;
   cell_t rstk_cips_[SP_MAX_RETURN_STACK];
+
+  // Track the currently executing native index.
+  uint32_t last_native_;
 };
 
 #endif //_INCLUDE_SOURCEPAWN_BASECONTEXT_H_

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -103,9 +103,18 @@ class PluginContext : public IPluginContext
   static inline size_t offsetOfNativeError() {
     return offsetof(PluginContext, native_error_);
   }
+  static inline size_t offsetOfSp() {
+    return offsetof(PluginContext, sp_);
+  }
+  static inline size_t offsetOfRuntime() {
+    return offsetof(PluginContext, m_pRuntime);
+  }
 
   int32_t *addressOfCip() {
     return &cip_;
+  }
+  int32_t *addressOfSp() {
+    return &sp_;
   }
   cell_t *addressOfFrm() {
     return &frm_;
@@ -175,7 +184,8 @@ class PluginContext : public IPluginContext
   // Most recent CIP.
   int32_t cip_;
 
-  // Frame pointer.
+  // Stack and frame pointer.
+  cell_t sp_;
   cell_t frm_;
 };
 

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -18,6 +18,18 @@
 #include "plugin-runtime.h"
 #include "jit_shared.h"
 
+struct HeapTracker
+{
+  HeapTracker()
+   : size(0),
+     pBase(nullptr),
+     pCur(nullptr)
+  {}
+  size_t size; 
+  ucell_t *pBase; 
+  ucell_t *pCur;
+};
+
 class PluginContext : public IPluginContext
 {
  public:
@@ -82,6 +94,9 @@ class PluginContext : public IPluginContext
   static inline size_t offsetOfRstkCips() {
     return offsetof(PluginContext, rstk_cips_);
   }
+  static inline size_t offsetOfTracker() {
+    return offsetof(PluginContext, tracker_);
+  }
 
   bool pushReturnCip(cell_t cip) {
     if (rp_ >= SP_MAX_RETURN_STACK)
@@ -101,6 +116,9 @@ class PluginContext : public IPluginContext
     return rstk_cips_[index];
   }
 
+  int popTrackerAndSetHeap();
+  int pushTracker(uint32_t amount);
+
  private:
   void SetErrorMessage(const char *msg, va_list ap);
   void _SetErrorMessage(const char *msg, ...);
@@ -115,6 +133,9 @@ class PluginContext : public IPluginContext
   sp_context_t m_ctx;
   void *m_keys[4];
   bool m_keys_set[4];
+
+  // Tracker for local HEA growth.
+  HeapTracker tracker_;
 
   // Return stack.
   cell_t rp_;

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -100,6 +100,9 @@ class PluginContext : public IPluginContext
   static inline size_t offsetOfLastNative() {
     return offsetof(PluginContext, last_native_);
   }
+  static inline size_t offsetOfNativeError() {
+    return offsetof(PluginContext, native_error_);
+  }
 
   // Return stack logic.
   bool pushReturnCip(cell_t cip) {
@@ -151,8 +154,9 @@ class PluginContext : public IPluginContext
   cell_t rp_;
   cell_t rstk_cips_[SP_MAX_RETURN_STACK];
 
-  // Track the currently executing native index.
-  uint32_t last_native_;
+  // Track the currently executing native index, and any error it throws.
+  int32_t last_native_;
+  int native_error_;
 };
 
 #endif //_INCLUDE_SOURCEPAWN_BASECONTEXT_H_

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -76,6 +76,31 @@ class PluginContext : public IPluginContext
  public:
   bool IsInExec();
 
+  static inline size_t offsetOfRp() {
+    return offsetof(PluginContext, rp_);
+  }
+  static inline size_t offsetOfRstkCips() {
+    return offsetof(PluginContext, rstk_cips_);
+  }
+
+  bool pushReturnCip(cell_t cip) {
+    if (rp_ >= SP_MAX_RETURN_STACK)
+      return false;
+    rstk_cips_[rp_++] = cip;
+    return true;
+  }
+  void popReturnCip() {
+    assert(rp_ > 0);
+    rp_--;
+  }
+  cell_t rp() const {
+    return rp_;
+  }
+  cell_t getReturnStackCip(int index) {
+    assert(index >= 0 && index < SP_MAX_RETURN_STACK);
+    return rstk_cips_[index];
+  }
+
  private:
   void SetErrorMessage(const char *msg, va_list ap);
   void _SetErrorMessage(const char *msg, ...);
@@ -90,6 +115,10 @@ class PluginContext : public IPluginContext
   sp_context_t m_ctx;
   void *m_keys[4];
   bool m_keys_set[4];
+
+  // Return stack.
+  cell_t rp_;
+  cell_t rstk_cips_[SP_MAX_RETURN_STACK];
 };
 
 #endif //_INCLUDE_SOURCEPAWN_BASECONTEXT_H_

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -104,6 +104,13 @@ class PluginContext : public IPluginContext
     return offsetof(PluginContext, native_error_);
   }
 
+  int32_t *addressOfCip() {
+    return &cip_;
+  }
+  int32_t cip() const {
+    return cip_;
+  }
+
   // Return stack logic.
   bool pushReturnCip(cell_t cip) {
     if (rp_ >= SP_MAX_RETURN_STACK)
@@ -157,6 +164,9 @@ class PluginContext : public IPluginContext
   // Track the currently executing native index, and any error it throws.
   int32_t last_native_;
   int native_error_;
+
+  // Most recent CIP.
+  int32_t cip_;
 };
 
 #endif //_INCLUDE_SOURCEPAWN_BASECONTEXT_H_

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -107,8 +107,15 @@ class PluginContext : public IPluginContext
   int32_t *addressOfCip() {
     return &cip_;
   }
+  cell_t *addressOfFrm() {
+    return &frm_;
+  }
+
   int32_t cip() const {
     return cip_;
+  }
+  cell_t frm() const {
+    return frm_;
   }
 
   // Return stack logic.
@@ -167,6 +174,9 @@ class PluginContext : public IPluginContext
 
   // Most recent CIP.
   int32_t cip_;
+
+  // Frame pointer.
+  cell_t frm_;
 };
 
 #endif //_INCLUDE_SOURCEPAWN_BASECONTEXT_H_

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -119,12 +119,18 @@ class PluginContext : public IPluginContext
   cell_t *addressOfFrm() {
     return &frm_;
   }
+  cell_t *addressOfHp() {
+    return &hp_;
+  }
 
   int32_t cip() const {
     return cip_;
   }
   cell_t frm() const {
     return frm_;
+  }
+  cell_t hp() const {
+    return hp_;
   }
 
   // Return stack logic.
@@ -149,10 +155,25 @@ class PluginContext : public IPluginContext
   int popTrackerAndSetHeap();
   int pushTracker(uint32_t amount);
 
+  int generateArray(cell_t dims, cell_t *stk, bool autozero);
+  int generateFullArray(uint32_t argc, cell_t *argv, int autozero);
   cell_t invokeNative(ucell_t native_idx, cell_t *params);
   cell_t invokeBoundNative(SPVM_NATIVE_FUNC pfn, cell_t *params);
   int lastNative() const {
     return last_native_;
+  }
+
+  inline bool checkAddress(cell_t *stk, cell_t addr) {
+    if (uint32_t(addr) >= m_pRuntime->plugin()->mem_size)
+      return false;
+
+    if (addr < hp_)
+      return true;
+
+    if (reinterpret_cast<cell_t *>(m_pRuntime->plugin()->memory + addr) < stk)
+      return false;
+
+    return true;
   }
 
  private:
@@ -184,8 +205,9 @@ class PluginContext : public IPluginContext
   // Most recent CIP.
   int32_t cip_;
 
-  // Stack and frame pointer.
+  // Stack, heap, and frame pointer.
   cell_t sp_;
+  cell_t hp_;
   cell_t frm_;
 };
 

--- a/sourcepawn/jit/plugin-context.h
+++ b/sourcepawn/jit/plugin-context.h
@@ -39,7 +39,6 @@ class PluginContext : public IPluginContext
  public: //IPluginContext
   IVirtualMachine *GetVirtualMachine();
   sp_context_t *GetContext();
-  sp_context_t *GetCtx();
   bool IsDebugging();
   int SetDebugBreak(void *newpfn, void *oldpfn);
   IPluginDebugInfo *GetDebugInfo();
@@ -187,7 +186,6 @@ class PluginContext : public IPluginContext
   bool m_CustomMsg;
   bool m_InExec;
   PluginRuntime *m_pRuntime;
-  sp_context_t m_ctx;
   void *m_keys[4];
   bool m_keys_set[4];
 

--- a/sourcepawn/jit/plugin-runtime.h
+++ b/sourcepawn/jit/plugin-runtime.h
@@ -96,6 +96,10 @@ class PluginRuntime
     return m_JitFunctions[i];
   }
 
+  static inline size_t offsetToPlugin() {
+    return offsetof(PluginRuntime, m_plugin);
+  }
+
  private:
   void SetupFloatNativeRemapping();
 

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -1612,9 +1612,8 @@ Compiler::emitNativeCall(OPCODE op)
 
   // Relocate our absolute stk to be dat-relative, and update the context's
   // view.
-  __ movl(eax, intptr_t(rt_->GetBaseContext()->GetCtx()));
   __ subl(stk, dat);
-  __ movl(Operand(eax, offsetof(sp_context_t, sp)), stk);
+  __ movl(Operand(eax, PluginContext::offsetOfSp()), stk);
 
   sp_native_t *native = rt_->GetNativeByIndex(native_index);
   if ((native->status != SP_NATIVE_BOUND) ||

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -1632,8 +1632,8 @@ Compiler::emitNativeCall(OPCODE op)
   }
 
   // Check for errors.
-  __ movl(ecx, intptr_t(rt_->GetBaseContext()->GetCtx()));
-  __ movl(ecx, Operand(ecx, offsetof(sp_context_t, n_err)));
+  __ movl(ecx, intptr_t(rt_->GetBaseContext()));
+  __ movl(ecx, Operand(ecx, PluginContext::offsetOfNativeError()));
   __ testl(ecx, ecx);
   __ j(not_zero, &extern_error_);
   
@@ -1824,8 +1824,8 @@ Compiler::emitErrorPaths()
 
   if (extern_error_.used()) {
     __ bind(&extern_error_);
-    __ movl(eax, intptr_t(rt_->GetBaseContext()->GetCtx()));
-    __ movl(eax, Operand(eax, offsetof(sp_context_t, n_err)));
+    __ movl(eax, intptr_t(rt_->GetBaseContext()));
+    __ movl(eax, Operand(eax, PluginContext::offsetOfNativeError()));
     __ jmp(ExternalAddress(env_->stubs()->ReturnStub()));
   }
 }

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -303,6 +303,7 @@ CompileFromThunk(PluginRuntime *runtime, cell_t pcode_offs, void **addrp, char *
 Compiler::Compiler(PluginRuntime *rt, cell_t pcode_offs)
   : env_(Environment::get()),
     rt_(rt),
+    context_(rt->GetBaseContext()),
     plugin_(rt->plugin()),
     error_(SP_ERROR_NONE),
     pcode_start_(pcode_offs),

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -1462,8 +1462,8 @@ Compiler::emitCall()
 
   // eax = context
   // ecx = rp
-  __ movl(eax, intptr_t(rt_->GetBaseContext()->GetCtx()));
-  __ movl(ecx, Operand(eax, offsetof(sp_context_t, rp)));
+  __ movl(eax, intptr_t(rt_->GetBaseContext()));
+  __ movl(ecx, Operand(eax, PluginContext::offsetOfRp()));
 
   // Check if the return stack is used up.
   __ cmpl(ecx, SP_MAX_RETURN_STACK);
@@ -1471,10 +1471,10 @@ Compiler::emitCall()
 
   // Add to the return stack.
   uintptr_t cip = uintptr_t(cip_ - 2) - uintptr_t(plugin_->pcode);
-  __ movl(Operand(eax, ecx, ScaleFour, offsetof(sp_context_t, rstk_cips)), cip);
+  __ movl(Operand(eax, ecx, ScaleFour, PluginContext::offsetOfRstkCips()), cip);
 
   // Increment the return stack pointer.
-  __ addl(Operand(eax, offsetof(sp_context_t, rp)), 1);
+  __ addl(Operand(eax, PluginContext::offsetOfRp()), 1);
 
   // Store the CIP of the function we're about to call.
   __ movl(Operand(cipAddr()), offset);
@@ -1495,8 +1495,8 @@ Compiler::emitCall()
   __ movl(Operand(cipAddr()), cip);
 
   // Mark us as leaving the last frame.
-  __ movl(tmp, intptr_t(rt_->GetBaseContext()->GetCtx()));
-  __ subl(Operand(tmp, offsetof(sp_context_t, rp)), 1);
+  __ movl(tmp, intptr_t(rt_->GetBaseContext()));
+  __ subl(Operand(tmp, PluginContext::offsetOfRp()), 1);
   return true;
 }
 

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -1206,8 +1206,6 @@ Compiler::emitOp(OPCODE op)
 
     case OP_HALT:
       __ align(16);
-      __ movl(tmp, intptr_t(rt_->GetBaseContext()->GetCtx()));
-      __ movl(Operand(tmp, offsetof(sp_context_t, rval)), pri);
       __ movl(pri, readCell());
       __ jmp(&extern_error_);
       break;

--- a/sourcepawn/jit/x86/jit_x86.h
+++ b/sourcepawn/jit/x86/jit_x86.h
@@ -98,8 +98,7 @@ class Compiler
     return ExternalAddress(&ctx->hp);
   }
   ExternalAddress frmAddr() {
-    sp_context_t *ctx = rt_->GetBaseContext()->GetCtx();
-    return ExternalAddress(&ctx->frm);
+    return ExternalAddress(context_->addressOfFrm());
   }
 
  private:

--- a/sourcepawn/jit/x86/jit_x86.h
+++ b/sourcepawn/jit/x86/jit_x86.h
@@ -94,8 +94,7 @@ class Compiler
     return ExternalAddress(context_->addressOfCip());
   }
   ExternalAddress hpAddr() {
-    sp_context_t *ctx = rt_->GetBaseContext()->GetCtx();
-    return ExternalAddress(&ctx->hp);
+    return ExternalAddress(context_->addressOfHp());
   }
   ExternalAddress frmAddr() {
     return ExternalAddress(context_->addressOfFrm());

--- a/sourcepawn/jit/x86/jit_x86.h
+++ b/sourcepawn/jit/x86/jit_x86.h
@@ -91,8 +91,7 @@ class Compiler
   void emitFloatCmp(ConditionCode cc);
 
   ExternalAddress cipAddr() {
-    sp_context_t *ctx = rt_->GetBaseContext()->GetCtx();
-    return ExternalAddress(&ctx->cip);
+    return ExternalAddress(context_->addressOfCip());
   }
   ExternalAddress hpAddr() {
     sp_context_t *ctx = rt_->GetBaseContext()->GetCtx();
@@ -107,6 +106,7 @@ class Compiler
   AssemblerX86 masm;
   sp::Environment *env_;
   PluginRuntime *rt_;
+  PluginContext *context_;
   const sp_plugin_t *plugin_;
   int error_;
   uint32_t pcode_start_;


### PR DESCRIPTION
This is a holdover from SourceMod 1.0, when the VM was in core and the JIT was a closed-source implementation. sp_context_t allowed the two to share vital VM state. These days, it's confusing and irrelevant.

Once again this is largely a syntactic refactoring. Anything that accessed sp_context_t now accesses PluginContext instead. Many functions that had to take in some horrible combination of pointers now is a helper function directly on PluginContext.