### PR TITLE
New forward - AskPluginAutoLoad

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -957,15 +957,6 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 
 			AskPluginAutoLoad(pPlugin, gamehelpers->GetCurrentMap());
 
-			// List<String>::iterator s_iter;
-			// for (s_iter = m_pluginsToLoad.begin(); s_iter != m_pluginsToLoad.end(); s_iter++)
-			// {
-				// if (!pPlugin->Call_AskPluginAutoLoad((*s_iter).c_str()))
-				// {
-					// m_pluginsDisabledLoad.push_back((*s_iter).c_str());
-				// }
-			// }
-
 			return LoadRes_AlreadyLoaded;
 		}
 	}
@@ -987,15 +978,6 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 	}
 	else
 	{
-		// List<String>::iterator s_iter;
-		// for (s_iter = m_pluginsToLoad.begin(); s_iter != m_pluginsToLoad.end(); s_iter++)
-		// {
-			// if (!plugin->Call_AskPluginAutoLoad((*s_iter).c_str()))
-			// {
-				// m_pluginsDisabledLoad.push_back((*s_iter).c_str());
-			// }
-		// }
-
 		AskPluginAutoLoad(plugin, gamehelpers->GetCurrentMap());
 	}
 

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -126,6 +126,20 @@ forward bool:AskPluginLoad(Handle:myself, bool:late, String:error[], err_max);
 forward APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max);
 
 /**
+ * Called for every plugin that is about to auto load (plugins count times called in one plugin).
+ * If one plugin returns failure the given plugin is prevented from loading.
+ *
+ * @note Called before OnPluginStart and OnMapStart.
+ * @note Not called when late loading.
+ * @note If you do not return anything, it is treated like returning success. 
+ *
+ * @param plugin	Plugin that is about to auto load.
+ * @param map		Map on which is plugin about to auto load.
+ * @return			APLRes_Success for load success, APLRes_Failure or APLRes_SilentFailure otherwise.
+*/
+forward APLRes:AskPluginAutoLoad(const String:plugin[], const String:map[]);
+
+/**
  * Called when the plugin is about to be unloaded.
  *
  * It is not necessary to close any handles or remove hooks in this function.  


### PR DESCRIPTION
Ciao guys,

finaly I had some time to rewrite and fix my `AskPluginAutoLoad` forward. For those who don't remember my attempt, read bellow.

---

I added new forward function to allow/disallow plugins to auto load on certain maps.

``` SourcePawn
forward APLRes:AskPluginAutoLoad(const String:plugin[], const String:map[]);
```

This function is called for every plugin that is about to auto load (plugins count times - 1 called in one plugin), **not** late load. If one plugin returns failure the given plugin is prevented from loading.
`AskPluginAutoLoad` is always called before `AskPluginLoad`, so I fixed the issue when blocked plugin called `AskPluginLoad`.

I also made little [test plugin](https://gist.github.com/KissLick/2bf6d04dfbf944aac7e1#file-test-askpluginautoload-sp).

**Advantages against:**
- Unloading plugins in map config
  - Some plugins change convars, precache files etc. in OnMapStart - might cause big problems
- Putting plugins in disabled folder and loading them in map config
  - This might cause big dependencies problems (eg. Timer with whole web of dependecies)
  - The need to unload plugins when the map ends

I tested this and everything seems to work like a charm! :-) So, what do you guys think about this?
