### PR TITLE
Fix CoreConfig init to happen after SMGlobalClasses from logic bin are added.

### DIFF
--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -172,9 +172,6 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 		return false;
 	}
 
-	/* Initialize CoreConfig to get the SourceMod base path properly - this parses core.cfg */
-	g_CoreConfig.Initialize();
-
 	/* There will always be a path by this point, since it was force-set above. */
 	m_GotBasePath = true;
 
@@ -255,6 +252,9 @@ void SourceModBase::StartSourceMod(bool late)
 	gamedllPatch = SH_GET_CALLCLASS(gamedll);
 
 	InitLogicBridge();
+
+	/* Initialize CoreConfig to get the SourceMod base path properly - this parses core.cfg */
+	g_CoreConfig.Initialize();
 
 	/* Notify! */
 	SMGlobalClass *pBase = SMGlobalClass::head;


### PR DESCRIPTION
This fixes OnSourceModConfigChanged not being called for logic classes when
config is first read, matching behavior for core classes. The function is still called
before each class's OnSourceModStartup func.

This fixes [Bug 6304](https://bugs.alliedmods.net/show_bug.cgi?id=6304) where the initial Logging and LogMode settings on core.cfg are ignored until manually set to a different value later.

The BlockBadPlugins setting in PluginSys and ServerLang setting in Translator have the same issue and are fixed by this.

I also cannot find any case where this change would have a bad side effect, where there are config values used before StartSourcemod.