### PR TITLE
Compile SQLite so it supports DELETE/ UPDATE limit

### DIFF
--- a/extensions/sqlite/AMBuilder
+++ b/extensions/sqlite/AMBuilder
@@ -12,7 +12,8 @@ elif binary.compiler.vendor == 'msvc':
 
 binary.compiler.defines += [
   'SQLITE_OMIT_LOAD_EXTENSION',
-  'SQLITE_THREADSAFE'
+  'SQLITE_THREADSAFE',
+  'SQLITE_ENABLE_UPDATE_DELETE_LIMIT'
 ]
 if builder.target_platform == 'linux':
   binary.compiler.postlink += ['-ldl', '-lpthread']


### PR DESCRIPTION
http://www.sqlite.org/compile.html#enable_update_delete_limit

We need this, to make the SQL drivers more friendly each-other.
I know that `unix_timestamp(now())` **MySQL** is `julianday('now')` **SQLite**, but for the basic update/ delete syntax... Updating/ deleting limitation must work on SQLite as well.