### PR TITLE
Add notification callback for when CForward is modified.

### DIFF
--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -112,6 +112,7 @@ public: //IChangeableForward
 	virtual bool AddFunction(IPluginFunction *func);
 	virtual bool AddFunction(IPluginContext *ctx, funcid_t index);
 	virtual bool RemoveFunction(IPluginContext *ctx, funcid_t index);
+	virtual void FunctionsChanged(size_t count);
 public:
 	static CForward *CreateForward(const char *name, 
 								   ExecType et, 

--- a/public/IForwardSys.h
+++ b/public/IForwardSys.h
@@ -50,7 +50,7 @@
 using namespace SourcePawn;
 
 #define SMINTERFACE_FORWARDMANAGER_NAME		"IForwardManager"
-#define SMINTERFACE_FORWARDMANAGER_VERSION	3
+#define SMINTERFACE_FORWARDMANAGER_VERSION	4
 
 /*
  * There is some very important documentation at the bottom of this file.
@@ -183,6 +183,14 @@ namespace SourceMod
 		 * @return			Error code, if any.
 		 */
 		virtual int PushArray(cell_t *inarray, unsigned int cells, int flags=0) =0;
+
+		/**
+		 * @brief Callback for when the forward's listeners are modified.
+		 *
+		 * @param count	Number of Callbacks attached to the forward.
+		 * @noreturn
+		 */
+		virtual void FunctionsChanged(size_t count) =0;
 	};
 
 	/**


### PR DESCRIPTION
Extensions presently guess at if their callbacks are modified, this should help enable them to become more accurate.