### PR TITLE
Add SetClientName native.

### DIFF
--- a/extensions/sdktools/extension.h
+++ b/extensions/sdktools/extension.h
@@ -83,7 +83,7 @@ public: //public SDKExtension
 public:
 #if defined SMEXT_CONF_METAMOD
 	virtual bool SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlen, bool late);
-	//virtual bool SDK_OnMetamodUnload(char *error, size_t maxlen);
+	virtual bool SDK_OnMetamodUnload(char *error, size_t maxlen);
 	//virtual bool SDK_OnMetamodPauseChange(bool paused, char *error, size_t maxlen);
 #endif
 public: //IConCommandBaseAccessor
@@ -100,6 +100,9 @@ public: // IVoiceServer
 	void OnClientCommand(edict_t *pEntity, const CCommand &args);
 #else
 	void OnClientCommand(edict_t *pEntity);
+#endif
+#if SOURCE_ENGINE == SE_CSS
+	void OnSendClientCommand(edict_t *pPlayer, const char *szFormat);
 #endif
 
 public: //ICommandTargetProcessor

--- a/gamedata/sdktools.games/engine.bgt.txt
+++ b/gamedata/sdktools.games/engine.bgt.txt
@@ -120,6 +120,15 @@
 			}
 			
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+			}
+			
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+98h], 0

--- a/gamedata/sdktools.games/engine.blade.txt
+++ b/gamedata/sdktools.games/engine.blade.txt
@@ -211,6 +211,17 @@
 				"mac"		"64"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"63"
+				"mac"		"63"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/engine.contagion.txt
+++ b/gamedata/sdktools.games/engine.contagion.txt
@@ -170,6 +170,17 @@
 				"mac"		"63"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"62"
+				"mac"		"62"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -189,6 +189,17 @@
 			"SetUserCvar"
 			{
 				/* Not 100% sure on this, why would windows change and not linux - TEST ME */
+				"windows"	"28"
+				"linux"		"65"
+				"mac"		"65"
+			}
+			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
 				"windows"	"27"
 				"linux"		"64"
 				"mac"		"64"

--- a/gamedata/sdktools.games/engine.css.txt
+++ b/gamedata/sdktools.games/engine.css.txt
@@ -158,6 +158,17 @@
 				"mac"		"58"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"17"
+				"linux"		"57"
+				"mac"		"57"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+98h], 0

--- a/gamedata/sdktools.games/engine.darkm.txt
+++ b/gamedata/sdktools.games/engine.darkm.txt
@@ -189,6 +189,15 @@
 			{
 				"windows"	"17"
 			}
+			
+			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+			}
 
 			"UpdateUserSettings"
 			{

--- a/gamedata/sdktools.games/engine.dota.txt
+++ b/gamedata/sdktools.games/engine.dota.txt
@@ -218,6 +218,17 @@
 			"SetUserCvar"
 			{
 				"windows"	"26"
+				"linux"		"63"
+				"mac"		"63"
+			}
+			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"25"
 				"linux"		"62"
 				"mac"		"62"
 			}

--- a/gamedata/sdktools.games/engine.ep1.txt
+++ b/gamedata/sdktools.games/engine.ep1.txt
@@ -255,6 +255,16 @@
 				"linux"		"53"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"52"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+98h], 0

--- a/gamedata/sdktools.games/engine.ep2.txt
+++ b/gamedata/sdktools.games/engine.ep2.txt
@@ -220,6 +220,16 @@
 				"linux"		"55"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"54"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+98h], 0

--- a/gamedata/sdktools.games/engine.ep2valve.txt
+++ b/gamedata/sdktools.games/engine.ep2valve.txt
@@ -163,6 +163,17 @@
 				"mac"		"58"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"17"
+				"linux"		"57"
+				"mac"		"57"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+98h], 0

--- a/gamedata/sdktools.games/engine.eye.txt
+++ b/gamedata/sdktools.games/engine.eye.txt
@@ -150,6 +150,14 @@
 				"windows"	"17"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/engine.insurgency.txt
+++ b/gamedata/sdktools.games/engine.insurgency.txt
@@ -178,6 +178,17 @@
 				"mac"		"67"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"19"
+				"linux"		"66"
+				"mac"		"66"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/engine.l4d.txt
+++ b/gamedata/sdktools.games/engine.l4d.txt
@@ -186,6 +186,17 @@
 				"mac"		"63"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"62"
+				"mac"		"62"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/engine.l4d2.txt
+++ b/gamedata/sdktools.games/engine.l4d2.txt
@@ -61,6 +61,17 @@
 				"mac"		"63"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"62"
+				"mac"		"62"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/engine.sdk2013.txt
+++ b/gamedata/sdktools.games/engine.sdk2013.txt
@@ -92,6 +92,17 @@
 				"mac"		"58"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"17"
+				"linux"		"57"
+				"mac"		"57"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+98h], 0

--- a/gamedata/sdktools.games/engine.swarm.txt
+++ b/gamedata/sdktools.games/engine.swarm.txt
@@ -145,6 +145,14 @@
 				"windows"	"17"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/gamedata/sdktools.games/game.nucleardawn.txt
+++ b/gamedata/sdktools.games/game.nucleardawn.txt
@@ -120,6 +120,17 @@
 				"mac"		"63"
 			}
 			/**
+			 * CBaseClient::SetName(char  const*);
+			 * Linux offset straight from VTable dump.
+			 * Has string "(%d)%-0.*s"
+			 */
+			"SetClientName"
+			{
+				"windows"	"16"
+				"linux"		"62"
+				"mac"		"62"
+			}
+			/**
 			 * Offset into CBaseClient - Used by CBaseServer::UpdateUserSettings to determine when changes have been made.
 			 * Find CBaseClient::UpdateUserSettings (strings "net_maxroutable", "cl_updaterate" etc) and the offset is set to 0 near the end.
 			 * Linux: 	mov     byte ptr [esi+0B0h], 0

--- a/plugins/include/sdktools_functions.inc
+++ b/plugins/include/sdktools_functions.inc
@@ -333,7 +333,7 @@ native ActivateEntity(entity);
 native SetClientInfo(client, const String:key[], const String:value[]);
 
 /**
- * Something
+ * Changes a client's name.
  *
  * @param client		Player's index.
  * @param name			New name.

--- a/plugins/include/sdktools_functions.inc
+++ b/plugins/include/sdktools_functions.inc
@@ -333,6 +333,15 @@ native ActivateEntity(entity);
 native SetClientInfo(client, const String:key[], const String:value[]);
 
 /**
+ * Something
+ *
+ * @param client		Player's index.
+ * @param name			New name.
+ * @error               Invalid client index, or client not connected.
+ */
+native void SetClientName(int client, const char[] name);
+
+/**
  * Gives ammo of a certain type to a player.
  * This natives obeys the maximum amount of ammo a player can carry per ammo type.
  *

--- a/plugins/playercommands.sp
+++ b/plugins/playercommands.sp
@@ -50,9 +50,6 @@ public Plugin:myinfo =
 TopMenu hTopMenu;
 
 /* Used to get the SDK / Engine version. */
-/* This is used in sm_rename and sm_changeteam */
-new EngineVersion:g_ModVersion = Engine_Unknown;
-
 #include "playercommands/slay.sp"
 #include "playercommands/slap.sp"
 #include "playercommands/rename.sp"
@@ -65,8 +62,6 @@ public OnPluginStart()
 	RegAdminCmd("sm_slap", Command_Slap, ADMFLAG_SLAY, "sm_slap <#userid|name> [damage]");
 	RegAdminCmd("sm_slay", Command_Slay, ADMFLAG_SLAY, "sm_slay <#userid|name>");
 	RegAdminCmd("sm_rename", Command_Rename, ADMFLAG_SLAY, "sm_rename <#userid|name>");
-
-	g_ModVersion = GetEngineVersion();
 	
 	/* Account for late loading */
 	TopMenu topmenu;

--- a/plugins/playercommands/rename.sp
+++ b/plugins/playercommands/rename.sp
@@ -37,22 +37,8 @@ PerformRename(client, target)
 {
 	LogAction(client, target, "\"%L\" renamed \"%L\" to \"%s\")", client, target, g_NewName[target]);
 
-	/* Used on OB / L4D engine */
-	if (g_ModVersion != Engine_SourceSDK2006)
-	{
-		SetClientInfo(target, "name", g_NewName[target]);
-	}
-	else /* Used on CSS and EP1 / older engine */
-	{
-		if (!IsPlayerAlive(target)) /* Lets tell them about the player renamed on the next round since they're dead. */
-		{
-			decl String:m_TargetName[MAX_NAME_LENGTH];
+	SetClientName(target, g_NewName[target]);
 
-			GetClientName(target, m_TargetName, sizeof(m_TargetName));
-			ReplyToCommand(client, "[SM] %t", "Dead Player Rename", m_TargetName);
-		}
-		ClientCommand(target, "name %s", g_NewName[target]);
-	}
 	g_NewName[target][0] = '\0';
 }
 

--- a/translations/playercommands.phrases.txt
+++ b/translations/playercommands.phrases.txt
@@ -15,12 +15,6 @@
 	{
 		"en"			"Rename player"
 	}
-
-	"Dead Player Rename"
-	{
-		"#format"		"{1:s}"
-		"en"			"{1} will be renamed on the next round."
-	}
 	
 	"Slap player"
 	{


### PR DESCRIPTION
Our current method for changing names (SetUserInfo), as implemented in the sm_rename command, does not work on the top three games by SM install count - TF2 (temporarily due to game bug, this works around), CS:S, and CS:GO. There may be others as well.

By implementing a new SetClientName native to wrap CBaseClient::SetName, we gain better game compatibility as well as bypass name change cooldown restrictions in the engine. SetName is one function earlier in the same vtable as SetUserInfo for every supported game, so there's very little extra support burden.

I've also updated the playercommands plugin to use the new native for sm_rename. I removed the old, ep1-specific logic and message for name changes while dead, too. The game logic it was considering was actually specific to CS:S, not the ep1 base, and hasn't been present in CS:S since the Orangebox port years ago.

However, due to some of the legacy code in CS:S, a hook on IVEngineServer::ClientCommand was added to block changes of the client "name" convar sent from the server. Any change to that client convar in Orangebox or later now resets the client's name to their Steam name.

@GoD-Tony 
@KyleSanderson 