### PR TITLE
Don't export (all) symbols from included static lib on Linux/Mac.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -216,7 +216,7 @@ class SMConfig(object):
       '-Wno-overloaded-virtual',
       '-fvisibility-inlines-hidden',
     ]
-    cxx.linkflags += ['-m32']
+    cxx.linkflags += ['-m32', '-Wl,--exclude-libs,ALL']
 
     have_gcc = cxx.vendor == 'gcc'
     have_clang = cxx.vendor == 'clang'


### PR DESCRIPTION
@asherkin 

Partial fix for https://github.com/Source-Python-Dev-Team/Source.Python/issues/101
(Source.Python will need the same or similar fix applied as well)