### PR TITLE
Documentation oddities for Call_PushStringEx

### DIFF
--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -318,10 +318,10 @@ native Call_PushString(const String:value[]);
  * @param value				String to push.
  * @param length			Length of string buffer.
  * @param szflags			Flags determining how string should be handled.
- *							See SP_PARAM_STRING_* constants for details.
- *							The default (0) is to push ASCII.
+ *							See SM_PARAM_STRING_* constants for details.
+ *							The default (0) is to push UTF-8.
  * @param cpflags			Whether or not changes should be copied back to the input array.
- *							See SP_PARAM_* constants for details.		
+ *							See SM_PARAM_* constants for details.		
  * @noreturn
  * @error					Called before a call has been started.
  */

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -319,7 +319,7 @@ native Call_PushString(const String:value[]);
  * @param length			Length of string buffer.
  * @param szflags			Flags determining how string should be handled.
  *							See SM_PARAM_STRING_* constants for details.
- *							The default (0) is to push UTF-8.
+ *							The default (0) is to push ASCII.
  * @param cpflags			Whether or not changes should be copied back to the input array.
  *							See SM_PARAM_* constants for details.		
  * @noreturn


### PR DESCRIPTION
See changes for details, should be obvious. What also strikes me as odd is that there is only one cpflag atm. Has this always been the case? Will there be more in the future? Or why is this designed to be a flagstring?