### PR TITLE
Corrected/updated Killtimer description.

### DIFF
--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -90,7 +90,7 @@ typeset Timer
 native Handle:CreateTimer(Float:interval, Timer:func, any:data=INVALID_HANDLE, flags=0);
 
 /**
- * Kills a timer.  Use this instead of CloseHandle() if you need more options.
+ * Kills a timer.  Use this instead of CloseHandle() if you want to close a repeating timer.
  *
  * @param timer				Timer Handle to kill.
  * @param autoClose			If autoClose is true, the data that was passed to CreateTimer() will


### PR DESCRIPTION
As you know Killtimer has two uses compared to CloseHandle.
-You can specify if you want to close the handle you passed
-You can kill repeating timers

The latter isn't obvious until you stumble upon the problem yourself and/or read up on what KillTimer does https://github.com/alliedmodders/sourcemod/blob/3291e3a38f8a458c7aebc233811e9514a2ec5f11/core/TimerSys.cpp#L388

Recent example showing that the first three people apparently don't know they should use KillTimer here:
https://forums.alliedmods.net/showthread.php?t=266180

Cheers and rip travis.