### PR TITLE
sm_who reserved slot showing as admin fix

### DIFF
--- a/plugins/basecommands/who.sp
+++ b/plugins/basecommands/who.sp
@@ -54,7 +54,15 @@ PerformWho(client, target, ReplySource:reply, bool:is_admin)
 	{
 		if (!is_admin)
 		{
-			ReplyToCommand(client, "[SM] %t", "Player is an admin", name);
+			new flags = GetUserFlagBits(target);
+			if (flags == ADMFLAG_RESERVATION)
+			{
+				ReplyToCommand(client, "[SM] %t", "Player is not an admin", name);
+			}
+			else
+			{
+				ReplyToCommand(client, "[SM] %t", "Player is an admin", name);
+			}
 		}
 		else
 		{
@@ -227,7 +235,7 @@ public Action:Command_Who(client, args)
 			}
 			else
 			{
-				if (flags == 0)
+				if (flags == 0 || flags == ADMFLAG_RESERVATION)
 				{
 					PrintToConsole(client, "%2d. %-24.23s %t", i, name, "No");
 				}


### PR DESCRIPTION
Currently the sm_who command shows clients with the reservation flag as an admin. This causes a lot of confusion when a player needs an admin and wrongfully assumes another player with only the reservation flag is an admin.

This pull request will no longer show players with only the reservation flag as an admin. Technically admin commands can be mapped to the reservation flag but I feel this is bad plugin design and the reservation flag should be strictly used for a reserved slot.