### PR TITLE
Make path id default to "GAME" instead of NULL for FileExists and FileSize if param missing.

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -551,7 +551,8 @@ static cell_t sm_FileExists(IPluginContext *pContext, const cell_t *params)
 
 	if (params[0] >= 2 && params[2] == 1)
 	{
-		char *pathID = "GAME";
+		static char szDefaultPath[] = "GAME";
+		char *pathID = szDefaultPath;
 		if (params[0] >= 3)
 			pContext->LocalToStringNULL(params[3], &pathID);
 		
@@ -664,7 +665,8 @@ static cell_t sm_FileSize(IPluginContext *pContext, const cell_t *params)
 
 	if (params[0] >= 2 && params[2] == 1)
 	{
-		char *pathID = "GAME";
+		static char szDefaultPath[] = "GAME";
+		char *pathID = szDefaultPath;
 		if (params[0] >= 3)
 			pContext->LocalToStringNULL(params[3], &pathID);
 		

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -551,7 +551,7 @@ static cell_t sm_FileExists(IPluginContext *pContext, const cell_t *params)
 
 	if (params[0] >= 2 && params[2] == 1)
 	{
-		char *pathID = NULL;
+		char *pathID = "GAME";
 		if (params[0] >= 3)
 			pContext->LocalToStringNULL(params[3], &pathID);
 		
@@ -664,7 +664,7 @@ static cell_t sm_FileSize(IPluginContext *pContext, const cell_t *params)
 
 	if (params[0] >= 2 && params[2] == 1)
 	{
-		char *pathID = NULL;
+		char *pathID = "GAME";
 		if (params[0] >= 3)
 			pContext->LocalToStringNULL(params[3], &pathID);
 		


### PR DESCRIPTION
This only affects plugins compiled before the param existed in the includes. NULL defaults to "GAME"
on some engine versions, but is invalid on others, causing any file to not be found.