### PR TITLE
Fix reentrancy issues in CPluginManager.

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -777,12 +777,6 @@ CPluginManager::CPluginManager()
 
 CPluginManager::~CPluginManager()
 {
-	CStack<CPluginManager::CPluginIterator *>::iterator iter;
-	for (iter=m_iters.begin(); iter!=m_iters.end(); iter++)
-	{
-		delete (*iter);
-	}
-	m_iters.popall();
 }
 
 void CPluginManager::Shutdown()
@@ -1490,20 +1484,12 @@ void CPluginManager::RemovePluginsListener(IPluginsListener *listener)
 
 IPluginIterator *CPluginManager::GetPluginIterator()
 {
-	if (m_iters.empty())
-	{
-		return new CPluginIterator(&m_plugins);
-	} else {
-		CPluginIterator *iter = m_iters.front();
-		m_iters.pop();
-		iter->Reset();
-		return iter;
-	}
+	return new CPluginIterator(&m_plugins);
 }
 
 void CPluginManager::ReleaseIterator(CPluginIterator *iter)
 {
-	m_iters.push(iter);
+	delete iter;
 }
 
 bool CPluginManager::TestAliasMatch(const char *alias, const char *localpath)

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -537,7 +537,6 @@ private:
 private:
 	List<IPluginsListener *> m_listeners;
 	List<CPlugin *> m_plugins;
-	CStack<CPluginManager::CPluginIterator *> m_iters;
 	NameHashSet<CPlugin *> m_LoadLookup;
 	bool m_AllPluginsLoaded;
 	IdentityToken_t *m_MyIdent;

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -54,6 +54,7 @@
 #include <am-string.h>
 #include <bridge/include/IScriptManager.h>
 #include <am-function.h>
+#include <ReentrantList.h>
 
 class CPlayer;
 
@@ -344,20 +345,21 @@ public:
 	~CPluginManager();
 public:
 	/* Implements iterator class */
-	class CPluginIterator : public IPluginIterator
+	class CPluginIterator
+		: public IPluginIterator,
+		  public IPluginsListener
 	{
 	public:
-		CPluginIterator(List<CPlugin *> *mylist);
+		CPluginIterator(ReentrantList<CPlugin *>& in);
 		virtual ~CPluginIterator();
 		virtual bool MorePlugins();
 		virtual IPlugin *GetPlugin();
 		virtual void NextPlugin();
 		void Release();
-	public:
-		void Reset();
+		void OnPluginDestroyed(IPlugin *plugin) override;
 	private:
-		List<CPlugin *> *mylist;
-		List<CPlugin *>::iterator current;
+		ke::LinkedList<CPlugin *> mylist;
+		ke::LinkedList<CPlugin *>::iterator current;
 	};
 	friend class CPluginManager::CPluginIterator;
 public: //IScriptManager
@@ -393,6 +395,7 @@ public: //IScriptManager
 	}
 	const CVector<SMPlugin *> *ListPlugins();
 	void FreePluginList(const CVector<SMPlugin *> *plugins);
+
 public: //SMGlobalClass
 	void OnSourceModAllInitialized();
 	void OnSourceModShutdown();
@@ -521,11 +524,6 @@ private:
 
 	bool ScheduleUnload(CPlugin *plugin);
 	void UnloadPluginImpl(CPlugin *plugin);
-protected:
-	/**
-	 * Caching internal objects
-	 */
-	void ReleaseIterator(CPluginIterator *iter);
 public:
 	inline IdentityToken_t *GetIdentity()
 	{
@@ -535,8 +533,13 @@ public:
 private:
 	void TryRefreshDependencies(CPlugin *pOther);
 private:
-	List<IPluginsListener *> m_listeners;
-	List<CPlugin *> m_plugins;
+	ReentrantList<IPluginsListener *> m_listeners;
+	ReentrantList<CPlugin *> m_plugins;
+	ke::LinkedList<CPluginIterator *> m_iterators;
+
+	typedef decltype(m_listeners)::iterator ListenerIter;
+	typedef decltype(m_plugins)::iterator PluginIter;
+
 	NameHashSet<CPlugin *> m_LoadLookup;
 	bool m_AllPluginsLoaded;
 	IdentityToken_t *m_MyIdent;

--- a/public/ReentrantList.h
+++ b/public/ReentrantList.h
@@ -60,6 +60,7 @@ public:
 
 	class iterator
 	{
+		friend class ReentrantList;
 	public:
 		iterator(ReentrantList& list)
 			: iterator(&list)
@@ -143,6 +144,16 @@ public:
 				break;
 			}
 		}
+	}
+
+	template <typename U>
+	void insertBefore(iterator& where, U &&obj) {
+		BaseType::insertBefore(where.impl_, ke::Forward<U>(obj));
+	}
+
+	template <typename U>
+	bool contains(const U &obj) {
+		return BaseType::find(obj) != BaseType::end();
 	}
 
 private:


### PR DESCRIPTION
This switches CPluginManager's lists to ReentrantList, fixing a bunch of potential reentrancy issues. It also fixes an issue where CPluginIterators could hold onto dangling pointers, if a plugin is somehow removed while the iterator is live.

In the interest of simplicity, I removed the CPluginIterator cache and it now copies the plugin list locally. It also registers itself as a plugin listener so it can watch for unloads.