### PR TITLE
Remove ConCommand hook clutter.

### DIFF
--- a/core/ChatTriggers.h
+++ b/core/ChatTriggers.h
@@ -34,6 +34,7 @@
 
 #include "sm_globals.h"
 #include "sourcemm_api.h"
+#include "GameHooks.h"
 #include <IGameHelpers.h>
 #include <compat_wrappers.h>
 #include <IForwardSys.h>
@@ -55,16 +56,8 @@ public: //SMGlobalClass
 		char *error, 
 		size_t maxlength);
 private: //ConCommand
-#if SOURCE_ENGINE == SE_DOTA
-	void OnSayCommand_Pre(const CCommandContext &, const CCommand &command);
-	void OnSayCommand_Post(const CCommandContext &, const CCommand &command);
-#elif SOURCE_ENGINE >= SE_ORANGEBOX
-	void OnSayCommand_Pre(const CCommand &command);
-	void OnSayCommand_Post(const CCommand &command);
-#else
-	void OnSayCommand_Pre();
-	void OnSayCommand_Post();
-#endif
+	bool OnSayCommand_Pre(const ICommandArgs *args);
+	bool OnSayCommand_Post(const ICommandArgs *args);
 public:
 	unsigned int GetReplyTo();
 	unsigned int SetReplyTo(unsigned int reply);
@@ -75,13 +68,7 @@ private:
 	bool ClientIsFlooding(int client);
 	cell_t CallOnClientSayCommand(int client);
 private:
-	ConCommand *m_pSayCmd;
-	ConCommand *m_pSayTeamCmd;
-#if SOURCE_ENGINE == SE_EPISODEONE
-	ConCommand *m_pSay2Cmd;
-#elif SOURCE_ENGINE == SE_NUCLEARDAWN
-	ConCommand *m_pSaySquadCmd;
-#endif
+	ke::Vector<ke::Ref<CommandHook>> hooks_;
 	ke::AString m_PubTrigger;
 	ke::AString m_PrivTrigger;
 	bool m_bWillProcessInPost;

--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -36,19 +36,13 @@
 #include "ChatTriggers.h"
 #include "logic_bridge.h"
 #include "sourcemod.h"
+#include "provider.h"
+#include "command_args.h"
 #include <bridge/include/IScriptManager.h>
 
 using namespace ke;
 
 ConCmdManager g_ConCmds;
-
-#if SOURCE_ENGINE == SE_DOTA
-	SH_DECL_HOOK2_void(ConCommand, Dispatch, SH_NOATTRIB, false, const CCommandContext &, const CCommand &);
-#elif SOURCE_ENGINE >= SE_ORANGEBOX
-	SH_DECL_HOOK1_void(ConCommand, Dispatch, SH_NOATTRIB, false, const CCommand &);
-#else
-	SH_DECL_HOOK0_void(ConCommand, Dispatch, SH_NOATTRIB, false);
-#endif
 
 SH_DECL_HOOK1_void(IServerGameClients, SetCommandClient, SH_NOATTRIB, false, int);
 
@@ -142,23 +136,13 @@ void ConCmdManager::OnPluginDestroyed(IPlugin *plugin)
 	delete pList;
 }
 
-#if SOURCE_ENGINE == SE_DOTA
-void CommandCallback(const CCommandContext &context, const CCommand &command)
+void CommandCallback(DISPATCH_ARGS)
 {
-#elif SOURCE_ENGINE >= SE_ORANGEBOX
-void CommandCallback(const CCommand &command)
-{
-#else
-void CommandCallback()
-{
-	CCommand command;
-#endif
+	DISPATCH_PROLOGUE;
+	EngineArgs args(command);
 
-	g_HL2.PushCommandStack(&command);
-
-	g_ConCmds.InternalDispatch(command);
-
-	g_HL2.PopCommandStack();
+	AutoEnterCommand autoEnterCommand(&args);
+	g_ConCmds.InternalDispatch(&args);
 }
 
 void ConCmdManager::SetCommandClient(int client)
@@ -232,7 +216,7 @@ ResultType ConCmdManager::DispatchClientCommand(int client, const char *cmd, int
 	return (ResultType)result;
 }
 
-void ConCmdManager::InternalDispatch(const CCommand &command)
+void ConCmdManager::InternalDispatch(const ICommandArgs *args)
 {
 	int client = m_CmdClient;
 
@@ -275,7 +259,7 @@ void ConCmdManager::InternalDispatch(const CCommand &command)
 		return;
 
 	cell_t result = Pl_Continue;
-	int args = command.ArgC() - 1;
+	int argc = args->ArgC() - 1;
 
 	// On a listen server, sometimes the server host's client index can be set
 	// as 0. So index 1 is passed to the command callback to correct this
@@ -311,7 +295,7 @@ void ConCmdManager::InternalDispatch(const CCommand &command)
 			hook->pf->PushCell(realClient);
 		}
 
-		hook->pf->PushCell(args);
+		hook->pf->PushCell(argc);
 
 		cell_t tempres = result;
 		if (hook->pf->Execute(&tempres) == SP_ERROR_NONE)
@@ -556,15 +540,12 @@ void ConCmdManager::RemoveConCmd(ConCmdInfo *info, const char *name, bool is_rea
 		}
 		else
 		{
-			if (is_read_safe)
-			{
-				/* Remove the external hook */
-				SH_REMOVE_HOOK(ConCommand, Dispatch, info->pCmd, SH_STATIC(CommandCallback), false);
-			}
+			// If it's not safe to read the pointer, we zap the SourceHook hook so it
+			// doesn't attempt to access the pointer's vtable.
+			if (!is_read_safe)
+				info->sh_hook->Zap();
 			if (untrack)
-			{
 				UntrackConCommandBase(info->pCmd, this);
-			}
 		}
 	}
 	
@@ -623,7 +604,11 @@ ConCmdInfo *ConCmdManager::AddOrFindCommand(const char *name, const char *descri
 		else
 		{
 			TrackConCommandBase(pCmd, this);
-			SH_ADD_HOOK(ConCommand, Dispatch, pCmd, SH_STATIC(CommandCallback), false);
+			CommandHook::Callback callback = [this] (const ICommandArgs *args) {
+				AutoEnterCommand autoEnterCommand(args);
+				this->InternalDispatch(args);
+			};
+			pInfo->sh_hook = sCoreProviderImpl.AddCommandHook(pCmd, callback);
 		}
 
 		pInfo->pCmd = pCmd;

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -143,7 +143,7 @@ public:
 	bool LookForSourceModCommand(const char *cmd);
 	bool LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags);
 private:
-	void InternalDispatch(const ICommandArgs *args);
+	bool InternalDispatch(const ICommandArgs *args);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
 	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
 	void SetCommandClient(int client);

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -40,6 +40,7 @@
 #include <IRootConsoleMenu.h>
 #include <IAdminSystem.h>
 #include "concmd_cleaner.h"
+#include "GameHooks.h"
 #include <sm_stringhashmap.h>
 #include <am-utility.h>
 #include <am-inlinelist.h>
@@ -105,6 +106,7 @@ struct ConCmdInfo
 	ConCommand *pCmd;				/**< Pointer to the command itself */
 	CmdHookList hooks;				/**< Hook list */
 	FlagBits eflags;				/**< Effective admin flags */
+	ke::Ref<CommandHook> sh_hook;   /**< SourceHook hook, if any. */
 };
 
 typedef List<ConCmdInfo *> ConCmdList;
@@ -115,13 +117,7 @@ class ConCmdManager :
 	public IPluginsListener,
 	public IConCommandTracker
 {
-#if SOURCE_ENGINE == SE_DOTA
-	friend void CommandCallback(const CCommandContext &context, const CCommand &command);
-#elif SOURCE_ENGINE >= SE_ORANGEBOX
-	friend void CommandCallback(const CCommand &command);
-#else
-	friend void CommandCallback();
-#endif
+	friend void CommandCallback(DISPATCH_ARGS);
 public:
 	ConCmdManager();
 	~ConCmdManager();
@@ -147,7 +143,7 @@ public:
 	bool LookForSourceModCommand(const char *cmd);
 	bool LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags);
 private:
-	void InternalDispatch(const CCommand &command);
+	void InternalDispatch(const ICommandArgs *args);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
 	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
 	void SetCommandClient(int client);

--- a/core/ConsoleDetours.h
+++ b/core/ConsoleDetours.h
@@ -36,6 +36,10 @@
 #include <IForwardSys.h>
 #include <sm_stringhashmap.h>
 
+namespace SourceMod {
+class ICommandArgs;
+} // namespace SourceMod
+
 class ConsoleDetours :
 	public SMGlobalClass,
 	public IFeatureProvider
@@ -54,7 +58,7 @@ public:
 	bool AddListener(IPluginFunction *fun, const char *command);
 	bool RemoveListener(IPluginFunction *fun, const char *command);
 private:
-	cell_t InternalDispatch(int client, const CCommand& args);
+	cell_t InternalDispatch(int client, const SourceMod::ICommandArgs *args);
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	static cell_t Dispatch(ConCommand *pBase, const CCommand& args);
 #else

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -169,8 +169,10 @@ void CommandHook::Dispatch(DISPATCH_ARGS)
 	EngineArgs args(command);
 
 	AddRef();
-	callback_(&args);
+	bool rval = callback_(&args);
 	Release();
+	if (rval)
+		RETURN_META(MRES_SUPERCEDE);
 }
 
 void CommandHook::Zap()

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -43,7 +43,7 @@ SH_DECL_HOOK5_void(IServerPluginCallbacks, OnQueryCvarValueFinished, SH_NOATTRIB
 #endif
 
 GameHooks::GameHooks()
-	: query_hook_mode_(QueryHookMode::Unavailable)
+	: client_cvar_query_mode_(ClientCvarQueryMode::Unavailable)
 {
 }
 
@@ -60,14 +60,14 @@ void GameHooks::Start()
 #if SOURCE_ENGINE == SE_EPISODEONE
 	if (g_SMAPI->GetGameDLLVersion() >= 6) {
 		hooks_ += SH_ADD_HOOK(IServerGameDLL, OnQueryCvarValueFinished, gamedll, SH_MEMBER(this, &GameHooks::OnQueryCvarValueFinished), false);
-		query_hook_mode_ = QueryHookMode::DLL;
+		client_cvar_query_mode_ = ClientCvarQueryMode::DLL;
 	}
 #endif
 }
 
 void GameHooks::OnVSPReceived()
 {
-	if (query_hook_mode_ != QueryHookMode::Unavailable)
+	if (client_cvar_query_mode_ != ClientCvarQueryMode::Unavailable)
 		return;
 
 	// For later MM:S versions, use the updated API, since it's cleaner.
@@ -81,7 +81,7 @@ void GameHooks::OnVSPReceived()
 
 #if SOURCE_ENGINE != SE_DARKMESSIAH && SOURCE_ENGINE != SE_DOTA
 	hooks_ += SH_ADD_HOOK(IServerPluginCallbacks, OnQueryCvarValueFinished, vsp_interface, SH_MEMBER(this, &GameHooks::OnQueryCvarValueFinished), false);
-	query_hook_mode_ = QueryHookMode::VSP;
+	client_cvar_query_mode_ = ClientCvarQueryMode::VSP;
 #endif
 }
 
@@ -91,7 +91,7 @@ void GameHooks::Shutdown()
 		SH_REMOVE_HOOK_ID(hooks_[i]);
 	hooks_.clear();
 
-	query_hook_mode_ = QueryHookMode::Unavailable;
+	client_cvar_query_mode_ = ClientCvarQueryMode::Unavailable;
 }
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -38,7 +38,7 @@ class ConVar;
 
 namespace SourceMod {
 
-enum class QueryHookMode {
+enum class ClientCvarQueryMode {
 	Unavailable,
 	DLL,
 	VSP
@@ -53,8 +53,8 @@ public:
 	void Shutdown();
 	void OnVSPReceived();
 
-	QueryHookMode GetQueryHookMode() const {
-		return query_hook_mode_;
+	ClientCvarQueryMode GetClientCvarQueryMode() const {
+		return client_cvar_query_mode_;
 	}
 
 private:
@@ -85,7 +85,7 @@ private:
 	};
 	HookList hooks_;
 
-	QueryHookMode query_hook_mode_;
+	ClientCvarQueryMode client_cvar_query_mode_;
 };
 
 } // namespace SourceMod

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -65,7 +65,8 @@ class ICommandArgs;
 class CommandHook : public ke::Refcounted<CommandHook>
 {
 public:
-	typedef ke::Lambda<void(const ICommandArgs *)> Callback;
+	// return false to RETURN_META(MRES_IGNORED), or true to SUPERCEDE.
+	typedef ke::Lambda<bool(const ICommandArgs *)> Callback;
 
 public:
 	CommandHook(ConCommand *cmd, const Callback &callback, bool post);

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -825,7 +825,7 @@ bool CHalfLife2::KVLoadFromFile(KeyValues *kv, IBaseFileSystem *filesystem, cons
 	}
 }
 
-void CHalfLife2::PushCommandStack(const CCommand *cmd)
+void CHalfLife2::PushCommandStack(const ICommandArgs *cmd)
 {
 	CachedCommandInfo info;
 
@@ -837,7 +837,7 @@ void CHalfLife2::PushCommandStack(const CCommand *cmd)
 	m_CommandStack.push(info);
 }
 
-const CCommand *CHalfLife2::PeekCommandStack()
+const ICommandArgs *CHalfLife2::PeekCommandStack()
 {
 	if (m_CommandStack.empty())
 	{

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -49,7 +49,9 @@
 #include <tier0/icommandline.h>
 #include <string_t.h>
 
-class CCommand;
+namespace SourceMod {
+class ICommandArgs;
+} // namespace SourceMod
 
 using namespace SourceHook;
 using namespace SourceMod;
@@ -100,7 +102,7 @@ struct DelayedFakeCliCmd
 
 struct CachedCommandInfo
 {
-	const CCommand *args;
+	const ICommandArgs *args;
 #if SOURCE_ENGINE <= SE_DARKMESSIAH
 	char cmd[300];
 #endif
@@ -141,6 +143,7 @@ class CHalfLife2 :
 	public SMGlobalClass,
 	public IGameHelpers
 {
+	friend class AutoEnterCommand;
 public:
 	CHalfLife2();
 	~CHalfLife2();
@@ -190,9 +193,7 @@ public:
 	void AddToFakeCliCmdQueue(int client, int userid, const char *cmd);
 	void ProcessFakeCliCmdQueue();
 public:
-	void PushCommandStack(const CCommand *cmd);
-	void PopCommandStack();
-	const CCommand *PeekCommandStack();
+	const ICommandArgs *PeekCommandStack();
 	const char *CurrentCommandName();
 	void AddDelayedKick(int client, int userid, const char *msg);
 	void ProcessDelayedKicks();
@@ -200,6 +201,8 @@ public:
 	bool IsOriginalEngine();
 #endif
 private:
+	void PushCommandStack(const ICommandArgs *cmd);
+	void PopCommandStack();
 	DataTableInfo *_FindServerClass(const char *classname);
 private:
 	void InitLogicalEntData();
@@ -223,5 +226,16 @@ private:
 extern CHalfLife2 g_HL2;
 
 bool IndexToAThings(cell_t, CBaseEntity **pEntData, edict_t **pEdictData);
+
+class AutoEnterCommand
+{
+public:
+	AutoEnterCommand(const ICommandArgs *args) {
+		g_HL2.PushCommandStack(args);
+	}
+	~AutoEnterCommand() {
+		g_HL2.PopCommandStack();
+	}
+};
 
 #endif //_INCLUDE_SOURCEMOD_CHALFLIFE2_H_

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -47,6 +47,7 @@
 #include "logic_bridge.h"
 #include <sourcemod_version.h>
 #include "smn_keyvalues.h"
+#include "command_args.h"
 #include <ITranslator.h>
 #include <bridge/include/IExtensionBridge.h>
 #include <bridge/include/IScriptManager.h>
@@ -1180,7 +1181,8 @@ void PlayerManager::OnClientCommand(edict_t *pEntity)
 		RETURN_META(MRES_SUPERCEDE);
 	}
 
-	g_HL2.PushCommandStack(&args);
+	EngineArgs cargs(args);
+	AutoEnterCommand autoEnterCommand(&cargs);
 
 	int argcount = args.ArgC() - 1;
 	const char *cmd = g_HL2.CurrentCommandName();
@@ -1199,10 +1201,9 @@ void PlayerManager::OnClientCommand(edict_t *pEntity)
 
 	if (g_ConsoleDetours.IsEnabled())
 	{
-		cell_t res2 = g_ConsoleDetours.InternalDispatch(client, args);
+		cell_t res2 = g_ConsoleDetours.InternalDispatch(client, &cargs);
 		if (res2 >= Pl_Stop)
 		{
-			g_HL2.PopCommandStack();
 			RETURN_META(MRES_SUPERCEDE);
 		}
 		else if (res2 > res)
@@ -1226,13 +1227,10 @@ void PlayerManager::OnClientCommand(edict_t *pEntity)
 
 	if (res >= Pl_Stop)
 	{
-		g_HL2.PopCommandStack();
 		RETURN_META(MRES_SUPERCEDE);
 	}
 
 	res = g_ConCmds.DispatchClientCommand(client, cmd, argcount, (ResultType)res);
-
-	g_HL2.PopCommandStack();
 
 	if (res >= Pl_Handled)
 	{

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -742,6 +742,18 @@ bool CoreProviderImpl::LoadBridge(char *error, size_t maxlength)
 	return true;
 }
 
+ke::PassRef<CommandHook>
+CoreProviderImpl::AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback)
+{
+	return hooks_.AddCommandHook(cmd, callback);
+}
+
+ke::PassRef<CommandHook>
+CoreProviderImpl::AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback)
+{
+	return hooks_.AddPostCommandHook(cmd, callback);
+}
+
 void CoreProviderImpl::InitializeHooks()
 {
 	hooks_.Start();

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -639,20 +639,20 @@ void CoreProviderImpl::UnloadMMSPlugin(int id)
 
 bool CoreProviderImpl::IsClientConVarQueryingSupported()
 {
-	return hooks_.GetQueryHookMode() != QueryHookMode::Unavailable;
+	return hooks_.GetClientCvarQueryMode() != ClientCvarQueryMode::Unavailable;
 }
 
 int CoreProviderImpl::QueryClientConVar(int client, const char *cvar)
 {
 #if SOURCE_ENGINE != SE_DARKMESSIAH
-	switch (hooks_.GetQueryHookMode()) {
-	case QueryHookMode::DLL:
+	switch (hooks_.GetClientCvarQueryMode()) {
+	case ClientCvarQueryMode::DLL:
 # if SOURCE_ENGINE == SE_DOTA
 		return ::engine->StartQueryCvarValue(CEntityIndex(client), cvar);
 # else
 		return ::engine->StartQueryCvarValue(PEntityOfEntIndex(client), cvar);
 # endif
-	case QueryHookMode::VSP:
+	case ClientCvarQueryMode::VSP:
 # if SOURCE_ENGINE != SE_DOTA
 		return serverpluginhelpers->StartQueryCvarValue(PEntityOfEntIndex(client), cvar);
 # endif

--- a/core/provider.h
+++ b/core/provider.h
@@ -65,6 +65,9 @@ public:
 	int QueryClientConVar(int client, const char *cvar) override;
 	bool IsClientConVarQueryingSupported() override;
 
+	ke::PassRef<CommandHook> AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
+	ke::PassRef<CommandHook> AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
+
 private:
 	ke::Ref<ke::SharedLib> logic_;
 	LogicInitFunction logic_init_;

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -784,7 +784,7 @@ static cell_t sm_RegAdminCmd(IPluginContext *pContext, const cell_t *params)
 
 static cell_t sm_GetCmdArgs(IPluginContext *pContext, const cell_t *params)
 {
-	const CCommand *pCmd = g_HL2.PeekCommandStack();
+	const ICommandArgs *pCmd = g_HL2.PeekCommandStack();
 
 	if (!pCmd)
 	{
@@ -796,7 +796,7 @@ static cell_t sm_GetCmdArgs(IPluginContext *pContext, const cell_t *params)
 
 static cell_t sm_GetCmdArg(IPluginContext *pContext, const cell_t *params)
 {
-	const CCommand *pCmd = g_HL2.PeekCommandStack();
+	const ICommandArgs *pCmd = g_HL2.PeekCommandStack();
 
 	if (!pCmd)
 	{
@@ -814,7 +814,7 @@ static cell_t sm_GetCmdArg(IPluginContext *pContext, const cell_t *params)
 
 static cell_t sm_GetCmdArgString(IPluginContext *pContext, const cell_t *params)
 {
-	const CCommand *pCmd = g_HL2.PeekCommandStack();
+	const ICommandArgs *pCmd = g_HL2.PeekCommandStack();
 
 	if (!pCmd)
 	{


### PR DESCRIPTION
This series of patches isolates ConCommand dispatch hooking to GameHooks. Unfortunately it's a little tricky to do that, because there are three different signatures for a command dispatch callback.

What I did here was add a new reference-counted class, CommandHook, which encapsulates a hook id and a callback function. SH_ADD occurs against this class, which handles the different signatures, wrapping the arguments, and dispatching to the callback. When all references to a CommandHook are gone, the hook is removed. The reference is bumped during callbacks just in case some weird re-entrancy stuff goes on.

In addition a bunch more places that used CCommand have been converted to ICommandArgs.

All in all this was a very nice simplification to ChatTriggers and I think we can use the same mechanism to move CON_COMMAND usage over to logic. It should also simplify moving ConCmdManager and ChatTriggers.