### PR TITLE
Introduce a datapack position tag.

### DIFF
--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -141,7 +141,7 @@ native void ResetPack(Handle pack, bool clear=false);
  * Returns the read or write position in a data pack.
  *
  * @param pack		Handle to the data pack.
- * @return			Numerical position in the data pack.
+ * @return			Position in the data pack, only usable with calls to SetPackPosition.
  * @error			Invalid handle.
  */
 native DataPackPos GetPackPosition(Handle pack);
@@ -150,7 +150,7 @@ native DataPackPos GetPackPosition(Handle pack);
  * Sets the read/write position in a data pack.
  *
  * @param pack		Handle to the data pack.
- * @param position	New position to set.
+ * @param position	New position to set. Must have been previously retrieved from a call to GetPackPosition.
  * @noreturn
  * @error			Invalid handle, or position is beyond the pack bounds.
  */

--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -35,6 +35,13 @@
 #endif
 #define _datapack_included
 
+
+/**
+ * Opaque handle to a datapack position.
+ */
+ enum DataPackPos: {};
+
+
 /**
  * Creates a new data pack.
  *
@@ -137,7 +144,7 @@ native void ResetPack(Handle pack, bool clear=false);
  * @return			Numerical position in the data pack.
  * @error			Invalid handle.
  */
-native int GetPackPosition(Handle pack);
+native DataPackPos GetPackPosition(Handle pack);
 
 /**
  * Sets the read/write position in a data pack.
@@ -147,7 +154,7 @@ native int GetPackPosition(Handle pack);
  * @noreturn
  * @error			Invalid handle, or position is beyond the pack bounds.
  */
-native void SetPackPosition(Handle pack, int position);
+native void SetPackPosition(Handle pack, DataPackPos position);
 
 /**
  * Returns whether or not a specified number of bytes from the data pack
@@ -174,7 +181,7 @@ methodmap DataPack < Handle
 	public Reset() = ResetPack;
 	public IsReadable() = IsPackReadable;
 	
-	property int Position {
+	property DataPackPos Position {
 		public get() = GetPackPosition;
 		public set() = SetPackPosition;
 	}


### PR DESCRIPTION
Lots of users appear to be misusing the datapack position APIs and are making incorrect assumptions about what kind of values can be used as the position value.

This change aims to hide the value of a datapack's position behind a tag, thus requiring users to use the tagged value retrieved from a previous call to `GetPackPosition`, otherwise they'll encounter a compiler warning. This also updates the documentation to clarify how the functions should be used.

Hopefully using `enum` is still the usual way of declaring a tag in the new syntax.

@psychonic 