### PR TITLE
Don't try to call functions in paused plugins

### DIFF
--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -252,6 +252,9 @@ int CForward::Execute(cell_t *result, IForwardFilter *filter)
 		if (filter)
 			filter->Preprocess(func, temp_info);
 
+		if (func->GetParentRuntime()->IsPaused())
+			continue;
+
 		for (unsigned int i=0; i<num_params; i++)
 		{
 			int err = SP_ERROR_PARAM;


### PR DESCRIPTION
This avoids spam of "Plugin not runnable" exceptions on shutdown or
plugin unload.

When re/unloading a plugin which has other ones depending on it, like
the adminmenu, It pauses the depending plugins putting them in an
"Depends on plugin: %s" error state. ForwardSys doesn't remove them from
the forward lists on pause, specially the global forwards, and still
tries to call all the global forwards like OnPlayerRunCmd and
OnLibraryAdded etc. on the paused plugins. Executing functions in paused
runtimes has been ignored in the VM before introducing the "Exception"
mechanism, but now they're all logged.

This adds checks to make sure the plugin is runnable before calling a
function. (Stolen from #438)