### PR TITLE
Allow GetMapHistorySize to return numbers greater than 20.

### DIFF
--- a/core/NextMap.cpp
+++ b/core/NextMap.cpp
@@ -64,6 +64,7 @@ extern bool __SourceHook_FHRemoveConCommandDispatch(void *,bool,class fastdelega
 ConCommand *changeLevelCmd = NULL;
 
 ConVar sm_nextmap("sm_nextmap", "", FCVAR_NOTIFY);
+ConVar sm_maphistory_size("sm_maphistory_size", "20");
 
 bool g_forcedChange = false;
 
@@ -172,15 +173,18 @@ void NextMapManager::OnSourceModLevelChange( const char *mapName )
 			m_mapHistory.push_back(new MapChangeData(lastMap, newReason, m_tempChangeInfo.startTime));
 		}
 
-		/* TODO: Should this be customizable? */
-		if (m_mapHistory.size() > 20)
+		int historydiff = sm_maphistory_size.GetInt();
+		if (historydiff > 0)
 		{
-			SourceHook::List<MapChangeData *>::iterator iter;
-			iter = m_mapHistory.begin();
+			historydiff -= m_mapHistory.size();
+		} else if (historydiff < 0)
+		{
+			historydiff = (m_mapHistory.size() * -1);
+		}
 
+		for (SourceHook::List<MapChangeData *>::iterator iter = m_mapHistory.begin(); historydiff++ < 0; iter = m_mapHistory.erase(iter))
+		{
 			delete (MapChangeData *)*iter;
-
-			m_mapHistory.erase(iter);
 		}
 	}
 


### PR DESCRIPTION
I've had a plugin that iterates GetMapHistory for quite a while, seeing the list limited to 20 entries when the server is running for over a month saddens me :(