### PR TITLE
Revert "Changing MAX_NAME_LENGTH from 32 to 128 due to CSGO having 128."

### DIFF
--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -70,7 +70,7 @@ enum AuthIdType
  */
 
 #define MAXPLAYERS		65	/**< Maximum number of players SourceMod supports */
-#define MAX_NAME_LENGTH 128	/**< Maximum buffer required to store a client name */
+#define MAX_NAME_LENGTH 32	/**< Maximum buffer required to store a client name */
 
 public const MaxClients;	/**< Maximum number of players the server supports (dynamic) */
 


### PR DESCRIPTION
Reverts alliedmodders/sourcemod#355