### PR TITLE
Pre-fill buffer for GetClientAuth*

### DIFF
--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -347,6 +347,8 @@ enum class AuthIdType
 
 static cell_t SteamIdToLocal(IPluginContext *pCtx, int index, AuthIdType authType, cell_t local_addr, size_t bytes, bool validate)
 {
+	pCtx->StringToLocal(local_addr, bytes, "STEAM_ID_STOP_IGNORING_RETVALS");
+
 	if ((index < 1) || (index > playerhelpers->GetMaxClients()))
 	{
 		return pCtx->ThrowNativeError("Client index %d is invalid", index);


### PR DESCRIPTION
While we could use blank which will solve the worst of the problems without the perf hit, I think it is worth directly addressing this. Hopefully respecting the STEAM_ID_PENDING / STEAM_ID_BOT format will play nice with other code.

@psychonic