### PR TITLE
Add new ResolveFuzzyMapName native

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1210,11 +1210,14 @@ const char *CHalfLife2::GetEntityClassname(CBaseEntity *pEntity)
 
 bool CHalfLife2::ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int size)
 {
+#if SOURCE_ENGINE != SE_TF2
+	// TF2's engine->IsMapValid doesn't seem to work at the moment, don't bother trying to call it
 	if (engine->IsMapValid(fuzzyName))
 	{
 		strncopy(outFullname, fuzzyName, size);
 		return true;
 	}
+#endif
 #if SOURCE_ENGINE >= SE_LEFT4DEAD
 	static ConCommand *pHelperCmd = g_pCVar->FindCommand("changelevel");
 	if (!pHelperCmd || !pHelperCmd->CanAutoComplete())

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1210,6 +1210,11 @@ const char *CHalfLife2::GetEntityClassname(CBaseEntity *pEntity)
 
 bool CHalfLife2::ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int size)
 {
+	if (engine->IsMapValid(fuzzyName))
+	{
+		strncopy(outFullname, fuzzyName, size);
+		return true;
+	}
 #if SOURCE_ENGINE >= SE_LEFT4DEAD
 	static ConCommand *pHelperCmd = g_pCVar->FindCommand("changelevel");
 	if (!pHelperCmd || !pHelperCmd->CanAutoComplete())
@@ -1234,7 +1239,7 @@ bool CHalfLife2::ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, i
 	char szTmp[PLATFORM_MAX_PATH];
 	strncopy(szTmp, fuzzyName, sizeof(szTmp));
 
-	if (engine->FindMap(szTmp, sizeof(szTmp)) == eFindMap_NotFound || strcmp(szTmp, fuzzyName) == 0)
+	if (engine->FindMap(szTmp, sizeof(szTmp)) == eFindMap_NotFound)
 		return false;
 
 	strncopy(outFullname, szTmp, size);

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1208,9 +1208,9 @@ const char *CHalfLife2::GetEntityClassname(CBaseEntity *pEntity)
 	return *(const char **)(((unsigned char *)pEntity) + offset);
 }
 
-#if SOURCE_ENGINE >= SE_LEFT4DEAD
-static bool ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int size)
+bool CHalfLife2::ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int size)
 {
+#if SOURCE_ENGINE >= SE_LEFT4DEAD
 	static ConCommand *pHelperCmd = g_pCVar->FindCommand("changelevel");
 	if (!pHelperCmd || !pHelperCmd->CanAutoComplete())
 		return false;
@@ -1230,8 +1230,20 @@ static bool ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int si
 	strncopy(outFullname, &results[0][helperCmdLen + 1], size);
 
 	return true;
-}
+#elif SOURCE_ENGINE == SE_TF2
+	char szTmp[PLATFORM_MAX_PATH];
+	strncopy(szTmp, fuzzyName, sizeof(szTmp));
+
+	if (engine->FindMap(szTmp, sizeof(szTmp)) == eFindMap_NotFound || strcmp(szTmp, fuzzyName) == 0)
+		return false;
+
+	strncopy(outFullname, szTmp, size);
+
+	return true;
+#else
+	return false;
 #endif
+}
 
 bool CHalfLife2::IsMapValid(const char *map)
 {

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -173,6 +173,7 @@ public: //IGameHelpers
 	ICommandLine *GetValveCommandLine();
 	const char *GetEntityClassname(edict_t *pEdict);
 	const char *GetEntityClassname(CBaseEntity *pEntity);
+	bool ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int size);
 	bool IsMapValid(const char *map);
 public:
 	void AddToFakeCliCmdQueue(int client, int userid, const char *cmd);

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -59,6 +59,22 @@ static cell_t GetRandomInt(IPluginContext *pContext, const cell_t *params)
 	return ::RandomInt(params[1], params[2]);
 }
 
+static cell_t ResolveFuzzyMapName(IPluginContext *pContext, const cell_t *params)
+{
+	char *fuzzyName, *outFullname;
+
+	pContext->LocalToString(params[1], &fuzzyName);
+	pContext->LocalToString(params[2], &outFullname);
+
+	if (!g_HL2.ResolveFuzzyMapName(fuzzyName, outFullname, params[3]))
+	{
+		return false;
+	}
+
+	pContext->StringToLocal(params[2], params[3], outFullname);
+	return true;
+}
+
 static cell_t IsMapValid(IPluginContext *pContext, const cell_t *params)
 {
 	char *map;
@@ -625,6 +641,7 @@ REGISTER_NATIVES(halflifeNatives)
 	{"GetRandomFloat",			GetRandomFloat},
 	{"GetRandomInt",			GetRandomInt},
 	{"IsDedicatedServer",		IsDedicatedServer},
+	{"ResolveFuzzyMapName",		ResolveFuzzyMapName},
 	{"IsMapValid",				IsMapValid},
 	{"SetFakeClientConVar",		SetFakeClientConVar},
 	{"SetRandomSeed",			SetRandomSeed},

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -129,6 +129,22 @@ native Float:GetRandomFloat(Float:fMin=0.0, Float:fMax=1.0);
 native GetRandomInt(nmin, nmax);
 
 /**
+ * Give a map entry name, find its real name
+ * 
+ * Will always return false on games that do not support fuzzy names.
+ *
+ * NOTE: If this function returns false, outFullname is NOT set, so remember to check
+ * the return value!
+ *
+ * @param fuzzyName 			Map entry name
+ * @param outFullname			Full map path, excluding .bsp extension
+ * @param size				Length of outFullname
+ *
+ * @return				True if outFullname is set, false otherwise
+ */
+native bool:ResolveFuzzyMapName(const String:fuzzyName[], String:outFullname[], size);
+
+/**
  * Returns whether a map is valid or not.
  * 
  * @param map 			Map name, excluding .bsp extension.

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -141,7 +141,7 @@ native GetRandomInt(nmin, nmax);
  * @param size				Length of outFullname
  *
  * @return				True if this map resolves to a real map, false if 
- *					it doesn't exist or is already the real map path.
+ *						it doesn't exist.
  */
 native bool:ResolveFuzzyMapName(const String:fuzzyName[], String:outFullname[], size);
 

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -129,7 +129,7 @@ native Float:GetRandomFloat(Float:fMin=0.0, Float:fMax=1.0);
 native GetRandomInt(nmin, nmax);
 
 /**
- * Give a map entry name, find its real name
+ * Given a map entry name, find its real name
  * 
  * Will always return false on games that do not support fuzzy names.
  *
@@ -140,7 +140,8 @@ native GetRandomInt(nmin, nmax);
  * @param outFullname			Full map path, excluding .bsp extension
  * @param size				Length of outFullname
  *
- * @return				True if outFullname is set, false otherwise
+ * @return				True if this map resolves to a real map, false if 
+ *					it doesn't exist or is already the real map path.
  */
 native bool:ResolveFuzzyMapName(const String:fuzzyName[], String:outFullname[], size);
 

--- a/public/IGameHelpers.h
+++ b/public/IGameHelpers.h
@@ -40,7 +40,7 @@
  */
 
 #define SMINTERFACE_GAMEHELPERS_NAME		"IGameHelpers"
-#define SMINTERFACE_GAMEHELPERS_VERSION		10
+#define SMINTERFACE_GAMEHELPERS_VERSION		11
 
 class CBaseEntity;
 class CBaseHandle;
@@ -314,6 +314,19 @@ namespace SourceMod
 		 * @return				Pointer to the string, or NULL if bad pointer.
 		 */
 		virtual const char *GetEntityClassname(CBaseEntity *pEntity) =0;
+
+		/**
+		 * @brief Resolves a fuzzy map name to its real map name that works
+		 * with the engine's Changelevel functionality.
+		 * Used internally for some games by IsMapValid.
+		 *
+		 * @param fuzzyName		Map entry name
+		 * @param outFullname	Full map path, excluding .bsp extension
+		 * @param size			Length of outFullname
+		 * @return				True if this map resolves to a real map, false if
+		 *						it doesn't exist.
+		 */
+		virtual bool ResolveFuzzyMapName(const char *fuzzyName, char *outFullname, int size) =0;
 
 		/**
 		 * @brief Returns whether or not a map name is valid to use with the


### PR DESCRIPTION
This also modifies the internal ResolveFuzzyMapName to have multiple implementations, decided at compile time.

While I have tested to make sure I can [compile a plugin against it](https://github.com/powerlord/sourcemod-snippets/blob/master/scripting/resolvefuzzyname.sp), I have not yet had a chance to test it on a real server... and chances are I won't have a chance to until tomorrow.