### PR TITLE
Fix custom menu sounds not working on newer games (bug 6433).

### DIFF
--- a/core/MenuManager.cpp
+++ b/core/MenuManager.cpp
@@ -720,10 +720,8 @@ ConfigResult MenuManager::OnSourceModConfigChanged(const char *key,
 	return ConfigResult_Ignore;
 }
 
-const char *MenuManager::GetMenuSound(ItemSelection sel)
+bool MenuManager::GetMenuSound(ItemSelection sel, char *pszOut, size_t maxlen)
 {
-	const char *sound = NULL;
-
 	switch (sel)
 	{
 	case ItemSel_Back:
@@ -732,7 +730,12 @@ const char *MenuManager::GetMenuSound(ItemSelection sel)
 		{
 			if (m_SelectSound.size() > 0)
 			{
-				sound = m_SelectSound.c_str();
+#if SOURCE_ENGINE >= SE_LEFT4DEAD
+				ke::SafeSprintf(pszOut, maxlen, "*%s", m_SelectSound.c_str());
+#else
+				ke::SafeStrcpy(pszOut, maxlen, m_SelectSound.c_str());
+#endif
+				return true;
 			}
 			break;
 		}
@@ -740,7 +743,12 @@ const char *MenuManager::GetMenuSound(ItemSelection sel)
 		{
 			if (m_ExitBackSound.size() > 0)
 			{
-				sound = m_ExitBackSound.c_str();
+#if SOURCE_ENGINE >= SE_LEFT4DEAD
+				ke::SafeSprintf(pszOut, maxlen, "*%s", m_ExitBackSound.c_str());
+#else
+				ke::SafeStrcpy(pszOut, maxlen, m_ExitBackSound.c_str());
+#endif
+				return true;
 			}
 			break;
 		}
@@ -748,17 +756,18 @@ const char *MenuManager::GetMenuSound(ItemSelection sel)
 		{
 			if (m_ExitSound.size() > 0)
 			{
-				sound = m_ExitSound.c_str();
+#if SOURCE_ENGINE >= SE_LEFT4DEAD
+				ke::SafeSprintf(pszOut, maxlen, "*%s", m_ExitSound.c_str());
+#else
+				ke::SafeStrcpy(pszOut, maxlen, m_ExitSound.c_str());
+#endif
+				return true;
 			}
 			break;
 		}
-	default:
-		{
-			break;
-		}
 	}
-
-	return sound;
+	
+	return false;
 }
 
 void MenuManager::OnSourceModLevelChange(const char *mapName)

--- a/core/MenuManager.h
+++ b/core/MenuManager.h
@@ -99,7 +99,7 @@ public:
 	HandleError ReadStyleHandle(Handle_t handle, IMenuStyle **style);
 public:
 	bool MenuSoundsEnabled();
-	const char *GetMenuSound(ItemSelection sel);
+	bool GetMenuSound(ItemSelection sel, char *pszOut, size_t maxlen);
 protected:
 	Handle_t CreateMenuHandle(IBaseMenu *menu, IdentityToken_t *pOwner);
 	Handle_t CreateStyleHandle(IMenuStyle *style);

--- a/core/MenuStyle_Base.cpp
+++ b/core/MenuStyle_Base.cpp
@@ -311,9 +311,8 @@ void BaseMenuStyle::ClientPressedKey(int client, unsigned int key_press)
 			clients[0] = client;
 			filter.Initialize(clients, 1);
 
-			const char *sound = g_Menus.GetMenuSound(type);
-
-			if (sound != NULL)
+			char sound[PLATFORM_MAX_PATH];
+			if (g_Menus.GetMenuSound(type, sound, sizeof(sound)) && sound[0])
 			{
 				edict_t *pEdict = PEntityOfEntIndex(client);
 				if (pEdict)


### PR DESCRIPTION
This hasn't been tested yet, but will be before landing.

While we support configuring menu sounds in core.cfg, it has always been up to the user to add the sounds to the downloads stringtable if there were custom sounds, so we arguably never "supported" these. However, even doing that, they do not work on newer games that have more aggressive precaching clientside.

The only way we've found to play custom sounds on any game since Left 4 Dead is to add the '*' sound char before the filename, forcing the game to stream it from disk directly instead of starting from the cache. This adds that for those games (whether or not the sound is custom). Note that people cannot just put it directly into the config with the asterisk as then it would attempt to call PrecacheSound with that added, which will fail due to that being treated as part of the filename.