### PR TITLE
Better string_t support for Get/Set EntPropString

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1278,6 +1278,8 @@ bool CHalfLife2::IsMapValid(const char *map)
 	return FindMap(szTmp, sizeof(szTmp)) != SMFindMapResult::NotFound;
 }
 
+// TODO: Add ep1 support for this. (No IServerTools available there)
+#if SOURCE_ENGINE >= SE_ORANGEBOX
 string_t CHalfLife2::AllocPooledString(const char *pszValue)
 {
 	// This is admittedly a giant hack, but it's a relatively safe method for
@@ -1311,3 +1313,4 @@ string_t CHalfLife2::AllocPooledString(const char *pszValue)
 
 	return newString;
 }
+#endif

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1290,17 +1290,14 @@ string_t CHalfLife2::AllocPooledString(const char *pszValue)
 	// read back the new targetname value, restore the old value, and return the new one.
 
 	CBaseEntity *pEntity = ((IServerUnknown *) servertools->FirstEntity())->GetBaseEntity();
-	auto *pNetworkable = ((IServerUnknown *) pEntity)->GetNetworkable();
-	assert(pNetworkable);
-
-	auto pServerClass = pNetworkable->GetServerClass();
-	assert(pServerClass);
+	auto *pDataMap = GetDataMap(pEntity);
+	assert(pDataMap);
 
 	static int offset = -1;
 	if (offset == -1)
 	{
-		sm_sendprop_info_t info;
-		bool found = UTIL_FindInSendTable(pServerClass->m_pTable, "m_iName", &info, 0);
+		sm_datatable_info_t info;
+		bool found = FindDataMapInfo(pDataMap, "m_iName", &info);
 		assert(found);
 		offset = info.actual_offset;
 	}

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -47,9 +47,7 @@
 #include <datamap.h>
 #include <ihandleentity.h>
 #include <tier0/icommandline.h>
-#if SOURCE_ENGINE >= SE_PORTAL2
 #include <string_t.h>
-#endif
 
 class CCommand;
 
@@ -185,6 +183,7 @@ public: //IGameHelpers
 	const char *GetEntityClassname(CBaseEntity *pEntity);
 	bool IsMapValid(const char *map);
 	SMFindMapResult FindMap(char *pMapName, int nMapNameMax);
+	string_t AllocPooledString(const char *pszValue);
 public:
 	void AddToFakeCliCmdQueue(int client, int userid, const char *cmd);
 	void ProcessFakeCliCmdQueue();

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -183,7 +183,9 @@ public: //IGameHelpers
 	const char *GetEntityClassname(CBaseEntity *pEntity);
 	bool IsMapValid(const char *map);
 	SMFindMapResult FindMap(char *pMapName, int nMapNameMax);
+#if SOURCE_ENGINE >= SE_ORANGEBOX
 	string_t AllocPooledString(const char *pszValue);
+#endif
 public:
 	void AddToFakeCliCmdQueue(int client, int userid, const char *cmd);
 	void ProcessFakeCliCmdQueue();

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -2020,6 +2020,13 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 	int offset;
 	int maxlen;
 	edict_t *pEdict;
+	bool bIsStringIndex;
+
+	int element = 0;
+	if (params[0] >= 5)
+	{
+		element = params[5];
+	}
 
 	if (!IndexToAThings(params[1], &pEntity, &pEdict))
 	{
@@ -2043,17 +2050,31 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 			}
 			
 			typedescription_t *td = info.prop;
-			if (td->fieldType != FIELD_CHARACTER)
+			if (td->fieldType != FIELD_CHARACTER
+				&& td->fieldType != FIELD_STRING
+				&& td->fieldType != FIELD_MODELNAME
+				&& td->fieldType != FIELD_SOUNDNAME)
 			{
 				return pContext->ThrowNativeError("Property \"%s\" is not a valid string", prop);
 			}
+
 			offset = info.actual_offset;
-			maxlen = td->fieldSize;
+
+			bIsStringIndex = (td->fieldType != FIELD_CHARACTER);
+			if (bIsStringIndex)
+			{
+				offset += (element * (td->fieldSizeInBytes / td->fieldSize));
+			}
+			else
+			{
+				maxlen = td->fieldSize;
+			}
+
 			break;
 		}
 	case Prop_Send:
 		{
-			char *prop;
+			sm_sendprop_info_t info;
 			IServerUnknown *pUnk = (IServerUnknown *)pEntity;
 			IServerNetworkable *pNet = pUnk->GetNetworkable();
 			if (!pNet)
@@ -2061,17 +2082,37 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 				return pContext->ThrowNativeError("The edict is not networkable");
 			}
 			pContext->LocalToString(params[3], &prop);
-			SendProp *pSend = g_HL2.FindInSendTable(pNet->GetServerClass()->GetName(), prop);
-			if (!pSend)
+			if (!g_HL2.FindSendPropInfo(pNet->GetServerClass()->GetName(), prop, &info))
 			{
 				return pContext->ThrowNativeError("Property \"%s\" not found for entity %d", prop, params[1]);
 			}
-			if (pSend->GetType() != DPT_String)
+
+			offset = info.prop->GetOffset();
+
+			if (info.prop->GetType() != DPT_String)
 			{
 				return pContext->ThrowNativeError("Property \"%s\" is not a valid string", prop);
 			}
-			offset = pSend->GetOffset();
-			maxlen = DT_MAX_STRING_BUFFERSIZE;
+			else if (element != 0)
+			{
+				return pContext->ThrowNativeError("SendProp %s is not an array. Element %d is invalid.",
+					prop,
+					element);
+			}
+
+			if (info.prop->GetProxyFn())
+			{
+				DVariant var;
+				info.prop->GetProxyFn()(info.prop, pEntity, (const void *) ((intptr_t) pEntity + offset), &var, element, params[1]);
+				if (var.m_pString == ((string_t *) ((intptr_t) pEntity + offset))->ToCStr())
+				{
+					bIsStringIndex = true;
+				}
+			}
+			else
+			{
+				maxlen = DT_MAX_STRING_BUFFERSIZE;
+			}
 			break;
 		}
 	default:
@@ -2081,10 +2122,19 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 	}
 
 	char *src;
-	char *dest = (char *)((uint8_t *)pEntity + offset);
-
+	size_t len;
 	pContext->LocalToString(params[4], &src);
-	size_t len = strncopy(dest, src, maxlen);
+
+	if (bIsStringIndex)
+	{
+		*(string_t *) ((intptr_t) pEntity + offset) = g_HL2.AllocPooledString(src);
+		len = strlen(src);
+	}
+	else
+	{
+		char *dest = (char *) ((uint8_t *) pEntity + offset);
+		len = strncopy(dest, src, maxlen);
+	}
 
 	if (params[2] == Prop_Send && (pEdict != NULL))
 	{

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -2127,8 +2127,12 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 
 	if (bIsStringIndex)
 	{
+#if SOURCE_ENGINE < SE_ORANGEBOX
+		return pContext->ThrowNativeError("Cannot set %s. Setting string_t values not supported on this game.", prop);
+#else
 		*(string_t *) ((intptr_t) pEntity + offset) = g_HL2.AllocPooledString(src);
 		len = strlen(src);
+#endif
 	}
 	else
 	{

--- a/plugins/include/entity.inc
+++ b/plugins/include/entity.inc
@@ -650,18 +650,16 @@ native GetEntPropString(entity, PropType:type, const String:prop[], String:buffe
 
 /**
  * Sets a network property as a string.
- *
- * This cannot set property fields of type PropField_String_T (such as "m_target").
- * To set such fields, you should use DispatchKeyValue() from SDKTools.
  * 
  * @param entity		Edict index.
  * @param type			Property type.
  * @param prop			Property to use.
  * @param buffer		String to set.		
+ * @param element		Element # (starting from 0) if property is an array.
  * @return				Number of non-null bytes written.
  * @error				Invalid entity, offset out of reasonable bounds, or property is not a valid string.
  */
-native SetEntPropString(entity, PropType:type, const String:prop[], const String:buffer[]);
+native SetEntPropString(entity, PropType:type, const String:prop[], const String:buffer[], element=0);
 
 /**
  * Retrieves the count of values that an entity property's array can store.


### PR DESCRIPTION
This adds support for identifying Prop_Send string_t values for the DPT_String type (as opposed to char arrays), as well as getting values for Prop_Send string_t fields (Prop_Data was already supported) and setting values for both Prop_Send and Prop_Data string_t fields.

For setting, we have to allocate a string in the game's stringpool. The method here for it is a bit sketch, but it works and should not easily break.

This is not tested yet (other than the concept used for the AllocPooledString), but I plan to test in the near future.