### PR TITLE
Evict plugins that fail to load.

### DIFF
--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -237,8 +237,10 @@ public:
 		return m_EnteredSecondPass;
 	}
 
-	bool HasErrorOrFail() const {
-		return m_status == Plugin_Error || m_status == Plugin_Failed;
+	bool IsInErrorState() const {
+		if (m_status == Plugin_Running || m_status == Plugin_Loaded)
+			return false;
+		return true;
 	}
 
 	bool TryCompile();


### PR DESCRIPTION
This introduces a new "Evicted" state for plugins. Eviction fires all the usual destruction callbacks and removes the plugin's context and runtime, but does not remove it from the plugin list. We retain information like its timestamp and description/author lines.

For extension compatibility, there is a new "Plugin_Evicted" status that (in ABI terms) should mean roughly the same thing as "BadLoad". Internally, SourceMod can still access the real status so it can display meaningful information to the user.

Like unloading, it is not safe to evict a plugin while it may be running. I don't think code in SourceMod will generally expect that to happen, and I'm not keen to try it out and see what happens. The callstack must be empty. In this patch, we evict plugins that have an error state immediately after loading. The callstack is always empty in those cases (save for maybe a plugin using ServerCommandEx and forcing "sm plugin load" to run).

While it is not safe to destroy a runtime/context while running, it may be safe to fire other things like callbacks and dependency-drop notifications. That might not be a good idea though, it might be better to have everything run at once. I'm not sure yet, but this is a good place to start.