### PR TITLE
Don't use server commands for scheduling plugin unloads.

### DIFF
--- a/bridge/include/IProviderCallbacks.h
+++ b/bridge/include/IProviderCallbacks.h
@@ -35,6 +35,9 @@ class IProviderCallbacks
 public:
 	// Called when a log message is printed. Return true to supercede.
 	virtual bool OnLogPrint(const char *msg) = 0;
+
+	// Called each frame tick.
+	virtual void OnThink(bool simulating) = 0;
 };
 
 } // namespace SourceMod

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -80,6 +80,7 @@ binary.sources += [
   'LibrarySys.cpp',
   'RootConsoleMenu.cpp',
   'CDataPack.cpp',
+  'frame_tasks.cpp',
 ]
 if builder.target_platform == 'windows':
   binary.sources += ['thread/WinThreads.cpp']

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -222,20 +222,21 @@ public:
 	 */
 	IPhraseCollection *GetPhrases();
 public:
-	/**
-	 * Returns the modification time during last plugin load.
-	 */
+	// Returns the modification time during last plugin load.
 	time_t GetTimeStamp();
 
-	/**
-	 * Returns the current modification time of the plugin file.
-	 */
+	// Returns the current modification time of the plugin file.
 	time_t GetFileTimeStamp();
 
-	/** 
-	 * Returns true if the plugin was running, but is now invalid.
-	 */
+	// Returns true if the plugin was running, but is now invalid.
 	bool WasRunning();
+
+	bool WaitingToUnload() const {
+		return m_WaitingToUnload;
+	}
+	void SetWaitingToUnload() {
+		m_WaitingToUnload = true;
+	}
 
 	Handle_t GetMyHandle();
 
@@ -243,8 +244,7 @@ public:
 	void AddConfig(bool autoCreate, const char *cfg, const char *folder);
 	size_t GetConfigCount();
 	AutoConfig *GetConfig(size_t i);
-	inline void AddLibrary(const char *name)
-	{
+	inline void AddLibrary(const char *name) {
 		m_Libraries.push_back(name);
 	}
 	void LibraryActions(LibraryAction action);
@@ -260,6 +260,7 @@ private:
 	unsigned int m_serial;
 
 	PluginStatus m_status;
+	bool m_WaitingToUnload;
 
 	// Statuses that are set during failure.
 	bool m_SilentFailure;

--- a/core/logic/common_logic.cpp
+++ b/core/logic/common_logic.cpp
@@ -51,6 +51,7 @@
 #include "AdminCache.h"
 #include "ProfileTools.h"
 #include "Logger.h"
+#include "frame_tasks.h"
 #include "sprintf.h"
 #include "LibrarySys.h"
 #include "RootConsoleMenu.h"
@@ -136,6 +137,9 @@ class ProviderCallbackListener : public IProviderCallbacks
 public:
 	bool OnLogPrint(const char *msg) override {
 		return ::OnLogPrint(msg);
+	}
+	void OnThink(bool simulating) override {
+		RunScheduledFrameTasks(simulating);
 	}
 } sProviderCallbackListener;
 

--- a/core/logic/frame_tasks.cpp
+++ b/core/logic/frame_tasks.cpp
@@ -1,0 +1,55 @@
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
+#include "frame_tasks.h"
+#include <am-vector.h>
+
+using namespace SourceMod;
+
+ke::Vector<ke::Lambda<void()>> sNextTasks;
+ke::Vector<ke::Lambda<void()>> sWorkTasks;
+
+void
+SourceMod::ScheduleTaskForNextFrame(ke::Lambda<void()>&& task)
+{
+	sNextTasks.append(ke::Forward<decltype(task)>(task));
+}
+
+void
+SourceMod::RunScheduledFrameTasks(bool simulating)
+{
+	if (sNextTasks.empty())
+		return;
+
+	// Swap.
+	ke::Vector<ke::Lambda<void()>> temp(ke::Move(sNextTasks));
+	sNextTasks = ke::Move(sWorkTasks);
+	sWorkTasks = ke::Move(temp);
+
+	for (size_t i = 0; i < sWorkTasks.length(); i++)
+		sWorkTasks[i]();
+	sWorkTasks.clear();
+}

--- a/core/logic/frame_tasks.h
+++ b/core/logic/frame_tasks.h
@@ -1,0 +1,40 @@
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
+#ifndef _include_sourcemod_logic_frame_tasks_h_
+#define _include_sourcemod_logic_frame_tasks_h_
+
+#include <am-function.h>
+
+namespace SourceMod {
+
+void ScheduleTaskForNextFrame(ke::Lambda<void()>&& task);
+
+void RunScheduledFrameTasks(bool simulating);
+
+}
+
+#endif // _include_sourcemod_logic_frame_tasks_h_

--- a/core/sourcemm_api.cpp
+++ b/core/sourcemm_api.cpp
@@ -78,11 +78,15 @@ bool SourceMod_Core::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen
 		engine = (IVEngineServer *)ismm->GetEngineFactory()("VEngineServer022", nullptr);
 		if (!engine)
 		{
-			if (error && maxlen)
+			engine = (IVEngineServer *)ismm->GetEngineFactory()("VEngineServer021", nullptr);
+			if (!engine)
 			{
-				ismm->Format(error, maxlen, "Could not find interface: VEngineServer023 or VEngineServer022");
+				if (error && maxlen)
+				{
+					ismm->Format(error, maxlen, "Could not find interface: VEngineServer023 or VEngineServer022");
+				}
+				return false;
 			}
-			return false;
 		}
 	}
 #else

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -46,11 +46,13 @@
 #include <amtl/os/am-path.h>
 #include <bridge/include/IExtensionBridge.h>
 #include <bridge/include/IScriptManager.h>
+#include <bridge/include/IProviderCallbacks.h>
 #include <bridge/include/ILogger.h>
 
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);
 SH_DECL_HOOK0_void(IServerGameDLL, LevelShutdown, SH_NOATTRIB, false);
 SH_DECL_HOOK1_void(IServerGameDLL, GameFrame, SH_NOATTRIB, false, bool);
+SH_DECL_HOOK1_void(IServerGameDLL, Think, SH_NOATTRIB, false, bool);
 SH_DECL_HOOK1_void(IVEngineServer, ServerCommand, SH_NOATTRIB, false, const char *);
 
 SourceModBase g_SourceMod;
@@ -322,6 +324,8 @@ void SourceModBase::StartSourceMod(bool late)
 	{
 		g_pSourcePawn2->InstallWatchdogTimer(atoi(timeout) * 1000);
 	}
+
+	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
 static bool g_LevelEndBarrier = false;
@@ -539,6 +543,7 @@ void SourceModBase::ShutdownServices()
 
 	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
 	SH_REMOVE_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
+	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
 void SourceModBase::LogMessage(IExtension *pExt, const char *format, ...)

--- a/gamedata/sdkhooks.games/engine.csgo.txt
+++ b/gamedata/sdkhooks.games/engine.csgo.txt
@@ -42,27 +42,27 @@
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"293"
-				"linux"		"294"
-				"mac"		"294"
+				"windows"	"294"
+				"linux"		"295"
+				"mac"		"295"
 			}
 			"PreThink"
-			{
-				"windows"	"366"
-				"linux"		"367"
-				"mac"		"367"
-			}
-			"PostThink"
 			{
 				"windows"	"367"
 				"linux"		"368"
 				"mac"		"368"
 			}
+			"PostThink"
+			{
+				"windows"	"368"
+				"linux"		"369"
+				"mac"		"369"
+			}
 			"Reload"
 			{
-				"windows"	"308"
-				"linux"		"314"
-				"mac"		"314"
+				"windows"	"309"
+				"linux"		"315"
+				"mac"		"315"
 			}
 			"SetTransmit"
 			{
@@ -120,33 +120,33 @@
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"285"
-				"linux"		"286"
-				"mac"		"286"
+				"windows"	"286"
+				"linux"		"287"
+				"mac"		"287"
 			}
 			"Weapon_CanUse"
-			{
-				"windows"	"279"
-				"linux"		"280"
-				"mac"		"280"
-			}
-			"Weapon_Drop"
-			{
-				"windows"	"282"
-				"linux"		"283"
-				"mac"		"283"
-			}
-			"Weapon_Equip"
 			{
 				"windows"	"280"
 				"linux"		"281"
 				"mac"		"281"
 			}
-			"Weapon_Switch"
+			"Weapon_Drop"
 			{
 				"windows"	"283"
 				"linux"		"284"
 				"mac"		"284"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"281"
+				"linux"		"282"
+				"mac"		"282"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"284"
+				"linux"		"285"
+				"mac"		"285"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -232,21 +232,21 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"446"
-				"linux"		"447"
-				"mac"		"447"
+				"windows"	"448"
+				"linux"		"449"
+				"mac"		"449"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"291"
-				"linux"		"292"
-				"mac"		"292"
+				"windows"	"292"
+				"linux"		"293"
+				"mac"		"293"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"287"
-				"linux"		"288"
-				"mac"		"288"
+				"windows"	"288"
+				"linux"		"289"
+				"mac"		"289"
 			}
 			"Ignite"
 			{
@@ -268,9 +268,9 @@
 			}
 			"CommitSuicide"
 			{
-				"windows"	"496"
-				"linux"		"496"
-				"mac"		"496"
+				"windows"	"498"
+				"linux"		"498"
+				"mac"		"498"
 			}
 			"GetVelocity"
 			{
@@ -298,9 +298,9 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"280"
-				"linux"		"281"
-				"mac"		"281"
+				"windows"	"281"
+				"linux"		"282"
+				"mac"		"282"
 			}
 			"Activate"
 			{
@@ -310,15 +310,15 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"466"
-				"linux"		"467"
-				"mac"		"467"
+				"windows"	"468"
+				"linux"		"469"
+				"mac"		"469"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"273"
-				"linux"		"274"
-				"mac"		"274"
+				"windows"	"274"
+				"linux"		"275"
+				"mac"		"275"
 			}
 		}
 	}

--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -348,11 +348,15 @@ bool SDKExtension::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, 
 		engine = (IVEngineServer *) ismm->GetEngineFactory()("VEngineServer022", nullptr);
 		if (!engine)
 		{
-			if (error && maxlen)
+			engine = (IVEngineServer *) ismm->GetEngineFactory()("VEngineServer021", nullptr);
+			if (!engine)
 			{
-				ismm->Format(error, maxlen, "Could not find interface: VEngineServer023 or VEngineServer022");
+				if (error && maxlen)
+				{
+					ismm->Format(error, maxlen, "Could not find interface: VEngineServer023 or VEngineServer022");
+				}
+				return false;
 			}
-			return false;
 		}
 	}
 #else

--- a/tools/gdc-psyfork/gdc.cpp
+++ b/tools/gdc-psyfork/gdc.cpp
@@ -431,14 +431,15 @@ void CheckWindowsSigOffset(char* name, const char* symbol, int file)
 		if(sigOffset != -1 && sigOffsetByte != NULL)//Got the offset in the function
 		{
 			uint8_t iByte = strtoul(sigOffsetByte, NULL, 16);
+			uint8_t iCompare = *(uint8_t *)((intptr_t)ptr + sigOffset);
 
-			if(iByte == *(uint8_t *)((intptr_t)ptr + sigOffset))
+			if(iByte == iCompare)
 			{
-				printf("     w: %s -> %s (%4d) == \\x%s GOOD\n", name, sigOffsetKey, sigOffset, sigOffsetByte);
+				printf("     w: %s -> %s (%4d) \\x%02X == \\x%02X GOOD\n", name, sigOffsetKey, sigOffset, iCompare, iByte);
 			}
 			else
 			{
-				printf("!    w: %s -> %s (%4d) != \\x%s BAD\n", name, sigOffsetKey, sigOffset, sigOffsetByte);
+				printf("!    w: %s -> %s (%4d) \\x%02X != \\x%02X BAD\n", name, sigOffsetKey, sigOffset, iCompare, iByte);
 			}
 		}
 	}
@@ -482,14 +483,15 @@ void CheckLinuxSigOffset(char* name, const char* symbol, void * handle)
 			if(sigOffset != -1 && sigOffsetByte != NULL)//Got the offset in the function
 			{
 				uint8_t iByte = strtoul(sigOffsetByte, NULL, 16);
+				uint8_t iCompare = *(uint8_t *)((intptr_t)ptr + sigOffset);
 
-				if(iByte == *(uint8_t *)((intptr_t)ptr + sigOffset))
+				if(iByte == iCompare)
 				{
-					printf("     l: %s -> %s (%4d) == \\x%s GOOD\n", name, sigOffsetKey, sigOffset, sigOffsetByte);
+					printf("     l: %s -> %s (%4d) \\x%02X == \\x%02X GOOD\n", name, sigOffsetKey, sigOffset, iCompare, iByte);
 				}
 				else
 				{
-					printf("!    l: %s -> %s (%4d) != \\x%s BAD\n", name, sigOffsetKey, sigOffset, sigOffsetByte);
+					printf("!    l: %s -> %s (%4d) \\x%02X != \\x%02X BAD\n", name, sigOffsetKey, sigOffset, iCompare, iByte);
 				}
 			}
 		}
@@ -502,14 +504,15 @@ void CheckLinuxSigOffset(char* name, const char* symbol, void * handle)
 		if(sigOffset != -1 && sigOffsetByte != NULL)//Got the offset in the function
 		{
 			uint8_t iByte = strtoul(sigOffsetByte, NULL, 16);
+			uint8_t iCompare = *(uint8_t *)((intptr_t)ptr + sigOffset);
 
-			if(iByte == *(uint8_t *)((intptr_t)ptr + sigOffset))
+			if(iByte == iCompare)
 			{
-				printf("     l: %s -> %s (%4d) == \\x%s GOOD\n", name, sigOffsetKey, sigOffset, sigOffsetByte);
+				printf("     l: %s -> %s (%4d) \\x%02X == \\x%02X GOOD\n", name, sigOffsetKey, sigOffset, iCompare, iByte);
 			}
 			else
 			{
-				printf("!    l: %s -> %s (%4d) != \\x%s BAD\n", name, sigOffsetKey, sigOffset, sigOffsetByte);
+				printf("!    l: %s -> %s (%4d) \\x%02X != \\x%02X BAD\n", name, sigOffsetKey, sigOffset, iCompare, iByte);
 			}
 		}
 	}


### PR DESCRIPTION
If a plugin is currently active on the call stack, we can't unload immediately unload it since we would crash. The old code to deal with this used server commands to unload the plugin. That's pretty sketchy for a bunch of reasons.

The new method below adds the ability to attack one-off callbacks to IServerGameDLL::Think(), and then we use that to flush plugin unloads instead.