### PR TITLE
Add support for hooking CanBeAutobalanced to SDKHooks.

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -92,6 +92,9 @@ HookTypeData g_HookTypes[SDKHook_MAXHOOKS] =
 	{"BlockedPost",           "",                       false},
 	{"OnTakeDamageAlive",     "DT_BaseCombatCharacter", false},
 	{"OnTakeDamageAlivePost", "DT_BaseCombatCharacter", false},
+
+	// There is no DT for CBaseMultiplayerPlayer. Going up a level
+	{"CanBeAutobalanced",     "DT_BasePlayer",          false},
 };
 
 SDKHooks g_Interface;
@@ -198,6 +201,7 @@ SH_DECL_MANUALHOOK3_void(Weapon_Drop, 0, 0, 0, CBaseCombatWeapon *, const Vector
 SH_DECL_MANUALHOOK1_void(Weapon_Equip, 0, 0, 0, CBaseCombatWeapon *);
 SH_DECL_MANUALHOOK2(Weapon_Switch, 0, 0, 0, bool, CBaseCombatWeapon *, int);
 SH_DECL_MANUALHOOK1_void(Blocked, 0, 0, 0, CBaseEntity *);
+SH_DECL_MANUALHOOK0(CanBeAutobalanced, 0, 0, 0, bool);
 
 
 /**
@@ -538,6 +542,7 @@ void SDKHooks::SetupHooks()
 	CHECKOFFSET_W(Switch,         true,  true);
 	CHECKOFFSET(VPhysicsUpdate,   true,  true);
 	CHECKOFFSET(Blocked,          true,  true);
+	CHECKOFFSET(CanBeAutobalanced, true, false);
 
 	// this one is in a class all its own -_-
 	offset = 0;
@@ -719,6 +724,9 @@ HookReturn SDKHooks::Hook(int entity, SDKHookType type, IPluginFunction *callbac
 				break;
 			case SDKHook_BlockedPost:
 				hookid = SH_ADD_MANUALVPHOOK(Blocked, pEnt, SH_MEMBER(&g_Interface, &SDKHooks::Hook_BlockedPost), true);
+				break;
+			case SDKHook_CanBeAutobalanced:
+				hookid = SH_ADD_MANUALVPHOOK(CanBeAutobalanced, pEnt, SH_MEMBER(&g_Interface, &SDKHooks::Hook_CanBeAutobalanced), false);
 				break;
 		}
 
@@ -905,6 +913,46 @@ bool SDKHooks::Hook_LevelInit(char const *pMapName, char const *pMapEntities, ch
 /**
  * CBaseEntity Hook Handlers
  */
+bool SDKHooks::Hook_CanBeAutobalanced()
+{
+	CBaseEntity *pPlayer = META_IFACEPTR(CBaseEntity);
+	int entity = gamehelpers->EntityToBCompatRef(pPlayer);
+
+	bool origRet = SH_MCALL(pPlayer, CanBeAutobalanced)();
+	bool newRet = origRet;
+
+	CVTableHook vhook(pPlayer);
+	ke::Vector<CVTableList *> &vtablehooklist = g_HookList[SDKHook_CanBeAutobalanced];
+	for (size_t entry = 0; entry < vtablehooklist.length(); ++entry)
+	{
+		if (vhook != vtablehooklist[entry]->vtablehook)
+		{
+			continue;
+		}
+
+		ke::Vector<IPluginFunction *> callbackList;
+		PopulateCallbackList(vtablehooklist[entry]->hooks, callbackList, entity);
+		for (entry = 0; entry < callbackList.length(); ++entry)
+		{
+			cell_t res;
+			IPluginFunction *callback = callbackList[entry];
+			callback->PushCell(entity);
+			callback->PushCell(origRet);
+			callback->Execute(&res);
+
+			// Only update our new ret if different from original
+			// (so if multiple plugins returning different answers,
+			//  the one(s) that changed it win)
+			if ((res != 0) != origRet)
+				newRet = !origRet;
+		}
+
+		break;
+	}
+
+	RETURN_META_VALUE(MRES_SUPERCEDE, newRet);
+}
+
 void SDKHooks::Hook_EndTouch(CBaseEntity *pOther)
 {
 	cell_t result = Call(META_IFACEPTR(CBaseEntity), SDKHook_EndTouch, pOther);

--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -92,6 +92,7 @@ enum SDKHookType
 	SDKHook_BlockedPost,
 	SDKHook_OnTakeDamage_Alive,
 	SDKHook_OnTakeDamage_AlivePost,
+	SDKHook_CanBeAutobalanced,
 	SDKHook_MAXHOOKS
 };
 
@@ -284,6 +285,7 @@ public:
 	/**
 	 * CBaseEntity Hook Handlers
 	 */
+	bool Hook_CanBeAutobalanced();
 	void Hook_EndTouch(CBaseEntity *pOther);
 	void Hook_EndTouchPost(CBaseEntity *pOther);
 	void Hook_FireBulletsPost(const FireBulletsInfo_t &info);

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -5,6 +5,12 @@
 	{
 		"Offsets"
 		{
+			"CanBeAutobalanced"
+			{
+				"windows"	"458"
+				"linux"		"459"
+				"mac"		"459"
+			}
 			"EndTouch"
 			{
 				"windows"	"100"

--- a/gamedata/sdkhooks.games/game.fof.txt
+++ b/gamedata/sdkhooks.games/game.fof.txt
@@ -4,6 +4,12 @@
 	{
 		"Offsets"
 		{
+			"CanBeAutobalanced"
+			{
+				"windows"	"462"
+				"linux"		"463"
+				"mac"		"463"
+			}
 			"Blocked"
 			{
 				"windows"	"102"

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -121,6 +121,7 @@ enum SDKHookType
 	SDKHook_BlockedPost,
 	SDKHook_OnTakeDamageAlive,
 	SDKHook_OnTakeDamageAlivePost,
+	SDKHook_CanBeAutobalanced,
 };
 
 /*
@@ -128,6 +129,8 @@ enum SDKHookType
 
 	SDKHook_Blocked,
 	SDKHook_BlockedPost,
+	
+	SDKHook_CanBeAutobalanced,
 	
 	SDKHook_EndTouch,
 	SDKHook_EndTouchPost,
@@ -291,6 +294,9 @@ typeset SDKHookCB
 	
 	// Reload post
 	function void (int weapon, bool bSuccessful);
+	
+	// CanBeAutobalanced
+	function bool (int client, bool origRet);
 };
 
 


### PR DESCRIPTION
Not many games support this, but it is in the SDK (and thus likely in many mods). This is also already an often used feature in TF2, provided by an unsupported extension that breaks often (using a different method to hook).

I don't know offhand of other games/mods that support this, but it's trivial to add the offset when finding one.