### PR TITLE
Fix crash on failing to load dependent extension.

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -297,16 +297,15 @@ bool CExtension::Load(char *error, size_t maxlength)
 	CreateIdentity();
 	if (!m_pAPI->OnExtensionLoad(this, &g_ShareSys, error, maxlength, !bridge->IsMapLoading()))
 	{
+		g_ShareSys.RemoveInterfaces(this);
 		DestroyIdentity();
 		return false;
 	}
-	else
+
+	/* Check if we're past load time */
+	if (!bridge->IsMapLoading())
 	{
-		/* Check if we're past load time */
-		if (!bridge->IsMapLoading())
-		{
-			m_pAPI->OnExtensionsAllLoaded();
-		}
+		m_pAPI->OnExtensionsAllLoaded();
 	}
 
 	return true;


### PR DESCRIPTION
This one is kind of nasty - it still leaves the failed ext in the libs, but is the sanest way to fix the crash without actually implementing `CExtensionManager::AddDependency` properly.

ShareSys has a couple of things that are designed to cleanup automatically on unload (rather than having a deregistration function that the extension is meant to call on unload) - this was not being done for autoloaded dependencies that failed to load, which could result in bad interface ptrs being left around. Instead, clean up immediately whenever any ext fails to load rather than waiting until unload time.

AFAICT, there is no downside to this change.