### PR TITLE
Fix some ctype misuses (bug 6377).

### DIFF
--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -423,7 +423,7 @@ static cell_t IsCharAlpha(IPluginContext *pContext, const cell_t *params)
 		return 0;
 	}
 
-	return isalpha(chr);
+	return isalpha(chr) == 0 ? 0 : 1;
 }
 
 static cell_t IsCharNumeric(IPluginContext *pContext, const cell_t *params)
@@ -435,7 +435,7 @@ static cell_t IsCharNumeric(IPluginContext *pContext, const cell_t *params)
 		return 0;
 	}
 
-	return isdigit(chr);
+	return isdigit(chr) == 0 ? 0 : 1;
 }
 
 static cell_t IsCharSpace(IPluginContext *pContext, const cell_t *params)
@@ -447,7 +447,7 @@ static cell_t IsCharSpace(IPluginContext *pContext, const cell_t *params)
 		return 0;
 	}
 
-	return isspace(chr);
+	return isspace(chr) == 0 ? 0 : 1;
 }
 
 static cell_t IsCharMB(IPluginContext *pContext, const cell_t *params)
@@ -472,7 +472,7 @@ static cell_t IsCharUpper(IPluginContext *pContext, const cell_t *params)
 		return 0;
 	}
 
-	return isupper(chr);
+	return isupper(chr) == 0 ? 0 : 1;
 }
 
 static cell_t IsCharLower(IPluginContext *pContext, const cell_t *params)
@@ -484,7 +484,7 @@ static cell_t IsCharLower(IPluginContext *pContext, const cell_t *params)
 		return 0;
 	}
 
-	return islower(chr);
+	return islower(chr) == 0 ? 0 : 1;
 }
 
 static cell_t ReplaceString(IPluginContext *pContext, const cell_t *params)


### PR DESCRIPTION
isalpha, isdigit, isupper, and islower do not return 0/1. They return 0 or anything-else. Since the bool tag in pawn only supports exactly 0 and 1, we need to return 1 for all truthy returns in the natives that wrap these.