### PR TITLE
Implement an auto-escaping Format native for SQL query construction

### DIFF
--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -32,6 +32,7 @@
 #include "common_logic.h"
 #include "Database.h"
 #include "ExtensionSys.h"
+#include "sprintf.h"
 #include "stringutil.h"
 #include "ISourceMod.h"
 #include "AutoHandleRooter.h"
@@ -730,6 +731,24 @@ static cell_t SQL_QuoteString(IPluginContext *pContext, const cell_t *params)
 	*addr = (cell_t)written;
 
 	return s ? 1 : 0;
+}
+
+static cell_t SQL_FormatQuery(IPluginContext *pContext, const cell_t *params)
+{
+	IDatabase *db = NULL;
+	HandleError err;
+
+	if ((err = g_DBMan.ReadHandle(params[1], DBHandle_Database, (void **)&db))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid database Handle %x (error: %d)", params[1], err);
+	}
+
+	g_FormatEscapeDatabase = db;
+	cell_t result = InternalFormat(pContext, params, 1);
+	g_FormatEscapeDatabase = NULL;
+
+	return result;
 }
 
 static cell_t SQL_FastQuery(IPluginContext *pContext, const cell_t *params)
@@ -1814,6 +1833,7 @@ REGISTER_NATIVES(dbNatives)
 	{"Database.Driver.get",				Database_Driver_get},
 	{"Database.SetCharset",				SQL_SetCharset},
 	{"Database.Escape",					SQL_QuoteString},
+	{"Database.Format",					SQL_FormatQuery},
 	{"Database.IsSameConnection",		SQL_IsSameConnection},
 	{"Database.Execute",				SQL_ExecuteTransaction},
 
@@ -1827,6 +1847,7 @@ REGISTER_NATIVES(dbNatives)
 	{"SQL_Connect",				SQL_Connect},
 	{"SQL_ConnectEx",			SQL_ConnectEx},
 	{"SQL_EscapeString",		SQL_QuoteString},
+	{"SQL_FormatQuery",			SQL_FormatQuery},
 	{"SQL_Execute",				SQL_Execute},
 	{"SQL_FastQuery",			SQL_FastQuery},
 	{"SQL_FetchFloat",			SQL_FetchFloat},

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -146,7 +146,7 @@ error_out:
 	return 0;
 }
 
-void AddString(char **buf_p, size_t &maxlen, const char *string, int width, int prec, int flags)
+bool AddString(char **buf_p, size_t &maxlen, const char *string, int width, int prec, int flags)
 {
 	int size = 0;
 	char *buf;
@@ -196,6 +196,8 @@ void AddString(char **buf_p, size_t &maxlen, const char *string, int width, int 
 	}
 
 	*buf_p = buf;
+
+	return true;
 }
 
 void AddFloat(char **buf_p, size_t &maxlen, double fval, int width, int prec, int flags)
@@ -1140,7 +1142,8 @@ reswitch:
 						sizeof(buffer),
 						"Console<0><Console><Console>");
 				}
-				AddString(&buf_p, llen, buffer, width, prec, flags);
+				if (!AddString(&buf_p, llen, buffer, width, prec, flags))
+					return pCtx->ThrowNativeError("Escaped string would be truncated (arg %d)", arg);
 				arg++;
 				break;
 			}
@@ -1155,7 +1158,8 @@ reswitch:
 					if (!bridge->DescribePlayer(*value, &name, nullptr, nullptr))
 						return pCtx->ThrowNativeError("Client index %d is invalid (arg %d)", *value, arg);
 				}
-				AddString(&buf_p, llen, name, width, prec, flags);
+				if (!AddString(&buf_p, llen, name, width, prec, flags))
+					return pCtx->ThrowNativeError("Escaped string would be truncated (arg %d)", arg);
 				arg++;
 				break;
 			}
@@ -1164,7 +1168,8 @@ reswitch:
 				CHECK_ARGS(0);
 				char *str;
 				pCtx->LocalToString(params[arg], &str);
-				AddString(&buf_p, llen, str, width, prec, flags);
+				if (!AddString(&buf_p, llen, str, width, prec, flags))
+					return pCtx->ThrowNativeError("Escaped string would be truncated (arg %d)", arg);
 				arg++;
 				break;
 			}

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -147,7 +147,7 @@ error_out:
 	return 0;
 }
 
-void AddString(char **buf_p, size_t &maxlen, const char *string, int width, int prec)
+void AddString(char **buf_p, size_t &maxlen, const char *string, int width, int prec, int flags)
 {
 	int size = 0;
 	char *buf;
@@ -212,7 +212,7 @@ void AddFloat(char **buf_p, size_t &maxlen, double fval, int width, int prec, in
 
 	if (ke::IsNaN(fval))
 	{
-		AddString(buf_p, maxlen, "NaN", width, prec);
+		AddString(buf_p, maxlen, "NaN", width, prec, flags);
 		return;
 	}
 
@@ -750,7 +750,7 @@ reswitch:
 				}
 				const char *str = (const char *)params[curparam];
 				curparam++;
-				AddString(&buf_p, llen, str, width, prec);
+				AddString(&buf_p, llen, str, width, prec, flags);
 				arg++;
 				break;
 			}
@@ -1141,7 +1141,7 @@ reswitch:
 						sizeof(buffer),
 						"Console<0><Console><Console>");
 				}
-				AddString(&buf_p, llen, buffer, width, prec);
+				AddString(&buf_p, llen, buffer, width, prec, flags);
 				arg++;
 				break;
 			}
@@ -1156,7 +1156,7 @@ reswitch:
 					if (!bridge->DescribePlayer(*value, &name, nullptr, nullptr))
 						return pCtx->ThrowNativeError("Client index %d is invalid", *value);
 				}
-				AddString(&buf_p, llen, name, width, prec);
+				AddString(&buf_p, llen, name, width, prec, flags);
 				arg++;
 				break;
 			}
@@ -1165,7 +1165,7 @@ reswitch:
 				CHECK_ARGS(0);
 				char *str;
 				pCtx->LocalToString(params[arg], &str);
-				AddString(&buf_p, llen, str, width, prec);
+				AddString(&buf_p, llen, str, width, prec, flags);
 				arg++;
 				break;
 			}

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -36,9 +36,9 @@
 
 using namespace SourceMod;
 
-#define LADJUST			0x00000004		/* left adjustment */
-#define ZEROPAD			0x00000080		/* zero (as opposed to blank) pad */
-#define UPPERDIGITS		0x00000200		/* make alpha digits uppercase */
+#define LADJUST			0x00000001		/* left adjustment */
+#define ZEROPAD			0x00000002		/* zero (as opposed to blank) pad */
+#define UPPERDIGITS		0x00000004		/* make alpha digits uppercase */
 #define to_digit(c)		((c) - '0')
 #define is_digit(c)		((unsigned)to_digit(c) <= 9)
 

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -87,7 +87,7 @@ try_serverlang:
 	}
 	else
 	{
-		pCtx->ThrowNativeErrorEx(SP_ERROR_PARAM, "Translation failed: invalid client index %d", target);
+		pCtx->ThrowNativeErrorEx(SP_ERROR_PARAM, "Translation failed: invalid client index %d (arg %d)", target, *arg);
 		goto error_out;
 	}
 
@@ -102,13 +102,13 @@ try_serverlang:
 		{
 			if (pPhrases->FindTranslation(key, SOURCEMOD_LANGUAGE_ENGLISH, &pTrans) != Trans_Okay)
 			{
-				pCtx->ThrowNativeErrorEx(SP_ERROR_PARAM, "Language phrase \"%s\" not found", key);
+				pCtx->ThrowNativeErrorEx(SP_ERROR_PARAM, "Language phrase \"%s\" not found (arg %d)", key, *arg);
 				goto error_out;
 			}
 		}
 		else
 		{
-			pCtx->ThrowNativeErrorEx(SP_ERROR_PARAM, "Language phrase \"%s\" not found", key);
+			pCtx->ThrowNativeErrorEx(SP_ERROR_PARAM, "Language phrase \"%s\" not found (arg %d)", key, *arg);
 			goto error_out;
 		}
 	}
@@ -123,9 +123,8 @@ try_serverlang:
 		if ((*arg) + (max_params - 1) > (size_t)params[0])
 		{
 			pCtx->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, 
-				"Translation string formatted incorrectly - missing at least %d parameters", 
-				((*arg + (max_params - 1)) - params[0])
-				);
+				"Translation string formatted incorrectly - missing at least %d parameters (arg %d)", 
+				((*arg + (max_params - 1)) - params[0]), *arg);
 			goto error_out;
 		}
 
@@ -1127,7 +1126,7 @@ reswitch:
 					const char *auth;
 					int userid;
 					if (!bridge->DescribePlayer(*value, &name, &auth, &userid))
-						return pCtx->ThrowNativeError("Client index %d is invalid", *value);
+						return pCtx->ThrowNativeError("Client index %d is invalid (arg %d)", *value, arg);
 					ke::SafeSprintf(buffer, 
 						sizeof(buffer), 
 						"%s<%d><%s><>", 
@@ -1154,7 +1153,7 @@ reswitch:
 				const char *name = "Console";
 				if (*value) {
 					if (!bridge->DescribePlayer(*value, &name, nullptr, nullptr))
-						return pCtx->ThrowNativeError("Client index %d is invalid", *value);
+						return pCtx->ThrowNativeError("Client index %d is invalid (arg %d)", *value, arg);
 				}
 				AddString(&buf_p, llen, name, width, prec, flags);
 				arg++;

--- a/core/logic/sprintf.h
+++ b/core/logic/sprintf.h
@@ -30,6 +30,7 @@
 #include <sp_vm_api.h>
 
 namespace SourceMod {
+class IDatabase;
 class IPhraseCollection;
 }
 
@@ -56,5 +57,7 @@ bool gnprintf(char *buffer,
               unsigned int &curparam,
               size_t *pOutLength,
               const char **pFailPhrase);
+
+extern SourceMod::IDatabase *g_FormatEscapeDatabase;
 
 #endif // _include_sourcemod_core_logic_sprintf_h_

--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -29,11 +29,13 @@
  * Version: $Id$
  */
 
+#include "common_logic.h"
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <sm_platform.h>
 #include "stringutil.h"
+#include "sprintf.h"
 #include <am-string.h>
 #include "TextParsers.h"
 
@@ -361,3 +363,76 @@ char *UTIL_TrimWhitespace(char *str, size_t &len)
 	return str;
 }
 
+class StaticCharBuf
+{
+    char *buffer;
+    size_t max_size;
+public:
+    StaticCharBuf() : buffer(NULL), max_size(0)
+    {
+    }
+    ~StaticCharBuf()
+    {
+        free(buffer);
+    }
+    char* GetWithSize(size_t len)
+    {
+        if (len > max_size)
+        {
+            buffer = (char *)realloc(buffer, len);
+            max_size = len;
+        }
+        return buffer;
+    }
+};
+
+static char g_formatbuf[2048];
+static StaticCharBuf g_extrabuf;
+cell_t InternalFormat(IPluginContext *pCtx, const cell_t *params, int start)
+{
+	char *buf, *fmt, *destbuf;
+	cell_t start_addr, end_addr, maxparam;
+	size_t res, maxlen;
+	int arg = start + 4;
+	bool copy = false;
+	char *__copy_buf;
+
+	pCtx->LocalToString(params[start + 1], &destbuf);
+	pCtx->LocalToString(params[start + 3], &fmt);
+
+	maxlen = static_cast<size_t>(params[start + 2]);
+	start_addr = params[start + 1];
+	end_addr = params[start + 1] + maxlen;
+	maxparam = params[0];
+
+	for (cell_t i = (start + 3); i <= maxparam; i++)
+	{
+		if ((params[i] >= start_addr) && (params[i] <= end_addr))
+		{
+			copy = true;
+			break;
+		}
+	}
+
+	if (copy)
+	{
+		if (maxlen > sizeof(g_formatbuf))
+		{
+			__copy_buf = g_extrabuf.GetWithSize(maxlen);
+		}
+		else
+		{
+			__copy_buf = g_formatbuf;
+		}
+	}
+
+	buf = (copy) ? __copy_buf : destbuf;
+	res = atcprintf(buf, maxlen, fmt, pCtx, params, &arg);
+
+	if (copy)
+	{
+		memcpy(destbuf, __copy_buf, res+1);
+	}
+
+	return static_cast<cell_t>(res);
+}

--- a/core/logic/stringutil.h
+++ b/core/logic/stringutil.h
@@ -43,5 +43,9 @@ size_t UTIL_DecodeHexString(unsigned char *buffer, size_t maxlength, const char 
 void UTIL_StripExtension(const char *in, char *out, int outSize);
 char *UTIL_TrimWhitespace(char *str, size_t &len);
 
+// Internal copying Format helper, expects (char[] buffer, int maxlength, const char[] format, any ...) starting at |start|
+// i.e. you can stuff your own params before |buffer|.
+cell_t InternalFormat(IPluginContext *pCtx, const cell_t *params, int start);
+
 #endif /* _INCLUDE_SOURCEMOD_COMMON_STRINGUTIL_H_ */
 

--- a/extensions/sqlite/driver/SqDatabase.cpp
+++ b/extensions/sqlite/driver/SqDatabase.cpp
@@ -84,6 +84,18 @@ IDBDriver *SqDatabase::GetDriver()
 
 bool SqDatabase::QuoteString(const char *str, char buffer[], size_t maxlen, size_t *newSize)
 {
+	unsigned long size = static_cast<unsigned long>(strlen(str));
+	unsigned long needed = size * 2 + 1;
+
+	if (maxlen < needed)
+	{
+		if (newSize != NULL)
+		{
+			*newSize = (size_t)needed;
+		}
+		return false;
+	}
+
 	char *res = sqlite3_snprintf(static_cast<int>(maxlen), buffer, "%q", str);
 
 	if (res != NULL && newSize != NULL)

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -380,6 +380,16 @@ methodmap Database < Handle
 	//                       The buffer must be at least 2*strlen(string)+1.
 	public native bool Escape(const char[] string, char[] buffer, int maxlength, int &written=0);
 
+	// Formats a string according to the SourceMod format rules (see documentation).
+	// All format specifiers are escaped (see SQL_EscapeString) unless the '!' flag is used.
+	//
+	// @param buffer		Destination string buffer.
+	// @param maxlength		Maximum length of output string buffer.
+	// @param format		Formatting rules.
+	// @param ...			Variable number of format parameters.
+	// @return				Number of cells written.
+	public native int Format(const char[] buffer, int maxlength, const char[] format, any ...);
+
 	// Returns whether a database is the same connection as another database.
 	public native bool IsSameConnection(Database other);
 
@@ -640,6 +650,19 @@ native bool SQL_EscapeString(Handle database,
 							 char[] buffer, 
 							 int maxlength, 
 							 int &written=0);
+
+/**
+ * Formats a string according to the SourceMod format rules (see documentation).
+ * All format specifiers are escaped (see SQL_EscapeString) unless the '!' flag is used.
+ *
+ * @param database		A database Handle.
+ * @param buffer		Destination string buffer.
+ * @param maxlength		Maximum length of output string buffer.
+ * @param format		Formatting rules.
+ * @param ...			Variable number of format parameters.
+ * @return				Number of cells written.
+ */
+native int SQL_FormatQuery(Handle database, const char[] buffer, int maxlength, const char[] format, any ...);
 
 /**
  * This is a backwards compatibility stock.  You should use SQL_EscapeString() 


### PR DESCRIPTION
Probably best to look at this one commit-by-commit.

Will need some doc work on the wiki after landing.
The gist of it is that if formatting via the new native, "%s", "%N", "%L" etc are automatically escaped unless a new "!" flag is set (i.e. "%!s"), and an error is thrown if the string is going to be truncated (to avoid leaving a trailing escape character).

Old:
```
char name[MAX_NAME_LENGTH];
if (!GetClientName(client, name, sizeof(name))) {
  return false;
}

int safeNameLen = (strlen(name) * 2) + 1;
char[] safeName = new char[safeNameLen];
db.Escape(name, safeName, safeNameLen);

char steamId[32];
if (!GetClientAuthId(client, AuthId_Steam2, steamId, sizeof(steamId))) {
  return false;
}

int safeSteamIdLen = (strlen(steamId) * 2) + 1;
char[] safeSteamId = new char[safeSteamIdLen];
db.Escape(steamId, safeSteamId, safeSteamIdLen);

char buffer[512];
Format(buffer, sizeof(buffer), "UPDATE players SET name = '%s' WHERE steamid = '%s'", safeName, safeSteamId);
db.Query(OnQueryComplete, buffer);
```

New:
```
char steamId[32];
if (!GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid))) {
  return false;
}

char buffer[512];
db.Format(buffer, sizeof(buffer), "UPDATE players SET name = '%N' WHERE steamid = '%s'", client, steamId);
db.Query(OnQueryComplete, buffer);
```