### PR TITLE
Enable finding mapcycle in cfg dir on sdk2013 and bms.

### DIFF
--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -91,7 +91,8 @@ public:
 		const char *pMapCycleFileName = m_pMapCycleFile ? smcore.GetCvarString(m_pMapCycleFile) : "mapcycle.txt";
 
 		if (strcmp(pEngineName, "tf2") == 0 || strcmp(pEngineName, "css") == 0
-			|| strcmp(pEngineName, "dods") == 0 || strcmp(pEngineName, "hl2dm") == 0)
+			|| strcmp(pEngineName, "dods") == 0 || strcmp(pEngineName, "hl2dm") == 0
+			|| strcmp(pEngineName, "sdk2013") == 0 || strcmp(pEngineName, "bms") == 0)
 		{
 			// These four games and Source SDK 2013 do a lookup in this order; so shall we.
 			g_pSM->Format(pBuffer, maxlen, "cfg/%s", pMapCycleFileName);

--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -87,29 +87,16 @@ public:
 	}
 	void GetMapCycleFilePath(char *pBuffer, int maxlen)
 	{
-		const char *pEngineName = smcore.GetSourceEngineName();
 		const char *pMapCycleFileName = m_pMapCycleFile ? smcore.GetCvarString(m_pMapCycleFile) : "mapcycle.txt";
 
-		if (strcmp(pEngineName, "tf2") == 0 || strcmp(pEngineName, "css") == 0
-			|| strcmp(pEngineName, "dods") == 0 || strcmp(pEngineName, "hl2dm") == 0
-			|| strcmp(pEngineName, "sdk2013") == 0 || strcmp(pEngineName, "bms") == 0)
-		{
-			// These four games and Source SDK 2013 do a lookup in this order; so shall we.
-			g_pSM->Format(pBuffer, maxlen, "cfg/%s", pMapCycleFileName);
-
-			if (!smcore.filesystem->FileExists(pBuffer, "GAME"))
-			{
-				g_pSM->Format(pBuffer, maxlen, "%s", pMapCycleFileName);
-
-				if (!smcore.filesystem->FileExists(pBuffer, "GAME"))
-				{
-					g_pSM->Format(pBuffer, maxlen, "cfg/mapcycle_default.txt");
-				}
-			}
-		}
-		else
+		g_pSM->Format(pBuffer, maxlen, "cfg/%s", pMapCycleFileName);
+		if (!smcore.filesystem->FileExists(pBuffer, "GAME"))
 		{
 			g_pSM->Format(pBuffer, maxlen, "%s", pMapCycleFileName);
+			if (!smcore.filesystem->FileExists(pBuffer, "GAME"))
+			{
+				g_pSM->Format(pBuffer, maxlen, "cfg/mapcycle_default.txt");
+			}
 		}
 	}
 	void AddOrUpdateDefault(const char *name, const char *file)


### PR DESCRIPTION
Alternatively, we can just remove the engine checks as it probably will not hurt to enable the logic for all.