### PR TITLE
Fix for crashes related to the GameRules_Set* natives.

### DIFF
--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -264,7 +264,6 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 		*(int32_t *)((intptr_t)pGameRules + offset) = params[2];
 		if (sendChange)
 		{
-			*(int32_t *)((intptr_t)pProxy + offset) = params[2];
 			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 		}
 	}
@@ -273,7 +272,6 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 		*(int16_t *)((intptr_t)pGameRules + offset) = (int16_t)params[2];
 		if (sendChange)
 		{
-			*(int16_t *)((intptr_t)pProxy + offset) = (int16_t)params[2];
 			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 		}
 	}
@@ -282,7 +280,6 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 		*(int8_t *)((intptr_t)pGameRules + offset) = (int8_t)params[2];
 		if (sendChange)
 		{
-			*(int8_t *)((intptr_t)pProxy + offset) = (int8_t)params[2];
 			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 		}
 	}
@@ -291,7 +288,6 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 		*(bool *)((intptr_t)pGameRules + offset) = (params[2] == 0) ? false : true;
 		if (sendChange)
 		{
-			*(bool *)((intptr_t)pProxy + offset) = (params[2] == 0) ? false : true;
 			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 		}
 	}
@@ -350,7 +346,6 @@ static cell_t GameRules_SetPropFloat(IPluginContext *pContext, const cell_t *par
 
 	if (sendChange)
 	{
-		*(float *)((intptr_t)pProxy + offset) = newVal;
 		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 	}
 
@@ -430,17 +425,6 @@ static cell_t GameRules_SetPropEnt(IPluginContext *pContext, const cell_t *param
 
 	if (sendChange)
 	{
-		CBaseHandle &hndl = *(CBaseHandle *)((intptr_t)pProxy + offset);
-		if (params[2] == -1)
-		{
-			hndl.Set(NULL);
-		}
-		else
-		{
-			IHandleEntity *pHandleEnt = (IHandleEntity *)pOther;
-			hndl.Set(pHandleEnt);
-		}
-
 		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 	}
 
@@ -510,11 +494,6 @@ static cell_t GameRules_SetPropVector(IPluginContext *pContext, const cell_t *pa
 
 	if (sendChange)
 	{
-		v = (Vector *)((intptr_t)pProxy + offset);
-		v->x = sp_ctof(vec[0]);
-		v->y = sp_ctof(vec[1]);
-		v->z = sp_ctof(vec[2]);
-
 		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 	}
 
@@ -625,8 +604,6 @@ static cell_t GameRules_SetPropString(IPluginContext *pContext, const cell_t *pa
 
 	if (sendChange)
 	{
-		dest = (char *)((intptr_t)pProxy + offset);
-		strncopy(dest, src, maxlen);
 		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
 	}
 


### PR DESCRIPTION
## The GameRules_Set* natives cause memory corruption when changeState is set to true.

This gave us a lot of grief with our stop that tank mod. Eventually a TF2 update made the crashes reliable enough that I was able to track down the root of the problem:

`GameRules_SetProp("m_bPlayingHybrid_CTF_CP", true, 4, 0, true);`
`*(bool *)((intptr_t)pProxy + offset) = (params[2] == 0) ? false : true;`

It makes no sense to directly set the value on CTFGameRulesProxy. Anytime the game makes a change to CTFGameRules, it calls CGameRulesProxy::NotifyNetworkStateChanged which then runs the equivalent of CBaseEdict::StateChanged(). It should be sufficient enough to mark the offset as changed so I left that portion unchanged. I've tested this and my client gets the change immediately.

I've looked at both the CTFGameRules and CTFGameRulesProxy pointers in memory and their class structure isn't the same. When running the `GameRules_SetProp`, it ends up corrupting memory that belongs to another entity.

### Recreate the crash
This is tricky due to the inherently random nature..but this process has been reliable on Windows (TF2):
1. Start the server on pl_badwater
2. Run the following command from a plugin: `GameRules_SetProp("m_bPlayingHybrid_CTF_CP", true, 4, 0, true);`
3. Change the map to ctf_turbine

It seems to frequently crash on round start as well. Last time I tested Linux was Tough Break and it crashed almost instantly. Since patching this, almost all our crashes have stopped. I think this would have been discovered sooner if the default value of changeState was not false. Thanks for reading!