### PR TITLE
Populate MaxClients before OnPluginStart is called.

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -128,7 +128,7 @@ public:
 PlayerManager::PlayerManager()
 {
 	m_AuthQueue = NULL;
-	m_FirstPass = false;
+	m_bServerActivated = false;
 	m_maxClients = 0;
 
 	m_SourceTVUserId = -1;
@@ -307,7 +307,7 @@ void PlayerManager::OnServerActivate(edict_t *pEdictList, int edictCount, int cl
 	m_PlayersSinceActive = 0;
 	
 	g_OnMapStarted = true;
-	m_FirstPass = true;
+	m_bServerActivated = true;
 
 #if SOURCE_ENGINE == SE_DOTA
 	extsys->CallOnCoreMapStart(gpGlobals->pEdicts, gpGlobals->maxEntities, gpGlobals->maxClients);
@@ -339,7 +339,7 @@ void PlayerManager::OnServerActivate(edict_t *pEdictList, int edictCount, int cl
 
 bool PlayerManager::IsServerActivated()
 {
-	return m_FirstPass;
+	return m_bServerActivated;
 }
 
 bool PlayerManager::CheckSetAdmin(int index, CPlayer *pPlayer, AdminId id)

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -138,6 +138,8 @@ PlayerManager::PlayerManager()
 
 	m_UserIdLookUp = new int[USHRT_MAX+1];
 	memset(m_UserIdLookUp, 0, sizeof(int) * (USHRT_MAX+1));
+
+	InitializePlayers();
 }
 
 PlayerManager::~PlayerManager()
@@ -146,6 +148,20 @@ PlayerManager::~PlayerManager()
 
 	delete [] m_AuthQueue;
 	delete [] m_UserIdLookUp;
+}
+
+void PlayerManager::InitializePlayers()
+{
+	/* Initialize all players */
+
+	m_PlayerCount = 0;
+	m_Players = new CPlayer[SM_MAXPLAYERS + 1];
+	m_AuthQueue = new unsigned int[SM_MAXPLAYERS + 1];
+	m_FirstPass = true;
+
+	memset(m_AuthQueue, 0, sizeof(unsigned int) * (SM_MAXPLAYERS + 1));
+
+	g_NumPlayersToAuth = &m_AuthQueue[0];
 }
 
 void PlayerManager::OnSourceModAllInitialized()
@@ -285,9 +301,6 @@ void PlayerManager::OnServerActivate(edict_t *pEdictList, int edictCount, int cl
 	static ConVar *replay_enable = icvar->FindVar("replay_enable");
 #endif
 
-	// clientMax will not necessarily be correct here (such as on late SourceTV enable)
-	m_maxClients = gpGlobals->maxClients;
-
 	ICommandLine *commandLine = g_HL2.GetValveCommandLine();
 	m_bIsSourceTVActive = (tv_enable && tv_enable->GetBool() && (!commandLine || commandLine->FindParm("-nohltv") == 0));
 	m_bIsReplayActive = false;
@@ -298,19 +311,8 @@ void PlayerManager::OnServerActivate(edict_t *pEdictList, int edictCount, int cl
 	
 	if (!m_FirstPass)
 	{
-		/* Initialize all players */
-
-		m_PlayerCount = 0;
-		m_Players = new CPlayer[SM_MAXPLAYERS + 1];
-		m_AuthQueue = new unsigned int[SM_MAXPLAYERS + 1];
-		m_FirstPass = true;
-
-		memset(m_AuthQueue, 0, sizeof(unsigned int) * (SM_MAXPLAYERS + 1));
-
-		g_NumPlayersToAuth = &m_AuthQueue[0];
+		InitializePlayers();
 	}
-
-	scripts->SyncMaxClients(m_maxClients);
 
 	g_OnMapStarted = true;
 

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -138,8 +138,6 @@ PlayerManager::PlayerManager()
 
 	m_UserIdLookUp = new int[USHRT_MAX+1];
 	memset(m_UserIdLookUp, 0, sizeof(int) * (USHRT_MAX+1));
-
-	InitializePlayers();
 }
 
 PlayerManager::~PlayerManager()
@@ -150,14 +148,13 @@ PlayerManager::~PlayerManager()
 	delete [] m_UserIdLookUp;
 }
 
-void PlayerManager::InitializePlayers()
+void PlayerManager::OnSourceModStartup(bool late)
 {
 	/* Initialize all players */
 
 	m_PlayerCount = 0;
 	m_Players = new CPlayer[SM_MAXPLAYERS + 1];
 	m_AuthQueue = new unsigned int[SM_MAXPLAYERS + 1];
-	m_FirstPass = true;
 
 	memset(m_AuthQueue, 0, sizeof(unsigned int) * (SM_MAXPLAYERS + 1));
 
@@ -309,12 +306,8 @@ void PlayerManager::OnServerActivate(edict_t *pEdictList, int edictCount, int cl
 #endif
 	m_PlayersSinceActive = 0;
 	
-	if (!m_FirstPass)
-	{
-		InitializePlayers();
-	}
-
 	g_OnMapStarted = true;
+	m_FirstPass = true;
 
 #if SOURCE_ENGINE == SE_DOTA
 	extsys->CallOnCoreMapStart(gpGlobals->pEdicts, gpGlobals->maxEntities, gpGlobals->maxClients);
@@ -1828,11 +1821,6 @@ void PlayerManager::OnSourceModMaxPlayersChanged( int newvalue )
 
 void PlayerManager::MaxPlayersChanged( int newvalue /*= -1*/ )
 {
-	if (!m_FirstPass)
-	{
-		return;
-	}
-
 	if (newvalue == -1)
 	{
 		newvalue = gpGlobals->maxClients;

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -234,6 +234,8 @@ private:
 #endif
 	void InvalidatePlayer(CPlayer *pPlayer);
 private:
+	void InitializePlayers();
+private:
 	List<IClientListener *> m_hooks;
 	IForward *m_clconnect;
 	IForward *m_clconnect_post;

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -154,6 +154,7 @@ public:
 	PlayerManager();
 	~PlayerManager();
 public: //SMGlobalClass
+	void OnSourceModStartup(bool late) override;
 	void OnSourceModAllInitialized();
 	void OnSourceModShutdown();
 	void OnSourceModLevelEnd();

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -235,8 +235,6 @@ private:
 #endif
 	void InvalidatePlayer(CPlayer *pPlayer);
 private:
-	void InitializePlayers();
-private:
 	List<IClientListener *> m_hooks;
 	IForward *m_clconnect;
 	IForward *m_clconnect_post;

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -253,7 +253,7 @@ private:
 	int m_maxClients;
 	int m_PlayerCount;
 	int m_PlayersSinceActive;
-	bool m_FirstPass;
+	bool m_bServerActivated;
 	unsigned int *m_AuthQueue;
 	String m_PassInfoVar;
 	bool m_QueryLang;

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -320,6 +320,8 @@ void SourceModBase::StartSourceMod(bool late)
 static bool g_LevelEndBarrier = false;
 bool SourceModBase::LevelInit(char const *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame, bool background)
 {
+	g_Players.MaxPlayersChanged();
+
 	/* If we're not loaded... */
 	if (!g_Loaded)
 	{

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -67,9 +67,6 @@ enum AuthIdType
 /**
  * MAXPLAYERS is not the same as MaxClients.
  * MAXPLAYERS is a hardcoded value as an upper limit.  MaxClients changes based on the server.
- *
- * Both GetMaxClients() and MaxClients are only available once the map is loaded, and should 
- * not be used in OnPluginStart().
  */
 
 #define MAXPLAYERS		65	/**< Maximum number of players SourceMod supports */


### PR DESCRIPTION
Now gets set in hook on LevelInit (and before plugins are initialized) rather than in hook on the later ServerActivate.

Also made players array initialized sooner for subsystems that relied on it being populated when max was set.