### PR TITLE
Improve DataPack memory allocation & Report size for DataPack Handles

### DIFF
--- a/core/CDataPack.cpp
+++ b/core/CDataPack.cpp
@@ -33,7 +33,7 @@
 #include <string.h>
 #include "CDataPack.h"
 
-#define DATAPACK_INITIAL_SIZE		512
+#define DATAPACK_INITIAL_SIZE 64
 
 CDataPack::CDataPack()
 {
@@ -64,9 +64,10 @@ void CDataPack::CheckSize(size_t typesize)
 	do
 	{
 		m_capacity *= 2;
-		m_pBase = (char *)realloc(m_pBase, m_capacity);
-		m_curptr = m_pBase + pos;
-	} while (m_curptr - m_pBase + typesize > m_capacity);
+	} while (pos + typesize > m_capacity);
+	
+	m_pBase = (char *)realloc(m_pBase, m_capacity);
+	m_curptr = m_pBase + pos;
 }
 
 void CDataPack::ResetSize()

--- a/core/CDataPack.h
+++ b/core/CDataPack.h
@@ -61,6 +61,7 @@ public: //IDataPack
 	void PackFunction(cell_t function);
 public:
 	void Initialize();
+	inline size_t GetCapacity() const { return m_capacity; }
 private:
 	void CheckSize(size_t sizetype);
 private:

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -31,8 +31,13 @@
 
 #include "common_logic.h"
 #include <IHandleSys.h>
-#include <IDataPack.h>
 #include <ISourceMod.h>
+
+// This just in from the bucket o' hacks department.
+// One day, IDataPack will go away and CDataPack will be merged into this file.
+// This internal header is included directly to access GetCapacity,
+// which can not be added to the public interface due to ABI issues.
+#include "../CDataPack.h"
 
 HandleType_t g_DataPackType;
 
@@ -62,6 +67,12 @@ public:
 	void OnHandleDestroy(HandleType_t type, void *object)
 	{
 		g_pSM->FreeDataPack(reinterpret_cast<IDataPack *>(object));
+	}
+	bool GetHandleApproxSize(HandleType_t type, void *object, unsigned int *pSize)
+	{
+		CDataPack *pack = reinterpret_cast<CDataPack *>(object);
+		*pSize = sizeof(CDataPack) + pack->GetCapacity();
+		return true;
 	}
 };
 


### PR DESCRIPTION
See individual commits.

The size reporting is a big hack, I'm not against shelving that until the iface can be trashed.
A slightly less hacky method would be to add something to the logic bridge.

Both changes have had light testing, although the alloc logic could do with some eyes to double-check.

@psychonic @Fyren 