### PR TITLE
Disentangle CPlugin from CPluginManager.

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -698,12 +698,9 @@ void CPlugin::DropEverything()
 	/* Other plugins could be holding weak references that were
 	 * added by us.  We need to clean all of those up now.
 	 */
-	for (List<CPlugin *>::iterator iter = g_PluginSys.m_plugins.begin();
-		 iter != g_PluginSys.m_plugins.end();
-		 iter++)
-	{
-		(*iter)->ToNativeOwner()->DropRefsTo(this);
-	}
+	g_PluginSys.ForEachPlugin([this] (CPlugin *other) -> void {
+		other->ToNativeOwner()->DropRefsTo(this);
+	});
 
 	/* Proceed with the rest of the necessities. */
 	CNativeOwner::DropEverything();
@@ -2488,6 +2485,12 @@ const CVector<SMPlugin *> *CPluginManager::ListPlugins()
 void CPluginManager::FreePluginList(const CVector<SMPlugin *> *list)
 {
 	delete const_cast<CVector<SMPlugin *> *>(list);
+}
+
+void CPluginManager::ForEachPlugin(ke::Lambda<void(CPlugin *)> callback)
+{
+	for (auto iter = m_plugins.begin(); iter != m_plugins.end(); iter++)
+		callback(*iter);
 }
 
 class OldPluginAPI : public IPluginManager

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1355,7 +1355,7 @@ void CPluginManager::TryRefreshDependencies(CPlugin *pPlugin)
 	if (pPlugin->GetStatus() == Plugin_Error)
 	{
 		/* If we got here, all natives are okay again! */
-		if (pPlugin->m_pRuntime->IsPaused())
+		if (pPlugin->GetRuntime()->IsPaused())
 		{
 			pPlugin->SetPauseState(false);
 		}
@@ -2125,8 +2125,8 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 					rootmenu->ConsolePrint("  Timestamp: %s", pl->m_DateTime);
 				}
 				
-				unsigned char *pCodeHash = pl->m_pRuntime->GetCodeHash();
-				unsigned char *pDataHash = pl->m_pRuntime->GetDataHash();
+				unsigned char *pCodeHash = pl->GetRuntime()->GetCodeHash();
+				unsigned char *pDataHash = pl->GetRuntime()->GetDataHash();
 				
 				char combinedHash[33];
 				for (int i = 0; i < 16; i++)

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -717,6 +717,12 @@ bool CPlugin::AddFakeNative(IPluginFunction *pFunc, const char *name, SPVM_FAKEN
 	return true;
 }
 
+void CPlugin::BindFakeNativesTo(CPlugin *other)
+{
+	for (size_t i = 0; i < m_fakes.length(); i++)
+		g_ShareSys.BindNativeToPlugin(other, m_fakes[i]);
+}
+
 /*******************
  * PLUGIN ITERATOR *
  *******************/
@@ -1274,7 +1280,7 @@ bool CPluginManager::RunSecondPass(CPlugin *pPlugin, char *error, size_t maxleng
 	pPlugin->Call_OnPluginStart();
 
 	/* Now, if we have fake natives, go through all plugins that might need rebinding */
-	if (pPlugin->GetStatus() <= Plugin_Paused && pPlugin->m_fakes.length())
+	if (pPlugin->GetStatus() <= Plugin_Paused && pPlugin->HasFakeNatives())
 	{
 		List<CPlugin *>::iterator pl_iter;
 		for (pl_iter = m_plugins.begin();
@@ -1293,8 +1299,7 @@ bool CPluginManager::RunSecondPass(CPlugin *pPlugin, char *error, size_t maxleng
 					 && pOther != pPlugin)
 			{
 				g_ShareSys.BeginBindingFor(pPlugin);
-				for (size_t i = 0; i < pPlugin->m_fakes.length(); i++)
-					g_ShareSys.BindNativeToPlugin(pOther, pPlugin->m_fakes[i]);
+				pPlugin->BindFakeNativesTo(pOther);
 			}
 		}
 	}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1283,8 +1283,8 @@ bool CPluginManager::RunSecondPass(CPlugin *pPlugin, char *error, size_t maxleng
 		{
 			CPlugin *pOther = (*pl_iter);
 			if ((pOther->GetStatus() == Plugin_Error
-				&& (pOther->m_FakeNativesMissing || pOther->m_LibraryMissing))
-				|| pOther->m_FakeNativesMissing)
+				&& (pOther->HasMissingFakeNatives() || pOther->m_LibraryMissing))
+				|| pOther->HasMissingFakeNatives())
 			{
 				TryRefreshDependencies(pOther);
 			}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -916,7 +916,7 @@ IPlugin *CPluginManager::LoadPlugin(const char *path, bool debug, PluginType typ
 	*wasloaded = false;
 	if ((res=LoadPlugin(&pl, path, true, PluginType_MapUpdated)) == LoadRes_Failure)
 	{
-		ke::SafeStrcpy(error, maxlength, pl->m_errormsg);
+		ke::SafeStrcpy(error, maxlength, pl->GetErrorMsg());
 		delete pl;
 		return NULL;
 	}
@@ -957,7 +957,7 @@ void CPluginManager::LoadAutoPlugin(const char *plugin)
 	LoadRes res;
 	if ((res=LoadPlugin(&pl, plugin, false, PluginType_MapUpdated)) == LoadRes_Failure)
 	{
-		g_Logger.LogError("[SM] Failed to load plugin \"%s\": %s.", plugin, pl->m_errormsg);
+		g_Logger.LogError("[SM] Failed to load plugin \"%s\": %s.", plugin, pl->GetErrorMsg());
 	}
 
 	if (res == LoadRes_Successful || res == LoadRes_Failure)
@@ -1914,7 +1914,8 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				for (_iter=m_FailList.begin(); _iter!=m_FailList.end(); _iter++)
 				{
 					pl = (CPlugin *)*_iter;
-					rootmenu->ConsolePrint("%s: %s",(IS_STR_FILLED(pl->GetPublicInfo()->name)) ? pl->GetPublicInfo()->name : pl->GetFilename(), pl->m_errormsg);
+					rootmenu->ConsolePrint("%s: %s", (IS_STR_FILLED(pl->GetPublicInfo()->name)) ? pl->GetPublicInfo()->name : pl->GetFilename(),
+					                       pl->GetErrorMsg());
 				}
 			}
 
@@ -2108,7 +2109,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				}
 				if (pl->GetStatus() == Plugin_Error || pl->GetStatus() == Plugin_Failed)
 				{
-					rootmenu->ConsolePrint("  Error: %s", pl->m_errormsg);
+					rootmenu->ConsolePrint("  Error: %s", pl->GetErrorMsg());
 				}
 				else
 				{
@@ -2137,7 +2138,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 			}
 			else
 			{
-				rootmenu->ConsolePrint("  Load error: %s", pl->m_errormsg);
+				rootmenu->ConsolePrint("  Load error: %s", pl->GetErrorMsg());
 				if (pl->GetStatus() < Plugin_Created)
 				{
 					rootmenu->ConsolePrint("  File info: (title \"%s\") (version \"%s\")",

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -71,6 +71,7 @@ CPlugin::CPlugin(const char *file)
 
 	m_serial = ++MySerial;
 	m_errormsg[0] = '\0';
+	m_DateTime[0] = '\0';
 	ke::SafeSprintf(m_filename, sizeof(m_filename), "%s", file);
 
 	memset(&m_info, 0, sizeof(m_info));
@@ -2122,7 +2123,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				}
 				if (pl->m_FileVersion >= 3)
 				{
-					rootmenu->ConsolePrint("  Timestamp: %s", pl->m_DateTime);
+					rootmenu->ConsolePrint("  Timestamp: %s", pl->GetDateTime());
 				}
 				
 				unsigned char *pCodeHash = pl->GetRuntime()->GetCodeHash();

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -977,7 +977,7 @@ void CPluginManager::AddPlugin(CPlugin *pPlugin)
 	}
 
 	m_plugins.push_back(pPlugin);
-	m_LoadLookup.insert(pPlugin->m_filename, pPlugin);
+	m_LoadLookup.insert(pPlugin->GetFilename(), pPlugin);
 }
 
 void CPluginManager::LoadAll_SecondPass()
@@ -1397,7 +1397,7 @@ void CPluginManager::UnloadPluginImpl(CPlugin *pPlugin)
 {
 	/* Remove us from the lookup table and linked list */
 	m_plugins.remove(pPlugin);
-	m_LoadLookup.remove(pPlugin->m_filename);
+	m_LoadLookup.remove(pPlugin->GetFilename());
 
 	/* Go through our libraries and tell other plugins they're gone */
 	pPlugin->ForEachLibrary([this] (const char *lib) -> void {
@@ -1897,7 +1897,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				}
 				else
 				{
-					ke::SafeSprintf(&buffer[len], sizeof(buffer)-len, " %s", pl->m_filename);
+					ke::SafeSprintf(&buffer[len], sizeof(buffer)-len, " %s", pl->GetFilename());
 				}
 				rootmenu->ConsolePrint("%s", buffer);
 			}
@@ -2235,7 +2235,7 @@ bool CPluginManager::ReloadPlugin(CPlugin *pl)
 	IPlugin *newpl;
 	int id = 1;
 
-	strcpy(filename, pl->m_filename);
+	strcpy(filename, pl->GetFilename());
 	ptype = pl->GetType();
 
 	for (iter=m_plugins.begin(); iter!=m_plugins.end(); iter++, id++)

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -2121,7 +2121,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 						rootmenu->ConsolePrint("  Status: not running");
 					}
 				}
-				if (pl->m_FileVersion >= 3)
+				if (pl->GetFileVersion() >= 3)
 				{
 					rootmenu->ConsolePrint("  Timestamp: %s", pl->GetDateTime());
 				}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1283,7 +1283,7 @@ bool CPluginManager::RunSecondPass(CPlugin *pPlugin, char *error, size_t maxleng
 		{
 			CPlugin *pOther = (*pl_iter);
 			if ((pOther->GetStatus() == Plugin_Error
-				&& (pOther->HasMissingFakeNatives() || pOther->m_LibraryMissing))
+				&& (pOther->HasMissingFakeNatives() || pOther->HasMissingLibrary()))
 				|| pOther->HasMissingFakeNatives())
 			{
 				TryRefreshDependencies(pOther);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -311,7 +311,6 @@ class CPluginManager :
 	public IHandleTypeDispatch,
 	public IRootConsoleCommand
 {
-	friend class CPlugin;
 public:
 	CPluginManager();
 	~CPluginManager();
@@ -451,6 +450,10 @@ public:
 	void SyncMaxClients(int max_clients);
 
 	void ListPluginsToClient(CPlayer *player, const CCommand &args);
+
+	void _SetPauseState(CPlugin *pPlugin, bool pause);
+
+	void ForEachPlugin(ke::Lambda<void(CPlugin *)> callback);
 private:
 	LoadRes LoadPlugin(CPlugin **pPlugin, const char *path, bool debug, PluginType type);
 
@@ -487,8 +490,6 @@ private:
 	* Manages required natives.
 	*/
 	bool FindOrRequirePluginDeps(CPlugin *pPlugin, char *error, size_t maxlength);
-
-	void _SetPauseState(CPlugin *pPlugin, bool pause);
 
 	bool ScheduleUnload(CPlugin *plugin);
 	void UnloadPluginImpl(CPlugin *plugin);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -279,11 +279,16 @@ public:
 	bool HasMissingLibrary() const {
 		return m_LibraryMissing;
 	}
+	bool HasFakeNatives() const {
+		return m_fakes.length() > 0;
+	}
+
+	bool TryCompile();
+	void BindFakeNativesTo(CPlugin *other);
 
 protected:
 	bool ReadInfo();
 	void DependencyDropped(CPlugin *pOwner);
-	bool TryCompile();
 
 private:
 	time_t GetFileTimeStamp();

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -273,6 +273,10 @@ public:
 	void AddRequiredLib(const char *name);
 	bool ForEachRequiredLib(ke::Lambda<bool(const char *)> callback);
 
+	bool HasMissingFakeNatives() const {
+		return m_FakeNativesMissing;
+	}
+
 protected:
 	bool ReadInfo();
 	void DependencyDropped(CPlugin *pOwner);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -128,7 +128,6 @@ class CPlugin :
 	public SMPlugin,
 	public CNativeOwner
 {
-	friend class CPluginManager;
 public:
 	CPlugin(const char *file);
 	~CPlugin();

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -266,6 +266,9 @@ public:
 	int GetFileVersion() const {
 		return m_FileVersion;
 	}
+	const char *GetErrorMsg() const {
+		return m_errormsg;
+	}
 
 protected:
 	bool ReadInfo();

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -270,6 +270,9 @@ public:
 		return m_errormsg;
 	}
 
+	void AddRequiredLib(const char *name);
+	bool ForEachRequiredLib(ke::Lambda<bool(const char *)> callback);
+
 protected:
 	bool ReadInfo();
 	void DependencyDropped(CPlugin *pOwner);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -276,6 +276,9 @@ public:
 	bool HasMissingFakeNatives() const {
 		return m_FakeNativesMissing;
 	}
+	bool HasMissingLibrary() const {
+		return m_LibraryMissing;
+	}
 
 protected:
 	bool ReadInfo();

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -260,6 +260,10 @@ public:
 	// since the last call to HasUpdatedFile().
 	bool HasUpdatedFile();
 
+	const char *GetDateTime() {
+		return m_DateTime;
+	}
+
 protected:
 	bool ReadInfo();
 	void DependencyDropped(CPlugin *pOwner);

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -260,8 +260,11 @@ public:
 	// since the last call to HasUpdatedFile().
 	bool HasUpdatedFile();
 
-	const char *GetDateTime() {
+	const char *GetDateTime() const {
 		return m_DateTime;
+	}
+	int GetFileVersion() const {
+		return m_FileVersion;
 	}
 
 protected:

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -129,7 +129,6 @@ class CPlugin :
 	public CNativeOwner
 {
 	friend class CPluginManager;
-	friend class CFunction;
 public:
 	CPlugin(const char *file);
 	~CPlugin();
@@ -164,6 +163,8 @@ public:
 
 	typedef ke::Lambda<bool(const sp_pubvar_t *, const ExtVar& ext)> ExtVarCallback;
 	bool ForEachExtVar(const ExtVarCallback& callback);
+
+	void ForEachLibrary(ke::Lambda<void(const char *)> callback);
 public:
 	/**
 	 * Creates a plugin object with default values.
@@ -247,6 +248,9 @@ public:
 	AutoConfig *GetConfig(size_t i);
 	inline void AddLibrary(const char *name) {
 		m_Libraries.push_back(name);
+	}
+	inline bool HasLibrary(const char *name) {
+		return m_Libraries.find(name) != m_Libraries.end();
 	}
 	void LibraryActions(LibraryAction action);
 	void SyncMaxClients(int max_clients);


### PR DESCRIPTION
These two classes have a pretty incestuous relationship. This set of patches removes direct field access one by one, and then removes their "friend" declarations.