### PR TITLE
Begin refactoring the core/logic bridge.

### DIFF
--- a/core/logic/AdminCache.cpp
+++ b/core/logic/AdminCache.cpp
@@ -328,7 +328,7 @@ void AdminCache::AddCommandOverride(const char *cmd, OverrideType type, FlagBits
 		return;
 
 	map->insert(cmd, flags);
-	smcore.UpdateAdminCmdFlags(cmd, type, flags, false);
+	bridge->UpdateAdminCmdFlags(cmd, type, flags, false);
 }
 
 bool AdminCache::GetCommandOverride(const char *cmd, OverrideType type, FlagBits *pFlags)
@@ -357,13 +357,13 @@ void AdminCache::UnsetCommandOverride(const char *cmd, OverrideType type)
 void AdminCache::_UnsetCommandGroupOverride(const char *group)
 {
 	m_CmdGrpOverrides.remove(group);
-	smcore.UpdateAdminCmdFlags(group, Override_CommandGroup, 0, true);
+	bridge->UpdateAdminCmdFlags(group, Override_CommandGroup, 0, true);
 }
 
 void AdminCache::_UnsetCommandOverride(const char *cmd)
 {
 	m_CmdOverrides.remove(cmd);
-	smcore.UpdateAdminCmdFlags(cmd, Override_Command, 0, true);
+	bridge->UpdateAdminCmdFlags(cmd, Override_Command, 0, true);
 }
 
 void AdminCache::DumpCommandOverrideCache(OverrideType type)
@@ -1516,7 +1516,7 @@ bool AdminCache::CanAdminTarget(AdminId id, AdminId target)
 	}
 
 	/** Fourth, if the targeted admin is immune from targeting admin. */
-	int mode = smcore.GetImmunityMode();
+	int mode = bridge->GetImmunityMode();
 	switch (mode)
 	{
 		case 1:
@@ -1653,7 +1653,7 @@ bool AdminCache::CanAdminUseCommand(int client, const char *cmd)
 		cmd++;
 	}
 
-	if (!smcore.LookForCommandAdminFlags(cmd, &bits))
+	if (!bridge->LookForCommandAdminFlags(cmd, &bits))
 	{
 		if (!GetCommandOverride(cmd, otype, &bits))
 		{
@@ -1728,7 +1728,7 @@ bool AdminCache::CheckAccess(int client, const char *cmd, FlagBits flags, bool o
 	bool found_command = false;
 	if (!override_only)
 	{
-		found_command = smcore.LookForCommandAdminFlags(cmd, &bits);
+		found_command = bridge->LookForCommandAdminFlags(cmd, &bits);
 	}
 
 	if (!found_command)

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -79,7 +79,7 @@ CLocalExtension::CLocalExtension(const char *filename)
 		PLATFORM_MAX_PATH,
 		"extensions/%s.%s." PLATFORM_LIB_EXT,
 		filename,
-		smcore.gamesuffix);
+		bridge->gamesuffix);
 
 	if (libsys->IsPathFile(path))
 	{
@@ -87,9 +87,9 @@ CLocalExtension::CLocalExtension(const char *filename)
 	}
 
 	/* COMPAT HACK: One-halfth, if ep2v, see if there is an engine specific build in the new place with old naming */
-	if (strcmp(smcore.gamesuffix, "2.tf2") == 0
-		|| strcmp(smcore.gamesuffix, "2.dods") == 0
-		|| strcmp(smcore.gamesuffix, "2.hl2dm") == 0
+	if (strcmp(bridge->gamesuffix, "2.tf2") == 0
+		|| strcmp(bridge->gamesuffix, "2.dods") == 0
+		|| strcmp(bridge->gamesuffix, "2.hl2dm") == 0
 		)
 	{
 		g_pSM->BuildPath(Path_SM,
@@ -103,7 +103,7 @@ CLocalExtension::CLocalExtension(const char *filename)
 			goto found;
 		}
 	}
-	else if (strcmp(smcore.gamesuffix, "2.nd") == 0)
+	else if (strcmp(bridge->gamesuffix, "2.nd") == 0)
 	{
 		g_pSM->BuildPath(Path_SM,
 			path,
@@ -123,7 +123,7 @@ CLocalExtension::CLocalExtension(const char *filename)
 		PLATFORM_MAX_PATH,
 		"extensions/auto.%s/%s." PLATFORM_LIB_EXT,
 		filename,
-		smcore.gamesuffix);
+		bridge->gamesuffix);
 
 	/* Try the "normal" version */
 	if (!libsys->IsPathFile(path))
@@ -192,7 +192,7 @@ bool CLocalExtension::Load(char *error, size_t maxlength)
 	if (m_pAPI->IsMetamodExtension())
 	{
 		bool ok;
-		m_PlId = smcore.LoadMMSPlugin(m_Path.c_str(), &ok, error, maxlength);
+		m_PlId = bridge->LoadMMSPlugin(m_Path.c_str(), &ok, error, maxlength);
 
 		if (!m_PlId || !ok)
 		{
@@ -209,7 +209,7 @@ bool CLocalExtension::Load(char *error, size_t maxlength)
 		{
 			if (m_PlId)
 			{
-				smcore.UnloadMMSPlugin(m_PlId);
+				bridge->UnloadMMSPlugin(m_PlId);
 				m_PlId = 0;
 			}
 		}
@@ -230,7 +230,7 @@ void CLocalExtension::Unload()
 {
 	if (m_pAPI != NULL && m_PlId)
 	{
-		smcore.UnloadMMSPlugin(m_PlId);
+		bridge->UnloadMMSPlugin(m_PlId);
 		m_PlId = 0;
 	}
 
@@ -293,7 +293,7 @@ bool CExtension::PerformAPICheck(char *error, size_t maxlength)
 bool CExtension::Load(char *error, size_t maxlength)
 {
 	CreateIdentity();
-	if (!m_pAPI->OnExtensionLoad(this, &g_ShareSys, error, maxlength, !smcore.IsMapLoading()))
+	if (!m_pAPI->OnExtensionLoad(this, &g_ShareSys, error, maxlength, !bridge->IsMapLoading()))
 	{
 		DestroyIdentity();
 		return false;
@@ -301,7 +301,7 @@ bool CExtension::Load(char *error, size_t maxlength)
 	else
 	{
 		/* Check if we're past load time */
-		if (!smcore.IsMapLoading())
+		if (!bridge->IsMapLoading())
 		{
 			m_pAPI->OnExtensionsAllLoaded();
 		}

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -151,7 +151,7 @@ CGameConfig::CGameConfig(const char *file, const char *engine)
 	m_CustomHandler = NULL;
 
 	if (!engine)
-		m_pEngine = smcore.GetSourceEngineName();
+		m_pEngine = bridge->GetSourceEngineName();
 	else
 		m_pEngine = engine;
 
@@ -548,11 +548,11 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 			void *addrInBase = NULL;
 			if (strcmp(s_TempSig.library, "server") == 0)
 			{
-				addrInBase = smcore.serverFactory;
+				addrInBase = bridge->serverFactory;
 			} else if (strcmp(s_TempSig.library, "engine") == 0) {
-				addrInBase = smcore.engineFactory;
+				addrInBase = bridge->engineFactory;
 			} else if (strcmp(s_TempSig.library, "matchmaking_ds") == 0) {
-				addrInBase = smcore.matchmakingDSFactory;
+				addrInBase = bridge->matchmakingDSFactory;
 			}
 			void *final_addr = NULL;
 			if (addrInBase == NULL)
@@ -580,7 +580,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 						void *handle = dlopen(info.dli_fname, RTLD_NOW);
 						if (handle)
 						{
-							if (smcore.SymbolsAreHidden())
+							if (bridge->SymbolsAreHidden())
 								final_addr = g_MemUtils.ResolveSymbol(handle, &s_TempSig.sig[1]);
 							else
 								final_addr = dlsym(handle, &s_TempSig.sig[1]);
@@ -1039,8 +1039,8 @@ void GameConfigManager::OnSourceModStartup(bool late)
 	LoadGameConfigFile("core.games", &g_pGameConf, NULL, 0);
 
 	strncopy(g_Game, g_pSM->GetGameFolderName(), sizeof(g_Game));
-	strncopy(g_GameDesc + 1, smcore.GetGameDescription(), sizeof(g_GameDesc) - 1);
-	smcore.GetGameName(g_GameName + 1, sizeof(g_GameName) - 1);
+	strncopy(g_GameDesc + 1, bridge->GetGameDescription(), sizeof(g_GameDesc) - 1);
+	bridge->GetGameName(g_GameName + 1, sizeof(g_GameName) - 1);
 }
 
 void GameConfigManager::OnSourceModAllInitialized()

--- a/core/logic/Logger.cpp
+++ b/core/logic/Logger.cpp
@@ -262,7 +262,7 @@ void Logger::LogToOpenFileEx(FILE *fp, const char *msg, va_list ap)
 		return;
 	}
 
-	static ConVar *sv_logecho = smcore.FindConVar("sv_logecho");
+	static ConVar *sv_logecho = bridge->FindConVar("sv_logecho");
 
 	char buffer[3072];
 	ke::SafeVsprintf(buffer, sizeof(buffer), msg, ap);
@@ -274,11 +274,11 @@ void Logger::LogToOpenFileEx(FILE *fp, const char *msg, va_list ap)
 
 	fprintf(fp, "L %s: %s\n", date, buffer);
 
-	if (!sv_logecho || smcore.GetCvarBool(sv_logecho))
+	if (!sv_logecho || bridge->GetCvarBool(sv_logecho))
 	{
 		static char conBuffer[4096];
 		ke::SafeSprintf(conBuffer, sizeof(conBuffer), "L %s: %s\n", date, buffer);
-		smcore.ConPrint(conBuffer);
+		bridge->ConPrint(conBuffer);
 	}
 }
 
@@ -475,7 +475,7 @@ void Logger::_PrintToGameLog(const char *fmt, va_list ap)
 	msg[len++] = '\n';
 	msg[len] = '\0';
 
-	smcore.LogToGame(msg);
+	bridge->LogToGame(msg);
 }
 
 const char *Logger::GetLogFileName(LogType type) const

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -374,7 +374,7 @@ void CPlugin::Call_OnAllPluginsLoaded()
 		pFunction->Execute(&result);
 	}
 
-	if (smcore.IsMapRunning())
+	if (bridge->IsMapRunning())
 	{
 		if ((pFunction = m_pRuntime->GetFunctionByName("OnMapStart")) != NULL)
 		{
@@ -382,9 +382,9 @@ void CPlugin::Call_OnAllPluginsLoaded()
 		}
 	}
 
-	if (smcore.AreConfigsExecuted())
+	if (bridge->AreConfigsExecuted())
 	{
-		smcore.ExecuteConfigs(GetBaseContext());
+		bridge->ExecuteConfigs(GetBaseContext());
 	}
 }
 
@@ -1801,7 +1801,7 @@ bool CPluginManager::TestAliasMatch(const char *alias, const char *localpath)
 
 bool CPluginManager::IsLateLoadTime() const
 {
-	return (m_AllPluginsLoaded || !smcore.IsMapLoading());
+	return (m_AllPluginsLoaded || !bridge->IsMapLoading());
 }
 
 void CPluginManager::OnSourceModAllInitialized()
@@ -2275,7 +2275,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 		else if (strcmp(cmd, "refresh") == 0)
 		{
 			RefreshAll();
-			smcore.DoGlobalPluginLoads();
+			bridge->DoGlobalPluginLoads();
 			rootmenu->ConsolePrint("[SM] The plugin list has been refreshed and reloaded.");
 			return;
 		}

--- a/core/logic/RootConsoleMenu.cpp
+++ b/core/logic/RootConsoleMenu.cpp
@@ -65,7 +65,7 @@ void RootConsoleMenu::ConsolePrint(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	smcore.ConsolePrintVa(fmt, ap);
+	bridge->ConsolePrintVa(fmt, ap);
 	va_end(ap);
 }
 

--- a/core/logic/Translator.cpp
+++ b/core/logic/Translator.cpp
@@ -737,7 +737,7 @@ void Translator::OnSourceModAllInitialized()
 {
 	AddLanguage("en", "English");
 
-	const char* lang = smcore.GetCoreConfigValue("ServerLang");
+	const char* lang = bridge->GetCoreConfigValue("ServerLang");
 	if (lang)
 	{
 		strncpy(m_InitialLang, lang, sizeof(m_InitialLang));

--- a/core/logic/common_logic.cpp
+++ b/core/logic/common_logic.cpp
@@ -55,30 +55,32 @@
 #include "LibrarySys.h"
 #include "RootConsoleMenu.h"
 
-sm_core_t smcore;
-IHandleSys *handlesys = &g_HandleSys;
-IdentityToken_t *g_pCoreIdent;
 SMGlobalClass *SMGlobalClass::head = NULL;
-ISourceMod *g_pSM;
+
+CoreProvider *bridge = nullptr;
+ISourceMod *g_pSM = nullptr;
+IVEngineServer *engine = nullptr;
+IdentityToken_t *g_pCoreIdent = nullptr;
+ITimerSystem *timersys = nullptr;
+IGameHelpers *gamehelpers = nullptr;
+IMenuManager *menus = nullptr;
+IPlayerManager *playerhelpers = nullptr;
+
+IHandleSys *handlesys = &g_HandleSys;
 ILibrarySys *libsys = &g_LibSys;
 ITextParsers *textparser = &g_TextParser;
-IVEngineServer *engine;
 IShareSys *sharesys = &g_ShareSys;
 IRootConsole *rootmenu = &g_RootMenu;
 IPluginManager *pluginsys = g_PluginSys.GetOldAPI();
 IForwardManager *forwardsys = &g_Forwards;
-ITimerSystem *timersys;
 ServerGlobals serverGlobals;
-IPlayerManager *playerhelpers;
 IAdminSystem *adminsys = &g_Admins;
-IGameHelpers *gamehelpers;
 ISourcePawnEngine *g_pSourcePawn;
 ISourcePawnEngine2 *g_pSourcePawn2;
-CNativeOwner g_CoreNatives;
 IScriptManager *scripts = &g_PluginSys;
 IExtensionSys *extsys = &g_Extensions;
 ILogger *logger = &g_Logger;
-IMenuManager *menus;
+CNativeOwner g_CoreNatives;
 
 static void AddCorePhraseFile(const char *filename)
 {
@@ -159,11 +161,11 @@ static sm_logic_t logic =
 	-1.0f
 };
 
-static void logic_init(const sm_core_t* core, sm_logic_t* _logic)
+static void logic_init(CoreProvider* core, sm_logic_t* _logic)
 {
 	logic.head = SMGlobalClass::head;
 
-	memcpy(&smcore, core, sizeof(sm_core_t));
+	bridge = core;
 	memcpy(_logic, &logic, sizeof(sm_logic_t));
 	memcpy(&serverGlobals, core->serverGlobals, sizeof(ServerGlobals));
 

--- a/core/logic/common_logic.h
+++ b/core/logic/common_logic.h
@@ -37,7 +37,7 @@
 #include "../sm_globals.h"
 #include "intercom.h"
 
-extern sm_core_t smcore;
+extern CoreProvider *bridge;
 extern IHandleSys *handlesys;
 extern ISourceMod *g_pSM;
 extern ILibrarySys *libsys;

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 41)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 42)
 
 #if defined SM_LOGIC
 class IVEngineServer
@@ -289,12 +289,21 @@ public:
 	IMenuManager	*menus;
 	ISourcePawnEngine **spe1;
 	ISourcePawnEngine2 **spe2;
-	/* Functions */
-	ConVar *		(*FindConVar)(const char*);
+	const char		*gamesuffix;
+	/* Data */
+	ServerGlobals   *serverGlobals;
+	void *          serverFactory;
+	void *          engineFactory;
+	void *          matchmakingDSFactory;
+	SMGlobalClass *	listeners;
+
+	// ConVar functions.
+	virtual ConVar *FindConVar(const char *name) = 0;
+	virtual const char *GetCvarString(ConVar *cvar) = 0;
+	virtual bool GetCvarBool(ConVar* cvar) = 0;
+
 	void			(*LogToGame)(const char *message);
 	void			(*ConPrint)(const char *message);
-	const char *	(*GetCvarString)(ConVar*);
-	bool			(*GetCvarBool)(ConVar*);
 	bool            (*GetGameName)(char *buffer, size_t maxlength);
 	const char *    (*GetGameDescription)();
 	const char *    (*GetSourceEngineName)();
@@ -316,13 +325,6 @@ public:
 	int             (*MaxClients)();
 	int             (*GetGlobalTarget)();
 	void            (*ConsolePrintVa)(const char *fmt, va_list ap);
-	const char		*gamesuffix;
-	/* Data */
-	ServerGlobals   *serverGlobals;
-	void *          serverFactory;
-	void *          engineFactory;
-	void *          matchmakingDSFactory;
-	SMGlobalClass *	listeners;
 };
 
 struct sm_logic_t

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 39)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 40)
 
 #if defined SM_LOGIC
 class IVEngineServer
@@ -275,8 +275,9 @@ private:
 	const CVector<IExtension *> *list_;
 };
 
-struct sm_core_t
+class CoreProvider
 {
+public:
 	/* Objects */
 	ISourceMod		*sm;
 	IVEngineServer	*engine;
@@ -357,7 +358,7 @@ struct sm_logic_t
 	float			sentinel;
 };
 
-typedef void (*LogicInitFunction)(const sm_core_t *core, sm_logic_t *logic);
+typedef void (*LogicInitFunction)(CoreProvider *core, sm_logic_t *logic);
 typedef LogicInitFunction (*LogicLoadFunction)(uint32_t magic);
 typedef ITextParsers *(*GetITextParsers)();
 

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 42)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 43)
 
 #if defined SM_LOGIC
 class IVEngineServer
@@ -302,12 +302,14 @@ public:
 	virtual const char *GetCvarString(ConVar *cvar) = 0;
 	virtual bool GetCvarBool(ConVar* cvar) = 0;
 
+	// Game description functions.
+	virtual bool GetGameName(char *buffer, size_t maxlength) = 0;
+	virtual const char *GetGameDescription() = 0;
+	virtual const char *GetSourceEngineName() = 0;
+	virtual bool SymbolsAreHidden() = 0;
+
 	void			(*LogToGame)(const char *message);
 	void			(*ConPrint)(const char *message);
-	bool            (*GetGameName)(char *buffer, size_t maxlength);
-	const char *    (*GetGameDescription)();
-	const char *    (*GetSourceEngineName)();
-	bool            (*SymbolsAreHidden)();
 	const char *	(*GetCoreConfigValue)(const char*);
 	bool			(*IsMapLoading)();
 	bool			(*IsMapRunning)();

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 40)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 41)
 
 #if defined SM_LOGIC
 class IVEngineServer

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 43)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 44)
 
 #if defined SM_LOGIC
 class IVEngineServer
@@ -308,11 +308,16 @@ public:
 	virtual const char *GetSourceEngineName() = 0;
 	virtual bool SymbolsAreHidden() = 0;
 
-	void			(*LogToGame)(const char *message);
-	void			(*ConPrint)(const char *message);
+	// Game state and helper functions.
+	virtual bool IsMapLoading() = 0;
+	virtual bool IsMapRunning() = 0;
+	virtual int MaxClients() = 0;
+	virtual bool DescribePlayer(int index, const char **namep, const char **authp, int *useridp) = 0;
+	virtual void LogToGame(const char *message) = 0;
+	virtual void ConPrint(const char *message) = 0;
+	virtual void ConsolePrintVa(const char *fmt, va_list ap) = 0;
+
 	const char *	(*GetCoreConfigValue)(const char*);
-	bool			(*IsMapLoading)();
-	bool			(*IsMapRunning)();
 	int				(*LoadMMSPlugin)(const char *file, bool *ok, char *error, size_t maxlength);
 	void			(*UnloadMMSPlugin)(int id);
 	void			(*DoGlobalPluginLoads)();
@@ -323,10 +328,7 @@ public:
 	int				(*GetImmunityMode)();
 	void			(*UpdateAdminCmdFlags)(const char *cmd, OverrideType type, FlagBits bits, bool remove);
 	bool			(*LookForCommandAdminFlags)(const char *cmd, FlagBits *pFlags);
-	bool            (*DescribePlayer)(int index, const char **namep, const char **authp, int *useridp);
-	int             (*MaxClients)();
 	int             (*GetGlobalTarget)();
-	void            (*ConsolePrintVa)(const char *fmt, va_list ap);
 };
 
 struct sm_logic_t

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 44)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 45)
 
 #if defined SM_LOGIC
 class IVEngineServer
@@ -317,9 +317,11 @@ public:
 	virtual void ConPrint(const char *message) = 0;
 	virtual void ConsolePrintVa(const char *fmt, va_list ap) = 0;
 
+	// Metamod:Source functions.
+	virtual int LoadMMSPlugin(const char *file, bool *ok, char *error, size_t maxlength) = 0;
+	virtual void UnloadMMSPlugin(int id) = 0;
+
 	const char *	(*GetCoreConfigValue)(const char*);
-	int				(*LoadMMSPlugin)(const char *file, bool *ok, char *error, size_t maxlength);
-	void			(*UnloadMMSPlugin)(int id);
 	void			(*DoGlobalPluginLoads)();
 	bool			(*AreConfigsExecuted)();
 	void			(*ExecuteConfigs)(IPluginContext *ctx);

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,13 +52,17 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 45)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 46)
 
 #if defined SM_LOGIC
-class IVEngineServer
+# define IVEngineClass IVEngineServer
+# define IFileSystemClass IFileSystem
 #else
-class IVEngineServer_Logic
+# define IVEngineClass IVEngineServer_Logic
+# define IFileSystemClass IFileSystem_Logic
 #endif
+
+class IVEngineClass
 {
 public:
 	virtual bool IsDedicatedServer() = 0;
@@ -73,11 +77,7 @@ public:
 typedef void * FileHandle_t;
 typedef int FileFindHandle_t; 
 
-#if defined SM_LOGIC
-class IFileSystem
-#else
-class IFileSystem_Logic
-#endif
+class IFileSystemClass
 {
 public:
 	virtual const char *FindFirstEx(const char *pWildCard, const char *pPathID, FileFindHandle_t *pHandle) = 0;
@@ -123,8 +123,6 @@ namespace SourceMod
 	class ICommandArgs;
 }
 
-class IVEngineServer;
-class IFileSystem;
 class ConVar;
 class KeyValues;
 class SMGlobalClass;
@@ -280,8 +278,8 @@ class CoreProvider
 public:
 	/* Objects */
 	ISourceMod		*sm;
-	IVEngineServer	*engine;
-	IFileSystem		*filesystem;
+	IVEngineClass	*engine;
+	IFileSystemClass *filesystem;
 	IPlayerInfo_Logic *playerInfo;
 	ITimerSystem    *timersys;
 	IPlayerManager  *playerhelpers;

--- a/core/logic/smn_banning.cpp
+++ b/core/logic/smn_banning.cpp
@@ -271,7 +271,7 @@ static cell_t BanClient(IPluginContext *pContext, const cell_t *params)
 	ban_source = params[7];
 
 	/* Check how we should ban the player */
-	if (!strcmp(smcore.GetSourceEngineName(), "darkmessiah"))
+	if (!strcmp(bridge->GetSourceEngineName(), "darkmessiah"))
 	{
 		/* Dark Messiah doesn't have Steam IDs so there is only one ban method to choose */
 		ban_flags |= BANFLAG_IP;

--- a/core/logic/smn_console.cpp
+++ b/core/logic/smn_console.cpp
@@ -52,7 +52,7 @@ static cell_t CheckCommandAccess(IPluginContext *pContext, const cell_t *params)
 	bool found_command = false;
 	if (params[0] < 4 || !params[4])
 	{
-		found_command = smcore.LookForCommandAdminFlags(cmd, &bits);
+		found_command = bridge->LookForCommandAdminFlags(cmd, &bits);
 	}
 
 	if (!found_command)
@@ -73,7 +73,7 @@ static cell_t CheckAccess(IPluginContext *pContext, const cell_t *params)
 	bool found_command = false;
 	if (params[0] < 4 || !params[4])
 	{
-		found_command = smcore.LookForCommandAdminFlags(cmd, &bits);
+		found_command = bridge->LookForCommandAdminFlags(cmd, &bits);
 	}
 
 	if (!found_command)
@@ -96,7 +96,7 @@ static cell_t sm_PrintToServer(IPluginContext *pCtx, const cell_t *params)
 	buffer[res++] = '\n';
 	buffer[res] = '\0';
 
-	smcore.ConPrint(buffer);
+	bridge->ConPrint(buffer);
 
 	return 1;
 }
@@ -140,7 +140,7 @@ static cell_t sm_PrintToConsole(IPluginContext *pCtx, const cell_t *params)
 		pPlayer->PrintToConsole(buffer);
 	}
 	else {
-		smcore.ConPrint(buffer);
+		bridge->ConPrint(buffer);
 	}
 
 	return 1;
@@ -277,7 +277,7 @@ static cell_t ReplyToCommand(IPluginContext *pContext, const cell_t *params)
 		/* Print */
 		buffer[len++] = '\n';
 		buffer[len] = '\0';
-		smcore.ConPrint(buffer);
+		bridge->ConPrint(buffer);
 		return 1;
 	}
 

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -78,7 +78,7 @@ public:
 			Param_Cell,
 			Param_String);
 		
-		sm_datetime_format = smcore.FindConVar("sm_datetime_format");
+		sm_datetime_format = bridge->FindConVar("sm_datetime_format");
 	}
 	void OnHandleDestroy(HandleType_t type, void *object)
 	{
@@ -173,7 +173,7 @@ static cell_t FormatTime(IPluginContext *pContext, const cell_t *params)
 
 	if (format == NULL)
 	{
-		format = const_cast<char *>(smcore.GetCvarString(sm_datetime_format));
+		format = const_cast<char *>(bridge->GetCvarString(sm_datetime_format));
 	}
 
 #if defined SUBPLATFORM_SECURECRT

--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -1405,7 +1405,7 @@ static cell_t SQL_ConnectCustom(IPluginContext *pContext, const cell_t *params)
 										  err);
 	}
 
-	DatabaseInfo info = smcore.GetDBInfoFromKeyValues(kv);
+	DatabaseInfo info = bridge->GetDBInfoFromKeyValues(kv);
 
 	IDBDriver *driver;
 	if (info.driver[0] == '\0' || strcmp(info.driver, "default") == 0)

--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -87,13 +87,13 @@ public:
 	}
 	void GetMapCycleFilePath(char *pBuffer, int maxlen)
 	{
-		const char *pMapCycleFileName = m_pMapCycleFile ? smcore.GetCvarString(m_pMapCycleFile) : "mapcycle.txt";
+		const char *pMapCycleFileName = m_pMapCycleFile ? bridge->GetCvarString(m_pMapCycleFile) : "mapcycle.txt";
 
 		g_pSM->Format(pBuffer, maxlen, "cfg/%s", pMapCycleFileName);
-		if (!smcore.filesystem->FileExists(pBuffer, "GAME"))
+		if (!bridge->filesystem->FileExists(pBuffer, "GAME"))
 		{
 			g_pSM->Format(pBuffer, maxlen, "%s", pMapCycleFileName);
-			if (!smcore.filesystem->FileExists(pBuffer, "GAME"))
+			if (!bridge->filesystem->FileExists(pBuffer, "GAME"))
 			{
 				g_pSM->Format(pBuffer, maxlen, "cfg/mapcycle_default.txt");
 			}
@@ -158,7 +158,7 @@ public:
 			return;
 		}
 
-		m_pMapCycleFile = smcore.FindConVar("mapcyclefile");
+		m_pMapCycleFile = bridge->FindConVar("mapcyclefile");
 
 		/* Dump everything we know about. */
 		List<maplist_info_t *> compat;
@@ -363,7 +363,7 @@ public:
 			cell_t *blk;
 
 			FileFindHandle_t findHandle;
-			const char *fileName = smcore.filesystem->FindFirstEx("maps/*.bsp", "GAME", &findHandle);
+			const char *fileName = bridge->filesystem->FindFirstEx("maps/*.bsp", "GAME", &findHandle);
 
 			while (fileName)
 			{
@@ -373,22 +373,22 @@ public:
 
 				if (!gamehelpers->IsMapValid(buffer))
 				{
-					fileName = smcore.filesystem->FindNext(findHandle);
+					fileName = bridge->filesystem->FindNext(findHandle);
 					continue;
 				}
 
 				if ((blk = pNewArray->push()) == NULL)
 				{
-					fileName = smcore.filesystem->FindNext(findHandle);
+					fileName = bridge->filesystem->FindNext(findHandle);
 					continue;
 				}
 
 				strncopy((char *)blk, buffer, 255);
 
-				fileName = smcore.filesystem->FindNext(findHandle);
+				fileName = bridge->filesystem->FindNext(findHandle);
 			}
 
-			smcore.filesystem->FindClose(findHandle);
+			bridge->filesystem->FindClose(findHandle);
 
 			/* Remove the array if there were no items. */
 			if (pNewArray->size() == 0)
@@ -493,7 +493,7 @@ private:
 			cell_t *blk;
 			char buffer[255];
 
-			if ((fp = smcore.filesystem->Open(pMapList->path, "rt", "GAME")) == NULL)
+			if ((fp = bridge->filesystem->Open(pMapList->path, "rt", "GAME")) == NULL)
 			{
 				return false;
 			}
@@ -501,7 +501,7 @@ private:
 			delete pMapList->pArray;
 			pMapList->pArray = new CellArray(64);
 
-			while (!smcore.filesystem->EndOfFile(fp) && smcore.filesystem->ReadLine(buffer, sizeof(buffer), fp) != NULL)
+			while (!bridge->filesystem->EndOfFile(fp) && bridge->filesystem->ReadLine(buffer, sizeof(buffer), fp) != NULL)
 			{
 				size_t len = strlen(buffer);
 				char *ptr = UTIL_TrimWhitespace(buffer, len);
@@ -512,7 +512,7 @@ private:
 					continue;
 				}
 				
-				if (strcmp(smcore.GetSourceEngineName(), "insurgency") == 0)
+				if (strcmp(bridge->GetSourceEngineName(), "insurgency") == 0)
 				{
 					// Insurgency (presumably?) doesn't allow spaces in map names
 					// and does use a space to delimit the map name from the map mode
@@ -539,7 +539,7 @@ private:
 				}
 			}
 
-			smcore.filesystem->Close(fp);
+			bridge->filesystem->Close(fp);
 
 			pMapList->last_modified_time = last_time;
 			pMapList->serial = ++m_nSerialChange;

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -281,13 +281,13 @@ static cell_t sm_GetClientName(IPluginContext *pCtx, const cell_t *params)
 		static ConVar *hostname = NULL;
 		if (!hostname)
 		{
-			hostname = smcore.FindConVar("hostname");
+			hostname = bridge->FindConVar("hostname");
 			if (!hostname)
 			{
 				return pCtx->ThrowNativeError("Could not find \"hostname\" cvar");
 			}
 		}
-		pCtx->StringToLocalUTF8(params[2], static_cast<size_t>(params[3]), smcore.GetCvarString(hostname), NULL);
+		pCtx->StringToLocalUTF8(params[2], static_cast<size_t>(params[3]), bridge->GetCvarString(hostname), NULL);
 		return 1;
 	}
 
@@ -763,7 +763,7 @@ static cell_t IsClientObserver(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	return smcore.playerInfo->IsObserver(pInfo) ? 1 : 0;
+	return bridge->playerInfo->IsObserver(pInfo) ? 1 : 0;
 }
 
 static cell_t GetClientTeam(IPluginContext *pContext, const cell_t *params)
@@ -785,7 +785,7 @@ static cell_t GetClientTeam(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	return smcore.playerInfo->GetTeamIndex(pInfo);
+	return bridge->playerInfo->GetTeamIndex(pInfo);
 }
 
 static cell_t GetFragCount(IPluginContext *pContext, const cell_t *params)
@@ -807,7 +807,7 @@ static cell_t GetFragCount(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	return smcore.playerInfo->GetFragCount(pInfo);
+	return bridge->playerInfo->GetFragCount(pInfo);
 }
 
 static cell_t GetDeathCount(IPluginContext *pContext, const cell_t *params)
@@ -829,7 +829,7 @@ static cell_t GetDeathCount(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	return smcore.playerInfo->GetDeathCount(pInfo);
+	return bridge->playerInfo->GetDeathCount(pInfo);
 }
 
 static cell_t GetArmorValue(IPluginContext *pContext, const cell_t *params)
@@ -851,7 +851,7 @@ static cell_t GetArmorValue(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	return smcore.playerInfo->GetArmorValue(pInfo);
+	return bridge->playerInfo->GetArmorValue(pInfo);
 }
 
 static cell_t GetAbsOrigin(IPluginContext *pContext, const cell_t *params)
@@ -877,7 +877,7 @@ static cell_t GetAbsOrigin(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToPhysAddr(params[2], &pVec);
 
 	float x, y, z;
-	smcore.playerInfo->GetAbsOrigin(pInfo, &x, &y, &z);
+	bridge->playerInfo->GetAbsOrigin(pInfo, &x, &y, &z);
 	pVec[0] = sp_ftoc(x);
 	pVec[1] = sp_ftoc(y);
 	pVec[2] = sp_ftoc(z);
@@ -908,7 +908,7 @@ static cell_t GetAbsAngles(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToPhysAddr(params[2], &pAng);
 
 	float x, y, z;
-	smcore.playerInfo->GetAbsAngles(pInfo, &x, &y, &z);
+	bridge->playerInfo->GetAbsAngles(pInfo, &x, &y, &z);
 	pAng[0] = sp_ftoc(x);
 	pAng[1] = sp_ftoc(y);
 	pAng[2] = sp_ftoc(z);
@@ -939,7 +939,7 @@ static cell_t GetPlayerMins(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToPhysAddr(params[2], &pVec);
 
 	float x, y, z;
-	smcore.playerInfo->GetPlayerMins(pInfo, &x, &y, &z);
+	bridge->playerInfo->GetPlayerMins(pInfo, &x, &y, &z);
 	pVec[0] = sp_ftoc(x);
 	pVec[1] = sp_ftoc(y);
 	pVec[2] = sp_ftoc(z);
@@ -970,7 +970,7 @@ static cell_t GetPlayerMaxs(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToPhysAddr(params[2], &pVec);
 
 	float x, y, z;
-	smcore.playerInfo->GetPlayerMaxs(pInfo, &x, &y, &z);
+	bridge->playerInfo->GetPlayerMaxs(pInfo, &x, &y, &z);
 	pVec[0] = sp_ftoc(x);
 	pVec[1] = sp_ftoc(y);
 	pVec[2] = sp_ftoc(z);
@@ -997,7 +997,7 @@ static cell_t GetWeaponName(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	const char *weapon = smcore.playerInfo->GetWeaponName(pInfo);
+	const char *weapon = bridge->playerInfo->GetWeaponName(pInfo);
 	pContext->StringToLocalUTF8(params[2], static_cast<size_t>(params[3]), weapon ? weapon : "", NULL);
 
 	return 1;
@@ -1022,7 +1022,7 @@ static cell_t GetModelName(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	const char *model = smcore.playerInfo->GetModelName(pInfo);
+	const char *model = bridge->playerInfo->GetModelName(pInfo);
 	pContext->StringToLocalUTF8(params[2], static_cast<size_t>(params[3]), model ? model : "", NULL);
 
 	return 1;
@@ -1047,7 +1047,7 @@ static cell_t GetHealth(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	return smcore.playerInfo->GetHealth(pInfo);
+	return bridge->playerInfo->GetHealth(pInfo);
 }
 
 static cell_t GetClientOfUserId(IPluginContext *pContext, const cell_t *params)
@@ -1062,7 +1062,7 @@ static cell_t _ShowActivity(IPluginContext *pContext,
 {
 	char message[255];
 	char buffer[255];
-	int value = smcore.GetActivityFlags();
+	int value = bridge->GetActivityFlags();
 	unsigned int replyto = playerhelpers->GetReplyTo();
 	int client = params[1];
 
@@ -1113,7 +1113,7 @@ static cell_t _ShowActivity(IPluginContext *pContext,
 		}
 
 		g_pSM->Format(message, sizeof(message), "%s%s\n", tag, buffer);
-		smcore.ConPrint(message);
+		bridge->ConPrint(message);
 	}
 
 	if (value == kActivityNone)
@@ -1193,7 +1193,7 @@ static cell_t _ShowActivity2(IPluginContext *pContext,
 {
 	char message[255];
 	char buffer[255];
-	int value = smcore.GetActivityFlags();
+	int value = bridge->GetActivityFlags();
 	unsigned int replyto = playerhelpers->GetReplyTo();
 	int client = params[1];
 
@@ -1240,7 +1240,7 @@ static cell_t _ShowActivity2(IPluginContext *pContext,
 		}
 
 		g_pSM->Format(message, sizeof(message), "%s%s\n", tag, buffer);
-		smcore.ConPrint(message);
+		bridge->ConPrint(message);
 	}
 
 	if (value == kActivityNone)
@@ -1426,7 +1426,7 @@ static cell_t ChangeClientTeam(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("IPlayerInfo not supported by game");
 	}
 
-	smcore.playerInfo->ChangeTeam(pInfo, params[2]);
+	bridge->playerInfo->ChangeTeam(pInfo, params[2]);
 
 	return 1;
 }
@@ -1528,7 +1528,7 @@ static cell_t FormatActivitySource(IPluginContext *pContext, const cell_t *param
 		return pContext->ThrowNativeError("Client %d not connected", target);
 	}
 
-	value = smcore.GetActivityFlags();
+	value = bridge->GetActivityFlags();
 
 	if (client != 0)
 	{

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -78,7 +78,7 @@ try_serverlang:
 	{
 		langid = g_Translator.GetServerLanguage();
  	}
-	else if ((target >= 1) && (target <= smcore.MaxClients()))
+	else if ((target >= 1) && (target <= bridge->MaxClients()))
 	{
 		langid = g_Translator.GetClientLanguage(target);
 	}
@@ -794,7 +794,7 @@ try_again:
 				{
 					lang_id = g_Translator.GetServerLanguage();
 				}
-				else if (target >= 1 && target <= smcore.MaxClients())
+				else if (target >= 1 && target <= bridge->MaxClients())
 				{
 					lang_id = g_Translator.GetClientLanguage(target);
 				}
@@ -1123,7 +1123,7 @@ reswitch:
 					const char *name;
 					const char *auth;
 					int userid;
-					if (!smcore.DescribePlayer(*value, &name, &auth, &userid))
+					if (!bridge->DescribePlayer(*value, &name, &auth, &userid))
 						return pCtx->ThrowNativeError("Client index %d is invalid", *value);
 					ke::SafeSprintf(buffer, 
 						sizeof(buffer), 
@@ -1150,7 +1150,7 @@ reswitch:
 
 				const char *name = "Console";
 				if (*value) {
-					if (!smcore.DescribePlayer(*value, &name, nullptr, nullptr))
+					if (!bridge->DescribePlayer(*value, &name, nullptr, nullptr))
 						return pCtx->ThrowNativeError("Client index %d is invalid", *value);
 				}
 				AddString(&buf_p, llen, name, width, prec);
@@ -1190,7 +1190,7 @@ reswitch:
 				char *key;
 				bool error;
 				size_t res;
-				cell_t target = smcore.GetGlobalTarget();
+				cell_t target = bridge->GetGlobalTarget();
 				pCtx->LocalToString(params[arg++], &key);
 				res = Translate(buf_p, llen, pCtx, key, target, params, &arg, &error);
 				if (error)

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -608,7 +608,7 @@ void UTIL_ConsolePrint(const char *fmt, ...)
 
 static ServerGlobals serverGlobals;
 
-static sm_core_t core_bridge =
+static CoreProvider core_bridge =
 {
 	/* Objects */
 	&g_SourceMod,

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -300,11 +300,6 @@ static ConVar sm_show_activity("sm_show_activity", "13", FCVAR_SPONLY, "Activity
 static ConVar sm_immunity_mode("sm_immunity_mode", "1", FCVAR_SPONLY, "Mode for deciding immunity protection");
 static ConVar sm_datetime_format("sm_datetime_format", "%m/%d/%Y - %H:%M:%S", 0, "Default formatting time rules");
 
-static ConVar *find_convar(const char *name)
-{
-	return icvar->FindVar(name);
-}
-
 static void log_to_game(const char *message)
 {
 	Engine_LogPrintWrapper(message);
@@ -313,16 +308,6 @@ static void log_to_game(const char *message)
 static void conprint(const char *message)
 {
 	META_CONPRINT(message);
-}
-
-static const char *get_cvar_string(ConVar* cvar)
-{
-	return cvar->GetString();
-}
-
-static bool get_cvar_bool(ConVar* cvar)
-{
-	return cvar->GetBool();
 }
 
 static bool get_game_name(char *buffer, size_t maxlength)
@@ -623,11 +608,8 @@ public:
 		this->menus = &g_Menus;
 		this->spe1 = &g_pSourcePawn;
 		this->spe2 = &g_pSourcePawn2;
-		this->FindConVar = find_convar;
 		this->LogToGame = log_to_game;
 		this->ConPrint = conprint;
-		this->GetCvarString = get_cvar_string;
-		this->GetCvarBool = get_cvar_bool;
 		this->GetGameName = get_game_name;
 		this->GetGameDescription = get_game_description;
 		this->GetSourceEngineName = get_source_engine_name;
@@ -656,7 +638,26 @@ public:
 		this->matchmakingDSFactory = nullptr;
 		this->listeners = nullptr;
 	}
+
+	ConVar *FindConVar(const char *name) override;
+	const char *GetCvarString(ConVar *cvar) override;
+	bool GetCvarBool(ConVar* cvar) override;
 } sCoreProviderImpl;
+
+ConVar *CoreProviderImpl::FindConVar(const char *name)
+{
+	return icvar->FindVar(name);
+}
+
+const char *CoreProviderImpl::GetCvarString(ConVar* cvar)
+{
+	return cvar->GetString();
+}
+
+bool CoreProviderImpl::GetCvarBool(ConVar* cvar)
+{
+	return cvar->GetBool();
+}
 
 void InitLogicBridge()
 {

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -310,99 +310,6 @@ static void conprint(const char *message)
 	META_CONPRINT(message);
 }
 
-static bool get_game_name(char *buffer, size_t maxlength)
-{
-	KeyValues *pGameInfo = new KeyValues("GameInfo");
-	if (g_HL2.KVLoadFromFile(pGameInfo, basefilesystem, "gameinfo.txt"))
-	{
-		const char *str;
-		if ((str = pGameInfo->GetString("game", NULL)) != NULL)
-		{
-			strncopy(buffer, str, maxlength);
-			pGameInfo->deleteThis();
-			return true;
-		}
-	}
-	pGameInfo->deleteThis();
-	return false;
-}
-
-static const char *get_game_description()
-{
-	return SERVER_CALL(GetGameDescription)();
-}
-
-static const char *get_source_engine_name()
-{
-#if !defined SOURCE_ENGINE
-# error "Unknown engine type"
-#endif
-#if SOURCE_ENGINE == SE_EPISODEONE
-	return "original";
-#elif SOURCE_ENGINE == SE_DARKMESSIAH
-	return "darkmessiah";
-#elif SOURCE_ENGINE == SE_ORANGEBOX
-	return "orangebox";
-#elif SOURCE_ENGINE == SE_BLOODYGOODTIME
-	return "bloodygoodtime";
-#elif SOURCE_ENGINE == SE_EYE
-	return "eye";
-#elif SOURCE_ENGINE == SE_CSS
-	return "css";
-#elif SOURCE_ENGINE == SE_HL2DM
-	return "hl2dm";
-#elif SOURCE_ENGINE == SE_DODS
-	return "dods";
-#elif SOURCE_ENGINE == SE_SDK2013
-	return "sdk2013";
-#elif SOURCE_ENGINE == SE_BMS
-	return "bms";
-#elif SOURCE_ENGINE == SE_TF2
-	return "tf2";
-#elif SOURCE_ENGINE == SE_LEFT4DEAD
-	return "left4dead";
-#elif SOURCE_ENGINE == SE_NUCLEARDAWN
-	return "nucleardawn";
-#elif SOURCE_ENGINE == SE_CONTAGION
-	return "contagion";
-#elif SOURCE_ENGINE == SE_LEFT4DEAD2
-	return "left4dead2";
-#elif SOURCE_ENGINE == SE_ALIENSWARM
-	return "alienswarm";
-#elif SOURCE_ENGINE == SE_PORTAL2
-	return "portal2";
-#elif SOURCE_ENGINE == SE_BLADE
-	return "blade";
-#elif SOURCE_ENGINE == SE_INSURGENCY
-	return "insurgency";
-#elif SOURCE_ENGINE == SE_CSGO
-	return "csgo";
-#elif SOURCE_ENGINE == SE_DOTA
-	return "dota";
-#endif
-}
-
-static bool symbols_are_hidden()
-{
-#if (SOURCE_ENGINE == SE_CSS)            \
-	|| (SOURCE_ENGINE == SE_HL2DM)       \
-	|| (SOURCE_ENGINE == SE_DODS)        \
-	|| (SOURCE_ENGINE == SE_SDK2013)     \
-	|| (SOURCE_ENGINE == SE_BMS)         \
-	|| (SOURCE_ENGINE == SE_TF2)         \
-	|| (SOURCE_ENGINE == SE_LEFT4DEAD)   \
-	|| (SOURCE_ENGINE == SE_NUCLEARDAWN) \
-	|| (SOURCE_ENGINE == SE_LEFT4DEAD2)  \
-	|| (SOURCE_ENGINE == SE_INSURGENCY)  \
-	|| (SOURCE_ENGINE == SE_BLADE)       \
-	|| (SOURCE_ENGINE == SE_CSGO)        \
-	|| (SOURCE_ENGINE == SE_DOTA)
-	return true;
-#else
-	return false;
-#endif
-}
-
 static const char* get_core_config_value(const char* key)
 {
 	return g_CoreConfig.GetCoreConfigValue(key);
@@ -610,10 +517,6 @@ public:
 		this->spe2 = &g_pSourcePawn2;
 		this->LogToGame = log_to_game;
 		this->ConPrint = conprint;
-		this->GetGameName = get_game_name;
-		this->GetGameDescription = get_game_description;
-		this->GetSourceEngineName = get_source_engine_name;
-		this->SymbolsAreHidden = symbols_are_hidden;
 		this->GetCoreConfigValue = get_core_config_value;
 		this->IsMapLoading = is_map_loading;
 		this->IsMapRunning = is_map_running;
@@ -642,6 +545,10 @@ public:
 	ConVar *FindConVar(const char *name) override;
 	const char *GetCvarString(ConVar *cvar) override;
 	bool GetCvarBool(ConVar* cvar) override;
+	bool GetGameName(char *buffer, size_t maxlength) override;
+	const char *GetGameDescription() override;
+	const char *GetSourceEngineName() override;
+	bool SymbolsAreHidden() override;
 } sCoreProviderImpl;
 
 ConVar *CoreProviderImpl::FindConVar(const char *name)
@@ -657,6 +564,99 @@ const char *CoreProviderImpl::GetCvarString(ConVar* cvar)
 bool CoreProviderImpl::GetCvarBool(ConVar* cvar)
 {
 	return cvar->GetBool();
+}
+
+bool CoreProviderImpl::GetGameName(char *buffer, size_t maxlength)
+{
+	KeyValues *pGameInfo = new KeyValues("GameInfo");
+	if (g_HL2.KVLoadFromFile(pGameInfo, basefilesystem, "gameinfo.txt"))
+	{
+		const char *str;
+		if ((str = pGameInfo->GetString("game", NULL)) != NULL)
+		{
+			strncopy(buffer, str, maxlength);
+			pGameInfo->deleteThis();
+			return true;
+		}
+	}
+	pGameInfo->deleteThis();
+	return false;
+}
+
+const char *CoreProviderImpl::GetGameDescription()
+{
+	return SERVER_CALL(GetGameDescription)();
+}
+
+const char *CoreProviderImpl::GetSourceEngineName()
+{
+#if !defined SOURCE_ENGINE
+# error "Unknown engine type"
+#endif
+#if SOURCE_ENGINE == SE_EPISODEONE
+	return "original";
+#elif SOURCE_ENGINE == SE_DARKMESSIAH
+	return "darkmessiah";
+#elif SOURCE_ENGINE == SE_ORANGEBOX
+	return "orangebox";
+#elif SOURCE_ENGINE == SE_BLOODYGOODTIME
+	return "bloodygoodtime";
+#elif SOURCE_ENGINE == SE_EYE
+	return "eye";
+#elif SOURCE_ENGINE == SE_CSS
+	return "css";
+#elif SOURCE_ENGINE == SE_HL2DM
+	return "hl2dm";
+#elif SOURCE_ENGINE == SE_DODS
+	return "dods";
+#elif SOURCE_ENGINE == SE_SDK2013
+	return "sdk2013";
+#elif SOURCE_ENGINE == SE_BMS
+	return "bms";
+#elif SOURCE_ENGINE == SE_TF2
+	return "tf2";
+#elif SOURCE_ENGINE == SE_LEFT4DEAD
+	return "left4dead";
+#elif SOURCE_ENGINE == SE_NUCLEARDAWN
+	return "nucleardawn";
+#elif SOURCE_ENGINE == SE_CONTAGION
+	return "contagion";
+#elif SOURCE_ENGINE == SE_LEFT4DEAD2
+	return "left4dead2";
+#elif SOURCE_ENGINE == SE_ALIENSWARM
+	return "alienswarm";
+#elif SOURCE_ENGINE == SE_PORTAL2
+	return "portal2";
+#elif SOURCE_ENGINE == SE_BLADE
+	return "blade";
+#elif SOURCE_ENGINE == SE_INSURGENCY
+	return "insurgency";
+#elif SOURCE_ENGINE == SE_CSGO
+	return "csgo";
+#elif SOURCE_ENGINE == SE_DOTA
+	return "dota";
+#endif
+}
+
+bool CoreProviderImpl::SymbolsAreHidden()
+{
+#if (SOURCE_ENGINE == SE_CSS)            \
+	|| (SOURCE_ENGINE == SE_HL2DM)       \
+	|| (SOURCE_ENGINE == SE_DODS)        \
+	|| (SOURCE_ENGINE == SE_SDK2013)     \
+	|| (SOURCE_ENGINE == SE_BMS)         \
+	|| (SOURCE_ENGINE == SE_TF2)         \
+	|| (SOURCE_ENGINE == SE_LEFT4DEAD)   \
+	|| (SOURCE_ENGINE == SE_NUCLEARDAWN) \
+	|| (SOURCE_ENGINE == SE_LEFT4DEAD2)  \
+	|| (SOURCE_ENGINE == SE_INSURGENCY)  \
+	|| (SOURCE_ENGINE == SE_BLADE)       \
+	|| (SOURCE_ENGINE == SE_CSGO)        \
+	|| (SOURCE_ENGINE == SE_DOTA)
+	return true;
+#else
+	return false;
+#endif
 }
 
 void InitLogicBridge()


### PR DESCRIPTION
Long term, the design of the core/logic bridge should be much more one-sided: what's currently called "core" should be a loader and a thin wrapper around ABI details of the SDK. Everything else should be under "logic". At that point, the bridge becomes one-way, and logic shouldn't need to provide anything back to core.

We've done a good job of moving things there so far, but to make the last stretch a refactoring will help a lot.

The first step is to rename `sm_core_t` to `CoreProvider`. This is the interface that a SourceMod loader must implement. Function pointers in this interface are now virtual members instead. (Except for the ones that will go away when the entire "move-stuff" project is complete.)