### PR TITLE
Simplify the JIT function cache.

### DIFF
--- a/sourcepawn/jit/plugin-context.cpp
+++ b/sourcepawn/jit/plugin-context.cpp
@@ -550,17 +550,15 @@ PluginContext::Execute2(IPluginFunction *function, const cell_t *params, unsigne
   EnterProfileScope scriptScope("SourcePawn", cfun->FullName());
 
   /* See if we have to compile the callee. */
-  if (Environment::get()->IsJitEnabled() &&
-      (fn = m_pRuntime->m_PubJitFuncs[public_id]) == NULL)
-  {
+  if (Environment::get()->IsJitEnabled()) {
     /* We might not have to - check pcode offset. */
-    fn = m_pRuntime->GetJittedFunctionByOffset(cfun->Public()->code_offs);
-    if (fn) {
-      m_pRuntime->m_PubJitFuncs[public_id] = fn;
-    } else {
-      if ((fn = CompileFunction(m_pRuntime, cfun->Public()->code_offs, &ir)) == NULL)
-        return ir;
-      m_pRuntime->m_PubJitFuncs[public_id] = fn;
+    if ((fn = cfun->cachedCompiledFunction()) == nullptr) {
+      fn = m_pRuntime->GetJittedFunctionByOffset(cfun->Public()->code_offs);
+      if (!fn) {
+        if ((fn = CompileFunction(m_pRuntime, cfun->Public()->code_offs, &ir)) == NULL)
+          return ir;
+      }
+      cfun->setCachedCompiledFunction(fn);
     }
   }
 

--- a/sourcepawn/jit/plugin-runtime.h
+++ b/sourcepawn/jit/plugin-runtime.h
@@ -16,6 +16,7 @@
 #include <sp_vm_api.h>
 #include <am-vector.h>
 #include <am-inlinelist.h>
+#include <am-hashmap.h>
 #include "jit_shared.h"
 #include "compiled-function.h"
 #include "scripted-invoker.h"
@@ -110,15 +111,24 @@ class PluginRuntime
   unsigned int m_NumFuncs;
   unsigned int m_MaxFuncs;
   floattbl_t *float_table_;
-  CompiledFunction **function_map_;
-  size_t function_map_size_;
+
+  struct FunctionMapPolicy {
+    static inline uint32_t hash(ucell_t value) {
+      return ke::HashInteger<4>(value);
+    }
+    static inline bool matches(ucell_t a, ucell_t b) {
+      return a == b;
+    }
+  };
+  typedef ke::HashMap<ucell_t, CompiledFunction *, FunctionMapPolicy> FunctionMap;
+
+  FunctionMap function_map_;
   ke::Vector<CompiledFunction *> m_JitFunctions;
 
  public:
   DebugInfo m_Debug;
   PluginContext *m_pCtx;
   ScriptedInvoker **m_PubFuncs;
-  CompiledFunction **m_PubJitFuncs;
 
  public:
   unsigned int m_CompSerial;

--- a/sourcepawn/jit/scripted-invoker.cpp
+++ b/sourcepawn/jit/scripted-invoker.cpp
@@ -52,7 +52,8 @@ ScriptedInvoker::GetParentContext()
 ScriptedInvoker::ScriptedInvoker(PluginRuntime *runtime, funcid_t id, uint32_t pub_id)
  : m_curparam(0),
    m_errorstate(SP_ERROR_NONE),
-   m_FnId(id)
+   m_FnId(id),
+   cc_function_(nullptr)
 {
   m_pRuntime = runtime;
 

--- a/sourcepawn/jit/scripted-invoker.h
+++ b/sourcepawn/jit/scripted-invoker.h
@@ -19,6 +19,10 @@ class PluginRuntime;
 
 using namespace SourcePawn;
 
+namespace sp {
+class CompiledFunction;
+}
+
 struct ParamInfo
 {
   int flags;      /* Copy-back flags */
@@ -70,6 +74,13 @@ class ScriptedInvoker : public IPluginFunction
     return public_;
   }
 
+  sp::CompiledFunction *cachedCompiledFunction() const {
+    return cc_function_;
+  }
+  void setCachedCompiledFunction(sp::CompiledFunction *fn) {
+    cc_function_ = fn;
+  }
+
  private:
   int _PushString(const char *string, int sz_flags, int cp_flags, size_t len);
   int SetError(int err);
@@ -83,6 +94,7 @@ class ScriptedInvoker : public IPluginFunction
   funcid_t m_FnId;
   char *full_name_;
   sp_public_t *public_;
+  sp::CompiledFunction *cc_function_;
 };
 
 #endif //_INCLUDE_SOURCEMOD_BASEFUNCTION_H_

--- a/sourcepawn/jit/x86/jit_x86.cpp
+++ b/sourcepawn/jit/x86/jit_x86.cpp
@@ -165,7 +165,7 @@ CompileFromThunk(PluginRuntime *runtime, cell_t pcode_offs, void **addrp, char *
   }
 
 #if defined JIT_SPEW
-  g_engine1.GetDebugHook()->OnDebugSpew(
+  Environment::get()->debugger()->OnDebugSpew(
       "Patching thunk to %s::%s\n",
       runtime->plugin()->name,
       GetFunctionName(runtime->plugin(), pcode_offs));


### PR DESCRIPTION
The function cache is stupid. It wastes about 1000X more memory than is needed. Hashtable lookup should be fine, moving the public-id cache to `ScriptedInvoker`.