### PR TITLE
Move the SetCommandClient hook into GameHooks.

### DIFF
--- a/core/ChatTriggers.cpp
+++ b/core/ChatTriggers.cpp
@@ -103,11 +103,11 @@ void ChatTriggers::OnSourceModGameInitialized()
 {
 	ConCommand *say_team = FindCommand("say_team");
 
-	CommandHook::Callback pre_hook = [this] (const ICommandArgs *args) -> bool {
-		return this->OnSayCommand_Pre(args);
+	CommandHook::Callback pre_hook = [this] (int client, const ICommandArgs *args) -> bool {
+		return this->OnSayCommand_Pre(client, args);
 	};
-	CommandHook::Callback post_hook = [this] (const ICommandArgs *args) -> bool {
-		return this->OnSayCommand_Post(args);
+	CommandHook::Callback post_hook = [this] (int client, const ICommandArgs *args) -> bool {
+		return this->OnSayCommand_Post(client, args);
 	};
 
 	if (ConCommand *say = FindCommand("say")) {
@@ -145,9 +145,8 @@ void ChatTriggers::OnSourceModShutdown()
 	forwardsys->ReleaseForward(m_pOnClientSayCmd_Post);
 }
 
-bool ChatTriggers::OnSayCommand_Pre(const ICommandArgs *command)
+bool ChatTriggers::OnSayCommand_Pre(int client, const ICommandArgs *command)
 {
-	int client = g_ConCmds.GetCommandClient();
 	m_bIsChatTrigger = false;
 	m_bWasFloodedMessage = false;
 	m_bPluginIgnored = true;
@@ -287,10 +286,8 @@ bool ChatTriggers::OnSayCommand_Pre(const ICommandArgs *command)
 	return false;
 }
 
-bool ChatTriggers::OnSayCommand_Post(const ICommandArgs *command)
+bool ChatTriggers::OnSayCommand_Post(int client, const ICommandArgs *command)
 {
-	int client = g_ConCmds.GetCommandClient();
-
 	if (m_bWillProcessInPost)
 	{
 		/* Reset this for re-entrancy */

--- a/core/ChatTriggers.h
+++ b/core/ChatTriggers.h
@@ -56,8 +56,8 @@ public: //SMGlobalClass
 		char *error, 
 		size_t maxlength);
 private: //ConCommand
-	bool OnSayCommand_Pre(const ICommandArgs *args);
-	bool OnSayCommand_Post(const ICommandArgs *args);
+	bool OnSayCommand_Pre(int client, const ICommandArgs *args);
+	bool OnSayCommand_Post(int client, const ICommandArgs *args);
 public:
 	unsigned int GetReplyTo();
 	unsigned int SetReplyTo(unsigned int reply);

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -143,10 +143,9 @@ public:
 	bool LookForSourceModCommand(const char *cmd);
 	bool LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags);
 private:
-	bool InternalDispatch(const ICommandArgs *args);
+	bool InternalDispatch(int client, const ICommandArgs *args);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
 	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
-	void SetCommandClient(int client);
 	void AddToCmdList(ConCmdInfo *info);
 	void RemoveConCmd(ConCmdInfo *info, const char *cmd, bool is_read_safe, bool untrack);
 	bool CheckAccess(int client, const char *cmd, AdminCmdInfo *pAdmin);
@@ -157,10 +156,6 @@ private:
 	// Case sensitive
 	ConCmdInfo *FindInTrie(const char *name);
 public:
-	inline int GetCommandClient()
-	{
-		return m_CmdClient;
-	}
 	inline const List<ConCmdInfo *> & GetCommandList()
 	{
 		return m_CmdList;
@@ -171,7 +166,6 @@ private:
 	StringHashMap<ConCmdInfo *> m_Cmds; /* command lookup */
 	GroupMap m_CmdGrps;				/* command group map */
 	ConCmdList m_CmdList;			/* command list */
-	int m_CmdClient;				/* current client */
 };
 
 extern ConCmdManager g_ConCmds;

--- a/core/ConsoleDetours.cpp
+++ b/core/ConsoleDetours.cpp
@@ -51,6 +51,7 @@
 #include "ConCommandBaseIterator.h"
 #include "logic_bridge.h"
 #include "command_args.h"
+#include "provider.h"
 #include <am-utility.h>
 #include <bridge/include/ILogger.h>
 
@@ -719,7 +720,7 @@ cell_t ConsoleDetours::Dispatch(ConCommand *pBase)
 	cell_t res;
 	{
 		AutoEnterCommand autoEnterCommand(&cargs);
-		res = g_ConsoleDetours.InternalDispatch(g_ConCmds.GetCommandClient(), &cargs);
+		res = g_ConsoleDetours.InternalDispatch(sCoreProviderImpl.CommandClient(), &cargs);
 	}
 
 #if SH_IMPL_VERSION < 4

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -66,7 +66,7 @@ class CommandHook : public ke::Refcounted<CommandHook>
 {
 public:
 	// return false to RETURN_META(MRES_IGNORED), or true to SUPERCEDE.
-	typedef ke::Lambda<bool(const ICommandArgs *)> Callback;
+	typedef ke::Lambda<bool(int, const ICommandArgs *)> Callback;
 
 public:
 	CommandHook(ConCommand *cmd, const Callback &callback, bool post);
@@ -96,6 +96,10 @@ public:
 	ke::PassRef<CommandHook> AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 	ke::PassRef<CommandHook> AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 
+	int CommandClient() const {
+		return last_command_client_;
+	}
+
 private:
 	// Static callback that Valve's ConVar object executes when the convar's value changes.
 #if SOURCE_ENGINE >= SE_ORANGEBOX
@@ -113,6 +117,8 @@ private:
 	                              const char *cvarName, const char *cvarValue);
 #endif
 
+	void SetCommandClient(int client);
+
 private:
 	class HookList : public ke::Vector<int>
 	{
@@ -125,6 +131,7 @@ private:
 	HookList hooks_;
 
 	ClientCvarQueryMode client_cvar_query_mode_;
+	int last_command_client_;
 };
 
 } // namespace SourceMod

--- a/core/provider.h
+++ b/core/provider.h
@@ -68,6 +68,10 @@ public:
 	ke::PassRef<CommandHook> AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 	ke::PassRef<CommandHook> AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 
+	int CommandClient() const {
+		return hooks_.CommandClient();
+	}
+
 private:
 	ke::Ref<ke::SharedLib> logic_;
 	LogicInitFunction logic_init_;


### PR DESCRIPTION
Also makes the client an argument into command callbacks, so consumers don't have to know about SetCommandClient.