### PR TITLE
Update metamod-attached extensions to use same engine ptr lookup as core

### DIFF
--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -340,8 +340,25 @@ bool SDKExtension::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, 
 	GET_V_IFACE_CURRENT(engineFactory, engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
 #else
 	GET_V_IFACE_ANY(GetServerFactory, gamedll, IServerGameDLL, INTERFACEVERSION_SERVERGAMEDLL);
+#if SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_SDK2013
+	// Shim to avoid hooking shims
+	engine = (IVEngineServer *) ismm->GetEngineFactory()("VEngineServer023", nullptr);
+	if (!engine)
+	{
+		engine = (IVEngineServer *) ismm->GetEngineFactory()("VEngineServer022", nullptr);
+		if (!engine)
+		{
+			if (error && maxlen)
+			{
+				ismm->Format(error, maxlen, "Could not find interface: VEngineServer023 or VEngineServer022");
+			}
+			return false;
+		}
+	}
+#else
 	GET_V_IFACE_CURRENT(GetEngineFactory, engine, IVEngineServer, INTERFACEVERSION_VENGINESERVER);
-#endif
+#endif // TF2 / CSS / DODS / HL2DM / SDK2013
+#endif // !METAMOD_PLAPI_VERSION
 #endif //META_NO_HL2SDK
 
 	m_SourceMMLoaded = true;


### PR DESCRIPTION
We already did this in core, and it's not relevant to any supported games yet except for any 2013 mods that have updated to the new SDK since we haven't updated our hl2sdk-sdk2013 yet.

On TF2-branch games, always look for engine v23, and fallback to v22 if not available. Their vtable layouts are compatible with the only differences being 23 possibly having more functions at the end, and the behavior of IsMapValid being different. This ensures continued compatibility with CS:S, DoD:S, and HL2:DM are their sync happening soon, as well as with any SDK 2013 mods that have or have not updated to the latest 2013 SDK, before or after we update our copy of it.