### PR TITLE
Fix maxlen in SetEntPropString not being initialized (bug 6391).

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -2109,10 +2109,10 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 					bIsStringIndex = true;
 				}
 			}
-			else
-			{
-				maxlen = DT_MAX_STRING_BUFFERSIZE;
-			}
+
+			// Only used if not string index.
+			maxlen = DT_MAX_STRING_BUFFERSIZE;
+			
 			break;
 		}
 	default:


### PR DESCRIPTION
This var is only used when setting a direct string, rather than a string_t. Some flawed
logic was causing it to only be set if the sendprop didn't have a proxy function (although
all strings should; that's how we detect whether it's a string_t or not). The var only needs
to be set if it's not a string_t, but does not hurt anything if it is.