### PR TITLE
Use the new Travis-CI Container environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
     - lib32stdc++6
     - lib32z1-dev
     - libc6-dev-i386
+	- linux-libc-dev
     sources:
     - llvm-toolchain-precise-3.5
     - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ addons:
     - lib32z1-dev
     - libc6-dev-i386
     - linux-libc-dev
-    - gcc-multilib
+    - g++-multilib
+    - g++4.8
     sources:
     - llvm-toolchain-precise-3.5
     - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     - lib32z1-dev
     - libc6-dev-i386
     - linux-libc-dev
+    - gcc-multilib
     sources:
     - llvm-toolchain-precise-3.5
     - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     - lib32stdc++6
     - lib32z1-dev
     - libc6-dev-i386
-	- linux-libc-dev
+    - linux-libc-dev
     sources:
     - llvm-toolchain-precise-3.5
     - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
+addons:
+  apt:
+    packages:
+    - clang-3.5
+    - lib32stdc++6
+    - lib32z1-dev
+    - libc6-dev-i386
+    sources:
+    - llvm-toolchain-precise-3.5
+    - ubuntu-toolchain-r-test
+  cache:
+    directories:
+    - ../mysql-5.0
 language: cpp
+sudo: false
 compiler:
   - clang
 before_script:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y python-software-properties
-  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq g++-4.8
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - echo "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" | sudo tee --append /etc/apt/sources.list
-  - echo "deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main" | sudo tee --append /etc/apt/sources.list
-  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get install -y g++-multilib libc6-dev-i386 lib32stdc++6 lib32z1-dev clang-3.5
   - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
 script:
   - mkdir build && cd build
+  - PATH="~/.local/bin:$PATH"
   - CC=clang-3.5 CXX=clang-3.5 python ../configure.py --enable-optimize --sdks=episode1,tf2,l4d2,csgo,dota
   - ambuild

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -118,7 +118,7 @@ if [ $? -eq 1 ]; then
     python setup.py install
   else
     python setup.py build
-    echo "About to install AMBuild - press Ctrl+C to abort, otherwise enter your password for sudo."
-    sudo python setup.py install
+    echo "Installing AMBuild at the user level. Location can be: ~/.local/bin"
+    python setup.py install --user
   fi
 fi


### PR DESCRIPTION
So... The new travis environment doesn't allow you to sudo. So I've added a virtual arch environment using juju ( https://github.com/fsquillace/juju ). The Ubuntu 12.04 image that Travis uses is still ancient. Benefit here is we can maintain our build environment completely, and our own repository if we're going this route...

It's actually pretty nice to work with in general.