### PR TITLE
Use present netchannel instead of cached netchannel in CHookManager::SendFile.

### DIFF
--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -332,7 +332,7 @@ bool CHookManager::SendFile(const char *filename, unsigned int transferID)
 	}
 
 	int userid = 0;
-	IClient *pClient = (IClient *)m_pActiveNetChannel->GetMsgHandler();
+	IClient *pClient = (IClient *)pNetChannel->GetMsgHandler();
 	if (pClient != NULL)
 	{
 		userid = pClient->GetUserID();


### PR DESCRIPTION
This corrects a potential oops if a file is being sent to another client when a packet is received from a different client. Last minute rejigging caused this unfortunately.