### PR TITLE
Fix a regression from the ConCmdManager refactoring that causes a crash using SourceMod commands in the server console.

### DIFF
--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -136,9 +136,7 @@ void CommandCallback(DISPATCH_ARGS)
 	EngineArgs args(command);
 
 	AutoEnterCommand autoEnterCommand(&args);
-	if (g_ConCmds.InternalDispatch(sCoreProviderImpl.CommandClient(), &args))
-		RETURN_META(MRES_SUPERCEDE);
-	RETURN_META(MRES_IGNORED);
+	g_ConCmds.InternalDispatch(sCoreProviderImpl.CommandClient(), &args);
 }
 
 ConCmdInfo *ConCmdManager::FindInTrie(const char *name)


### PR DESCRIPTION
Can't use RETURN_META when no hooks are on the stack. No hooks will ever be on the stack here. I don't know why I added these.