### PR TITLE
Expose experimental console debugger

### DIFF
--- a/bridge/include/BridgeAPI.h
+++ b/bridge/include/BridgeAPI.h
@@ -35,7 +35,7 @@ namespace SourceMod {
 
 // Add 1 to the RHS of this expression to bump the intercom file
 // This is to prevent mismatching core/logic binaries
-static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 56;
+static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 57;
 
 } // namespace SourceMod
 

--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -35,6 +35,7 @@
 namespace SourcePawn {
 class ISourcePawnEngine;
 class ISourcePawnEngine2;
+class IConsoleDebugger;
 } // namespace SourcePawn
 
 // SDK types.
@@ -83,6 +84,7 @@ public:
 	IMenuManager	*menus;
 	SourcePawn::ISourcePawnEngine **spe1;
 	SourcePawn::ISourcePawnEngine2 **spe2;
+	SourcePawn::IConsoleDebugger **consoledebugger;
 	const char		*gamesuffix;
 	/* Data */
 	ServerGlobals   *serverGlobals;

--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -281,15 +281,18 @@ void DebugReport::OnRootConsoleCommand(const char *cmdname, const ICommandArgs *
 				strcpy(name, pl->GetFilename());
 
 			if (g_pConsoleDebugger->StartDebugger(pl->GetBaseContext()))
-				rootmenu->ConsolePrint("[SM] Pausing Plugin %s for debugging. Will halt on next instruction.", name);
+				rootmenu->ConsolePrint("[SM] Pausing plugin %s for debugging. Will halt on next instruction.", name);
 			else
 				rootmenu->ConsolePrint("[SM] Failed to pause plugin %s for debugging.", name);
 
 			return;
 		}
 		else if (strcmp(cmd, "next") == 0) {
-			// TODO
-			rootmenu->ConsolePrint("[SM] Not implemented yet.");
+			
+			if (g_pConsoleDebugger->DebugNextLoadedPlugin())
+				rootmenu->ConsolePrint("[SM] Will halt on the first instruction of the next loaded plugin.");
+			else
+				rootmenu->ConsolePrint("[SM] Failed to mark next loaded plugin for debugging.");
 			return;
 		}
 		else if (strcmp(cmd, "bp") == 0) {

--- a/core/logic/DebugReporter.h
+++ b/core/logic/DebugReporter.h
@@ -34,16 +34,21 @@
 
 #include "sp_vm_api.h"
 #include "common_logic.h"
+#include <IRootConsoleMenu.h>
 
 class DebugReport : 
 	public SMGlobalClass, 
-	public IDebugListener
+	public IDebugListener,
+	public IRootConsoleCommand
 {
 public: // SMGlobalClass
 	void OnSourceModAllInitialized();
+	void OnSourceModShutdown();
 public: // IDebugListener
 	void ReportError(const IErrorReport &report, IFrameIterator &iter);
 	void OnDebugSpew(const char *msg, ...);
+public: //IRootConsoleCommand
+	void OnRootConsoleCommand(const char *cmdname, const ICommandArgs *command) override;
 public:
 	void GenerateError(IPluginContext *ctx, cell_t func_idx, int err, const char *message, ...);
 	void GenerateErrorVA(IPluginContext *ctx, cell_t func_idx, int err, const char *message, va_list ap); 

--- a/core/logic/DebugReporter.h
+++ b/core/logic/DebugReporter.h
@@ -42,6 +42,7 @@ class DebugReport :
 	public IRootConsoleCommand
 {
 public: // SMGlobalClass
+	void OnSourceModStartup(bool late);
 	void OnSourceModAllInitialized();
 	void OnSourceModShutdown();
 public: // IDebugListener

--- a/core/logic/common_logic.cpp
+++ b/core/logic/common_logic.cpp
@@ -82,6 +82,7 @@ ServerGlobals serverGlobals;
 IAdminSystem *adminsys = &g_Admins;
 ISourcePawnEngine *g_pSourcePawn;
 ISourcePawnEngine2 *g_pSourcePawn2;
+IConsoleDebugger *g_pConsoleDebugger;
 IScriptManager *scripts = &g_PluginSys;
 IExtensionSys *extsys = &g_Extensions;
 ILogger *logger = &g_Logger;
@@ -202,6 +203,7 @@ static void logic_init(CoreProvider* core, sm_logic_t* _logic)
 	menus = core->menus;
 	g_pSourcePawn = *core->spe1;
 	g_pSourcePawn2 = *core->spe2;
+	g_pConsoleDebugger = *core->consoledebugger;
 	SMGlobalClass::head = core->listeners;
 
 	g_ShareSys.Initialize();

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -414,6 +414,7 @@ CoreProviderImpl::CoreProviderImpl()
 	this->menus = &g_Menus;
 	this->spe1 = &g_pSourcePawn;
 	this->spe2 = &g_pSourcePawn2;
+	this->consoledebugger = &g_pConsoleDebugger;
 	this->GetCoreConfigValue = get_core_config_value;
 	this->DoGlobalPluginLoads = do_global_plugin_loads;
 	this->AreConfigsExecuted = SM_AreConfigsExecuted;

--- a/core/sm_globals.h
+++ b/core/sm_globals.h
@@ -38,6 +38,7 @@
 
 #include <sp_vm_types.h>
 #include <sp_vm_api.h>
+#include <sp_vm_debug_api.h>
 #include "sm_platform.h"
 #include <IShareSys.h>
 
@@ -207,6 +208,8 @@ namespace SourceMod
 
 extern IThreader *g_pThreader;
 extern ITextParsers *textparsers;
+
+extern IConsoleDebugger *g_pConsoleDebugger;
 
 #include "sm_autonatives.h"
 

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -62,6 +62,7 @@ SourceHook::String g_BaseDir;
 ISourcePawnEngine *g_pSourcePawn = NULL;
 ISourcePawnEngine2 *g_pSourcePawn2 = NULL;
 ISourcePawnEnvironment *g_pPawnEnv = NULL;
+IConsoleDebugger *g_pConsoleDebugger = NULL;
 IdentityToken_t *g_pCoreIdent = NULL;
 IForward *g_pOnMapEnd = NULL;
 IGameConfig *g_pGameConf = NULL;
@@ -85,6 +86,7 @@ void ShutdownJIT()
 		g_pPawnEnv = NULL;
 		g_pSourcePawn2 = NULL;
 		g_pSourcePawn = NULL;
+		g_pConsoleDebugger = NULL;
 	}
 
 	g_JIT = nullptr;
@@ -236,6 +238,8 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 	if (sm_disable_jit)
 		g_pSourcePawn2->SetJitEnabled(!sm_disable_jit);
 
+	LoadSourcePawnDebugger();
+
 	sSourceModInitialized = true;
 
 	/* Hook this now so we can detect startup without calling StartSourceMod() */
@@ -247,6 +251,24 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 		StartSourceMod(false);
 	}
 
+	return true;
+}
+
+bool SourceModBase::LoadSourcePawnDebugger()
+{
+	GetConsoleDebuggerFn debuggerFn =
+		g_JIT->get<decltype(debuggerFn)>("GetConsoleDebugger");
+
+	if (!debuggerFn) {
+		return false;
+	}
+
+	IConsoleDebugger *debugger = debuggerFn();
+	if (!debugger) {
+		return false;
+	}
+
+	g_pConsoleDebugger = debugger;
 	return true;
 }
 

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -263,7 +263,7 @@ bool SourceModBase::LoadSourcePawnDebugger()
 		return false;
 	}
 
-	IConsoleDebugger *debugger = debuggerFn();
+	IConsoleDebugger *debugger = debuggerFn(SOURCEPAWN_CONSOLE_DEBUGGER_API_VERSION);
 	if (!debugger) {
 		return false;
 	}

--- a/core/sourcemod.h
+++ b/core/sourcemod.h
@@ -138,6 +138,8 @@ public: // ISourceMod
 	void *FromPseudoAddress(uint32_t pseudoAddr);
 	uint32_t ToPseudoAddress(void *addr);
 private:
+	bool LoadSourcePawnDebugger();
+private:
 	void ShutdownServices();
 private:
 	char m_SMBaseDir[PLATFORM_MAX_PATH];


### PR DESCRIPTION
Exposes the experimental console debugger in sourcepawn. alliedmodders/sourcepawn#51 has to land and the submodule reference updated for this to compile.

Adds a `"EnableConsoleDebugger"` config option to core.cfg (defaulting to `"no"`) which enables a local debugging shell to step through plugins during execution. This isn't documented in the core.cfg for now, to keep non-developers from switching it on by accident ;) This should be considered alpha quality and we'll see how well it performs when developers start using it to debug their plugins.

It adds to the `sm` root console menu:

```
sm debug
SourceMod Debug Menu:
    start            - Start debugging a plugin
    next             - Start debugging the plugin which is loaded next
    bp               - Handle breakpoints in a plugin

sm debug start
[SM] Usage: sm debug start <#|file>

sm debug bp
[SM] Usage: sm debug bp <#|file> <option>
    list             - List breakpoints
    add              - Add a breakpoint
    clear            - Remove a breakpoint

sm debug bp plugin add
[SM] Usage: sm debug bp <#|file> add <file:line | file:function>
```

When `"EnableConsoleDebugger"` is set to `"yes"` the above menu is available to start debugging a plugin. Whenever it hits an error/exception or set breakpoint execution is stopped and a debugging shell is offered to examine and change plugin state, step through the code and list debugging information.

While the internal SourcePawn vm's watchdog is taken care of to handle debugging pauses, the watchdog in srcds, which monitors frame execution time, keeps running and terminates the process, if we spent too much time in the debugging shell. So `-nowatchdog` in the server startup line is required for games which include the watchdog. Maybe there's a way to disable it at runtime or at least warn if it's enabled?

![Workflow demonstration](https://user-images.githubusercontent.com/1635147/29742503-b21c19a6-8a80-11e7-8986-4b5224356f50.gif)