### PR TITLE
Make DirExists("") throw an error.

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -309,7 +309,7 @@ static cell_t sm_OpenDirectory(IPluginContext *pContext, const cell_t *params)
 	
 	if (!path[0])
 	{
-		return pContext->ThrowNativeError("Invalid file path");
+		return pContext->ThrowNativeError("Invalid path. An empty path string is not valid, use \".\" to refer to the current working directory.");
 	}
 	
 	Handle_t handle = 0;

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -619,7 +619,7 @@ static cell_t sm_DirExists(IPluginContext *pContext, const cell_t *params)
 
 	if (!name[0])
 	{
-		return pContext->ThrowNativeError("Invalid path. An empty path string is not valid, use "." to refer to the current working directory.");
+		return pContext->ThrowNativeError("Invalid path. An empty path string is not valid, use \".\" to refer to the current working directory.");
 	}
 
 	if (params[0] >= 2 && params[2] == 1)

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -616,7 +616,12 @@ static cell_t sm_DirExists(IPluginContext *pContext, const cell_t *params)
 {
 	char *name;
 	pContext->LocalToString(params[1], &name);
-	
+
+	if (!name[0])
+	{
+		return pContext->ThrowNativeError("Invalid path. An empty path string is not valid, use "." to refer to the current working directory.");
+	}
+
 	if (params[0] >= 2 && params[2] == 1)
 	{
 		char *pathID;


### PR DESCRIPTION
Apparently some (very few) plugins were relying on some undocumented behavior regarding passing an empty string to DirExists. SM was returning true, assuming that it referred to the current directory.

This change causes an error to be thrown in the case of an empty string being passed, similar to what we do for OpenDirectory. "." is still valid to explicitly work with the current directory.