### PR TITLE
Refactor LoadOrRequireExtensions.

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1160,42 +1160,25 @@ bool CPluginManager::LoadOrRequireExtensions(CPlugin *pPlugin, unsigned int pass
 			}
 		} else if (pass == 2) {
 			/* Is this required? */
-			if (ext->required)
-			{
+			if (ext->required) {
 				libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", file);
-				IExtension *pExt;
-				if ((pExt = g_Extensions.FindExtensionByFile(path)) == NULL)
-				{
+				IExtension *pExt = g_Extensions.FindExtensionByFile(path);
+				if (!pExt)
 					pExt = g_Extensions.FindExtensionByName(name);
-				}
-				/* :TODO: should we bind to unloaded extensions?
-				 * Currently the extension manager will ignore this.
-				 */
-				if (!pExt || !pExt->IsRunning(NULL, 0))
-				{
-					if (error)
-					{
-						ke::SafeSprintf(error, maxlength, "Required extension \"%s\" file(\"%s\") not running", name, file);
-					}
+
+				if (!pExt || !pExt->IsRunning(nullptr, 0)) {
+					ke::SafeSprintf(error, maxlength, "Required extension \"%s\" file(\"%s\") not running", name, file);
 					return false;
 				}
-				else
-				{
-					g_Extensions.BindChildPlugin(pExt, pPlugin);
-				}
-			}
-			else
-			{
-				IPluginFunction *pFunc;
+				g_Extensions.BindChildPlugin(pExt, pPlugin);
+			} else {
 				char buffer[64];
 				ke::SafeSprintf(buffer, sizeof(buffer), "__ext_%s_SetNTVOptional", &pubvar->name[6]);
 
-				if ((pFunc = pBase->GetFunctionByName(buffer)) != NULL)
-				{
+				if (IPluginFunction *pFunc = pBase->GetFunctionByName(buffer)) {
 					cell_t res;
 					if (pFunc->Execute(&res) != SP_ERROR_NONE) {
-						if (error)
-							ke::SafeSprintf(error, maxlength, "Fatal error during plugin initialization (ext req)");
+						ke::SafeSprintf(error, maxlength, "Fatal error during plugin initialization (ext req)");
 						return false;
 					}
 				}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1134,13 +1134,9 @@ bool CPluginManager::LoadOrRequireExtensions(CPlugin *pPlugin, unsigned int pass
 	} *ext;
 
 	IPluginContext *pBase = pPlugin->GetBaseContext();
-	uint32_t num = pBase->GetPubVarsNum();
-	sp_pubvar_t *pubvar;
-	IExtension *pExt;
-	char path[PLATFORM_MAX_PATH];
-	char *file, *name;
-	for (uint32_t i=0; i<num; i++)
+	for (uint32_t i = 0; i < pBase->GetPubVarsNum(); i++)
 	{
+		sp_pubvar_t *pubvar;
 		if (pBase->GetPubvarByIndex(i, &pubvar) != SP_ERROR_NONE)
 			continue;
 
@@ -1148,30 +1144,26 @@ bool CPluginManager::LoadOrRequireExtensions(CPlugin *pPlugin, unsigned int pass
 			continue;
 
 		ext = (_ext *)pubvar->offs;
+
+		char *file, *name;
 		if (pBase->LocalToString(ext->file, &file) != SP_ERROR_NONE)
-		{
 			continue;
-		}
 		if (pBase->LocalToString(ext->name, &name) != SP_ERROR_NONE)
-		{
 			continue;
-		}
-		if (pass == 1)
-		{
+
+		char path[PLATFORM_MAX_PATH];
+		if (pass == 1) {
 			/* Attempt to auto-load if necessary */
-			if (ext->autoload)
-			{
+			if (ext->autoload) {
 				libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", file);
-				bool bErrorOnMissing = ext->required ? true : false;
-				g_Extensions.LoadAutoExtension(path, bErrorOnMissing);
+				g_Extensions.LoadAutoExtension(path, !!ext->required);
 			}
-		}
-		else if (pass == 2)
-		{
+		} else if (pass == 2) {
 			/* Is this required? */
 			if (ext->required)
 			{
 				libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", file);
+				IExtension *pExt;
 				if ((pExt = g_Extensions.FindExtensionByFile(path)) == NULL)
 				{
 					pExt = g_Extensions.FindExtensionByName(name);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -53,6 +53,7 @@
 #include "PhraseCollection.h"
 #include <am-string.h>
 #include <bridge/include/IScriptManager.h>
+#include <am-function.h>
 
 class CPlayer;
 
@@ -155,6 +156,16 @@ public:
 	CNativeOwner *ToNativeOwner() {
 		return this;
 	}
+
+	struct ExtVar {
+		char *name;
+		char *file;
+		bool autoload;
+		bool required;
+	};
+
+	typedef ke::Lambda<bool(const sp_pubvar_t *, const ExtVar& ext)> ExtVarCallback;
+	bool ForEachExtVar(const ExtVarCallback& callback);
 public:
 	/**
 	 * Creates a plugin object with default values.

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -485,7 +485,8 @@ private:
 	/**
 	 * Runs an extension pass on a plugin.
 	 */
-	bool LoadOrRequireExtensions(CPlugin *pPlugin, unsigned int pass, char *error, size_t maxlength);
+	bool LoadExtensions(CPlugin *pPlugin, char *error, size_t maxlength);
+	bool RequireExtensions(CPlugin *pPlugin, char *error, size_t maxlength);
 
 	/**
 	* Manages required natives.


### PR DESCRIPTION
This nightmare of a function is weird. It does two totally separate things based on how you call it. Let's split it out into two functions and just share the iterator.

As per usual, this is split into a few separate commits because it has some precursor refactorings.