### PR TITLE
Remove strncopy from the core/logic bridge.

### DIFF
--- a/core/logic/Translator.cpp
+++ b/core/logic/Translator.cpp
@@ -718,7 +718,7 @@ ConfigResult Translator::OnSourceModConfigChanged(const char *key,
 
 			m_ServerLang = index;
 		} else {
-			smcore.strncopy(m_InitialLang, value, sizeof(m_InitialLang));
+			strncopy(m_InitialLang, value, sizeof(m_InitialLang));
 		}
 
 		return ConfigResult_Accept;
@@ -840,7 +840,7 @@ void Translator::RebuildLanguageDatabase()
 	{
 		logger->LogError("Server language was set to bad language \"%s\" -- reverting to English", m_InitialLang);
 
-		smcore.strncopy(m_InitialLang, "en", sizeof(m_InitialLang));
+		strncopy(m_InitialLang, "en", sizeof(m_InitialLang));
 		m_ServerLang = SOURCEMOD_LANGUAGE_ENGLISH;
 	}
 

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 31)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 32)
 
 #if defined SM_LOGIC
 class IVEngineServer
@@ -293,7 +293,6 @@ struct sm_core_t
 	ISourcePawnEngine2 **spe2;
 	/* Functions */
 	ConVar *		(*FindConVar)(const char*);
-	unsigned int	(*strncopy)(char*, const char*, size_t);
 	char *			(*TrimWhitespace)(char *, size_t &);
 	void			(*LogToGame)(const char *message);
 	void			(*ConPrint)(const char *message);

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -1,5 +1,5 @@
 /**
- * vim: set ts=4 :
+ * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
  * SourceMod
  * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include "common_logic.h"
 #include "CellArray.h"
+#include "stringutil.h"
 
 HandleType_t htCellArray;
 
@@ -181,7 +182,7 @@ static cell_t PushArrayString(IPluginContext *pContext, const cell_t *params)
 	char *str;
 	pContext->LocalToString(params[2], &str);
 
-	smcore.strncopy((char *)blk, str, array->blocksize() * sizeof(cell_t));
+	strncopy((char *)blk, str, array->blocksize() * sizeof(cell_t));
 
 	return (cell_t)(array->size() - 1);
 }
@@ -378,7 +379,7 @@ static cell_t SetArrayString(IPluginContext *pContext, const cell_t *params)
 	char *str;
 	pContext->LocalToString(params[3], &str);
 
-	return smcore.strncopy((char *)blk, str, array->blocksize() * sizeof(cell_t));
+	return strncopy((char *)blk, str, array->blocksize() * sizeof(cell_t));
 }
 
 static cell_t SetArrayArray(IPluginContext *pContext, const cell_t *params)

--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -33,6 +33,7 @@
 #include "common_logic.h"
 #include "CellArray.h"
 #include "handle_helpers.h"
+#include "stringutil.h"
 
 HandleType_t htCellStack;
 
@@ -125,7 +126,7 @@ static cell_t PushStackString(IPluginContext *pContext, const cell_t *params)
 	char *str;
 	pContext->LocalToString(params[2], &str);
 
-	smcore.strncopy((char *)blk, str, array->blocksize() * sizeof(cell_t));
+	strncopy((char *)blk, str, array->blocksize() * sizeof(cell_t));
 
 	return 1;
 }

--- a/core/logic/smn_banning.cpp
+++ b/core/logic/smn_banning.cpp
@@ -337,7 +337,7 @@ static cell_t BanClient(IPluginContext *pContext, const cell_t *params)
 		{
 			/* Get the IP address and strip the port */
 			char ip[24], *ptr;
-			smcore.strncopy(ip, pPlayer->GetIPAddress(), sizeof(ip));
+			strncopy(ip, pPlayer->GetIPAddress(), sizeof(ip));
 			if ((ptr = strchr(ip, ':')) != NULL)
 			{
 				*ptr = '\0';

--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -110,9 +110,9 @@ public:
 			pMapList->bIsCompat = true;
 			pMapList->bIsPath = true;
 			pMapList->last_modified_time = 0;
-			smcore.strncopy(pMapList->name, name, sizeof(pMapList->name));
+			strncopy(pMapList->name, name, sizeof(pMapList->name));
 			pMapList->pArray = NULL;
-			smcore.strncopy(pMapList->path, file, sizeof(pMapList->path));
+			strncopy(pMapList->path, file, sizeof(pMapList->path));
 			pMapList->serial = 0;
 			m_ListLookup.insert(name, pMapList);
 			m_MapLists.push_back(pMapList);
@@ -123,13 +123,13 @@ public:
 		if (!pMapList->bIsCompat)
 			return;
 
-		smcore.strncopy(path, file, sizeof(path));
+		strncopy(path, file, sizeof(path));
 
 		/* If the path matches, don't reset the serial/time */
 		if (strcmp(path, pMapList->path) == 0)
 			return;
 
-		smcore.strncopy(pMapList->path, path, sizeof(pMapList->path));
+		strncopy(pMapList->path, path, sizeof(pMapList->path));
 		pMapList->bIsPath = true;
 		pMapList->last_modified_time = 0;
 		pMapList->serial = 0;
@@ -168,7 +168,7 @@ public:
 		maplist_info_t *pDefList = new maplist_info_t;
 
 		pDefList->bIsPath = true;
-		smcore.strncopy(pDefList->name, "mapcyclefile", sizeof(pDefList->name));
+		strncopy(pDefList->name, "mapcyclefile", sizeof(pDefList->name));
 
 		GetMapCycleFilePath(pDefList->path, sizeof(pDefList->path));
 		
@@ -246,7 +246,7 @@ public:
 			m_pCurMapList = new maplist_info_t;
 
 			memset(m_pCurMapList, 0, sizeof(maplist_info_t));
-			smcore.strncopy(m_pCurMapList->name, name, sizeof(m_pCurMapList->name));
+			strncopy(m_pCurMapList->name, name, sizeof(m_pCurMapList->name));
 
 			m_CurState = MPS_MAPLIST;
 		}
@@ -266,12 +266,12 @@ public:
 
 		if (strcmp(key, "file") == 0)
 		{
-			smcore.strncopy(m_pCurMapList->path, value, sizeof(m_pCurMapList->path));
+			strncopy(m_pCurMapList->path, value, sizeof(m_pCurMapList->path));
 			m_pCurMapList->bIsPath = true;
 		}
 		else if (strcmp(key, "target") == 0)
 		{
-			smcore.strncopy(m_pCurMapList->path, value, sizeof(m_pCurMapList->path));
+			strncopy(m_pCurMapList->path, value, sizeof(m_pCurMapList->path));
 			m_pCurMapList->bIsPath = false;
 		}
 
@@ -383,7 +383,7 @@ public:
 					continue;
 				}
 
-				smcore.strncopy((char *)blk, buffer, 255);
+				strncopy((char *)blk, buffer, 255);
 
 				fileName = smcore.filesystem->FindNext(findHandle);
 			}
@@ -442,7 +442,7 @@ public:
 		{
 			blk_dst = pUseArray->push();
 			blk_src = pNewArray->at(i);
-			smcore.strncopy((char *)blk_dst, (char *)blk_src, pUseArray->blocksize() * sizeof(cell_t));
+			strncopy((char *)blk_dst, (char *)blk_src, pUseArray->blocksize() * sizeof(cell_t));
 		}
 
 		/* Free resources if necessary. */
@@ -480,7 +480,7 @@ private:
 
 			if (strcmp(path, pMapList->path) != 0)
 			{
-				smcore.strncopy(pMapList->path, path, sizeof(pMapList->path));
+				strncopy(pMapList->path, path, sizeof(pMapList->path));
 				pMapList->last_modified_time = 0;
 			}
 		}
@@ -535,7 +535,7 @@ private:
 
 				if ((blk = pMapList->pArray->push()) != NULL)
 				{
-					smcore.strncopy((char *)blk, ptr, 255);
+					strncopy((char *)blk, ptr, 255);
 				}
 			}
 

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -40,6 +40,7 @@
 #include "GameConfigs.h"
 #include "CellArray.h"
 #include "AutoHandleRooter.h"
+#include "stringutil.h"
 
 using namespace SourceHook;
 using namespace SourceMod;
@@ -163,7 +164,7 @@ public: //ICommandTargetProcessor
 				               ? COMMAND_TARGET_VALID
 				               : COMMAND_TARGET_EMPTY_FILTER;
 				if (info->num_targets) {
-					smcore.strncopy(info->target_name, smtf->phrase.c_str(), info->target_name_maxlength);
+					strncopy(info->target_name, smtf->phrase.c_str(), info->target_name_maxlength);
 					info->target_name_style = smtf->phraseIsML
 					                          ? COMMAND_TARGETNAME_ML
 					                          : COMMAND_TARGETNAME_RAW;

--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -1,5 +1,5 @@
 /**
- * vim: set ts=4 sw=4 tw=99 et :
+ * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
  * SourceMod
  * Copyright (C) 2004-2009 AlliedModders LLC.  All rights reserved.
@@ -34,6 +34,7 @@
 #include <ctype.h>
 #include <sm_platform.h>
 #include "stringutil.h"
+#include <am-string.h>
 
 // We're in logic so we don't have this from the SDK.
 #ifndef MIN
@@ -73,19 +74,7 @@ const char *stristr(const char *str, const char *substr)
 
 unsigned int strncopy(char *dest, const char *src, size_t count)
 {
-	if (!count)
-	{
-		return 0;
-	}
-
-	char *start = dest;
-	while ((*src) && (--count))
-	{
-		*dest++ = *src++;
-	}
-	*dest = '\0';
-
-	return (dest - start);
+	return ke::SafeStrcpy(dest, count, src);
 }
 
 unsigned int UTIL_ReplaceAll(char *subject, size_t maxlength, const char *search, const char *replace, bool caseSensitive)

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -583,7 +583,6 @@ static sm_core_t core_bridge =
 	&g_pSourcePawn2,
 	/* Functions */
 	find_convar,
-	strncopy,
 	UTIL_TrimWhitespace,
 	log_to_game,
 	conprint,

--- a/core/sm_stringutil.cpp
+++ b/core/sm_stringutil.cpp
@@ -1280,19 +1280,7 @@ done:
 
 unsigned int strncopy(char *dest, const char *src, size_t count)
 {
-	if (!count)
-	{
-		return 0;
-	}
-
-	char *start = dest;
-	while ((*src) && (--count))
-	{
-		*dest++ = *src++;
-	}
-	*dest = '\0';
-
-	return (dest - start);
+	return ke::SafeStrcpy(dest, count, src);
 }
 
 size_t UTIL_Format(char *buffer, size_t maxlength, const char *fmt, ...)


### PR DESCRIPTION
I just uplifted strncopy to AMTL - so we can ditch its impl in core+logic and also remove it from the bridge (it was unneeded there to begin with).