### PR TITLE
Remove Address_MinimumValid entry from sp incs

### DIFF
--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -643,8 +643,7 @@ enum NumberType
 
 enum Address
 {
-    Address_Null = 0,              //a typical invalid result when an address lookup fails
-    Address_MinimumValid = 0x10000 //addresses below this value are considered invalid to use for Load/Store
+    Address_Null = 0,              // a typical invalid result when an address lookup fails
 };
 
 /**


### PR DESCRIPTION
We have this defined in core for error checking, but it's useless in sp since unsigned comparisons are not supported.