### PR TITLE
Lock database before setting character set

### DIFF
--- a/extensions/mysql/mysql/MyDatabase.cpp
+++ b/extensions/mysql/mysql/MyDatabase.cpp
@@ -297,5 +297,9 @@ IDBDriver *MyDatabase::GetDriver()
 
 bool MyDatabase::SetCharacterSet(const char *characterset)
 {
-	return mysql_set_character_set(m_mysql, characterset) == 0 ? true : false;
+	bool res;
+	LockForFullAtomicOperation();
+	res = mysql_set_character_set(m_mysql, characterset) == 0 ? true : false;
+	UnlockFromFullAtomicOperation();
+	return res;
 }


### PR DESCRIPTION
SQL_SetCharset wasn't thread safe and could race with other threaded
queries causing a crash.