### PR TITLE
Add python syntax highlighting for AMBuildScripts on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+AMBuildScript linguist-language=Python

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -1,3 +1,4 @@
+# -*- mode: python;-*-
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os, sys
 

--- a/public/sample_ext/AMBuildScript
+++ b/public/sample_ext/AMBuildScript
@@ -1,3 +1,4 @@
+# -*- mode: python;-*-
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os, sys
 


### PR DESCRIPTION
Github allows per-file language overrides with the use of emacs mode lines. The global .gitattribute override only contributes to the language stats shown in the top bar.