### PR TITLE
Add BlamePluginError native

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -419,7 +419,7 @@ static cell_t BlamePluginError(IPluginContext *pContext, const cell_t *params)
 {
 	if (!params[1])
 	{
-		return 0;
+		return pContext->ThrowNativeError("No handle passed.");
 	}
 	HandleError err;
 	IPlugin *pPlugin = scripts->FindPluginByHandle(params[1], &err);
@@ -430,19 +430,19 @@ static cell_t BlamePluginError(IPluginContext *pContext, const cell_t *params)
 	IPluginContext *plContext = pPlugin->GetBaseContext();
 	if (!plContext)
 	{
-		return 0;
+		return pContext->ThrowNativeError("Unable to get plugin context for %x", params[1]);
 	}
 	IPluginFunction *plFunction = plContext->GetFunctionById(params[2]);
 	if (!plFunction)
 	{
-		return 0;
+		return pContext->ThrowNativeError("Unable to plugin function %d", params[2]);
 	}
 	char buffer[1024];
 	char *fmt;
 	int arg = 4;
 	pContext->LocalToString(params[3], &fmt);
 	size_t res = atcprintf(buffer, sizeof(buffer) - 1, fmt, pContext, params, &arg);
-	buffer[res++] = '\n';
+	buffer[res++] = '\0';
 	return plContext->BlamePluginError(plFunction, buffer);
 }
 

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -48,6 +48,7 @@
 #include <unistd.h>
 #include <sys/times.h>
 #endif
+#include "sprintf.h"
 #include <IForwardSys.h>
 #include <ILibrarySys.h>
 #include <bridge/include/CoreProvider.h>
@@ -414,6 +415,37 @@ static cell_t SetFailState(IPluginContext *pContext, const cell_t *params)
 	return 0;
 }
 
+static cell_t BlamePluginError(IPluginContext *pContext, const cell_t *params)
+{
+	if (!params[1])
+	{
+		return 0;
+	}
+	HandleError err;
+	IPlugin *pPlugin = scripts->FindPluginByHandle(params[1], &err);
+	if (!pPlugin)
+	{
+		return pContext->ThrowNativeError("Could not read Handle %x (error %d)", params[1], err);
+	}
+	IPluginContext *plContext = pPlugin->GetBaseContext();
+	if (!plContext)
+	{
+		return 0;
+	}
+	IPluginFunction *plFunction = plContext->GetFunctionById(params[2]);
+	if (!plFunction)
+	{
+		return 0;
+	}
+	char buffer[1024];
+	char *fmt;
+	int arg = 4;
+	pContext->LocalToString(params[3], &fmt);
+	size_t res = atcprintf(buffer, sizeof(buffer) - 1, fmt, pContext, params, &arg);
+	buffer[res++] = '\n';
+	return plContext->BlamePluginError(plFunction, buffer);
+}
+
 static cell_t GetSysTickCount(IPluginContext *pContext, const cell_t *params)
 {
 #if defined PLATFORM_WINDOWS
@@ -772,6 +804,7 @@ REGISTER_NATIVES(coreNatives)
 	{"IsPluginDebugging",		IsPluginDebugging},
 	{"GetPluginInfo",			GetPluginInfo},
 	{"SetFailState",			SetFailState},
+	{"BlamePluginError",		BlamePluginError},
 	{"GetSysTickCount",			GetSysTickCount},
 	{"AutoExecConfig",			AutoExecConfig},
 	{"MarkNativeAsOptional",	MarkNativeAsOptional},

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -314,6 +314,19 @@ native Handle:FindPluginByNumber(order_num);
 native SetFailState(const String:string[], any:...);
 
 /**
+ * This blames another plugin for a function error.
+ * @Note: Currently doesn't allow INVALID_HANDLE to be passed for plugin param.
+ *
+ * @param plugin        Plugin owning function your blaming error for.
+ * @param blame         Method your blaming error for.
+ * @param string		Format specifier string.
+ * @param ...			Formatting arguments.
+ * @noreturn
+ * @error               Throws if plugin handle couldn't be read.
+ */
+native void BlamePluginError(Handle plugin, Function blame, const char[] format, any ...);
+
+/**
  * Aborts the current callback and throws an error.  This function
  * does not return in that no code is executed following it.
  *

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -317,10 +317,10 @@ native SetFailState(const String:string[], any:...);
  * This blames another plugin for a function error.
  * @Note: Currently doesn't allow INVALID_HANDLE to be passed for plugin param.
  *
- * @param plugin        Plugin owning function your blaming error for.
- * @param blame         Method your blaming error for.
- * @param string		Format specifier string.
- * @param ...			Formatting arguments.
+ * @param plugin        Plugin owning function you're blaming error for.
+ * @param blame         Method you're blaming error for.
+ * @param format        Format specifier string.
+ * @param ...           Formatting arguments.
  * @noreturn
  * @error               Throws if plugin handle couldn't be read.
  */


### PR DESCRIPTION
Exposes recently added BlamePluginError method in IPluginContext to
allow SM plugins to utilize it. Ref:
https://forums.alliedmods.net/showthread.php?p=2367275

Note: Unable to test this as I have a VS 2015 installation(Can't remember where I found 2013 installer, will look for it).