### PR TITLE
Making hudtext user messages reliable.

### DIFF
--- a/core/smn_hudtext.cpp
+++ b/core/smn_hudtext.cpp
@@ -319,7 +319,7 @@ void UTIL_SendHudText(int client, const hud_text_parms &textparms, const char *p
 	players[0] = client;
 
 #if SOURCE_ENGINE == SE_DOTA
-	CUserMsg_HudMsg *msg = (CUserMsg_HudMsg *)g_UserMsgs.StartProtobufMessage(g_HudMsgNum, players, 1, 0);
+	CUserMsg_HudMsg *msg = (CUserMsg_HudMsg *)g_UserMsgs.StartProtobufMessage(g_HudMsgNum, players, 1, USERMSG_RELIABLE);
 	msg->set_channel(textparms.channel & 0xFF);
 
 	msg->set_x(textparms.x);
@@ -338,7 +338,7 @@ void UTIL_SendHudText(int client, const hud_text_parms &textparms, const char *p
 	msg->set_fx_time(textparms.fxTime);
 	msg->set_message(pMessage);
 #elif SOURCE_ENGINE == SE_CSGO
-	CCSUsrMsg_HudMsg *msg = (CCSUsrMsg_HudMsg *)g_UserMsgs.StartProtobufMessage(g_HudMsgNum, players, 1, 0);
+	CCSUsrMsg_HudMsg *msg = (CCSUsrMsg_HudMsg *)g_UserMsgs.StartProtobufMessage(g_HudMsgNum, players, 1, USERMSG_RELIABLE);
 	msg->set_channel(textparms.channel & 0xFF);
 
 	CMsgVector2D *pos = msg->mutable_pos();
@@ -364,7 +364,7 @@ void UTIL_SendHudText(int client, const hud_text_parms &textparms, const char *p
 	msg->set_fx_time(textparms.fxTime);
 	msg->set_text(pMessage);
 #else
-	bf_write *bf = g_UserMsgs.StartBitBufMessage(g_HudMsgNum, players, 1, 0);
+	bf_write *bf = g_UserMsgs.StartBitBufMessage(g_HudMsgNum, players, 1, USERMSG_RELIABLE);
 	bf->WriteByte(textparms.channel & 0xFF );
 	bf->WriteFloat(textparms.x);
 	bf->WriteFloat(textparms.y);


### PR DESCRIPTION
Noticed that Valve made this differently https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/util.cpp#L1052

I also had the issue that when I send two or more messages in the same frame, even though they used different channels, only one of them would show up. <- Fixed.