### PR TITLE
Fixed singles timer being deleted if plugin is paused (Bug 6338)

### DIFF
--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -253,12 +253,12 @@ void TimerSystem::RunFrame()
 		pTimer = (*iter);
 		if (curtime >= pTimer->m_ToExec)
 		{
-            // Bug 6338: Timers being deleted if a plugin is paused.
-            if (pTimer->m_Listener->IsPaused(pTimer, pTimer->m_pData))
-            {
-                pTimer->m_ToExec = curtime + pTimer->m_Interval;
-                continue;
-            }
+			// Bug 6338: Timers being deleted if a plugin is paused.
+			if (pTimer->m_Listener->IsPaused(pTimer, pTimer->m_pData))
+			{
+				pTimer->m_ToExec = curtime + pTimer->m_Interval;
+				continue;
+        	}
 			pTimer->m_InExec = true;
 			pTimer->m_Listener->OnTimer(pTimer, pTimer->m_pData);
 			pTimer->m_Listener->OnTimerEnd(pTimer, pTimer->m_pData);

--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -253,6 +253,12 @@ void TimerSystem::RunFrame()
 		pTimer = (*iter);
 		if (curtime >= pTimer->m_ToExec)
 		{
+            // Bug 6338: Timers being deleted if a plugin is paused.
+            if (pTimer->m_Listener->IsPaused(pTimer, pTimer->m_pData))
+            {
+                pTimer->m_ToExec = curtime + pTimer->m_Interval;
+                continue;
+            }
 			pTimer->m_InExec = true;
 			pTimer->m_Listener->OnTimer(pTimer, pTimer->m_pData);
 			pTimer->m_Listener->OnTimerEnd(pTimer, pTimer->m_pData);

--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -258,7 +258,7 @@ void TimerSystem::RunFrame()
 			{
 				pTimer->m_ToExec = curtime + pTimer->m_Interval;
 				continue;
-        	}
+			}
 			pTimer->m_InExec = true;
 			pTimer->m_Listener->OnTimer(pTimer, pTimer->m_pData);
 			pTimer->m_Listener->OnTimerEnd(pTimer, pTimer->m_pData);

--- a/core/logic/smn_timers.cpp
+++ b/core/logic/smn_timers.cpp
@@ -65,7 +65,7 @@ public:
 public: //ITimedEvent
 	ResultType OnTimer(ITimer *pTimer, void *pData);
 	void OnTimerEnd(ITimer *pTimer, void *pData);
-    bool IsPaused(ITimer *pTimer, void *pData);
+	bool IsPaused(ITimer *pTimer, void *pData);
 public: //IHandleTypeDispatch
 	void OnHandleDestroy(HandleType_t type, void *object);
 public: //SMGlobalClass
@@ -184,9 +184,9 @@ void TimerNatives::OnTimerEnd(ITimer *pTimer, void *pData)
 
 bool TimerNatives::IsPaused(ITimer *pTimer, void *pData)
 {
-    TimerInfo *pInfo = reinterpret_cast<TimerInfo *>(pData);
-    IPluginFunction *pFunc = pInfo->Hook;
-    return !pFunc->IsRunnable();
+	TimerInfo *pInfo = reinterpret_cast<TimerInfo *>(pData);
+	IPluginFunction *pFunc = pInfo->Hook;
+	return !pFunc->IsRunnable();
 }
 
 /*******************************

--- a/core/logic/smn_timers.cpp
+++ b/core/logic/smn_timers.cpp
@@ -65,6 +65,7 @@ public:
 public: //ITimedEvent
 	ResultType OnTimer(ITimer *pTimer, void *pData);
 	void OnTimerEnd(ITimer *pTimer, void *pData);
+    bool IsPaused(ITimer *pTimer, void *pData);
 public: //IHandleTypeDispatch
 	void OnHandleDestroy(HandleType_t type, void *object);
 public: //SMGlobalClass
@@ -179,6 +180,13 @@ void TimerNatives::OnTimerEnd(ITimer *pTimer, void *pData)
 	}
 
 	DeleteTimerInfo(pInfo);
+}
+
+bool TimerNatives::IsPaused(ITimer *pTimer, void *pData)
+{
+    TimerInfo *pInfo = reinterpret_cast<TimerInfo *>(pData);
+    IPluginFunction *pFunc = pInfo->Hook;
+    return !pFunc->IsRunnable();
 }
 
 /*******************************

--- a/public/ITimerSystem.h
+++ b/public/ITimerSystem.h
@@ -103,6 +103,16 @@ namespace SourceMod
 		 * @param pData			Private data pointer passed from host.
 		 */
 		virtual void OnTimerEnd(ITimer *pTimer, void *pData) =0;
+
+        /**
+         * @brief Is timer paused?
+         * Note: Only called if timer isn't a repeating timer.
+         *
+		 * @param pTimer		Pointer to the timer instance.
+		 * @param pData			Private data pointer passed from host.
+         * @return              True if timer is paused, otherwise false to allow OnTimer() to be called.
+         */
+        virtual bool IsPaused(ITimer *pTimer, void *pData) { return false; }
 	};
 
 	#define TIMER_FLAG_REPEAT			(1<<0)		/**< Timer will repeat until stopped */

--- a/public/ITimerSystem.h
+++ b/public/ITimerSystem.h
@@ -104,7 +104,7 @@ namespace SourceMod
 		 */
 		virtual void OnTimerEnd(ITimer *pTimer, void *pData) =0;
 
-        /**
+		/**
 		 * @brief Is timer paused?
 		 * Note: Only called if timer isn't a repeating timer.
 		 *

--- a/public/ITimerSystem.h
+++ b/public/ITimerSystem.h
@@ -105,14 +105,14 @@ namespace SourceMod
 		virtual void OnTimerEnd(ITimer *pTimer, void *pData) =0;
 
         /**
-         * @brief Is timer paused?
-         * Note: Only called if timer isn't a repeating timer.
-         *
+		 * @brief Is timer paused?
+		 * Note: Only called if timer isn't a repeating timer.
+		 *
 		 * @param pTimer		Pointer to the timer instance.
 		 * @param pData			Private data pointer passed from host.
-         * @return              True if timer is paused, otherwise false to allow OnTimer() to be called.
-         */
-        virtual bool IsPaused(ITimer *pTimer, void *pData) { return false; }
+		 * @return              True if timer is paused, otherwise false to allow OnTimer() to be called.
+		 */
+		virtual bool IsPaused(ITimer *pTimer, void *pData) { return false; }
 	};
 
 	#define TIMER_FLAG_REPEAT			(1<<0)		/**< Timer will repeat until stopped */


### PR DESCRIPTION
This fixes plugin timers attempting to be called(If not repeating) if a plugin is being called, but get deleted when it fails.