### PR TITLE
Fix not being able to block CS_OnCSWeaponDrop and clarify include file.

### DIFF
--- a/extensions/cstrike/forwards.cpp
+++ b/extensions/cstrike/forwards.cpp
@@ -177,7 +177,7 @@ DETOUR_DECL_MEMBER3(DetourCSWeaponDrop, void, CBaseEntity *, weapon, bool, bDrop
 	g_pCSWeaponDropForward->Execute(&result);
 
 
-	if (result >= Pl_Continue)
+	if (result == Pl_Continue)
 	{
 #if SOURCE_ENGINE == SE_CSGO
 		DETOUR_MEMBER_CALL(DetourCSWeaponDrop)(weapon, vec, unknown);

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -144,7 +144,7 @@ forward Action:CS_OnBuyCommand(client, const String:weapon[]);
 /**
  * Called when CSWeaponDrop is called
  * Return Plugin_Continue to allow the call or return a
- * higher action to deny.
+ * higher action to block.
  *
  * @param client	Client index
  * @param weaponIndex	Weapon index


### PR DESCRIPTION
It appears that CS_OnCSWeaponDrop has always been broken and it was impossible to actually block the function even though the include said it could be done :smiley: The bug report https://bugs.alliedmods.net/show_bug.cgi?id=6334. I've also changed the wording in the include file as it  wasnt that clear what "deny" exactly meant.