### PR TITLE
Improve the diagnostic given when a function prototype doesn't match an existing definition

### DIFF
--- a/sourcepawn/compiler/sc.h
+++ b/sourcepawn/compiler/sc.h
@@ -981,7 +981,7 @@ typedef struct array_info_s
 } array_info_t;
 
 enum FatalError {
-  FIRST_FATAL_ERROR = 180,
+  FIRST_FATAL_ERROR = 182,
 
   FATAL_ERROR_READ  = FIRST_FATAL_ERROR,
   FATAL_ERROR_WRITE,

--- a/sourcepawn/compiler/sc1.cpp
+++ b/sourcepawn/compiler/sc1.cpp
@@ -5535,7 +5535,7 @@ static int newfunc(declinfo_t *decl, const int *thistag, int fpublic, int fstati
   if ((sym->usage & uPROTOTYPED) && !compare_tag(sym->tag, decl->type.tag)) {
     int old_fline = fline;
     fline = funcline;
-    error(25);
+    error(180, type_to_name(sym->tag), type_to_name(decl->type.tag));
     fline = old_fline;
   }
 
@@ -5745,7 +5745,7 @@ static int declargs(symbol *sym, int chkshadow, const int *thistag)
       } else {
         /* check the argument with the earlier definition */
         if (argcnt>oldargcnt || !argcompare(&sym->dim.arglist[argcnt],&arg))
-          error(25);          /* function definition does not match prototype */
+          error(181, arg.name);          /* function argument does not match prototype */
         /* may need to free default array argument and the tag list */
         if (arg.ident==iREFARRAY && arg.hasdefault)
           free(arg.defvalue.array.data);

--- a/sourcepawn/compiler/sc5-in.scp
+++ b/sourcepawn/compiler/sc5-in.scp
@@ -223,6 +223,8 @@ static const char *errmsg[] = {
 /*177*/  "static method '%s' must be invoked via its type (try '%s.%s')\n",
 /*178*/  "cannot coerce %s[] to %s[]; storage classes differ\n",
 /*179*/  "cannot assign %s[] to %s[], storage classes differ\n",
+/*180*/  "function return type differs from prototype. expected '%s', but got '%s'\n",
+/*181*/  "function argument named '%s' differs from prototype\n",
 #else
   "\315e\306\227\266k\217:\235\277bu\201fo\220\204\223\012",
   "\202l\224\250s\205g\346\356e\233\201(\243\315\214\267\202) \253 f\255low ea\305 \042c\353e\042\012",
@@ -386,24 +388,24 @@ static const char *errmsg[] = {
 
 static const char *fatalmsg[] = {
 #ifdef SCPACK
-/*180*/  "cannot read from file: \"%s\"\n",
-/*181*/  "cannot write to file: \"%s\"\n",
-/*182*/  "table overflow: \"%s\"\n",
+/*182*/  "cannot read from file: \"%s\"\n",
+/*183*/  "cannot write to file: \"%s\"\n",
+/*184*/  "table overflow: \"%s\"\n",
           /* table can be: loop table
            *               literal table
            *               staging buffer
            *               option table (response file)
            *               peephole optimizer table
            */
-/*183*/  "insufficient memory\n",
-/*184*/  "invalid assembler instruction \"%s\"\n",
-/*185*/  "numeric overflow, exceeding capacity\n",
-/*186*/  "compiled script exceeds the maximum memory size (%ld bytes)\n",
-/*187*/  "too many error messages on one line\n",
-/*188*/  "codepage mapping file not found\n",
-/*189*/  "invalid path: \"%s\"\n",
-/*190*/  "assertion failed: %s\n",
-/*191*/  "user error: %s\n",
+/*185*/  "insufficient memory\n",
+/*186*/  "invalid assembler instruction \"%s\"\n",
+/*187*/  "numeric overflow, exceeding capacity\n",
+/*188*/  "compiled script exceeds the maximum memory size (%ld bytes)\n",
+/*189*/  "too many error messages on one line\n",
+/*190*/  "codepage mapping file not found\n",
+/*191*/  "invalid path: \"%s\"\n",
+/*192*/  "assertion failed: %s\n",
+/*193*/  "user error: %s\n",
 #else
   "\256\214a\204from \344le:\354",
   "\256writ\200\266 \344le:\354",


### PR DESCRIPTION
Currently, as forwards are being slowly ported to the new transitional syntax, there is a situation where new transitional code is being written against non-ported forwards, ex:

```c
forward OnPluginStart();

// in order for this newdecl function to compile
// it must be declared as returning int because the old syntax always implicitly returned cells
public int OnPluginStart()
{
}
```
Now later in the future when the forward is ported (and the return type changes to `void`), the following occurs:

```c
forward void OnPluginStart();

// error 025: function heading differs from prototype
public int OnPluginStart()
{
}
```

This PR improves the diagnostic message to be: `error 180: function return type differs from prototype. expected 'void', but got 'int'`.

Additionally, it improves the error message given when the argument of a function doesn't match the definition of a forward:

```c

forward void MyFunction(const char[] someString)

// error 181: function argument 'theFirstArgument' differs from prototype.
public void MyFunction(char[] theFirstArgument)
{
}
```

Lastly, there are a few cases where the old error 25 has been retained:
  * When the return tags don't match for a symbol that has `uPROTOTYPED` usage, which I'm unfamiliar with.
  * Functions argument mismatches that involve var args.