### PR TITLE
Fix race between plugin unload and asynchronous query completion.

### DIFF
--- a/core/logic/Database.cpp
+++ b/core/logic/Database.cpp
@@ -693,7 +693,7 @@ void DBManager::OnSourceModIdentityDropped(IdentityToken_t *pToken)
 	s_pAddBlock = NULL;
 }
 
-void DBManager::OnPluginUnloaded(IPlugin *plugin)
+void DBManager::OnPluginWillUnload(IPlugin *plugin)
 {
 	/* Kill the thread so we can flush everything into the think queue... */
 	KillWorkerThread();
@@ -719,9 +719,7 @@ void DBManager::OnPluginUnloaded(IPlugin *plugin)
 		}
 	}
 
-	for (iter = templist.begin();
-		 iter != templist.end();
-		 iter++)
+	for (iter = templist.begin(); iter != templist.end(); iter++)
 	{
 		IDBThreadOperation *op = (*iter);
 		op->RunThinkPart();

--- a/core/logic/Database.h
+++ b/core/logic/Database.h
@@ -101,7 +101,7 @@ public: //ke::IRunnable
 	void Run();
 	void ThreadMain();
 public: //IPluginsListener
-	void OnPluginUnloaded(IPlugin *plugin);
+	void OnPluginWillUnload(IPlugin *plugin);
 public:
 	ConfDbInfo *GetDatabaseConf(const char *name);
 	IDBDriver *FindOrLoadDriver(const char *name);

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1476,6 +1476,14 @@ void CPluginManager::Purge(CPlugin *plugin)
 	// Go through our libraries and tell other plugins they're gone.
 	plugin->LibraryActions(LibraryAction_Removed);
 
+	// Notify listeners of unloading.
+	if (plugin->EnteredSecondPass()) {
+		for (ListenerIter iter(m_listeners); !iter.done(); iter.next()) {
+			if ((*iter)->GetApiVersion() >= kMinPluginSysApiWithWillUnloadCallback)
+				(*iter)->OnPluginWillUnload(plugin);
+		}
+	}
+
 	// We only pair OnPluginEnd with OnPluginStart if we would have
 	// successfully called OnPluginStart, *and* SetFailState() wasn't called,
 	// which guarantees no further code will execute.

--- a/plugins/include/core.inc
+++ b/plugins/include/core.inc
@@ -1,5 +1,5 @@
 /**
- * vim: set ts=4 :
+ * vim: set ts=4 sw=4 tw=99 noet:
  * =============================================================================
  * SourceMod (C)2004-2008 AlliedModders LLC.  All rights reserved.
  * =============================================================================
@@ -92,6 +92,7 @@ enum PluginStatus
 	Plugin_Created,			/**< Plugin is created but not initialized */
 	Plugin_Uncompiled,		/**< Plugin is not yet compiled by the JIT */
 	Plugin_BadLoad,			/**< Plugin failed to load */
+	Plugin_Evicted			/**< Plugin was unloaded due to an error */
 };
 
 /**

--- a/public/IPluginSys.h
+++ b/public/IPluginSys.h
@@ -38,7 +38,7 @@
 #include <sp_vm_api.h>
 
 #define SMINTERFACE_PLUGINSYSTEM_NAME		"IPluginManager"
-#define SMINTERFACE_PLUGINSYSTEM_VERSION	7
+#define SMINTERFACE_PLUGINSYSTEM_VERSION	8
 
 /** Context user slot 3 is used Core for holding an IPluginContext pointer. */
 #define SM_CONTEXTVAR_USER		3
@@ -304,6 +304,11 @@ namespace SourceMod
 		// any plugin for which OnPluginLoaded was called, and is invoked
 		// immediately after OnPluginEnd(). The plugin may be in any state Failed
 		// or lower.
+		//
+		// This function must not cause the plugin to re-enter script code. If
+		// you wish to be notified of when a plugin is unloading, and to forbid
+		// future calls on that plugin, use OnPluginWillUnload and use a
+		// plugin property to block future calls.
 		virtual void OnPluginUnloaded(IPlugin *plugin)
 		{
 		}
@@ -322,7 +327,20 @@ namespace SourceMod
 		virtual unsigned int GetApiVersion() const {
 			return SMINTERFACE_PLUGINSYSTEM_VERSION;
 		}
+
+		// @brief Called when a plugin is about to be unloaded, before its
+		// OnPluginEnd callback is fired. This can be used to ensure that any
+		// asynchronous operations are flushed and no further operations can
+		// be started (via SetProperty).
+		//
+		// Like OnPluginUnloaded, this is only called for plugins which
+		// OnPluginLoaded was called.
+		virtual void OnPluginWillUnload(IPlugin *plugin)
+		{
+		}
 	};
+
+	static const unsigned int kMinPluginSysApiWithWillUnloadCallback = 8;
 
 	/**
 	 * @brief Manages the runtime loading and unloading of plugins.

--- a/public/IPluginSys.h
+++ b/public/IPluginSys.h
@@ -38,7 +38,7 @@
 #include <sp_vm_api.h>
 
 #define SMINTERFACE_PLUGINSYSTEM_NAME		"IPluginManager"
-#define SMINTERFACE_PLUGINSYSTEM_VERSION	6
+#define SMINTERFACE_PLUGINSYSTEM_VERSION	7
 
 /** Context user slot 3 is used Core for holding an IPluginContext pointer. */
 #define SM_CONTEXTVAR_USER		3
@@ -278,7 +278,7 @@ namespace SourceMod
 	/**
 	 * @brief Listens for plugin-oriented events.
 	 */
-	class IPluginsListener
+	class IPluginsListener_V1
 	{
 	public:
 		// @brief This callback should not be used since plugins may be in
@@ -315,6 +315,14 @@ namespace SourceMod
 		}
 	};
 
+	// @brief Listens for plugin-oriented events. Extends the V1 listener class.
+	class IPluginsListener : public IPluginsListener_V1
+	{
+	public:
+		virtual unsigned int GetApiVersion() const {
+			return SMINTERFACE_PLUGINSYSTEM_VERSION;
+		}
+	};
 
 	/**
 	 * @brief Manages the runtime loading and unloading of plugins.
@@ -381,6 +389,29 @@ namespace SourceMod
 		virtual IPluginIterator *GetPluginIterator() =0;
 
 		/** 
+		 * @brief Adds a V1 plugin manager listener.
+		 *
+		 * @param listener	Pointer to a listener.
+		 */
+		virtual void AddPluginsListener_V1(IPluginsListener_V1 *listener) =0;
+
+		/**
+		 * @brief Removes a V1 plugin listener.
+		 * 
+		 * @param listener	Pointer to a listener.
+		 */
+		virtual void RemovePluginsListener_V1(IPluginsListener_V1 *listener) =0;
+
+		/**
+		 * @brief Converts a Handle to an IPlugin if possible.
+		 *
+		 * @param handle	Handle.
+		 * @param err		Error, set on failure (otherwise undefined).
+		 * @return			IPlugin pointer, or NULL on failure.
+		 */
+		virtual IPlugin *PluginFromHandle(Handle_t handle, HandleError *err) =0;
+
+		/** 
 		 * @brief Adds a plugin manager listener.
 		 *
 		 * @param listener	Pointer to a listener.
@@ -393,15 +424,6 @@ namespace SourceMod
 		 * @param listener	Pointer to a listener.
 		 */
 		virtual void RemovePluginsListener(IPluginsListener *listener) =0;
-
-		/**
-		 * @brief Converts a Handle to an IPlugin if possible.
-		 *
-		 * @param handle	Handle.
-		 * @param err		Error, set on failure (otherwise undefined).
-		 * @return			IPlugin pointer, or NULL on failure.
-		 */
-		virtual IPlugin *PluginFromHandle(Handle_t handle, HandleError *err) =0;
 	};
 }
 


### PR DESCRIPTION
IPluginsListener::OnPluginUnloaded API runs *after* plugins receive OnPluginEnd(). Since that's supposed to be the last callback in the plugin, it is an unspoken rule that extensions and listeners should not call into plugins at this stage.

Database.cpp of course breaks this rule: it can callback into plugins that think they're finished, which can cause unexpected state in the plugin and within SourceMod. This is particularly dangerous if a callback does something strange like adds a new ConVar: state that was removed in a different OnPluginUnloaded callback could now be revived, leaving leaks or danging pointers around SourceMod.

The easy fix for this, of course, is to just add a callback that fires *before* OnPluginEnd(). (Arguably, a partial fix is that OnPluginDestroyed is a better callback for releasing resources, but that ship has sailed because of extensions.)

Unfortunately we can't add new callbacks to IPluginsListener because it's not versioned. To work around this, I renamed IPluginsListener to IPluginsListener_V1 and Add/RemovePluginsListener to have a V1 as well. This should retain ABI compatibility, and whenever extensions recompile they'll seamlessly opt into the new listener.

I didn't take the final step of simply disallowing plugin callbacks within OnPluginUnloaded, but it's worth considering for the future.