### PR TITLE
Fix build on Clang 3.6.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -181,6 +181,8 @@ class SMConfig(object):
       if have_clang or (have_gcc and cxx.version >= '4'):
         cxx.cflags += ['-fvisibility=hidden']
         cxx.cxxflags += ['-fvisibility-inlines-hidden']
+        if have_clang and cxx.version >= '3.6':
+          cxx.cxxflags += ['-Wno-inconsistent-missing-override']
         if have_clang or (have_gcc and cxx.version >= '4.6'):
           cxx.cflags += ['-Wno-narrowing']
         if (have_gcc and cxx.version >= '4.7') or (have_clang and cxx.version >= '3'):


### PR DESCRIPTION
On Clang 3.6, a warning is thrown if you use the override keyword on some virtual members in a class but not all. While consistency is great, I don't think that having this break the build is worth it. (Alternatively, we can update the code in all cases were this matters).