### PR TITLE
FIx some TF2 natives not having the correct vstk size.

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -41,7 +41,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 {
 	static ICallWrapper *pWrapper = NULL;
 
-	// CTFPlayerShared::MakeBleed(CTFPlayer*, CTFWeaponBase*, float, int=4)
+	// CTFPlayerShared::MakeBleed(CTFPlayer*, CTFWeaponBase*, float, int=4, bool=false)
 	if(!pWrapper)
 	{
 		REGISTER_NATIVE_ADDR("MakeBleed",
@@ -103,7 +103,7 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 {
 	static ICallWrapper *pWrapper = NULL;
 
-	// CTFPlayerShared::Burn(CTFPlayer*, CTFWeaponBase*)
+	// CTFPlayerShared::Burn(CTFPlayer*, CTFWeaponBase*, float=-1.0)
 	if (!pWrapper)
 	{
 		REGISTER_NATIVE_ADDR("Burn", 
@@ -160,7 +160,7 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 {
 	static ICallWrapper *pWrapper = NULL;
 
-	//CTFPlayerShared::Disguise(int, int, CTFPlayer *)
+	//CTFPlayerShared::Disguise(int, int, CTFPlayer *. bool=true)
 	if (!pWrapper)
 	{
 		REGISTER_NATIVE_ADDR("Disguise", 

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -160,7 +160,7 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 {
 	static ICallWrapper *pWrapper = NULL;
 
-	//CTFPlayerShared::Disguise(int, int, CTFPlayer *. bool=true)
+	//CTFPlayerShared::Disguise(int, int, CTFPlayer *, bool=true)
 	if (!pWrapper)
 	{
 		REGISTER_NATIVE_ADDR("Disguise", 

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -78,7 +78,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float) + sizeof(int)];
+	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float) + sizeof(int) + sizeof(bool)];
 	unsigned char *vptr = vstk;
 
 	*(void **)vptr = obj;
@@ -134,7 +134,7 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *)];
+	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float)];
 	unsigned char *vptr = vstk;
 
 	*(void **)vptr = obj;
@@ -195,7 +195,7 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Target client index %d is not valid", params[4]);
 	}
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(int) + sizeof(bool)];
+	unsigned char vstk[sizeof(void *) + 2*sizeof(int) + sizeof(CBaseEntity *) + sizeof(bool)];
 	unsigned char *vptr = vstk;
 
 


### PR DESCRIPTION
The vstk for some of the function calls is missing some of the sizes of some of the params. I think this is a bug as far as I know everything else has the size of all params.