### PR TITLE
Add shim for TerminateRound for  CS:GO

### DIFF
--- a/extensions/cstrike/forwards.cpp
+++ b/extensions/cstrike/forwards.cpp
@@ -122,6 +122,10 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 
 	cell_t result = Pl_Continue;
 
+	#if SOURCE_ENGINE == SE_CSGO
+	reason--;
+	#endif
+	
 	g_pTerminateRoundForward->PushFloatByRef(&delay);
 	g_pTerminateRoundForward->PushCellByRef(&reason);
 	g_pTerminateRoundForward->Execute(&result);
@@ -129,6 +133,10 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 	if (result >= Pl_Handled)
 		return;
 
+	#if SOURCE_ENGINE == SE_CSGO
+	reason++;
+	#endif
+	
 #if SOURCE_ENGINE != SE_CSGO || !defined(WIN32)
 	if (result == Pl_Changed)
 		return DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason);

--- a/extensions/cstrike/forwards.cpp
+++ b/extensions/cstrike/forwards.cpp
@@ -122,9 +122,9 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 
 	cell_t result = Pl_Continue;
 
-	#if SOURCE_ENGINE == SE_CSGO
+#if SOURCE_ENGINE == SE_CSGO
 	reason--;
-	#endif
+#endif
 	
 	g_pTerminateRoundForward->PushFloatByRef(&delay);
 	g_pTerminateRoundForward->PushCellByRef(&reason);
@@ -133,9 +133,9 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 	if (result >= Pl_Handled)
 		return;
 
-	#if SOURCE_ENGINE == SE_CSGO
+#if SOURCE_ENGINE == SE_CSGO
 	reason++;
-	#endif
+#endif
 	
 #if SOURCE_ENGINE != SE_CSGO || !defined(WIN32)
 	if (result == Pl_Changed)

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -330,6 +330,12 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("GameRules not available. TerminateRound native disabled.");
 	}
 
+	int reason = params[2];
+	
+#if SOURCE_ENGINE == SE_CSGO
+	reason++;
+#endif
+	
 #if SOURCE_ENGINE != SE_CSGO || !defined(WIN32)
 	static ICallWrapper *pWrapper = NULL;
 
@@ -356,7 +362,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	vptr += sizeof(void *);
 	*(float *)vptr = sp_ctof(params[1]);
 	vptr += sizeof(float);
-	*(int*)vptr = params[2];
+	*(int*)vptr = reason;
 
 	pWrapper->Execute(vstk, NULL);
 #else
@@ -371,7 +377,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 		g_pIgnoreTerminateDetour = true;
 
 	float delay = sp_ctof(params[1]);
-	int reason = params[2];
+	
 	__asm
 	{
 		push reason

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -51,8 +51,8 @@
 enum CSRoundEndReason
 {
 	CSRoundEnd_TargetBombed = 0,           /**< Target Successfully Bombed! */
-	CSRoundEnd_VIPEscaped,                 /**< The VIP has escaped! */
-	CSRoundEnd_VIPKilled,                  /**< VIP has been assassinated! */
+	CSRoundEnd_VIPEscaped,                 /**< The VIP has escaped! - Doesn't exist on CS:GO */
+	CSRoundEnd_VIPKilled,                  /**< VIP has been assassinated! - Doesn't exist on CS:GO */
 	CSRoundEnd_TerroristsEscaped,          /**< The terrorists have escaped! */
 	CSRoundEnd_CTStoppedEscape,            /**< The CTs have prevented most of the terrorists from escaping! */
 	CSRoundEnd_TerroristsStopped,          /**< Escaping terrorists have all been neutralized! */
@@ -64,13 +64,13 @@ enum CSRoundEndReason
 	CSRoundEnd_TargetSaved,                /**< Target has been saved! */
 	CSRoundEnd_HostagesNotRescued,         /**< Hostages have not been rescued! */
 	CSRoundEnd_TerroristsNotEscaped,       /**< Terrorists have not escaped! */
-	CSRoundEnd_VIPNotEscaped,              /**< VIP has not escaped! */
+	CSRoundEnd_VIPNotEscaped,              /**< VIP has not escaped! - Doesn't exist on CS:GO */
 	CSRoundEnd_GameStart,                  /**< Game Commencing! */
 	
 	// The below only exist on CS:GO
 	CSRoundEnd_TerroristsSurrender,        /**< Terrorists Surrender */
 	CSRoundEnd_CTSurrender,                /**< CTs Surrender */
-	CSRoundEnd_TerroristsPlaned,		   /**< Terrorists Planted the bomb */
+	CSRoundEnd_TerroristsPlanted,		   /**< Terrorists Planted the bomb */
 	CSRoundEnd_CTsReachedHostage,		   /**< CTs Reached the hostage */
 };
 

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -70,6 +70,8 @@ enum CSRoundEndReason
 	// The below only exist on CS:GO
 	CSRoundEnd_TerroristsSurrender,        /**< Terrorists Surrender */
 	CSRoundEnd_CTSurrender,                /**< CTs Surrender */
+	CSRoundEnd_TerroristsPlaned,		   /**< Terrorists Planted the bomb */
+	CSRoundEnd_CTsReachedHostage,		   /**< CTs Reached the hostage */
 };
 
 enum CSWeaponID


### PR DESCRIPTION
This simply adjusts the reason to match real value to the include one and vice versa for values coming from plugins.