### PR TITLE
GetMapDisplayName and associated core plugin changes

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1273,6 +1273,38 @@ SMFindMapResult CHalfLife2::FindMap(const char *pMapName, char *pFoundMap, size_
 #endif
 }
 
+bool CHalfLife2::GetMapDisplayName(const char *pMapName, char *pDisplayname, size_t nMapNameMax)
+{
+	SMFindMapResult result = FindMap(pMapName, pDisplayname, nMapNameMax);
+
+	if (result == SMFindMapResult::NotFound)
+	{
+		return false;
+	}
+
+#if SOURCE_ENGINE == SE_CSGO
+	char *lastSlashPos;
+	// In CSGO, workshop maps show up as workshop/123456789/mapname
+	if (strncmp(pDisplayname, "workshop/", 9) == 0 && (lastSlashPos = strrchr(pDisplayname, '/')) != NULL)
+	{
+		ke::SafeSprintf(pDisplayname, nMapNameMax, "%s", &lastSlashPos[1]);
+		return true;
+	}
+#elif SOURCE_ENGINE == SE_TF2
+	char *ugcPos;
+	// In TF2, workshop maps show up as workshop/mapname.ugc123456789
+	if (strncmp(pDisplayname, "workshop/", 9) == 0 && (ugcPos = strstr(pDisplayname, ".ugc")) != NULL)
+	{
+		// Overwrite the . with a nul and SafeSprintf will handle the rest
+		ugcPos[0] = '\0';
+		ke::SafeSprintf(pDisplayname, nMapNameMax, "%s", &pDisplayname[9]);
+		return true;
+	}
+#endif
+
+	return true;
+}
+
 bool CHalfLife2::IsMapValid(const char *map)
 {
 	if (!map || !map[0])

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -187,6 +187,7 @@ public: //IGameHelpers
 	bool IsMapValid(const char *map);
 	SMFindMapResult FindMap(char *pMapName, size_t nMapNameMax);
 	SMFindMapResult FindMap(const char *pMapName, char *pFoundMap = NULL, size_t nMapNameMax = 0);
+	bool GetMapDisplayName(const char *pMapName, char *pDisplayname, size_t nMapNameMax);
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	string_t AllocPooledString(const char *pszValue);
 #endif

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -82,6 +82,14 @@ static cell_t FindMap(IPluginContext *pContext, const cell_t *params)
 	return static_cast<cell_t>(g_HL2.FindMap(pMapname, pDestMap, params[3]));
 }
 
+static cell_t GetMapDisplayName(IPluginContext *pContext, const cell_t *params)
+{
+	char *pMapname, *pDisplayname;
+	pContext->LocalToString(params[1], &pMapname);
+	pContext->LocalToString(params[2], &pDisplayname);
+	return static_cast<cell_t>(g_HL2.GetMapDisplayName(pMapname, pDisplayname, params[3]));
+}
+
 static cell_t IsDedicatedServer(IPluginContext *pContext, const cell_t *params)
 {
 	return engine->IsDedicatedServer();
@@ -642,6 +650,7 @@ REGISTER_NATIVES(halflifeNatives)
 	{"IsDedicatedServer",		IsDedicatedServer},
 	{"IsMapValid",				IsMapValid},
 	{"FindMap",					FindMap},
+	{"GetMapDisplayName",		GetMapDisplayName},
 	{"SetFakeClientConVar",		SetFakeClientConVar},
 	{"SetRandomSeed",			SetRandomSeed},
 	{"PrecacheModel",			PrecacheModel},

--- a/plugins/basetriggers.sp
+++ b/plugins/basetriggers.sp
@@ -211,6 +211,7 @@ public Action:Command_Nextmap(client, args)
 	}
 	else
 	{
+		GetMapDisplayName(map, map, sizeof(map));
 		ReplyToCommand(client, "[SM] %t", "Next Map", map);
 	}
 	
@@ -291,7 +292,8 @@ public OnClientSayCommand_Post(client, const String:command[], const String:sArg
 	{
 		char map[PLATFORM_MAX_PATH];
 		GetNextMap(map, sizeof(map));
-			
+		GetMapDisplayName(map, map, sizeof(map));
+		
 		if (g_Cvar_TriggerShow.IntValue)
 		{
 			if (mapchooser && EndOfMapVoteEnabled() && !HasEndOfMapVoteFinished())

--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -116,7 +116,7 @@ public OnPluginStart()
 		OnAdminMenuReady(topmenu);
 	}
 	
-	g_SelectedMaps = CreateArray(33);
+	g_SelectedMaps = CreateArray(ByteCountToCells(PLATFORM_MAX_PATH));
 	
 	g_MapList = CreateMenu(MenuHandler_Map, MenuAction_DrawItem|MenuAction_Display);
 	g_MapList.SetTitle("%T", "Please select a map", LANG_SERVER);
@@ -311,8 +311,11 @@ public Handler_VoteCallback(Menu menu, MenuAction action, param1, param2)
 				
 				case (voteType:map):
 				{
+					// single-vote items don't use the display item
+					char displayName[PLATFORM_MAX_PATH];
+					GetMapDisplayName(item, displayName, sizeof(displayName));
 					LogAction(-1, -1, "Changing map to %s due to vote.", item);
-					PrintToChatAll("[SM] %t", "Changing map", item);
+					PrintToChatAll("[SM] %t", "Changing map", displayName);
 					new Handle:dp;
 					CreateDataTimer(5.0, Timer_ChangeMap, dp);
 					WritePackString(dp, item);		

--- a/plugins/basevotes/votemap.sp
+++ b/plugins/basevotes/votemap.sp
@@ -48,7 +48,7 @@ DisplayVoteMapMenu(client, mapCount, String:maps[5][])
 	
 	if (mapCount == 1)
 	{
-		strcopy(g_voteInfo[VOTE_NAME], sizeof(g_voteInfo[]), maps[0]);
+		GetMapDisplayName(maps[0], g_voteInfo[VOTE_NAME], sizeof(g_voteInfo[]));
 			
 		g_hVoteMenu.SetTitle("Change Map To");
 		g_hVoteMenu.AddItem(maps[0], "Yes");
@@ -61,7 +61,9 @@ DisplayVoteMapMenu(client, mapCount, String:maps[5][])
 		g_hVoteMenu.SetTitle("Map Vote");
 		for (new i = 0; i < mapCount; i++)
 		{
-			g_hVoteMenu.AddItem(maps[i], maps[i]);
+			decl String:displayName[PLATFORM_MAX_PATH];
+			GetMapDisplayName(maps[i], displayName, sizeof(displayName));
+			g_hVoteMenu.AddItem(maps[i], displayName);
 		}	
 	}
 	
@@ -288,8 +290,10 @@ int LoadMapList(Menu menu)
 	
 	for (new i = 0; i < map_count; i++)
 	{
+		decl String:displayName[PLATFORM_MAX_PATH];
 		GetArrayString(g_map_array, i, map_name, sizeof(map_name));
-		menu.AddItem(map_name, map_name);
+		GetMapDisplayName(map_name, displayName, sizeof(displayName));
+		menu.AddItem(map_name, displayName);
 	}
 	
 	return map_count;

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -168,6 +168,24 @@ native bool:IsMapValid(const String:map[]);
 native FindMapResult FindMap(const char[] map, char[] foundmap, int maxlen);
 
 /**
+ * Get the display name of a workshop map.
+ * 
+ * Note: You do not need to call FindMap first.  This native will call FindMap internally.
+ * 
+ * @param map 			Map name (usually same as map path relative to maps/ dir,
+ *						excluding .bsp extension).
+ * @param displayName	Map's display name, i.e. cp_mymapname or de_mymapname.
+ *						If FindMap returns FindMap_PossiblyAvailable or FindMap_NotFound,
+ *						the map cannot be resolved and this native will return false,
+ *						but displayName will be a copy of map.
+ * @param maxlen		Maximum length to write to displayName var.
+ * @return				true if FindMap returns FindMap_Found, FindMap_FuzzyMatch, or
+ * 						FindMap_NonCanonical.
+ * 						false if FindMap returns FindMap_PossiblyAvailable or FindMap_NotFound.
+ */
+native bool GetMapDisplayName(const char[] map, char[] displayName, int maxlen);
+
+/**
  * Returns whether the server is dedicated.
  *
  * @return				True if dedicated, false otherwise.

--- a/plugins/nextmap.sp
+++ b/plugins/nextmap.sp
@@ -153,7 +153,8 @@ void FindAndSetNextMap()
 		for (int i = 0; i < mapCount; i++)
 		{
 			g_MapList.GetString(i, mapName, sizeof(mapName));
-			if (strcmp(current, mapName, false) == 0)
+			if (FindMap(mapName, mapName, sizeof(mapName)) != FindMap_NotFound && 
+				strcmp(current, mapName, false) == 0)
 			{
 				g_MapPos = i;
 				break;

--- a/plugins/randomcycle.sp
+++ b/plugins/randomcycle.sp
@@ -82,6 +82,7 @@ public void OnConfigsExecuted()
 public Action Timer_RandomizeNextmap(Handle timer)
 {
 	char map[PLATFORM_MAX_PATH];
+	char resolvedMap[PLATFORM_MAX_PATH];
 
 	bool oldMaps = false;
 	if (g_Cvar_ExcludeMaps.IntValue && g_MapList.Length > g_Cvar_ExcludeMaps.IntValue)
@@ -89,16 +90,14 @@ public Action Timer_RandomizeNextmap(Handle timer)
 		oldMaps = true;
 	}
 	
-	int b = GetRandomInt(0, g_MapList.Length - 1);
-	g_MapList.GetString(b, map, sizeof(map));
-
-	while (oldMaps && g_OldMapList.FindString(map) != -1)
+	do
 	{
-		b = GetRandomInt(0, g_MapList.Length - 1);
+		int b = GetRandomInt(0, g_MapList.Length - 1);
 		g_MapList.GetString(b, map, sizeof(map));
-	}
+		FindMap(map, resolvedMap, sizeof(resolvedMap));
+	} while (oldMaps && g_OldMapList.FindString(resolvedMap) != -1);
 	
-	g_OldMapList.PushString(map);
+	g_OldMapList.PushString(resolvedMap);
 	SetNextMap(map);
 
 	if (g_OldMapList.Length > g_Cvar_ExcludeMaps.IntValue)

--- a/plugins/rockthevote.sp
+++ b/plugins/rockthevote.sp
@@ -243,6 +243,8 @@ void StartRTV()
 		char map[PLATFORM_MAX_PATH];
 		if (GetNextMap(map, sizeof(map)))
 		{
+			GetMapDisplayName(map, map, sizeof(map));
+			
 			PrintToChatAll("[SM] %t", "Changing Maps", map);
 			CreateTimer(5.0, Timer_ChangeMap, _, TIMER_FLAG_NO_MAPCHANGE);
 			g_InChange = true;

--- a/plugins/testsuite/mapdisplayname.sp
+++ b/plugins/testsuite/mapdisplayname.sp
@@ -1,0 +1,25 @@
+#include <sourcemod>
+
+public void OnPluginStart()
+{
+	RegServerCmd("test_mapdisplayname", test_mapdisplayname);
+}
+
+public Action test_mapdisplayname( int argc )
+{
+	char mapName[PLATFORM_MAX_PATH];
+	GetCmdArg(1, mapName, sizeof(mapName));
+	
+	char displayName[PLATFORM_MAX_PATH];
+	
+	if (GetMapDisplayName(mapName, displayName, sizeof(displayName)))
+	{
+		PrintToServer("GetMapDisplayName says \"%s\" for \"%s\"", displayName, mapName);
+	}
+	else
+	{
+		PrintToServer("GetMapDisplayName says \"%s\" was not found or not resolved", mapName);
+	}
+	
+	return Plugin_Handled;
+}


### PR DESCRIPTION
This replaces Pull Request #350.

This adds a new native named GetMapDisplayName.

Its purpose is to get the base name of a workshop map for display in various plugins.

At the present time, only CS:GO and TF2 actually do anything.

Its signature is 

    native bool GetMapDisplayName(const char[] map, char[] displayName, int maxlen);

This function returns false if a map can not be found or resolved, but true in all other circumstances (even for non-workshop maps).

No matter what it returns, displayName will always be populated, even if it is just by copying map to displayName.

The return type can be modified from its current behavior if needed.  Its current behavior was me being lazy.

The changes to core plugins are to implement both GetMapDisplayName and FindMap.

The plugins updated are:

* NextMap
* BaseTriggers
* BaseVotes (and basevotes/mapvote.sp)
* MapChooser
* Nominations
* RockTheVote
* RandomCycle

Note 1:  In TF2, the map must be tracked or it will not resolve.  This function will return false when a workshop map is asked for and FindMap returns that it is possibly available.  At the present moment, TF2 workshop maps can by tracked by using the `tf_workshop_map_sync` command or by loading the map once.

Valve's John S. has said

> In a future update we will automatically track maps found in the mapcycle, meaning you will only need tf_workshop_map_sync for maps you'd like to be prefetched but are not in the active cycle.

This change did not appear to land in the Gun Mettle Update.