### PR TITLE
Fixed DBResultSet.IsFieldNull

### DIFF
--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -223,7 +223,7 @@ methodmap DBResultSet < Handle
 	// @param field        The field index (starting from 0).
 	// @return             True if data is NULL, false otherwise.
 	// @error              Invalid field index, or no current result set.
-	public native bool IsFieldNull(Handle query, int field);
+	public native bool IsFieldNull(int field);
 
 	// Returns the length of a field's data in the current row of a result
 	// set.  This only needs to be called for strings to determine how many


### PR DESCRIPTION
DBResultSet.IsFieldNull has an extra parameter that shouldn't be there(That parameter is the one that should be the automatically inserted first "this" param)
Also exists in SM 1.7