### PR TITLE
Fix ConVar .IntValue, .BoolValue, and .FloatValue assignments (Bug 6405)

### DIFF
--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -361,13 +361,13 @@ static cell_t sm_SetConVarNum(IPluginContext *pContext, const cell_t *params)
 
 #if SOURCE_ENGINE < SE_ORANGEBOX
 	/* Should we replicate it? */
-	if (params[3] && IsFlagSet(pConVar, FCVAR_REPLICATED))
+	if (params[0] >= 3 && params[3] && IsFlagSet(pConVar, FCVAR_REPLICATED))
 	{
 		ReplicateConVar(pConVar);
 	}
 
 	/* Should we notify clients? */
-	if (params[4] && IsFlagSet(pConVar, FCVAR_NOTIFY))
+	if (params[0] >= 4 && params[4] && IsFlagSet(pConVar, FCVAR_NOTIFY))
 	{
 		NotifyConVar(pConVar);
 	}
@@ -410,13 +410,13 @@ static cell_t sm_SetConVarFloat(IPluginContext *pContext, const cell_t *params)
 
 #if SOURCE_ENGINE < SE_ORANGEBOX
 	/* Should we replicate it? */
-	if (params[3] && IsFlagSet(pConVar, FCVAR_REPLICATED))
+	if (params[0] >= 3 && params[3] && IsFlagSet(pConVar, FCVAR_REPLICATED))
 	{
 		ReplicateConVar(pConVar);
 	}
 
 	/* Should we notify clients? */
-	if (params[4] && IsFlagSet(pConVar, FCVAR_NOTIFY))
+	if (params[0] >= 4 && params[4] && IsFlagSet(pConVar, FCVAR_NOTIFY))
 	{
 		NotifyConVar(pConVar);
 	}
@@ -461,13 +461,13 @@ static cell_t sm_SetConVarString(IPluginContext *pContext, const cell_t *params)
 
 #if SOURCE_ENGINE < SE_ORANGEBOX
 	/* Should we replicate it? */
-	if (params[3] && IsFlagSet(pConVar, FCVAR_REPLICATED))
+	if (params[0] >= 3 && params[3] && IsFlagSet(pConVar, FCVAR_REPLICATED))
 	{
 		ReplicateConVar(pConVar);
 	}
 
 	/* Should we notify clients? */
-	if (params[4] && IsFlagSet(pConVar, FCVAR_NOTIFY))
+	if (params[0] >= 4 && params[4] && IsFlagSet(pConVar, FCVAR_NOTIFY))
 	{
 		NotifyConVar(pConVar);
 	}
@@ -1240,45 +1240,6 @@ static cell_t RemoveCommandListener(IPluginContext *pContext, const cell_t *para
 	return 1;
 }
 
-static cell_t ConVar_BoolValue_set(IPluginContext *pContext, const cell_t *params)
-{
-	static cell_t new_params[5] = {
-		4,
-		params[1],
-		params[2],
-		0, /* Default replicate setting. */
-		0, /* Default replicate setting. */
-	};
-
-	return sm_SetConVarNum(pContext, new_params);
-}
-
-static cell_t ConVar_IntValue_set(IPluginContext *pContext, const cell_t *params)
-{
-	static cell_t new_params[5] = {
-		4,
-		params[1],
-		params[2],
-		0, /* Default replicate setting. */
-		0, /* Default replicate setting. */
-	};
-
-	return sm_SetConVarNum(pContext, new_params);
-}
-
-static cell_t ConVar_FloatValue_set(IPluginContext *pContext, const cell_t *params)
-{
-	static cell_t new_params[5] = {
-		4,
-		params[1],
-		params[2],
-		0, /* Default replicate setting. */
-		0, /* Default replicate setting. */
-	};
-
-	return sm_SetConVarFloat(pContext, new_params);
-}
-
 static cell_t ConVar_ReplicateToClient(IPluginContext *pContext, const cell_t *params)
 {
 	// Old version is (client, handle, value).
@@ -1381,11 +1342,11 @@ REGISTER_NATIVES(consoleNatives)
 
 	// Transitional syntax support.
 	{"ConVar.BoolValue.get",	sm_GetConVarBool},
-	{"ConVar.BoolValue.set",	ConVar_BoolValue_set},
+	{"ConVar.BoolValue.set",	sm_SetConVarNum},
 	{"ConVar.FloatValue.get",	sm_GetConVarFloat},
-	{"ConVar.FloatValue.set",	ConVar_FloatValue_set},
+	{"ConVar.FloatValue.set",	sm_SetConVarFloat},
 	{"ConVar.IntValue.get",		sm_GetConVarInt},
-	{"ConVar.IntValue.set",		ConVar_IntValue_set},
+	{"ConVar.IntValue.set",		sm_SetConVarNum},
 	{"ConVar.Flags.get",		sm_GetConVarFlags},
 	{"ConVar.Flags.set",		sm_SetConVarFlags},
 	{"ConVar.SetBool",			sm_SetConVarNum},


### PR DESCRIPTION
This is a fix for [Bug 6405](https://bugs.alliedmods.net/show_bug.cgi?id=6405)

Simply put, this patch gets rid of `ConVar_BoolValue_set`, `ConVar_FloatValue_set`, and `ConVar_IntValue_set`.

Instead, it uses `sm_SetConVarNum` and `sm_SetConVarFloat` directly.

However, so we don't cause issues with pre-OrangeBox games,  the above two functions and `sm_SetConVarString` now check if `params[0]` (the parameter count) is >= the parameter number before using params 3 (replicate) and 4 (notify).