### PR TITLE
Fix more buffer sizes for map names.

### DIFF
--- a/plugins/basetriggers.sp
+++ b/plugins/basetriggers.sp
@@ -201,7 +201,7 @@ public Action:Command_Nextmap(client, args)
 	if (client && !IsClientInGame(client))
 		return Plugin_Handled;
 	
-	decl String:map[64];
+	decl String:map[PLATFORM_MAX_PATH];
 	
 	GetNextMap(map, sizeof(map));
 	
@@ -289,7 +289,7 @@ public OnClientSayCommand_Post(client, const String:command[], const String:sArg
 	}
 	else if (strcmp(sArgs, "nextmap", false) == 0)
 	{
-		char map[32];
+		char map[PLATFORM_MAX_PATH];
 		GetNextMap(map, sizeof(map));
 			
 		if (g_Cvar_TriggerShow.IntValue)

--- a/plugins/rockthevote.sp
+++ b/plugins/rockthevote.sp
@@ -239,7 +239,7 @@ StartRTV()
 	if (EndOfMapVoteEnabled() && HasEndOfMapVoteFinished())
 	{
 		/* Change right now then */
-		new String:map[65];
+		new String:map[PLATFORM_MAX_PATH];
 		if (GetNextMap(map, sizeof(map)))
 		{
 			PrintToChatAll("[SM] %t", "Changing Maps", map);
@@ -281,7 +281,7 @@ public Action:Timer_ChangeMap(Handle:hTimer)
 	
 	LogMessage("RTV changing map manually");
 	
-	new String:map[65];
+	new String:map[PLATFORM_MAX_PATH];
 	if (GetNextMap(map, sizeof(map)))
 	{	
 		ForceChangeLevel(map, "RTV after mapvote");


### PR DESCRIPTION
Followup to #343, fixes a couple more map buffer sizes where `GetNextMap` is called.