### PR TITLE
Fixed missing include in psyfork/memoryutils.cpp

### DIFF
--- a/tools/gdc-psyfork/MemoryUtils.cpp
+++ b/tools/gdc-psyfork/MemoryUtils.cpp
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <link.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 
 #define PAGE_SIZE			4096
 #define PAGE_ALIGN_UP(x)	((x + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1))


### PR DESCRIPTION
Error:
MemoryUtils.cpp: In member function ‘void* MemoryUtils::ResolveSymbol(void*, const char*)’:
MemoryUtils.cpp:249:43: error: ‘fstat’ was not declared in this scope
  if (dlfile == -1 || fstat(dlfile, &dlstat) == -1)

Fixed by adding missing include: #include <sys/stat.h>