### PR TITLE
Add support for listening to, blocking, changing, and faking ClientCommandKeyValues

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1264,6 +1264,9 @@ void PlayerManager::OnClientCommandKeyValues(edict_t *pEntity, KeyValues *pComma
 	m_clcommandkv->Execute(&res);
 	m_bInCCKVHook = false;
 
+	HandleSecurity sec(g_pCoreIdent, g_pCoreIdent);
+	handlesys->FreeHandle(hndl, &sec);
+
 	if (res >= Pl_Handled)
 	{
 		s_LastCCKVAllowed = false;
@@ -1303,6 +1306,9 @@ void PlayerManager::OnClientCommandKeyValues_Post(edict_t *pEntity, KeyValues *p
 	m_clcommandkv_post->PushCell(hndl);
 	m_clcommandkv_post->Execute();
 	m_bInCCKVHook = false;
+
+	HandleSecurity sec(g_pCoreIdent, g_pCoreIdent);
+	handlesys->FreeHandle(hndl, &sec);
 }
 #endif
 

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1265,6 +1265,8 @@ void PlayerManager::OnClientCommandKeyValues(edict_t *pEntity, KeyValues *pComma
 	m_bInCCKVHook = false;
 
 	HandleSecurity sec(g_pCoreIdent, g_pCoreIdent);
+
+	// Deletes pStk
 	handlesys->FreeHandle(hndl, &sec);
 
 	if (res >= Pl_Handled)
@@ -1308,6 +1310,8 @@ void PlayerManager::OnClientCommandKeyValues_Post(edict_t *pEntity, KeyValues *p
 	m_bInCCKVHook = false;
 
 	HandleSecurity sec(g_pCoreIdent, g_pCoreIdent);
+
+	// Deletes pStk
 	handlesys->FreeHandle(hndl, &sec);
 }
 #endif

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -181,6 +181,10 @@ public:
 	void OnClientDisconnect_Post(edict_t *pEntity);
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	void OnClientCommand(edict_t *pEntity, const CCommand &args);
+#if SOURCE_ENGINE >= SE_EYE && SOURCE_ENGINE != SE_DOTA
+	void OnClientCommandKeyValues(edict_t *pEntity, KeyValues *pCommand);
+	void OnClientCommandKeyValues_Post(edict_t *pEntity, KeyValues *pCommand);
+#endif
 #else
 	void OnClientCommand(edict_t *pEntity);
 #endif
@@ -224,6 +228,10 @@ public:
 	unsigned int GetReplyTo();
 	unsigned int SetReplyTo(unsigned int reply);
 	void MaxPlayersChanged(int newvalue = -1);
+	inline bool InClientCommandKeyValuesHook()
+	{
+		return m_bInCCKVHook;
+	}
 #if SOURCE_ENGINE == SE_CSGO
 	bool HandleConVarQuery(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue);
 #endif
@@ -242,6 +250,8 @@ private:
 	IForward *m_cldisconnect_post;
 	IForward *m_clputinserver;
 	IForward *m_clcommand;
+	IForward *m_clcommandkv;
+	IForward *m_clcommandkv_post;
 	IForward *m_clinfochanged;
 	IForward *m_clauth;
 	IForward *m_onActivate;
@@ -262,6 +272,7 @@ private:
 	bool m_bIsReplayActive;
 	int m_SourceTVUserId;
 	int m_ReplayUserId;
+	bool m_bInCCKVHook;
 };
 
 #if SOURCE_ENGINE == SE_DOTA

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -46,6 +46,7 @@
 #include "ConCommandBaseIterator.h"
 #include "logic_bridge.h"
 #include <sm_namehashset.h>
+#include "smn_keyvalues.h"
 
 #if SOURCE_ENGINE == SE_CSGO || SOURCE_ENGINE == SE_DOTA
 #include <netmessages.pb.h>
@@ -1292,6 +1293,50 @@ static cell_t ConVar_ReplicateToClient(IPluginContext *pContext, const cell_t *p
 	return SendConVarValue(pContext, new_params);
 }
 
+static cell_t FakeClientCommandKeyValues(IPluginContext *pContext, const cell_t *params)
+{
+#if SOURCE_ENGINE >= SE_EYE && SOURCE_ENGINE != SE_DOTA
+	int client = params[1];
+
+	CPlayer *pPlayer = g_Players.GetPlayerByIndex(client);
+	if (!pPlayer)
+	{
+		return pContext->ThrowNativeError("Client index %d is invalid", client);
+	}
+	else if (!pPlayer->IsConnected())
+	{
+		return pContext->ThrowNativeError("Client %d is not connected", client);
+	}
+
+	Handle_t hndl = static_cast<Handle_t>(params[2]);
+	HandleError herr;
+	HandleSecurity sec;
+	KeyValueStack *pStk;
+
+	sec.pOwner = NULL;
+	sec.pIdentity = g_pCoreIdent;
+
+	if ((herr = handlesys->ReadHandle(hndl, g_KeyValueType, &sec, (void **) &pStk))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid key value handle %x (error %d)", hndl, herr);
+	}
+
+	if (g_Players.InClientCommandKeyValuesHook())
+	{
+		SH_CALL(serverClients, &IServerGameClients::ClientCommandKeyValues)(pPlayer->GetEdict(), pStk->pBase);
+	}
+	else
+	{
+		serverClients->ClientCommandKeyValues(pPlayer->GetEdict(), pStk->pBase);
+	}
+
+	return 1;
+#else
+	return pContext->ThrowNativeError("FakeClientCommandKeyValues is not supported on this game.");
+#endif
+}
+
 REGISTER_NATIVES(consoleNatives)
 {
 	{"CreateConVar",		sm_CreateConVar},
@@ -1332,6 +1377,7 @@ REGISTER_NATIVES(consoleNatives)
 	{"SendConVarValue",		SendConVarValue},
 	{"AddCommandListener",	AddCommandListener},
 	{"RemoveCommandListener", RemoveCommandListener},
+	{"FakeClientCommandKeyValues", FakeClientCommandKeyValues},
 
 	// Transitional syntax support.
 	{"ConVar.BoolValue.get",	sm_GetConVarBool},

--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -29,6 +29,8 @@
  * Version: $Id$
  */
 
+#include "smn_keyvalues.h"
+
 #include "sourcemod.h"
 #include "sourcemm_api.h"
 #include "sm_stringutil.h"
@@ -38,12 +40,6 @@
 #include "logic_bridge.h"
 
 HandleType_t g_KeyValueType;
-
-struct KeyValueStack 
-{
-	KeyValues *pBase;
-	CStack<KeyValues *> pCurRoot;
-};
 
 class KeyValueNatives : 
 	public SMGlobalClass,
@@ -62,7 +58,11 @@ public:
 	void OnHandleDestroy(HandleType_t type, void *object)
 	{
 		KeyValueStack *pStk = reinterpret_cast<KeyValueStack *>(object);
-		pStk->pBase->deleteThis();
+		if (pStk->m_bDeleteOnDestroy)
+		{
+			pStk->pBase->deleteThis();
+		}
+
 		delete pStk;
 	}
 	int CalcKVSizeR(KeyValues *pv)

--- a/core/smn_keyvalues.h
+++ b/core/smn_keyvalues.h
@@ -1,0 +1,51 @@
+/**
+* vim: set ts=4 :
+* =============================================================================
+* SourceMod
+* Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, AlliedModders LLC gives you permission to link the
+* code of this program (as well as its derivative works) to "Half-Life 2," the
+* "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, AlliedModders LLC grants
+* this exception to all derivative works.  AlliedModders LLC defines further
+* exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+* or <http://www.sourcemod.net/license.php>.
+*
+* Version: $Id$
+*/
+
+#ifndef _INCLUDE_SOURCEMOD_KVWRAPPER_H_
+#define _INCLUDE_SOURCEMOD_KVWRAPPER_H_
+
+#include <IHandleSys.h>
+#include <sh_stack.h>
+
+using namespace SourceMod;
+
+class KeyValues;
+
+struct KeyValueStack
+{
+	KeyValues *pBase;
+	SourceHook::CStack<KeyValues *> pCurRoot;
+	bool m_bDeleteOnDestroy = true;
+};
+
+extern HandleType_t g_KeyValueType;;
+
+#endif // _INCLUDE_SOURCEMOD_KVWRAPPER_H_

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -138,9 +138,31 @@ forward void OnClientDisconnect_Post(client);
  *
  * @param client		Client index.
  * @param args			Number of arguments.
- * @noreturn
+ * @return				Plugin_Handled blocks the command from being sent,
+ *						and Plugin_Continue resumes normal functionality.
  */
 forward Action:OnClientCommand(client, args);
+
+/**
+ * Called when a client is sending a KeyValues command.
+ *
+ * @param client		Client index.
+ * @param kv			Editable KeyValues data to be sent as the command.
+ *						(This handle cannot be closed.)
+ * @return				Plugin_Handled blocks the command from being sent,
+ *						and Plugin_Continue resumes normal functionality.
+ */
+forward Action OnClientCommandKeyValues(int client, KeyValues kv);
+
+/**
+ * Called after a client has sent a KeyValues command.
+ *
+ * @param client		Client index.
+ * @param kv			KeyValues data sent as the command.
+ *						(This handle cannot be closed.)
+ * @noreturn
+ */
+forward void OnClientCommandKeyValues_Post(int client, KeyValues kv);
 
 /**
  * Called whenever the client's settings are changed.

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -148,7 +148,8 @@ forward Action:OnClientCommand(client, args);
  *
  * @param client		Client index.
  * @param kv			Editable KeyValues data to be sent as the command.
- *						(This handle cannot be closed.)
+ *						(This handle should not be stored and will be closed
+ *						after this forward completes.)
  * @return				Plugin_Handled blocks the command from being sent,
  *						and Plugin_Continue resumes normal functionality.
  */
@@ -159,7 +160,8 @@ forward Action OnClientCommandKeyValues(int client, KeyValues kv);
  *
  * @param client		Client index.
  * @param kv			KeyValues data sent as the command.
- *						(This handle cannot be closed.)
+ *						(This handle should not be stored and will be closed
+ *						after this forward completes.)
  * @noreturn
  */
 forward void OnClientCommandKeyValues_Post(int client, KeyValues kv);

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -191,6 +191,17 @@ native FakeClientCommand(client, const String:fmt[], any:...);
 native FakeClientCommandEx(client, const String:fmt[], any:...);
 
 /**
+ * Executes a KeyValues client command on the server without being networked.
+ *
+ * @param client		Index of the client.
+ * @param kv			KeyValues data to be sent.
+ * @noreturn
+ * @error				Invalid client index, client not connected,
+ *						or unsupported on current game.
+ */
+native void FakeClientCommandKeyValues(int client, KeyValues kv);
+
+/**
  * Sends a message to the server console.
  *
  * @param format		Formatting rules.


### PR DESCRIPTION
Adds forwards:

    // Pre-hook, blockable, can edit values on kv
    Action OnClientCommandKeyValues(int client, KeyValues kv)
    // Post-hook, only if not blocked
    void OnClientCommandKeyValues_Post(int client, KeyValues kv)

And native:

    // Bypasses hook if called within hook
    void FakeClientCommandKeyValues(int client, KeyValues kv)

Supported by all games that have CCKVs (all newer orangebox games and later, with the exception of Dota 2).

Editing the kv in OnClientCommandKeyValues will currently cause a crash on Windows, but I have a fix for that coming to tier1 in the SDK.