### PR TITLE
GetClientSerial does not have @error documentation

### DIFF
--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -821,6 +821,7 @@ native ChangeClientTeam(client, team);
  *
  * @param client		Client index.
  * @return	Serial number.
+ * @error				Invalid client index, or client not connected.
  */
 native GetClientSerial(client);
 


### PR DESCRIPTION
I encountered a 

>  Native "GetClientSerial" reported: Client index 0 is invalid

With the clients.inc not saying it could throw errors. 
