### PR TITLE
Add Community Update holiday

### DIFF
--- a/extensions/tf2/holiday.cpp
+++ b/extensions/tf2/holiday.cpp
@@ -153,6 +153,7 @@ void HolidayManager::OnPluginLoaded(IPlugin *plugin)
 	PopulateHolidayVar(pRuntime, "TFHoliday_Halloween");
 	PopulateHolidayVar(pRuntime, "TFHoliday_Christmas");
 	PopulateHolidayVar(pRuntime, "TFHoliday_EndOfTheLine");
+	PopulateHolidayVar(pRuntime, "TFHoliday_CommunityUpdate");
 	PopulateHolidayVar(pRuntime, "TFHoliday_ValentinesDay");
 	PopulateHolidayVar(pRuntime, "TFHoliday_MeetThePyro");
 	PopulateHolidayVar(pRuntime, "TFHoliday_SpyVsEngyWar");

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -157,14 +157,15 @@
 			"TFHoliday_Birthday"		"1"
 			"TFHoliday_Halloween"		"2"
 			"TFHoliday_Christmas"		"3"
-			"TFHoliday_EndOfTheLine"	"4"
-			"TFHoliday_ValentinesDay"	"5"
-			"TFHoliday_MeetThePyro"		"6"
-			"TFHoliday_SpyVsEngyWar"	"7"
-			"TFHoliday_FullMoon"		"8"
-			"TFHoliday_HalloweenOrFullMoon"				"9"
-			"TFHoliday_HalloweenOrFullMoonOrValentines"	"10"
-			"TFHoliday_AprilFools"		"11"
+			"TFHoliday_CommunityUpdate"	"4"
+			"TFHoliday_EndOfTheLine"	"5"
+			"TFHoliday_ValentinesDay"	"6"
+			"TFHoliday_MeetThePyro"		"7"
+			"TFHoliday_SpyVsEngyWar"	"8"
+			"TFHoliday_FullMoon"		"9"
+			"TFHoliday_HalloweenOrFullMoon"				"10"
+			"TFHoliday_HalloweenOrFullMoonOrValentines"	"11"
+			"TFHoliday_AprilFools"		"12"
 		}
 	}
 }

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -186,6 +186,7 @@ public const TFHoliday:TFHoliday_Birthday;
 public const TFHoliday:TFHoliday_Halloween;
 public const TFHoliday:TFHoliday_Christmas;
 public const TFHoliday:TFHoliday_EndOfTheLine;
+public const TFHoliday:TFHoliday_CommunityUpdate;
 public const TFHoliday:TFHoliday_ValentinesDay;
 public const TFHoliday:TFHoliday_MeetThePyro;
 public const TFHoliday:TFHoliday_SpyVsEngyWar;


### PR DESCRIPTION
Valve added a new holiday in the Invasion update.

It's Holiday 4, CommunityUpdate.

This is the update s_HolidayChecks:

    .rodata:010A92C0 _ZL15s_HolidayChecks dd offset _ZL19g_Holiday_NoHoliday, offset _ZL21g_Holiday_TF2Birthday
    .rodata:010A92C0                                         ; DATA XREF: _Z28EconHolidays_IsHolidayActiveiRK6CRTime+Br
    .rodata:010A92C0                                         ; _Z32EconHolidays_GetHolidayForStringPKc:loc_659C80r ...
    .rodata:010A92C0                 dd offset _ZL19g_Holiday_Halloween, offset _ZL19g_Holiday_Christmas
    .rodata:010A92C0                 dd offset _ZL25g_Holiday_CommunityUpdate, offset _ZL22g_Holiday_EndOfTheLine
    .rodata:010A92C0                 dd offset _ZL23g_Holiday_ValentinesDay, offset _ZL21g_Holiday_MeetThePyro
    .rodata:010A92C0                 dd offset _ZL22g_Holiday_SpyVsEngyWar, offset _ZL18g_Holiday_FullMoon
    .rodata:010A92C0                 dd offset _ZL29g_Holiday_HalloweenOrFullMoon, offset _ZL41g_Holiday_HalloweenOrFullMoonOrValentines
    .rodata:010A92C0                 dd offset _ZL20g_Holiday_AprilFools

I think I got the correct syntax down for adding a new holiday to the TF2 Extension as well.  If not, we can undo the changes to everything except the GameData.