### PR TITLE
Added IsFree() edict check to FindEntityByNetClass

### DIFF
--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -414,7 +414,7 @@ int FindEntityByNetClass(int start, const char *classname)
 	for (int i = ((start != -1) ? start : 0); i < gpGlobals->maxEntities; i++)
 	{
 		current = engine->PEntityOfEntIndex(i);
-		if (current == NULL)
+		if (current == NULL || current->IsFree())
 		{
 			continue;
 		}


### PR DESCRIPTION
I had a null pointer crash in FindEntityByNetClass

https://github.com/Thordin/sourcemod/blob/3a59baab2c899a749d3d6d7f1d0906f75a8ad53d/extensions/tf2/extension.cpp#L429

I found the same function here except they added an IsFree() check on the edict, so maybe that was the problem.

https://github.com/alliedmodders/sourcemod/blob/master/extensions/sdktools/gamerulesnatives.cpp#L43