### PR TITLE
Move ConVarManager hooks into a separate class.

### DIFF
--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -41,6 +41,7 @@ project.sources += [
   'ConsoleDetours.cpp',
   'vprof_tool.cpp',
   'smn_commandline.cpp',
+  'GameHooks.cpp',
 ]
 
 for sdk_name in SM.sdks:

--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -37,12 +37,6 @@
 
 ConVarManager g_ConVarManager;
 
-#if SOURCE_ENGINE >= SE_ORANGEBOX
-SH_DECL_HOOK3_void(ICvar, CallGlobalChangeCallbacks, SH_NOATTRIB, false, ConVar *, const char *, float);
-#else
-SH_DECL_HOOK2_void(ICvar, CallGlobalChangeCallback, SH_NOATTRIB, false, ConVar *, const char *);
-#endif
-
 #if SOURCE_ENGINE == SE_DOTA
 SH_DECL_HOOK5_void(IServerGameDLL, OnQueryCvarValueFinished, SH_NOATTRIB, 0, QueryCvarCookie_t, CEntityIndex, EQueryCvarValueStatus, const char *, const char *);
 SH_DECL_HOOK5_void(IServerPluginCallbacks, OnQueryCvarValueFinished, SH_NOATTRIB, 0, QueryCvarCookie_t, CEntityIndex, EQueryCvarValueStatus, const char *, const char *);
@@ -125,12 +119,6 @@ void ConVarManager::OnSourceModAllInitialized()
 
 	g_Players.AddClientListener(this);
 
-#if SOURCE_ENGINE >= SE_ORANGEBOX
-	SH_ADD_HOOK(ICvar, CallGlobalChangeCallbacks, icvar, SH_STATIC(OnConVarChanged), false);
-#else
-	SH_ADD_HOOK(ICvar, CallGlobalChangeCallback, icvar, SH_STATIC(OnConVarChanged), false);
-#endif
-
 	scripts->AddPluginsListener(this);
 
 	/* Add the 'convars' option to the 'sm' console command */
@@ -197,12 +185,6 @@ void ConVarManager::OnSourceModShutdown()
 #endif
 
 	g_Players.RemoveClientListener(this);
-
-#if SOURCE_ENGINE >= SE_ORANGEBOX
-	SH_REMOVE_HOOK(ICvar, CallGlobalChangeCallbacks, icvar, SH_STATIC(OnConVarChanged), false);
-#else
-	SH_REMOVE_HOOK(ICvar, CallGlobalChangeCallback, icvar, SH_STATIC(OnConVarChanged), false);
-#endif
 
 	/* Remove the 'convars' option from the 'sm' console command */
 	rootmenu->RemoveRootConsoleCommand("cvars", this);
@@ -696,11 +678,7 @@ void ConVarManager::AddConVarToPluginList(IPluginContext *pContext, const ConVar
 	}
 }
 
-#if SOURCE_ENGINE >= SE_ORANGEBOX
 void ConVarManager::OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue)
-#else
-void ConVarManager::OnConVarChanged(ConVar *pConVar, const char *oldValue)
-#endif
 {
 	/* If the values are the same, exit early in order to not trigger callbacks */
 	if (strcmp(pConVar->GetString(), oldValue) == 0)
@@ -720,16 +698,8 @@ void ConVarManager::OnConVarChanged(ConVar *pConVar, const char *oldValue)
 
 	if (pInfo->changeListeners.size() != 0)
 	{
-		for (List<IConVarChangeListener *>::iterator i = pInfo->changeListeners.begin();
-			 i != pInfo->changeListeners.end();
-			 i++)
-		{
-#if SOURCE_ENGINE >= SE_ORANGEBOX
+		for (auto i = pInfo->changeListeners.begin(); i != pInfo->changeListeners.end(); i++)
 			(*i)->OnConVarChanged(pConVar, oldValue, flOldValue);
-#else
-			(*i)->OnConVarChanged(pConVar, oldValue, atof(oldValue));
-#endif
-		}
 	}
 
 	if (pForward != NULL)

--- a/core/ConVarManager.h
+++ b/core/ConVarManager.h
@@ -44,11 +44,6 @@
 #include "concmd_cleaner.h"
 #include "PlayerManager.h"
 
-#if SOURCE_ENGINE == SE_DARKMESSIAH
-class EQueryCvarValueStatus;
-typedef int QueryCvarCookie_t;
-#endif
-
 using namespace SourceHook;
 
 class IConVarChangeListener
@@ -100,7 +95,6 @@ public: // SMGlobalClass
 	void OnSourceModStartup(bool late);
 	void OnSourceModAllInitialized();
 	void OnSourceModShutdown();
-	void OnSourceModVSPReceived();
 public: // IHandleTypeDispatch
 	void OnHandleDestroy(HandleType_t type, void *object);
 	bool GetHandleApproxSize(HandleType_t type, void *object, unsigned int *pSize);
@@ -149,29 +143,24 @@ public:
 
 	// Called via game hooks.
 	void OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue);
+#if SOURCE_ENGINE != SE_DARKMESSIAH
+	void OnClientQueryFinished(
+	  QueryCvarCookie_t cookie,
+	  int client,
+	  EQueryCvarValueStatus result,
+	  const char *cvarName,
+	  const char *cvarValue);
+#endif
 
 private:
 	/**
 	 * Adds a convar to a plugin's list.
 	 */
 	static void AddConVarToPluginList(IPluginContext *pContext, const ConVar *pConVar);
-
-	/**
-	 * Callback for when StartQueryCvarValue() has finished.
-	 */
-#if SOURCE_ENGINE == SE_DOTA
-	void OnQueryCvarValueFinished(QueryCvarCookie_t cookie, CEntityIndex player, EQueryCvarValueStatus result,
-	                              const char *cvarName, const char *cvarValue);
-#elif SOURCE_ENGINE != SE_DARKMESSIAH
-	void OnQueryCvarValueFinished(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result,
-	                              const char *cvarName, const char *cvarValue);
-#endif
 private:
 	HandleType_t m_ConVarType;
 	List<ConVarInfo *> m_ConVars;
 	List<ConVarQuery> m_ConVarQueries;
-	bool m_bIsDLLQueryHooked;
-	bool m_bIsVSPQueryHooked;
 };
 
 extern ConVarManager g_ConVarManager;

--- a/core/ConVarManager.h
+++ b/core/ConVarManager.h
@@ -147,20 +147,14 @@ public:
 
 	HandleError ReadConVarHandle(Handle_t hndl, ConVar **pVar);
 
+	// Called via game hooks.
+	void OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue);
+
 private:
 	/**
 	 * Adds a convar to a plugin's list.
 	 */
 	static void AddConVarToPluginList(IPluginContext *pContext, const ConVar *pConVar);
-
-	/**
-	 * Static callback that Valve's ConVar object executes when the convar's value changes.
-	 */
-#if SOURCE_ENGINE >= SE_ORANGEBOX
-	static void OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue);
-#else
-	static void OnConVarChanged(ConVar *pConVar, const char *oldValue);
-#endif
 
 	/**
 	 * Callback for when StartQueryCvarValue() has finished.

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -24,50 +24,29 @@
 // this exception to all derivative works.  AlliedModders LLC defines further
 // exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
 // or <http://www.sourcemod.net/license.php>.
-#ifndef _INCLUDE_SOURCEMOD_CORE_PROVIDER_IMPL_H_
-#define _INCLUDE_SOURCEMOD_CORE_PROVIDER_IMPL_H_
+#ifndef _INCLUDE_SOURCEMOD_PROVIDER_GAME_HOOKS_H_
+#define _INCLUDE_SOURCEMOD_PROVIDER_GAME_HOOKS_H_
 
-#include "logic/intercom.h"
-#include "GameHooks.h"
-#include <amtl/os/am-shared-library.h>
+class ConVar;
 
-class CoreProviderImpl : public CoreProvider
+namespace SourceMod {
+
+class GameHooks
 {
 public:
-	CoreProviderImpl();
+	GameHooks();
 
-	// Local functions.
-	void InitializeBridge();
-	bool LoadBridge(char *error, size_t maxlength);
-	void ShutdownBridge();
+	void Start();
+	void Shutdown();
 
-	void InitializeHooks();
-	void ShutdownHooks();
-
-	// Provider implementation.
-	ConVar *FindConVar(const char *name) override;
-	const char *GetCvarString(ConVar *cvar) override;
-	bool GetCvarBool(ConVar* cvar) override;
-	bool GetGameName(char *buffer, size_t maxlength) override;
-	const char *GetGameDescription() override;
-	const char *GetSourceEngineName() override;
-	bool SymbolsAreHidden() override;
-	bool IsMapLoading() override;
-	bool IsMapRunning() override;
-	int MaxClients() override;
-	bool DescribePlayer(int index, const char **namep, const char **authp, int *useridp) override;
-	void LogToGame(const char *message) override;
-	void ConPrint(const char *message) override;
-	void ConsolePrintVa(const char *fmt, va_list ap) override;
-	int LoadMMSPlugin(const char *file, bool *ok, char *error, size_t maxlength) override;
-	void UnloadMMSPlugin(int id) override;
-
-private:
-	ke::Ref<ke::SharedLib> logic_;
-	LogicInitFunction logic_init_;
-	GameHooks hooks_;
+	// Static callback that Valve's ConVar object executes when the convar's value changes.
+#if SOURCE_ENGINE >= SE_ORANGEBOX
+	static void OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue);
+#else
+	static void OnConVarChanged(ConVar *pConVar, const char *oldValue);
+#endif
 };
 
-extern CoreProviderImpl sCoreProviderImpl;
+} // namespace SourceMod
 
-#endif // _INCLUDE_SOURCEMOD_CORE_PROVIDER_IMPL_H_
+#endif // _INCLUDE_SOURCEMOD_PROVIDER_GAME_HOOKS_H_

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -2010,7 +2010,7 @@ void CmdMaxplayersCallback()
 }
 
 #if SOURCE_ENGINE == SE_CSGO
-bool PlayerManager::HandleConVarQuery(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue)
+bool PlayerManager::HandleConVarQuery(QueryCvarCookie_t cookie, int client, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue)
 {
 	for (int i = 1; i <= m_maxClients; i++)
 	{

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -233,7 +233,7 @@ public:
 		return m_bInCCKVHook;
 	}
 #if SOURCE_ENGINE == SE_CSGO
-	bool HandleConVarQuery(QueryCvarCookie_t cookie, edict_t *pPlayer, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue);
+	bool HandleConVarQuery(QueryCvarCookie_t cookie, int client, EQueryCvarValueStatus result, const char *cvarName, const char *cvarValue);
 #endif
 private:
 #if SOURCE_ENGINE == SE_DOTA

--- a/core/logic/intercom.h
+++ b/core/logic/intercom.h
@@ -52,7 +52,7 @@ using namespace SourceHook;
  * Add 1 to the RHS of this expression to bump the intercom file
  * This is to prevent mismatching core/logic binaries
  */
-#define SM_LOGIC_MAGIC		(0x0F47C0DE - 47)
+#define SM_LOGIC_MAGIC		(0x0F47C0DE - 48)
 
 #if defined SM_LOGIC
 # define IVEngineClass IVEngineServer
@@ -314,6 +314,10 @@ public:
 	virtual void LogToGame(const char *message) = 0;
 	virtual void ConPrint(const char *message) = 0;
 	virtual void ConsolePrintVa(const char *fmt, va_list ap) = 0;
+
+	// Game engine helper functions.
+	virtual bool IsClientConVarQueryingSupported() = 0;
+	virtual int QueryClientConVar(int client, const char *cvar) = 0;
 
 	// Metamod:Source functions.
 	virtual int LoadMMSPlugin(const char *file, bool *ok, char *error, size_t maxlength) = 0;

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -637,6 +637,32 @@ void CoreProviderImpl::UnloadMMSPlugin(int id)
 	g_pMMPlugins->Unload(id, true, ignore, sizeof(ignore));
 }
 
+bool CoreProviderImpl::IsClientConVarQueryingSupported()
+{
+	return hooks_.GetQueryHookMode() != QueryHookMode::Unavailable;
+}
+
+int CoreProviderImpl::QueryClientConVar(int client, const char *cvar)
+{
+#if SOURCE_ENGINE != SE_DARKMESSIAH
+	switch (hooks_.GetQueryHookMode()) {
+	case QueryHookMode::DLL:
+# if SOURCE_ENGINE == SE_DOTA
+		return ::engine->StartQueryCvarValue(CEntityIndex(client), cvar);
+# else
+		return ::engine->StartQueryCvarValue(PEntityOfEntIndex(client), cvar);
+# endif
+	case QueryHookMode::VSP:
+# if SOURCE_ENGINE != SE_DOTA
+		return serverpluginhelpers->StartQueryCvarValue(PEntityOfEntIndex(client), cvar);
+# endif
+	default:
+		return InvalidQueryCvarCookie;
+	}
+#endif
+	return -1;
+}
+
 void CoreProviderImpl::InitializeBridge()
 {
 	::serverGlobals.universalTime = g_pUniversalTime;
@@ -719,6 +745,11 @@ bool CoreProviderImpl::LoadBridge(char *error, size_t maxlength)
 void CoreProviderImpl::InitializeHooks()
 {
 	hooks_.Start();
+}
+
+void CoreProviderImpl::OnVSPReceived()
+{
+	hooks_.OnVSPReceived();
 }
 
 void CoreProviderImpl::ShutdownHooks()

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -716,6 +716,16 @@ bool CoreProviderImpl::LoadBridge(char *error, size_t maxlength)
 	return true;
 }
 
+void CoreProviderImpl::InitializeHooks()
+{
+	hooks_.Start();
+}
+
+void CoreProviderImpl::ShutdownHooks()
+{
+	hooks_.Shutdown();
+}
+
 void CoreProviderImpl::ShutdownBridge()
 {
 	logic_ = nullptr;

--- a/core/provider.h
+++ b/core/provider.h
@@ -43,6 +43,7 @@ public:
 
 	void InitializeHooks();
 	void ShutdownHooks();
+	void OnVSPReceived();
 
 	// Provider implementation.
 	ConVar *FindConVar(const char *name) override;
@@ -61,6 +62,8 @@ public:
 	void ConsolePrintVa(const char *fmt, va_list ap) override;
 	int LoadMMSPlugin(const char *file, bool *ok, char *error, size_t maxlength) override;
 	void UnloadMMSPlugin(int id) override;
+	int QueryClientConVar(int client, const char *cvar) override;
+	bool IsClientConVarQueryingSupported() override;
 
 private:
 	ke::Ref<ke::SharedLib> logic_;

--- a/core/sm_globals.h
+++ b/core/sm_globals.h
@@ -160,13 +160,6 @@ public:
 	}
 
 	/**
-	 * @brief Called when SourceMod receives a pointer to IServerPluginCallbacks from SourceMM
-	 */
-	virtual void OnSourceModVSPReceived()
-	{
-	}
-
-	/**
 	 * @brief Called once all MM:S plugins are loaded.
 	 */
 	virtual void OnSourceModGameInitialized()

--- a/core/sourcemm_api.cpp
+++ b/core/sourcemm_api.cpp
@@ -36,6 +36,7 @@
 #include "compat_wrappers.h"
 #include "logic_bridge.h"
 #include <sourcemod_version.h>
+#include "provider.h"
 
 SourceMod_Core g_SourceMod_Core;
 IVEngineServer *engine = NULL;
@@ -207,12 +208,7 @@ void SourceMod_Core::OnVSPListening(IServerPluginCallbacks *iface)
 #endif
 
 	/* Notify! */
-	SMGlobalClass *pBase = SMGlobalClass::head;
-	while (pBase)
-	{
-		pBase->OnSourceModVSPReceived();
-		pBase = pBase->m_pGlobalClassNext;
-	}
+    sCoreProviderImpl.OnVSPReceived();
 }
 
 #if defined METAMOD_PLAPI_VERSION || PLAPI_VERSION >= 11

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -267,6 +267,8 @@ void SourceModBase::StartSourceMod(bool late)
 	}
 	g_pGameConf = logicore.GetCoreGameConfig();
 
+	sCoreProviderImpl.InitializeHooks();
+
 	/* Notify! */
 	pBase = SMGlobalClass::head;
 	while (pBase)
@@ -519,6 +521,8 @@ void SourceModBase::ShutdownServices()
 		delete pd;
 	}
 	m_freepacks.popall();
+
+	sCoreProviderImpl.ShutdownHooks();
 
 	/* Notify! */
 	pBase = SMGlobalClass::head;

--- a/public/compat_wrappers.h
+++ b/public/compat_wrappers.h
@@ -1,5 +1,5 @@
 /**
- * vim: set ts=4 :
+ * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
  * SourceMod
  * Copyright (C) 2004-2010 AlliedModders LLC.  All rights reserved.
@@ -33,6 +33,11 @@
 #define _INCLUDE_SOURCEMOD_COMPAT_WRAPPERS_H_
 
 #include <datamap.h>
+
+#if SOURCE_ENGINE == SE_DARKMESSIAH
+class EQueryCvarValueStatus;
+typedef int QueryCvarCookie_t;
+#endif
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	#define CONVAR_REGISTER(object)				ConVar_Register(0, object)


### PR DESCRIPTION
The next step of the bridge refactoring is to extract all the assorted game-specific hooks SourceMod has to do, so that it can push those notifications into logic rather than having each translation unit have to know everything about each game.

This PR shows how this is will be done for future patches. Here, ConVarManager's hooks are moved into a global class. Another advantage of this is that PlayerManager loses a dependency on ConVarManager.

I can see `GameHooks.cpp` getting super gross to read though, because the entire file is going to be an ifdef party. We'll see, I guess.