### PR TITLE
Increased PrintToChat, PrintCenter & PrintHint w/ "all" version, buffer sizes from 192 to 254

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -498,7 +498,7 @@ bool CHalfLife2::TextMsg(int client, int dest, const char *msg)
 		/* Use SayText user message instead */
 		if (chat_saytext != NULL && strcmp(chat_saytext, "yes") == 0)
 		{
-			char buffer[192];
+			char buffer[253];
 			UTIL_Format(buffer, sizeof(buffer), "%s\1\n", msg);
 
 #if SOURCE_ENGINE == SE_DOTA

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -320,7 +320,7 @@ static cell_t PrintToChat(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
-	char buffer[192];
+	char buffer[254];
 
 	{
 		DetectExceptions eh(pContext);

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -354,7 +354,7 @@ static cell_t PrintCenterText(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
-	char buffer[192];
+	char buffer[254];
 	
 	{
 		DetectExceptions eh(pContext);
@@ -388,7 +388,7 @@ static cell_t PrintHintText(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
-	char buffer[192];
+	char buffer[254];
 	{
 		DetectExceptions eh(pContext);
 		g_SourceMod.FormatString(buffer, sizeof(buffer), pContext, params, 2);

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -323,7 +323,7 @@ native PrintToChat(client, const String:format[], any:...);
  */
 stock PrintToChatAll(const String:format[], any:...)
 {
-	decl String:buffer[192];
+	decl String:buffer[254];
 	
 	for (new i = 1; i <= MaxClients; i++)
 	{

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -356,7 +356,7 @@ native PrintCenterText(client, const String:format[], any:...);
  */
 stock PrintCenterTextAll(const String:format[], any:...)
 {
-	decl String:buffer[192];
+	decl String:buffer[254];
 
 	for (new i = 1; i <= MaxClients; i++)
 	{
@@ -389,7 +389,7 @@ native PrintHintText(client, const String:format[], any:...);
  */
 stock PrintHintTextToAll(const String:format[], any:...)
 {
-	decl String:buffer[192];
+	decl String:buffer[254];
 	
 	for (new i = 1; i <= MaxClients; i++)
 	{


### PR DESCRIPTION
Increased PrintToChat & PrintToChatAll buffer size from 192 to 254; works in CSS/CSGO; dunno for the rest