### PR TITLE
Format instead of BreakString

### DIFF
--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -279,7 +279,7 @@ public Action:Command_SmPsay(client, args)
 	GetCmdArgString(text, sizeof(text));
 
 	new len = BreakString(text, arg, sizeof(arg));
-	BreakString(text[len], message, sizeof(message));
+	Format(message,sizeof(message),"%s",text[len]);
 	
 	new target = FindTarget(client, arg, true, false);
 		


### PR DESCRIPTION
BreakString cuts off the following arguments:
sm_psay @me 1 2 3 //1
using format, or whatever is better it now prints:
sm_psay @me 1 2 3 //1 2 3