### PR TITLE
Change FindMap to take a const char* for searching instead of char*.

### DIFF
--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -185,7 +185,8 @@ public: //IGameHelpers
 	const char *GetEntityClassname(edict_t *pEdict);
 	const char *GetEntityClassname(CBaseEntity *pEntity);
 	bool IsMapValid(const char *map);
-	SMFindMapResult FindMap(char *pMapName, int nMapNameMax);
+	SMFindMapResult FindMap(char *pMapName, size_t nMapNameMax);
+	SMFindMapResult FindMap(const char *pMapName, char *pFoundMap = NULL, size_t nMapNameMax = 0);
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	string_t AllocPooledString(const char *pszValue);
 #endif

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -71,10 +71,15 @@ static cell_t FindMap(IPluginContext *pContext, const cell_t *params)
 {
 	char *pMapname;
 	pContext->LocalToString(params[1], &pMapname);
-		
-	cell_t size = params[2];
-	
-	return static_cast<cell_t>(g_HL2.FindMap(pMapname, size));
+
+	if (params[0] == 2)
+	{
+		return static_cast<cell_t>(g_HL2.FindMap(pMapname, params[2]));
+	}
+
+	char *pDestMap;
+	pContext->LocalToString(params[2], &pDestMap);
+	return static_cast<cell_t>(g_HL2.FindMap(pMapname, pDestMap, params[3]));
 }
 
 static cell_t IsDedicatedServer(IPluginContext *pContext, const cell_t *params)

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -159,12 +159,13 @@ native bool:IsMapValid(const String:map[]);
  * Returns whether a full or partial map name is found or can be resolved
  * 
  * @param map 			Map name (usually same as map path relative to maps/ dir,
- *						excluding .bsp extension). If result is FindMap_FuzzyMatch
- *						or FindMap_NonCanonical, this will be updated to the full path.
+ *						excluding .bsp extension).
+ * @param foundmap		Resolved map name. If the return is FindMap_FuzzyMatch
+ *						or FindMap_NonCanonical the buffer will be the full path.
  * @param maxlen		Maximum length to write to map var.
  * @return				Result of the find operation. Not all result types are supported on all games.
  */
-native FindMapResult FindMap(char[] map, int maxlen);
+native FindMapResult FindMap(const char[] map, char[] foundmap, int maxlen);
 
 /**
  * Returns whether the server is dedicated.


### PR DESCRIPTION
I dislike the FindMap API we have greatly because we're asking users to create a new buffer, fill it, and then pass it to FindMap to determine if the user input is valid. We don't have any other APIs like this, and it turns into a whole thing everytime this native is to be used. Internally we have the exact same pattern and we throw away the result...

The alternative I'm proposing is the top, bottom being present.
```native FindMapResult FindMap(const char[] map, char[] foundmap, int maxlen);```
```native FindMapResult FindMap(char[] map, int maxlen);```

This is only compile tested.