### PR TITLE
Clean up the first pass of plugin loading.

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -8,7 +8,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -108,8 +108,8 @@ void CPlugin::InitIdentity()
 
 unsigned int CPlugin::CalcMemUsage()
 {
-	unsigned int base_size = 
-		sizeof(CPlugin) 
+	unsigned int base_size =
+		sizeof(CPlugin)
 		+ sizeof(IdentityToken_t)
 		+ (m_configs.size() * (sizeof(AutoConfig *) + sizeof(AutoConfig)))
 		+ m_Props.mem_usage();
@@ -382,7 +382,7 @@ APLRes CPlugin::Call_AskPluginLoad(char *error, size_t maxlength)
 	bool haveNewAPL = false;
 	IPluginFunction *pFunction = m_pRuntime->GetFunctionByName("AskPluginLoad2");
 
-	if (pFunction) 
+	if (pFunction)
 	{
 		haveNewAPL = true;
 	}
@@ -400,7 +400,7 @@ APLRes CPlugin::Call_AskPluginLoad(char *error, size_t maxlength)
 		return APLRes_Failure;
 	}
 
-	if (haveNewAPL) 
+	if (haveNewAPL)
 	{
 		return (APLRes)result;
 	}
@@ -701,21 +701,21 @@ void CPlugin::DropEverything()
 
 	/* Tell everyone that depends on us that we're about to drop */
 	for (List<CPlugin *>::iterator iter = m_Dependents.begin();
-		 iter != m_Dependents.end(); 
+		 iter != m_Dependents.end();
 		 iter++)
 	{
 		pOther = static_cast<CPlugin *>(*iter);
 		pOther->DependencyDropped(this);
 	}
 
-	/* Note: we don't care about things we depend on. 
-	 * The reason is that extensions have their own cleanup 
-	 * code for plugins.  Although the "right" design would be 
-	 * to centralize that here, i'm omitting it for now.  Thus, 
+	/* Note: we don't care about things we depend on.
+	 * The reason is that extensions have their own cleanup
+	 * code for plugins.  Although the "right" design would be
+	 * to centralize that here, i'm omitting it for now.  Thus,
 	 * the code below to walk the plugins list will suffice.
 	 */
 	
-	/* Other plugins could be holding weak references that were 
+	/* Other plugins could be holding weak references that were
 	 * added by us.  We need to clean all of those up now.
 	 */
 	for (List<CPlugin *>::iterator iter = g_PluginSys.m_plugins.begin();
@@ -852,7 +852,7 @@ void CPluginManager::LoadPluginsFromDir(const char *basedir, const char *localpa
 
 	while (dir->MoreFiles())
 	{
-		if (dir->IsEntryDirectory() 
+		if (dir->IsEntryDirectory()
 			&& (strcmp(dir->GetEntryName(), ".") != 0)
 			&& (strcmp(dir->GetEntryName(), "..") != 0)
 			&& (strcmp(dir->GetEntryName(), "disabled") != 0)
@@ -923,7 +923,7 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 	if (plugin->GetStatus() != Plugin_Created)
 		return LoadRes_Failure;
 
-	APLRes result = plugin->Call_AskPluginLoad(error, maxlength);  
+	APLRes result = plugin->Call_AskPluginLoad(error, maxlength);
 	switch (result)
 	{
 	case APLRes_Success:
@@ -1005,7 +1005,7 @@ void CPluginManager::LoadAutoPlugin(const char *plugin)
 	{
 		g_Logger.LogError("[SM] Failed to load plugin \"%s\": %s.", plugin, error);
 		pl->SetErrorState(
-			pl->GetStatus() <= Plugin_Created ? Plugin_BadLoad : pl->GetStatus(), 
+			pl->GetStatus() <= Plugin_Created ? Plugin_BadLoad : pl->GetStatus(),
 			"%s",
 			error);
 	}
@@ -1628,7 +1628,7 @@ bool CPluginManager::TestAliasMatch(const char *alias, const char *localpath)
 					localptr++;
 				}
 				/* Check if we hit the end of our searchable area.
-				 * This probably isn't possible because of the path 
+				 * This probably isn't possible because of the path
 				 * count check, but it's a good idea anyway.
 				 */
 				if ((localptr - localpath) >= (int)local_path_end)
@@ -1800,10 +1800,10 @@ void CPluginManager::OnSourceModShutdown()
 	forwardsys->ReleaseForward(m_pOnLibraryRemoved);
 }
 
-ConfigResult CPluginManager::OnSourceModConfigChanged(const char *key, 
-												 const char *value, 
-												 ConfigSource source, 
-												 char *error, 
+ConfigResult CPluginManager::OnSourceModConfigChanged(const char *key,
+												 const char *value,
+												 ConfigSource source,
+												 char *error,
 												 size_t maxlength)
 {
 	if (strcmp(key, "BlockBadPlugins") == 0) {
@@ -2204,7 +2204,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				rootmenu->ConsolePrint("  Load error: %s", pl->m_errormsg);
 				if (pl->GetStatus() < Plugin_Created)
 				{
-					rootmenu->ConsolePrint("  File info: (title \"%s\") (version \"%s\")", 
+					rootmenu->ConsolePrint("  File info: (title \"%s\") (version \"%s\")",
 											info->name ? info->name : "<none>",
 											info->version ? info->version : "<none>");
 					if (IS_STR_FILLED(info->url))
@@ -2260,7 +2260,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 
 			char name[PLATFORM_MAX_PATH];
 			const sm_plugininfo_t *info = pl->GetPublicInfo();
-			if (pl->GetStatus() <= Plugin_Paused) 
+			if (pl->GetStatus() <= Plugin_Paused)
 				strcpy(name, (IS_STR_FILLED(info->name)) ? info->name : pl->GetFilename());
 			else
 				strcpy(name, pl->GetFilename());
@@ -2552,7 +2552,7 @@ void CPluginManager::FreePluginList(const CVector<SMPlugin *> *list)
 class OldPluginAPI : public IPluginManager
 {
 public:
-	IPlugin *LoadPlugin(const char *path, 
+	IPlugin *LoadPlugin(const char *path,
 						bool debug,
 						PluginType type,
 						char error[],

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -924,23 +924,11 @@ LoadRes CPluginManager::_LoadPlugin(CPlugin **aResult, const char *path, bool de
 		}
 	}
 
-	pPlugin = CPlugin::CreatePlugin(path, error, maxlength);
-	assert(pPlugin != NULL);
+	CPlugin *plugin = CompileAndPrep(path, error, maxlength);
 
-	if (pPlugin->m_status == Plugin_Uncompiled) {
-		pPlugin->TryCompile(error, maxlength);
-	}
-	if (pPlugin->m_status == Plugin_Created) {
-		MalwareCheckPass(pPlugin, error, maxlength);
-	}
-	
 	LoadRes loadFailure = LoadRes_Failure;
 	/* Get the status */
-	if (pPlugin->GetStatus() == Plugin_Created)
-	{
-		/* First native pass - add anything from Core */
-		g_ShareSys.BindNativesToPlugin(pPlugin, true);
-		pPlugin->InitIdentity();
+	if (pPlugin->GetStatus() == Plugin_Created) {
 		APLRes result = pPlugin->Call_AskPluginLoad(error, maxlength);  
 		switch (result)
 		{
@@ -1241,6 +1229,28 @@ bool CPluginManager::LoadOrRequireExtensions(CPlugin *pPlugin, unsigned int pass
 
 	return true;
 }
+
+CPlugin *CPluginManager::CompileAndPrep(const char *path, char *error, size_t maxlength)
+{
+	CPlugin *plugin = CPlugin::CreatePlugin(path, error, maxlength);
+	if (plugin->GetStatus() != Plugin_Uncompiled) {
+		assert(plugin->GetStatus() == Plugin_BadLoad);
+		return plugin;
+	}
+
+	if (!plugin->TryCompile(error, maxlength))
+		return plugin;
+	assert(plugin->GetStatus() == Plugin_Created);
+
+	if (!MalwareCheckPass(plugin, error, maxlength))
+		return plugin;
+	assert(plugin->GetStatus() == Plugin_Created);
+
+	g_ShareSys.BindNativesToPlugin(plugin, true);
+	plugin->InitIdentity();
+	return plugin;
+}
+
 
 bool CPluginManager::MalwareCheckPass(CPlugin *pPlugin, char *error, size_t maxlength)
 {

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -249,10 +249,13 @@ public:
 	}
 	void LibraryActions(LibraryAction action);
 	void SyncMaxClients(int max_clients);
+
 protected:
-	bool UpdateInfo();
+	bool ReadInfo();
 	void SetTimeStamp(time_t t);
 	void DependencyDropped(CPlugin *pOwner);
+
+	bool TryCompile(char *error, size_t maxlength);
 
 private:
 	// This information is static for the lifetime of the plugin.

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -462,6 +462,7 @@ private:
 	/**
 	 * First pass for loading a plugin, and its helpers.
 	 */
+	CPlugin *CompileAndPrep(const char *path, char *error, size_t maxlength);
 	bool MalwareCheckPass(CPlugin *pPlugin, char *error, size_t maxlength);
 
 	/**

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -460,6 +460,11 @@ private:
 	void AddPlugin(CPlugin *pPlugin);
 
 	/**
+	 * First pass for loading a plugin, and its helpers.
+	 */
+	bool MalwareCheckPass(CPlugin *pPlugin, char *error, size_t maxlength);
+
+	/**
 	 * Runs the second loading pass on a plugin.
 	 */
 	bool RunSecondPass(CPlugin *pPlugin, char *error, size_t maxlength);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -169,8 +169,8 @@ public:
 	{
 		return strcmp(plugin->m_filename, file) == 0;
 	}
-public:
 
+public:
 	/**
 	 * Sets an error state on the plugin
 	 */
@@ -221,13 +221,8 @@ public:
 	 * Get languages info.
 	 */
 	IPhraseCollection *GetPhrases();
+
 public:
-	// Returns the modification time during last plugin load.
-	time_t GetTimeStamp();
-
-	// Returns the current modification time of the plugin file.
-	time_t GetFileTimeStamp();
-
 	// Returns true if the plugin was running, but is now invalid.
 	bool WasRunning();
 
@@ -250,12 +245,18 @@ public:
 	void LibraryActions(LibraryAction action);
 	void SyncMaxClients(int max_clients);
 
+	// Returns true if the plugin's underlying file structure has a newer
+	// modification time than either when it was first instantiated or
+	// since the last call to HasUpdatedFile().
+	bool HasUpdatedFile();
+
 protected:
 	bool ReadInfo();
-	void SetTimeStamp(time_t t);
 	void DependencyDropped(CPlugin *pOwner);
-
 	bool TryCompile(char *error, size_t maxlength);
+
+private:
+	time_t GetFileTimeStamp();
 
 private:
 	// This information is static for the lifetime of the plugin.
@@ -285,7 +286,7 @@ private:
 	// Information that survives past eviction.
 	List<String> m_RequiredLibs;
 	List<String> m_Libraries;
-	time_t m_LastAccess;
+	time_t m_LastFileModTime;
 	Handle_t m_handle;
 	char m_DateTime[256];
 
@@ -445,7 +446,7 @@ public:
 
 	void ListPluginsToClient(CPlayer *player, const CCommand &args);
 private:
-	LoadRes _LoadPlugin(CPlugin **pPlugin, const char *path, bool debug, PluginType type, char error[], size_t maxlength);
+	LoadRes LoadPlugin(CPlugin **pPlugin, const char *path, bool debug, PluginType type, char error[], size_t maxlength);
 
 	void LoadAutoPlugin(const char *plugin);
 


### PR DESCRIPTION
This is some pretty straight forward shuffling of code around. "_LoadPlugin" gets split into a bunch of helpers and it gets a lot cleaner. You no longer need to understand the CPlugin::m_status state to follow the loading process.

The only part of note is that plugin timestamps are weird. I don't understand why (1) they were set so far into initialization or (2) right before being unloaded. I preserved the latter oddity for now, but all the details are hidden in CPlugin now, and timestamps are set in CPlugin::CreatePlugin.