### PR TITLE
Fix IsMapValid call on non-TF2 TF2-branch games to use old behavior requiring only map name

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1268,6 +1268,9 @@ SMFindMapResult CHalfLife2::FindMap(const char *pMapName, char *pFoundMap, size_
 	}
 
 	return static_cast<SMFindMapResult>(engine->FindMap(pFoundMap, static_cast<int>(nMapNameMax)));
+#elif SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_SDK2013
+	static IVEngineServer *engine21 = (IVEngineServer *)(g_SMAPI->GetEngineFactory()("VEngineServer021", nullptr));
+	return engine21->IsMapValid(pMapName) == 0 ? SMFindMapResult::NotFound : SMFindMapResult::Found;
 #else
 	return engine->IsMapValid(pMapName) == 0 ? SMFindMapResult::NotFound : SMFindMapResult::Found;
 #endif


### PR DESCRIPTION
This slimey hunk of hackeroni ensures that we get the "classic" IsMapValid behavior for games (other than TF2) that are on the TF2 branch, including CS:S, DoD:S, HL2:DM, and SDK 2013 mods.

The newer behavior is to have a relative (or maybe full?) map path as input, rather than just the map name. Since the rest of our logic only expects the map name, including on all other games, this normalizes that. It would also be necessary for TF2 if we weren't bypassing IsMapValid altogether and going through FindMap.