### PR TITLE
Fix calling timer callback in paused plugins

### DIFF
--- a/core/logic/smn_timers.cpp
+++ b/core/logic/smn_timers.cpp
@@ -133,7 +133,10 @@ ResultType TimerNatives::OnTimer(ITimer *pTimer, void *pData)
 {
 	TimerInfo *pInfo = reinterpret_cast<TimerInfo *>(pData);
 	IPluginFunction *pFunc = pInfo->Hook;
-	cell_t res = static_cast<ResultType>(Pl_Continue);
+	if (!pFunc->IsRunnable())
+		return Pl_Continue;
+
+	cell_t res = static_cast<cell_t>(Pl_Continue);
 
 	pFunc->PushCell(pInfo->TimerHandle);
 	pFunc->PushCell(pInfo->UserData);


### PR DESCRIPTION
Don't try to call the timer callback, if it's not runnable.
Error wasn't reported before the exception refactoring. This reproduces the old behavior of just keeping the timer running and trying to call the callback until it's available again.

A better approach would be to stop all timers completely, if the plugin isn't going to change to running again from that paused state or just remove that pause state completely :+1: 