### PR TITLE
Cleanup some PluginSys idiosyncracies.

### DIFF
--- a/core/logic/NativeOwner.cpp
+++ b/core/logic/NativeOwner.cpp
@@ -48,7 +48,8 @@ unsigned int CNativeOwner::GetMarkSerial()
 
 void CNativeOwner::AddDependent(CPlugin *pPlugin)
 {
-	m_Dependents.push_back(pPlugin);
+	if (m_Dependents.find(pPlugin) == m_Dependents.end())
+		m_Dependents.push_back(pPlugin);
 }
 
 void CNativeOwner::AddWeakRef(const WeakNative & ref)
@@ -64,23 +65,8 @@ void CNativeOwner::AddNatives(const sp_nativeinfo_t *natives)
 	m_natives.append(natives);
 }
 
-void CNativeOwner::PropagateMarkSerial(unsigned int serial)
-{
-	CNativeOwner *pOwner;
-	List<CPlugin *>::iterator iter;
-
-	for (iter = m_Dependents.begin();
-		 iter != m_Dependents.end();
-		 iter++)
-	{
-		pOwner = (*iter);
-		pOwner->SetMarkSerial(serial);
-	}
-}
-
 void CNativeOwner::UnbindWeakRef(const WeakNative &ref)
 {
-	sp_native_t *native;
 	IPluginContext *pContext;
 
 	pContext = ref.pl->GetBaseContext();

--- a/core/logic/NativeOwner.h
+++ b/core/logic/NativeOwner.h
@@ -69,7 +69,6 @@ public:
 public:
 	void SetMarkSerial(unsigned int serial);
 	unsigned int GetMarkSerial();
-	void PropagateMarkSerial(unsigned int serial);
 public:
 	void AddDependent(CPlugin *pPlugin);
 	void AddWeakRef(const WeakNative & ref);

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1381,6 +1381,7 @@ bool CPluginManager::RunSecondPass(CPlugin *pPlugin, char *error, size_t maxleng
 					  || pOther->GetStatus() == Plugin_Paused)
 					 && pOther != pPlugin)
 			{
+				g_ShareSys.BeginBindingFor(pPlugin);
 				for (size_t i = 0; i < pPlugin->m_fakes.length(); i++)
 					g_ShareSys.BindNativeToPlugin(pOther, pPlugin->m_fakes[i]);
 			}

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -50,6 +50,7 @@
 #include "IGameConfigs.h"
 #include "NativeOwner.h"
 #include "ShareSys.h"
+#include "PhraseCollection.h"
 #include <bridge/include/IScriptManager.h>
 
 class CPlayer;
@@ -140,7 +141,7 @@ public:
 	bool IsDebugging();
 	PluginStatus GetStatus();
 	bool IsSilentlyFailed();
-	void SetSilentlyFailed(bool sf);
+	void SetSilentlyFailed();
 	const sm_plugininfo_t *GetPublicInfo();
 	bool SetPauseState(bool paused);
 	unsigned int GetSerial();
@@ -251,31 +252,40 @@ protected:
 	bool UpdateInfo();
 	void SetTimeStamp(time_t t);
 	void DependencyDropped(CPlugin *pOwner);
+
 private:
-	PluginType m_type;
+	// This information is static for the lifetime of the plugin.
 	char m_filename[PLATFORM_MAX_PATH];
-	PluginStatus m_status;
-	bool m_bSilentlyFailed;
 	unsigned int m_serial;
-	sm_plugininfo_t m_info;
-	char m_errormsg[256];
-	time_t m_LastAccess;
-	IdentityToken_t *m_ident;
-	Handle_t m_handle;
-	bool m_WasRunning;
-	IPhraseCollection *m_pPhrases;
-	List<String> m_RequiredLibs;
-	List<String> m_Libraries;
-	StringHashMap<void *> m_Props;
+
+	PluginStatus m_status;
+
+	// Statuses that are set during failure.
+	bool m_SilentFailure;
 	bool m_FakeNativesMissing;
 	bool m_LibraryMissing;
-	CVector<AutoConfig *> m_configs;
-	bool m_bGotAllLoaded;
-	int m_FileVersion;
-	char m_DateTime[256];
-	IPluginRuntime *m_pRuntime;
+	char m_errormsg[256];
+
+	// Internal properties that must by reset if the runtime is evicted.
+	ke::AutoPtr<IPluginRuntime> m_pRuntime;
+	ke::AutoPtr<CPhraseCollection> m_pPhrases;
 	IPluginContext *m_pContext;
 	sp_pubvar_t *m_MaxClientsVar;
+	StringHashMap<void *> m_Props;
+	CVector<AutoConfig *> m_configs;
+	IdentityToken_t *m_ident;
+	bool m_bGotAllLoaded;
+	int m_FileVersion;
+
+	// Information that survives past eviction.
+	List<String> m_RequiredLibs;
+	List<String> m_Libraries;
+	time_t m_LastAccess;
+	Handle_t m_handle;
+	char m_DateTime[256];
+
+	// Cached.
+	sm_plugininfo_t m_info;
 };
 
 class CPluginManager : 

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -455,6 +455,9 @@ private:
 	bool FindOrRequirePluginDeps(CPlugin *pPlugin, char *error, size_t maxlength);
 
 	void _SetPauseState(CPlugin *pPlugin, bool pause);
+
+	bool ScheduleUnload(CPlugin *plugin);
+	void UnloadPluginImpl(CPlugin *plugin);
 protected:
 	/**
 	 * Caching internal objects

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -51,6 +51,7 @@
 #include "NativeOwner.h"
 #include "ShareSys.h"
 #include "PhraseCollection.h"
+#include <am-string.h>
 #include <bridge/include/IScriptManager.h>
 
 class CPlayer;
@@ -286,6 +287,11 @@ private:
 
 	// Cached.
 	sm_plugininfo_t m_info;
+	ke::AString info_name_;
+	ke::AString info_author_;
+	ke::AString info_description_;
+	ke::AString info_version_;
+	ke::AString info_url_;
 };
 
 class CPluginManager : 

--- a/core/logic/ShareSys.h
+++ b/core/logic/ShareSys.h
@@ -119,6 +119,7 @@ public:
 		return &m_IdentRoot;
 	}
 public:
+	void BeginBindingFor(CPlugin *pPlugin);
 	void BindNativesToPlugin(CPlugin *pPlugin, bool bCoreOnly);
 	void BindNativeToPlugin(CPlugin *pPlugin, const ke::Ref<Native> &pEntry);
 	ke::PassRef<Native> AddFakeNative(IPluginFunction *pFunc, const char *name, SPVM_FAKENATIVE_FUNC func);

--- a/core/logic/Translator.cpp
+++ b/core/logic/Translator.cpp
@@ -991,7 +991,7 @@ unsigned int Translator::GetInterfaceVersion()
 	return SMINTERFACE_TRANSLATOR_VERSION;
 }
 
-IPhraseCollection *Translator::CreatePhraseCollection()
+CPhraseCollection *Translator::CreatePhraseCollection()
 {
 	return new CPhraseCollection();
 }

--- a/core/logic/Translator.h
+++ b/core/logic/Translator.h
@@ -39,6 +39,7 @@
 #include "sm_memtable.h"
 #include "ITextParsers.h"
 #include <ITranslator.h>
+#include "PhraseCollection.h"
 
 /* :TODO: write a templatized version of tries? */
 
@@ -127,7 +128,7 @@ public: //ITranslator
 	unsigned int GetClientLanguage(int client);
 	const char *GetInterfaceName();
 	unsigned int GetInterfaceVersion();
-	IPhraseCollection *CreatePhraseCollection();
+	CPhraseCollection *CreatePhraseCollection();
 	int SetGlobalTarget(int index);
 	int GetGlobalTarget() const;
 	size_t FormatString(

--- a/core/logic/smn_fakenatives.cpp
+++ b/core/logic/smn_fakenatives.cpp
@@ -392,7 +392,6 @@ static cell_t FormatNativeString(IPluginContext *pContext, const cell_t *params)
 	}
 
 	/* Get buffer information */
-	int err;
 	char *output_buffer;
 	char *format_buffer;
 


### PR DESCRIPTION
This is a general cleanup, separated into a few commits for reviewability.

1. UnloadPlugin is now split up into an outer function and inner. The outer function just determines whether or not the unload can actually occur yet.
2. Dependency links were not formed correctly. The cache to optimize their creation was bogus in multiple ways, which has been fixed.
3. Dependency links were not created for library-only dependencies. That has been fixed.
4. The CPlugin class got some visual cleanup (organizing member variables, using AutoPtr, etc).
5. Plugin info is now stored in SH::String for safety. Requesting the info struct now taps into those strings instead of the runtime. This will let us persist info across unloads.