### PR TITLE
Notify plugin listeners of SetFailState'd plugins on unload. (bug 6347)

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1510,7 +1510,7 @@ bool CPluginManager::UnloadPlugin(IPlugin *plugin)
 	List<IPluginsListener *>::iterator iter;
 	IPluginsListener *pListener;
 
-	if (pPlugin->GetStatus() <= Plugin_Error)
+	if (pPlugin->GetStatus() <= Plugin_Error || pPlugin->GetStatus() == Plugin_Failed)
 	{
 		/* Notify plugin */
 		pPlugin->Call_OnPluginEnd();


### PR DESCRIPTION
Following #93, `SetFailState` was changed to put plugins in the `Plugin_Failed` state rather than `Plugin_Error`.

Unfortunately this had the side effect of not notifying plugin listeners when the failed plugin was then later unloaded which is described in [bug 6347](https://bugs.alliedmods.net/show_bug.cgi?id=6347).

#93 also introduced some cases where some conditional paths were enabled for plugins that are in `Plugin_Failed`, and this patch adds that for notifying plugin listeners.