### PR TITLE
Shim for TF2-branch games to find latest, non-shimmed engine iface.

### DIFF
--- a/core/sourcemm_api.cpp
+++ b/core/sourcemm_api.cpp
@@ -70,7 +70,21 @@ bool SourceMod_Core::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen
 	PLUGIN_SAVEVARS();
 
 	GET_V_IFACE_ANY(GetServerFactory, gamedll, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL);
+#if SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_SDK2013
+	// Shim to avoid hooking shims
+	engine = (IVEngineServer *)ismm->VInterfaceMatch(ismm->GetEngineFactory(), "VEngineServer023");
+	if (!engine)
+	{
+		engine = (IVEngineServer *)ismm->VInterfaceMatch(ismm->GetEngineFactory(), "VEngineServer022");
+		if (error && maxlen)
+		{
+			ismm->Format(error, maxlen, "Could not find interface: VEngineServer023 or VEngineServer022");
+		}
+		return false;
+	}
+#else
 	GET_V_IFACE_CURRENT(GetEngineFactory, engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
+#endif
 	GET_V_IFACE_CURRENT(GetServerFactory, serverClients, IServerGameClients, INTERFACEVERSION_SERVERGAMECLIENTS);
 	GET_V_IFACE_CURRENT(GetEngineFactory, icvar, ICvar, CVAR_INTERFACE_VERSION);
 	GET_V_IFACE_CURRENT(GetEngineFactory, gameevents, IGameEventManager2, INTERFACEVERSION_GAMEEVENTSMANAGER2);


### PR DESCRIPTION
This gross slab of hackeroni ensures that we get the latest (for now) engine iface available on TF2-branch games (including CS:S, DoD:S, HL2:DM, and SDK 2013 mods), so that we don't grab some older shim of an iface (causing our hooks to not fire).

This should allow seamless functionality now for TF2, both before and after the impending updates for CS:S, DoD:S, and HL2:DM, as well as both SDK 2013 mods that have updated to the newer iface and those that haven't.