### PR TITLE
Remove plugin pausing.

### DIFF
--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -81,6 +81,7 @@ binary.sources += [
   'RootConsoleMenu.cpp',
   'CDataPack.cpp',
   'frame_tasks.cpp',
+  'PluginGraph.cpp',
 ]
 if builder.target_platform == 'windows':
   binary.sources += ['thread/WinThreads.cpp']

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -81,7 +81,6 @@ private:
 	}
 protected:
 	mutable ReentrantList<IPluginFunction *> m_functions;
-	mutable ReentrantList<IPluginFunction *> m_paused;
 
 	/* Type and name information */
 	FwdParamInfo m_params[SP_MAX_EXEC_PARAMS];
@@ -118,7 +117,6 @@ public: //IForwardManager
 public: //IPluginsListener
 	void OnPluginLoaded(IPlugin *plugin);
 	void OnPluginUnloaded(IPlugin *plugin);
-	void OnPluginPauseChange(IPlugin *plugin, bool paused);
 public: //SMGlobalClass
 	void OnSourceModAllInitialized();
 private:

--- a/core/logic/NativeOwner.cpp
+++ b/core/logic/NativeOwner.cpp
@@ -79,10 +79,8 @@ void CNativeOwner::UnbindWeakRef(const WeakNative &ref)
 
 void CNativeOwner::DropEverything()
 {
-	List<WeakNative>::iterator iter;
-
-	/* Unbind and remove all weak references to us */
-	iter = m_WeakRefs.begin();
+	// Unbind and remove all weak references to us.
+	auto iter = m_WeakRefs.begin();
 	while (iter != m_WeakRefs.end())
 	{
 		UnbindWeakRef((*iter));
@@ -100,6 +98,9 @@ void CNativeOwner::DropEverything()
 	for (size_t i = 0; i < m_fakes.length(); i++)
 		g_ShareSys.ClearNativeFromCache(this, m_fakes[i]->name());
 	m_fakes.clear();
+
+	// At this point, we should have no more dependents.
+	m_Dependents.clear();
 }
 
 void CNativeOwner::DropWeakRefsTo(CPlugin *pPlugin)
@@ -126,4 +127,10 @@ void CNativeOwner::DropRefsTo(CPlugin *pPlugin)
 {
 	m_Dependents.remove(pPlugin);
 	DropWeakRefsTo(pPlugin);
+}
+
+void CNativeOwner::ForEachDependent(const ke::Lambda<void(CPlugin*)> &callback)
+{
+	for (auto iter = m_Dependents.begin(); iter != m_Dependents.end(); iter++)
+		callback(*iter);
 }

--- a/core/logic/NativeOwner.h
+++ b/core/logic/NativeOwner.h
@@ -33,11 +33,12 @@
 
 #include <sp_vm_types.h>
 #include <sh_list.h>
-#include <am-linkedlist.h>
-#include <am-vector.h>
+#include <amtl/am-linkedlist.h>
+#include <amtl/am-vector.h>
 #include "common_logic.h"
 #include "Native.h"
 #include <bridge/include/IScriptManager.h>
+#include <amtl/am-function.h>
 
 struct Native;
 class CPlugin;
@@ -63,7 +64,7 @@ class CNativeOwner
 public:
 	CNativeOwner();
 public:
-	virtual void DropEverything();
+	void DropEverything();
 public:
 	void AddNatives(const sp_nativeinfo_t *info);
 public:
@@ -73,6 +74,7 @@ public:
 	void AddDependent(CPlugin *pPlugin);
 	void AddWeakRef(const WeakNative & ref);
 	void DropRefsTo(CPlugin *pPlugin);
+	void ForEachDependent(const ke::Lambda<void(CPlugin*)> &callback);
 private:
 	void DropWeakRefsTo(CPlugin *pPlugin);
 	void UnbindWeakRef(const WeakNative & ref);

--- a/core/logic/PluginGraph.cpp
+++ b/core/logic/PluginGraph.cpp
@@ -1,0 +1,153 @@
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
+#include "PluginGraph.h"
+#include "PluginSys.h"
+
+PluginGraph::PluginGraph(CPlugin *root)
+	: root_(root)
+{
+}
+
+PluginGraph::~PluginGraph()
+{
+}
+
+bool
+PluginGraph::ComputeDependencies()
+{
+	// Reset the work queue state.
+	in_worklist_.clear();
+	assert(work_queue_.empty());
+
+	// Reset the differential output list.
+	change_list_.clear();
+
+	// The work queue is a deque, we append work to the back and remove it
+	// from the front. This means the output list is roughly in postorder,
+	// where the first item is the root and the last item is the right-most
+	// leaf. Plugin dependencies can form cycles, but we break these using
+	// the in_worklist_ test.
+	while (!work_queue_.empty()) {
+		CPlugin *parent = work_queue_.popFrontCopy();
+		AddToFullList(parent);
+
+		parent->ForEachDependent([this, parent] (CPlugin *child) -> void {
+			if (in_worklist_.has(child))
+				return;
+			if (!child->IsStronglyDependentOn(parent))
+				return;
+			AddToWorklist(child);
+		});
+	}
+
+	return change_list_.length() != 0;
+}
+
+void
+PluginGraph::AddToWorklist(CPlugin *plugin)
+{
+	assert(!in_worklist_.has(plugin));
+	in_worklist_.add(plugin);
+	work_queue_.append(plugin);
+}
+
+void
+PluginGraph::AddToFullList(CPlugin *plugin)
+{
+	if (in_full_list_.has(plugin))
+		return;
+	full_list_.append(plugin);
+	change_list_.append(plugin);
+	in_full_list_.add(plugin);
+}
+
+PluginEvictionGraph::PluginEvictionGraph(CPlugin *root)
+	: PluginGraph(root)
+{
+}
+
+PluginEvictionGraph::~PluginEvictionGraph()
+{
+}
+
+void
+PluginEvictionGraph::DoEviction()
+{
+	// Compute the dependency graph, then evict plugins. We iterate to a
+	// fixpoint since firing dependency callbacks could (in extremely rare
+	// cases) cause the dependency graph to change - for example via more
+	// eviction callbacks firing or by new plugins loading.
+	while (ComputeDependencies()) {
+		for (size_t i = change_list_.length() - 1; i < change_list_.length(); i--)
+			FireDependencyCallbacks(change_list_[i]);
+	}
+
+	for (size_t i = full_list_.length() - 1; i < full_list_.length(); i--)
+		Unlink(full_list_[i]);
+}
+
+void
+PluginEvictionGraph::FireDependencyCallbacks(CPlugin *plugin)
+{
+	plugin->LibraryActions(LibraryAction_Removed);
+	plugin->SetPaused();
+}
+
+void
+PluginEvictionGraph::Unlink(CPlugin *parent)
+{
+	parent->ForEachDependent([this, parent] (CPlugin *child) -> void {
+		// Note: we skip this error for the root plugin since the caller is
+		// responsible for its messaging.
+		//
+		// We allow the pause state to pass this test, since we paused plugins
+		// earlier in the FireDependencyCallbacks pass.
+		if (child != root_ &&
+			(child->GetStatus() == Plugin_Running ||
+			 child->GetStatus() == Plugin_Loaded ||
+			 child->GetStatus() == Plugin_Paused) &&
+		    child->IsStronglyDependentOn(parent))
+		{
+			child->DependencyError(Plugin_Error, "Depends on plugin: %s", parent->GetFilename());
+		}
+
+		// For safety, zap native bindings for fake natives. This is probably
+		// not needed since ShareSys should be doing it.
+		child->UnlinkNativesOwnedBy(parent);
+	});
+
+	// Zap incoming references to this plugin.
+	g_PluginSys.ForEachPlugin([parent] (CPlugin *child) -> void {
+		child->ToNativeOwner()->DropRefsTo(parent);
+	});
+
+	// Zap links in the native ownership system.
+	parent->ToNativeOwner()->DropEverything();
+
+	if (parent != root_)
+		g_PluginSys.Evict(parent);
+}

--- a/core/logic/PluginGraph.h
+++ b/core/logic/PluginGraph.h
@@ -1,0 +1,99 @@
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
+#ifndef _include_sourcemod_core_logic_DependencyGraph_h_
+#define _include_sourcemod_core_logic_DependencyGraph_h_
+
+#include <amtl/am-deque.h>
+#include <amtl/am-hashset.h>
+#include <amtl/am-vector.h>
+#include <amtl/am-function.h>
+
+class CPlugin;
+
+namespace SourceMod {
+
+class PluginGraph
+{
+public:
+	PluginGraph(CPlugin *root);
+	~PluginGraph();
+
+protected:
+	// Compute the dependency graph. If any new plugins were discovered since
+	// the last time the dependency graph was computed, returns true.
+	bool ComputeDependencies();
+
+private:
+	void AddToFullList(CPlugin *plugin);
+	void AddToWorklist(CPlugin *plugin);
+
+private:
+	struct PluginPtrHashPolicy {
+		static uint32_t hash(CPlugin *value) {
+			return ke::HashPointer(value);
+		}
+		static bool matches(CPlugin *a, CPlugin *b) {
+			return a == b;
+		}
+	};
+	typedef ke::HashSet<CPlugin *, PluginPtrHashPolicy> PluginSet;
+
+protected:
+	CPlugin *root_;
+
+	// The final list of plugins in rough RPO order (with cycles broken), and
+	// the membership test of whether or not a plugin is in the final list.
+	ke::Vector<CPlugin *> full_list_;
+	PluginSet in_full_list_;
+
+	// The difference of unload_list_ after each call to ComputeDependencies.
+	ke::Vector<CPlugin *> change_list_;
+
+private:
+	// The work queue, and membership test of whether or not a plugin was ever
+	// in the work queue.
+	ke::Deque<CPlugin *> work_queue_;
+	PluginSet in_worklist_;
+};
+
+class PluginEvictionGraph : public PluginGraph
+{
+public:
+	PluginEvictionGraph(CPlugin *root);
+	~PluginEvictionGraph();
+
+	void DoEviction();
+	void ForEach(const ke::Lambda<void(CPlugin*)> &callback);
+
+private:
+	void FireDependencyCallbacks(CPlugin *plugin);
+	void Unlink(CPlugin *plugin);
+};
+
+} // namespace SourceMod
+
+#endif // _include_sourcemod_core_logic_DependencyGraph_h_

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -150,6 +150,11 @@ public:
 public:
 	// Evicts the plugin from memory and sets an error state.
 	void EvictWithError(PluginStatus status, const char *error_fmt, ...);
+
+	// Sets an error state during the loading process. The plugin must not have
+	// gone through secondary binding.
+	void LoadingError(PluginStatus status, const char *error_fmt, ...);
+
 	void FinishEviction();
 
 	// Initializes the plugin's identity information

--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -236,6 +236,8 @@ public:
 	}
 	void CancelThinkPart()
 	{
+		if (!m_pFunction->IsRunnable())
+			return;
 		m_pFunction->PushCell(BAD_HANDLE);
 		m_pFunction->PushCell(BAD_HANDLE);
 		m_pFunction->PushString("Driver is unloading");
@@ -266,11 +268,13 @@ public:
 			}
 		}
 
-		m_pFunction->PushCell(m_MyHandle);
-		m_pFunction->PushCell(qh);
-		m_pFunction->PushString(qh == BAD_HANDLE ? error : "");
-		m_pFunction->PushCell(m_Data);
-		m_pFunction->Execute(NULL);
+		if (m_pFunction->IsRunnable()) {
+			m_pFunction->PushCell(m_MyHandle);
+			m_pFunction->PushCell(qh);
+			m_pFunction->PushString(qh == BAD_HANDLE ? error : "");
+			m_pFunction->PushCell(m_Data);
+			m_pFunction->Execute(NULL);
+		}
 
 		if (qh != BAD_HANDLE)
 		{
@@ -334,9 +338,11 @@ public:
 	void CancelThinkPart()
 	{
 		if (m_pDatabase)
-		{
 			m_pDatabase->Close();
-		}
+
+		if (m_pFunction->IsRunnable())
+			return;
+
 		if (m_ACM == ACM_Old)
 			m_pFunction->PushCell(BAD_HANDLE);
 		m_pFunction->PushCell(BAD_HANDLE);
@@ -347,6 +353,12 @@ public:
 	void RunThinkPart()
 	{
 		Handle_t hndl = BAD_HANDLE;
+
+		if (!m_pFunction->IsRunnable()) {
+			if (m_pDatabase)
+				m_pDatabase->Close();
+			return;
+		}
 		
 		if (m_pDatabase)
 		{
@@ -1659,12 +1671,14 @@ private:
 			data[i] = txn_->entries[i].data;
 		}
 
-		success_->PushCell(dbh);
-		success_->PushCell(data_);
-		success_->PushCell(txn_->entries.length());
-		success_->PushArray(handles, results_.length());
-		success_->PushArray(data, results_.length());
-		success_->Execute(NULL);
+		if (success_->IsRunnable()) {
+			success_->PushCell(dbh);
+			success_->PushCell(data_);
+			success_->PushCell(txn_->entries.length());
+			success_->PushArray(handles, results_.length());
+			success_->PushArray(data, results_.length());
+			success_->Execute(NULL);
+		}
 
 		// Cleanup. Note we clear results_, since freeing their handles will
 		// call Destroy(), and we don't want to double-free in ~TTransactOp.
@@ -1703,13 +1717,15 @@ public:
 				db_->AddRef();
 			}
 
-			failure_->PushCell(dbh);
-			failure_->PushCell(data_);
-			failure_->PushCell(txn_->entries.length());
-			failure_->PushString(error_.chars());
-			failure_->PushCell(failIndex_);
-			failure_->PushArray(data, txn_->entries.length());
-			failure_->Execute(NULL);
+			if (failure_->IsRunnable()) {
+				failure_->PushCell(dbh);
+				failure_->PushCell(data_);
+				failure_->PushCell(txn_->entries.length());
+				failure_->PushString(error_.chars());
+				failure_->PushCell(failIndex_);
+				failure_->PushArray(data, txn_->entries.length());
+				failure_->Execute(NULL);
+			}
 
 			handlesys->FreeHandle(dbh, &sec);
 		}

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -137,14 +137,6 @@ forward APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 forward void OnPluginEnd();
 
 /**
- * Called when the plugin's pause status is changing.
- *
- * @param pause			True if the plugin is being paused, false otherwise.
- * @noreturn
- */
-forward void OnPluginPauseChange(bool:pause);
-
-/**
  * Called before every server frame.  Note that you should avoid
  * doing expensive computations or declaring large local arrays.
  */

--- a/public/IPluginSys.h
+++ b/public/IPluginSys.h
@@ -181,11 +181,11 @@ namespace SourceMod
 		virtual PluginStatus GetStatus() =0;
 
 		/**
-		 * @brief Sets whether the plugin is paused or not.
+		 * @brief Deprecated; does nothing/
 		 *
-		 * @return			True on successful state change, false otherwise.
+		 * @return			Returns false.
 		 */
-		virtual bool SetPauseState(bool paused) =0;
+		virtual bool SetPauseState_OBSOLETE(bool) =0;
 
 		/**
 		 * @brief Returns the unique serial number of a plugin.
@@ -295,8 +295,8 @@ namespace SourceMod
 		{
 		}
 
-		// @brief Called when a plugin is paused or unpaused.
-		virtual void OnPluginPauseChange(IPlugin *plugin, bool paused)
+		// @brief Removed. This callback no longer fires.
+		virtual void OnPluginPauseChange(IPlugin *plugin, bool paused) final
 		{
 		}
 
@@ -309,6 +309,10 @@ namespace SourceMod
 		// you wish to be notified of when a plugin is unloading, and to forbid
 		// future calls on that plugin, use OnPluginWillUnload and use a
 		// plugin property to block future calls.
+		//
+		// Furthermore, when this callback fires, plugins may be in a paused
+		// state, and callbacks fired may report an error. Take care to check
+		// whether functions are runnable beforehand.
 		virtual void OnPluginUnloaded(IPlugin *plugin)
 		{
 		}


### PR DESCRIPTION
This is still a prototype, unfinished and untested. But it's nearing completion. This patch introduces a new "eviction" phase, which happens whenever we want a plugin to entered a paused state. Eviction works like this:
1. First, invoke callbacks related to dependency tracking in plugins. We do this for each dependent plugin, recursively, until the entire graph has been reached.
2. Pause each plugin in the dependency graph.
3. Iterate steps 1-2 until there are no changes in the dependency graph.
4. Break dependency links - mostly by removing and zapping fake natives, and clearing dependency lists.
5. Schedule an "eviction" event. This may happen immediately if we deem it safe to perform.
6. The eviction event will perform all plugin unload steps up to, but not including, removing it from the plugin list.

Pause change callbacks have been removed from both the C++ and SourcePawn API. ForwardSys was the only internal consumer, and it now checks the runtime pause status instead. It may still be possible to re-enter plugin code in between the dependency check and eviction event, but chances are low. Most likely is the caller will get a runtime error (as would be the case with Database.cpp, which will now check for pauses).

What's not done: automatic refreshing of plugins whose dependencies were removed and reloaded. I believe the correct way to approach this is different from how it works now: we should keep track of all the plugin filenames that it depended on, and only reload if all of them are present and operational.
