### PR TITLE
Include repo information in symbol files

### DIFF
--- a/tools/buildbot/upload_symbols.py
+++ b/tools/buildbot/upload_symbols.py
@@ -32,7 +32,53 @@ with open(symbol_file, 'w') as fp:
   fp.write(stdout)
   fp.write(stderr)
 
+lines = out.splitlines()
+
+paths = set()
+roots = {}
+
+for line in lines:
+  line = line.strip().split(None, 2)
+
+  if line[0] != 'FILE':
+    continue
+
+  path = os.path.dirname(line[2])
+
+  if path in paths:
+    continue
+
+  paths.add(path)
+
+  root = None
+  url = None
+  rev = None
+
+  with open(os.devnull, 'w') as devnull:
+    try:
+      root = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], stderr=devnull, cwd=path, universal_newlines=True).strip()
+
+      if root in roots:
+        continue
+
+      url = subprocess.check_output(['git', 'ls-remote', '--get-url', 'origin'], stderr=devnull, cwd=path, universal_newlines=True).strip()
+      rev = subprocess.check_output(['git', 'log', '--pretty=format:%H', '-n', '1'], stderr=devnull, cwd=path, universal_newlines=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+      continue
+
+  roots[root] = (url, rev)
+
+index = 1
+while lines[index].split(None, 1)[0] == 'INFO':
+  index += 1;
+
+for root, info in roots.items():
+  lines.insert(index, 'INFO REPO ' + ' '.join([root, info[0], info[1]]))
+  index += 1;
+
+out = os.linesep.join(lines)
+
 request = urllib.Request(SYMBOL_SERVER, out)
 request.add_header('Content-Type', 'text/plain')
-server_response = urllib.urlopen(request).read().decode('utf8')
+server_response = urllib.urlopen(request).read().decode('utf8').strip()
 print(server_response)

--- a/tools/buildbot/upload_symbols.py
+++ b/tools/buildbot/upload_symbols.py
@@ -73,7 +73,7 @@ while lines[index].split(None, 1)[0] == 'INFO':
   index += 1;
 
 for root, info in roots.items():
-  lines.insert(index, 'INFO REPO ' + ' '.join([root, info[0], info[1]]))
+  lines.insert(index, 'INFO REPO ' + ' '.join([info[1], info[0], root]))
   index += 1;
 
 out = os.linesep.join(lines)


### PR DESCRIPTION
Parse FILE records to find on-disk git repos, include root/remote/rev as an INFO record.

```
INFO REPO 60f878f132b3167efda42bd9400282f707918291 https://github.com/alliedmodders/metamod-source /home/asherkin/Code/metamod-source
INFO REPO 4be998c4dc3185b80e716c7b44fb30b4c221fcb6 https://github.com/alliedmodders/sourcemod /home/asherkin/Code/sourcemod
INFO REPO c35532ced5e7e4f882106857bfae8f3db0fbacf0 https://github.com/alliedmodders/amtl /home/asherkin/Code/sourcemod/public/amtl
INFO REPO c4237cc89cd769e999357300e57e4f53fef6983e https://github.com/alliedmodders/hl2sdk /home/asherkin/Code/hl2sdk-tf2
INFO REPO 8dd90b35890786441931dfe6622ea97fa99dbc27 https://github.com/alliedmodders/sourcepawn /home/asherkin/Code/sourcemod/sourcepawn
```

I fully admit that this code is horrible, but it is only run during a buildbot build (and is pretty quick despite the horribleness).