### PR TITLE
Refactor ForwardSys.

### DIFF
--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -47,11 +47,10 @@ void CForwardManager::OnSourceModAllInitialized()
 
 IForward *CForwardManager::CreateForward(const char *name, ExecType et, unsigned int num_params, const ParamType *types, ...)
 {
-	CForward *fwd;
 	va_list ap;
 	va_start(ap, types);
 	
-	fwd = CForward::CreateForward(name, et, num_params, types, ap);
+	CForward *fwd = CForward::CreateForward(name, et, num_params, types, ap);
 
 	va_end(ap);
 
@@ -67,11 +66,10 @@ IForward *CForwardManager::CreateForward(const char *name, ExecType et, unsigned
 
 IChangeableForward *CForwardManager::CreateForwardEx(const char *name, ExecType et, int num_params, const ParamType *types, ...)
 {
-	CForward *fwd;
 	va_list ap;
 	va_start(ap, types);
 
-	fwd = CForward::CreateForward(name, et, num_params, types, ap);
+	CForward *fwd = CForward::CreateForward(name, et, num_params, types, ap);
 
 	va_end(ap);
 
@@ -86,12 +84,9 @@ IChangeableForward *CForwardManager::CreateForwardEx(const char *name, ExecType 
 void CForwardManager::OnPluginLoaded(IPlugin *plugin)
 {
 	/* Attach any globally managed forwards */
-	List<CForward *>::iterator iter;
-	CForward *fwd;
-
-	for (iter=m_managed.begin(); iter!=m_managed.end(); iter++)
+	for (auto iter=m_managed.begin(); iter!=m_managed.end(); iter++)
 	{
-		fwd = (*iter);
+		CForward *fwd = (*iter);
 		IPluginFunction *pFunc = plugin->GetBaseContext()->GetFunctionByName(fwd->GetForwardName());
 		if (pFunc)
 		{
@@ -102,57 +97,41 @@ void CForwardManager::OnPluginLoaded(IPlugin *plugin)
 
 void CForwardManager::OnPluginUnloaded(IPlugin *plugin)
 {
-	List<CForward *>::iterator iter;
-	CForward *fwd;
-
-	for (iter=m_managed.begin(); iter!=m_managed.end(); iter++)
+	for (auto iter=m_managed.begin(); iter!=m_managed.end(); iter++)
 	{
-		fwd = (*iter);
+		CForward *fwd = (*iter);
 		fwd->RemoveFunctionsOfPlugin(plugin);
 	}
 
-	for (iter=m_unmanaged.begin(); iter!=m_unmanaged.end(); iter++)
+	for (auto iter=m_unmanaged.begin(); iter!=m_unmanaged.end(); iter++)
 	{
-		fwd = (*iter);
+		CForward *fwd = (*iter);
 		fwd->RemoveFunctionsOfPlugin(plugin);
 	}
 }
 
 IForward *CForwardManager::FindForward(const char *name, IChangeableForward **ifchng)
 {
-	List<CForward *>::iterator iter;
-	CForward *fwd;
-
-	for (iter=m_managed.begin(); iter!=m_managed.end(); iter++)
-	{
-		fwd = (*iter);
-		if (strcmp(fwd->GetForwardName(), name) == 0)
-		{
+	for (auto iter=m_managed.begin(); iter!=m_managed.end(); iter++) {
+		CForward *fwd = (*iter);
+		if (strcmp(fwd->GetForwardName(), name) == 0) {
 			if (ifchng)
-			{
 				*ifchng = NULL;
-			}
 			return fwd;
 		}
 	}
 
-	for (iter=m_unmanaged.begin(); iter!=m_unmanaged.end(); iter++)
-	{
-		fwd = (*iter);
-		if (strcmp(fwd->GetForwardName(), name) == 0)
-		{
+	for (auto iter=m_unmanaged.begin(); iter!=m_unmanaged.end(); iter++) {
+		CForward *fwd = (*iter);
+		if (strcmp(fwd->GetForwardName(), name) == 0) {
 			if (ifchng)
-			{
 				*ifchng = fwd;
-			}
 			return fwd;
 		}
 	}
 
 	if (ifchng)
-	{
 		*ifchng = NULL;
-	}
 
 	return NULL;
 }
@@ -167,16 +146,13 @@ void CForwardManager::ReleaseForward(IForward *aForward)
 
 void CForwardManager::OnPluginPauseChange(IPlugin *plugin, bool paused)
 {
-	if(paused)
+	if (paused)
 		return;
 
 	/* Attach any globally managed forwards */
-	List<CForward *>::iterator iter;
-	CForward *fwd;
-
-	for (iter=m_managed.begin(); iter!=m_managed.end(); iter++)
+	for (auto iter=m_managed.begin(); iter!=m_managed.end(); iter++)
 	{
-		fwd = (*iter);
+		CForward *fwd = (*iter);
 		IPluginFunction *pFunc = plugin->GetBaseContext()->GetFunctionByName(fwd->GetForwardName());
 		// Only add functions, if they aren't registered yet!
 		if (pFunc && !fwd->IsFunctionRegistered(pFunc))
@@ -262,7 +238,6 @@ int CForward::Execute(cell_t *result, IForwardFilter *filter)
 	}
 
 	FuncIter iter = m_functions.begin();
-	IPluginFunction *func;
 	cell_t cur_result = 0;
 	cell_t high_result = 0;
 	cell_t low_result = 0;
@@ -270,8 +245,6 @@ int CForward::Execute(cell_t *result, IForwardFilter *filter)
 	unsigned int success=0;
 	unsigned int num_params = m_curparam;
 	FwdParamInfo temp_info[SP_MAX_EXEC_PARAMS];
-	FwdParamInfo *param;
-	ParamType type;
 
 	/* Save local, reset */
 	memcpy(temp_info, m_params, sizeof(m_params));
@@ -281,7 +254,7 @@ int CForward::Execute(cell_t *result, IForwardFilter *filter)
 
 	while (iter != m_functions.end())
 	{
-		func = (*iter);
+		IPluginFunction *func = (*iter);
 
 		if (filter)
 			filter->Preprocess(func, temp_info);
@@ -289,16 +262,13 @@ int CForward::Execute(cell_t *result, IForwardFilter *filter)
 		for (unsigned int i=0; i<num_params; i++)
 		{
 			int err = SP_ERROR_PARAM;
-			param = &temp_info[i];
+			FwdParamInfo *param = &temp_info[i];
 
+			ParamType type;
 			if (i >= m_numparams || m_types[i] == Param_Any)
-			{
 				type = param->pushedas;
-			}
 			else
-			{
 				type = m_types[i];
-			}
 
 			if ((i >= m_numparams) || (type & SP_PARAMFLAG_BYREF))
 			{
@@ -645,17 +615,14 @@ bool CForward::RemoveFunction(IPluginContext *pContext, funcid_t index)
 bool CForward::RemoveFunction(IPluginFunction *func)
 {
 	bool found = false;
-	FuncIter iter;
 	List<IPluginFunction *> *lst;
 
 	if (func->IsRunnable())
-	{
 		lst = &m_functions;
-	} else {
+	else
 		lst = &m_paused;
-	}
 
-	for (iter=lst->begin(); iter!=lst->end(); iter++)
+	for (auto iter = lst->begin(); iter != lst->end(); iter++)
 	{
 		if ((*iter) == func)
 		{
@@ -677,13 +644,11 @@ bool CForward::RemoveFunction(IPluginFunction *func)
 
 unsigned int CForward::RemoveFunctionsOfPlugin(IPlugin *plugin)
 {
-	FuncIter iter;
-	IPluginFunction *func;
 	unsigned int removed = 0;
 	IPluginContext *pContext = plugin->GetBaseContext();
-	for (iter=m_functions.begin(); iter!=m_functions.end();)
+	for (auto iter=m_functions.begin(); iter!=m_functions.end();)
 	{
-		func = (*iter);
+		IPluginFunction *func = (*iter);
 		if (func->GetParentContext() == pContext)
 		{
 			iter = m_functions.erase(iter);
@@ -699,38 +664,27 @@ unsigned int CForward::RemoveFunctionsOfPlugin(IPlugin *plugin)
 bool CForward::AddFunction(IPluginFunction *func)
 {
 	if (m_curparam)
-	{
 		return false;
-	}
 
 	if (func->IsRunnable())
-	{
 		m_functions.push_back(func);
-	} else {
+	else
 		m_paused.push_back(func);
-	}
 
 	return true;
 }
 
 bool CForward::IsFunctionRegistered(IPluginFunction *func)
 {
-	FuncIter iter;
 	List<IPluginFunction *> *lst;
-
 	if (func->IsRunnable())
-	{
 		lst = &m_functions;
-	} else {
+	else
 		lst = &m_paused;
-	}
 
-	for (iter=m_functions.begin(); iter!=m_functions.end(); iter++)
-	{
+	for (auto iter = lst->begin(); iter != lst->end(); iter++) {
 		if ((*iter) == func)
-		{
 			return true;
-		}
 	}
 	return false;
 }

--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -1,33 +1,29 @@
-/**
- * vim: set ts=4 sw=4 tw=99 noet :
- * =============================================================================
- * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
- * =============================================================================
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, version 3.0, as published by the
- * Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * As a special exception, AlliedModders LLC gives you permission to link the
- * code of this program (as well as its derivative works) to "Half-Life 2," the
- * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
- * by the Valve Corporation.  You must obey the GNU General Public License in
- * all respects for all other code used.  Additionally, AlliedModders LLC grants
- * this exception to all derivative works.  AlliedModders LLC defines further
- * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
- * or <http://www.sourcemod.net/license.php>.
- *
- * Version: $Id$
- */
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
 
 #include <assert.h>
 #include <stdarg.h>
@@ -39,17 +35,8 @@
 
 CForwardManager g_Forwards;
 
-/**
- * Genesis turns to its source, reduction occurs stepwise although the essence is all one.
- * End of line.  FTL system check.
- *
- * :TODO: WHAT NEEDS TO BE TESTED IN THIS BEAST
- * VARARG FUNCTIONS:
- * - Pushing no varargs
- */
-
-// :TODO: IMPORTANT!!! The result pointer arg in the execute function maybe invalid if the forward fails
-// so later evaluation of this result may cause problems on higher levels of abstraction. DOCUMENT OR FIX ALL FORWARDS!
+// Genesis turns to its source, reduction occurs stepwise although the essence
+// is all one. End of line.  FTL system check.
 
 CForwardManager::~CForwardManager()
 {

--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -34,6 +34,8 @@
 #include <bridge/include/IScriptManager.h>
 #include <amtl/am-string.h>
 
+using namespace ke;
+
 CForwardManager g_Forwards;
 
 // Genesis turns to its source, reduction occurs stepwise although the essence
@@ -58,7 +60,7 @@ IForward *CForwardManager::CreateForward(const char *name, ExecType et, unsigned
 	{
 		scripts->AddFunctionsToForward(name, fwd);
 
-		m_managed.push_back(fwd);
+		m_managed.append(fwd);
 	}
 
 	return fwd;
@@ -75,7 +77,7 @@ IChangeableForward *CForwardManager::CreateForwardEx(const char *name, ExecType 
 
 	if (fwd)
 	{
-		m_unmanaged.push_back(fwd);
+		m_unmanaged.append(fwd);
 	}
 
 	return fwd;
@@ -615,7 +617,7 @@ bool CForward::RemoveFunction(IPluginContext *pContext, funcid_t index)
 bool CForward::RemoveFunction(IPluginFunction *func)
 {
 	bool found = false;
-	List<IPluginFunction *> *lst;
+	LinkedList<IPluginFunction *> *lst;
 
 	if (func->IsRunnable())
 		lst = &m_functions;
@@ -667,16 +669,16 @@ bool CForward::AddFunction(IPluginFunction *func)
 		return false;
 
 	if (func->IsRunnable())
-		m_functions.push_back(func);
+		m_functions.append(func);
 	else
-		m_paused.push_back(func);
+		m_paused.append(func);
 
 	return true;
 }
 
 bool CForward::IsFunctionRegistered(IPluginFunction *func)
 {
-	List<IPluginFunction *> *lst;
+	LinkedList<IPluginFunction *> *lst;
 	if (func->IsRunnable())
 		lst = &m_functions;
 	else
@@ -696,7 +698,7 @@ const char *CForward::GetForwardName()
 
 unsigned int CForward::GetFunctionCount()
 {
-	return m_functions.size();
+	return m_functions.length();
 }
 
 ExecType CForward::GetExecType()

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -1,33 +1,29 @@
-/**
- * vim: set ts=4 :
- * =============================================================================
- * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
- * =============================================================================
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, version 3.0, as published by the
- * Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * As a special exception, AlliedModders LLC gives you permission to link the
- * code of this program (as well as its derivative works) to "Half-Life 2," the
- * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
- * by the Valve Corporation.  You must obey the GNU General Public License in
- * all respects for all other code used.  Additionally, AlliedModders LLC grants
- * this exception to all derivative works.  AlliedModders LLC defines further
- * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
- * or <http://www.sourcemod.net/license.php>.
- *
- * Version: $Id$
- */
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
 
 #ifndef _INCLUDE_SOURCEMOD_FORWARDSYSTEM_H_
 #define _INCLUDE_SOURCEMOD_FORWARDSYSTEM_H_

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -32,7 +32,6 @@
 #include <IPluginSys.h>
 #include "common_logic.h"
 #include <sh_list.h>
-#include <sh_stack.h>
 #include "ISourceMod.h"
 
 using namespace SourceHook;
@@ -116,6 +115,9 @@ public:
 								   va_list ap);
 	bool IsFunctionRegistered(IPluginFunction *func);
 private:
+	CForward(ExecType et, const char *name,
+	         const ParamType *types, unsigned num_params);
+
 	void _Int_PushArray(cell_t *inarray, unsigned int cells, int flags);
 	void _Int_PushString(cell_t *inarray, unsigned int cells, int sz_flags, int cp_flags);
 	inline int SetError(int err)
@@ -150,8 +152,6 @@ class CForwardManager :
 	public SMGlobalClass
 {
 	friend class CForward;
-public:
-	~CForwardManager();
 public: //IForwardManager
 	IForward *CreateForward(const char *name, 
 		ExecType et, 
@@ -171,11 +171,7 @@ public: //IPluginsListener
 	void OnPluginPauseChange(IPlugin *plugin, bool paused);
 public: //SMGlobalClass
 	void OnSourceModAllInitialized();
-protected:
-	CForward *ForwardMake();
-	void ForwardFree(CForward *fwd);
 private:
-	CStack<CForward *> m_FreeForwards;
 	List<CForward *> m_managed;
 	List<CForward *> m_unmanaged;
 };

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -31,12 +31,10 @@
 #include <IForwardSys.h>
 #include <IPluginSys.h>
 #include "common_logic.h"
-#include <sh_list.h>
+#include <amtl/am-linkedlist.h>
 #include "ISourceMod.h"
 
-using namespace SourceHook;
-
-typedef List<IPluginFunction *>::iterator FuncIter;
+typedef ke::LinkedList<IPluginFunction *>::iterator FuncIter;
 
 /* :TODO: a global name max define for sourcepawn, should mirror compiler's sNAMEMAX */
 #define FORWARDS_NAME_MAX		64
@@ -129,8 +127,8 @@ protected:
 	/* :TODO: I want a caching list type here.
 	 * Destroying these things and using new/delete for their members feels bad.
 	 */
-	mutable List<IPluginFunction *> m_functions;
-	mutable List<IPluginFunction *> m_paused;
+	mutable ke::LinkedList<IPluginFunction *> m_functions;
+	mutable ke::LinkedList<IPluginFunction *> m_paused;
 	FuncIteratorGuard *m_IterGuard;
 
 	/* Type and name information */
@@ -172,8 +170,8 @@ public: //IPluginsListener
 public: //SMGlobalClass
 	void OnSourceModAllInitialized();
 private:
-	List<CForward *> m_managed;
-	List<CForward *> m_unmanaged;
+	ke::LinkedList<CForward *> m_managed;
+	ke::LinkedList<CForward *> m_unmanaged;
 };
 
 extern CForwardManager g_Forwards;

--- a/public/ReentrantList.h
+++ b/public/ReentrantList.h
@@ -1,0 +1,162 @@
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
+#ifndef _include_sourcemod_reentrant_iterator_h_
+#define _include_sourcemod_reentrant_iterator_h_
+
+#include <amtl/am-linkedlist.h>
+#include <amtl/am-function.h>
+
+namespace SourceMod {
+
+// ReentrantList is a wrapper around a LinkedList, with special attention twoard
+// reentrancy. The list may be mutated during iteration as long as its iterator
+// protocol is obeyed: iterators may only be used on the stack in a LIFO manner,
+// and it is illegal to request access to an iterator's item after the list has
+// been mutated.
+//
+// We guard against this using assertions. If an item in a list is removed, and
+// this affects any active iterators, those iterators cannot be used until their
+// next() function is called.
+template <typename T, class AllocPolicy = ke::SystemAllocatorPolicy>
+class ReentrantList : public ke::LinkedList<T, AllocPolicy>
+{
+	typedef typename ke::LinkedList<T> BaseType;
+	typedef typename ke::LinkedList<T>::iterator BaseTypeIter;
+
+public:
+	ReentrantList(AllocPolicy ap = AllocPolicy())
+		: ke::LinkedList<T, AllocPolicy>(ap),
+		  top_(nullptr)
+	{
+	}
+
+	// Begin and end are disallowed here.
+	void begin() = delete;
+	void end() = delete;
+
+	class iterator
+	{
+	public:
+		iterator(ReentrantList& list)
+			: iterator(&list)
+		{}
+		iterator(ReentrantList* list)
+			: list_(list),
+			  prev_(list_->top_),
+			  impl_(list->impl_begin()),
+			  mutated_(false)
+		{
+			list_->top_ = this;
+		}
+		~iterator() {
+			assert(list_->top_ == this);
+			list_->top_ = prev_;
+		}
+
+		// Returns true if the underlying iterator mutated during iteration.
+		bool mutated() const {
+			return mutated_;
+		}
+		bool more() {
+			return impl_ != list_->impl_end();
+		}
+		bool done() {
+			return impl_ == list_->impl_end();
+		}
+
+		// Accessors. It is illegal to access the current item if the list has
+		// mutated.
+		const T& operator *() const {
+			assert(!mutated());
+			return *impl_;
+		}
+		T& operator *() {
+			assert(!mutated());
+			return *impl_;
+		}
+		T* operator ->() {
+			assert(!mutated());
+			return &*impl_;
+		}
+		const T* operator ->() const {
+			assert(!mutated());
+			return &*impl_;
+		}
+
+		void next() {
+			if (mutated_) {
+				mutated_ = false;
+				return;
+			}
+			impl_++;
+		}
+
+		void remove() {
+			BaseTypeIter old_impl = impl_;
+			
+			impl_ = list_->erase(impl_);
+			mutated_ = true;
+			for (iterator* p = prev_; p; p = p->prev_) {
+				if (p->impl_ == old_impl) {
+					p->impl_ = impl_;
+					p->mutated_ = true;
+				}
+			}
+		}
+
+	private:
+		ReentrantList* list_;
+		iterator* prev_;
+		BaseTypeIter impl_;
+		bool mutated_;
+	};
+
+	// Same protocol as LinkedList::remove, but we use our own iterator.
+	void remove(const T& obj) {
+		for (iterator iter(this); !iter.done(); iter.next()) {
+			if (*iter == obj) {
+				iter.remove();
+				break;
+			}
+		}
+	}
+
+private:
+	BaseTypeIter impl_begin() {
+		return BaseType::begin();
+	}
+	BaseTypeIter impl_end() {
+		return BaseType::end();
+	}
+
+private:
+	iterator* top_;
+};
+
+} // namespace SourceMod
+
+#endif // _include_sourcemod_reentrant_iterator_h_


### PR DESCRIPTION
This is purely a syntactic refactoring. ForwardSys is possibly the oldest file in SourceMod. Having been introduced on Nov 11, 2006, it's almost 10 years old. It looks like early C++ using C89 syntax and has barely changed since it was introduiced.

Two main points of interest here. First, is I switched it to AMTL. Second, ForwardSys had an ad-hoc mechanism for protecting lists during iteration. I moved that out into its own helper class, and switched all of ForwardSys's lists to use it.

Mutation-during-iteration is a pervasive problem in SourceMod that we tend to just ignore until someone reports a specific test case. The new `ReentrantList<T>` inherits from `ke::LinkedList<T>` and is designed to handle this problem for future cases. It provides a new iterator and overrides remove/erase methods, making sure that when the list is mutated, any existing iterators are fixed up.