### PR TITLE
Fix crash regression in games that don't support radio style menus

### DIFF
--- a/core/MenuStyle_Radio.cpp
+++ b/core/MenuStyle_Radio.cpp
@@ -83,6 +83,10 @@ void CRadioStyle::OnSourceModLevelChange(const char *mapName)
 	}
 
 	g_bRadioInit = true;
+
+	// Always register the style. Use IsSupported() to check for validity before use.
+	g_Menus.AddStyle(this);
+
 	const char *msg = g_pGameConf->GetKeyValue("HudRadioMenuMsg");
 	if (!msg || msg[0] == '\0')
 	{
@@ -118,7 +122,6 @@ void CRadioStyle::OnSourceModLevelChange(const char *mapName)
 		}
 	}
 
-	g_Menus.AddStyle(this);
 	g_Menus.SetDefaultStyle(this);
 
 	g_UserMsgs.HookUserMessage(g_ShowMenuId, this, false);


### PR DESCRIPTION
Fix regression in ad7d920ce0f57cfec0a35bc942d2a6a8583498e7
GetMenuStyleHandle(MenuStyle_Radio) crashes games, which don't support
the radio menu style. The style is never added to the menu manager, if
it's not supported, so GetMenuStyleHandle tries to call IsSupported on a
nullptr.