### PR TITLE
Always send changes when using the GameRules_SetProp* natives.

### DIFF
--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -229,14 +229,10 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 	int offset;
 	int bit_count;
 
-	bool sendChange = true;
-	if (params[5] == 0)
-		sendChange = false;
-
 	void *pGameRules = GameRules();
 
 	CBaseEntity *pProxy = NULL;
-	if (sendChange && ((pProxy = GetGameRulesProxyEnt()) == NULL))
+	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity");
 	
 	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
@@ -262,35 +258,23 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 	if (bit_count >= 17)
 	{
 		*(int32_t *)((intptr_t)pGameRules + offset) = params[2];
-		if (sendChange)
-		{
-			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-		}
 	}
 	else if (bit_count >= 9)
 	{
 		*(int16_t *)((intptr_t)pGameRules + offset) = (int16_t)params[2];
-		if (sendChange)
-		{
-			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-		}
 	}
 	else if (bit_count >= 2)
 	{
 		*(int8_t *)((intptr_t)pGameRules + offset) = (int8_t)params[2];
-		if (sendChange)
-		{
-			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-		}
 	}
 	else
 	{
 		*(bool *)((intptr_t)pGameRules + offset) = (params[2] == 0) ? false : true;
-		if (sendChange)
-		{
-			gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-		}
 	}
+
+	edict_t *proxyEdict = gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy));
+	if (proxyEdict != NULL)
+		gamehelpers->SetEdictStateChanged(proxyEdict, offset);
 
 	return 0;
 }
@@ -323,14 +307,10 @@ static cell_t GameRules_SetPropFloat(IPluginContext *pContext, const cell_t *par
 	int offset;
 	int bit_count;
 
-	bool sendChange = true;
-	if (params[4] == 0)
-		sendChange = false;
-
 	void *pGameRules = GameRules();
 
 	CBaseEntity *pProxy = NULL;
-	if (sendChange && ((pProxy = GetGameRulesProxyEnt()) == NULL))
+	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
 	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
@@ -344,10 +324,9 @@ static cell_t GameRules_SetPropFloat(IPluginContext *pContext, const cell_t *par
 
 	*(float *)((intptr_t)pGameRules + offset) = newVal;
 
-	if (sendChange)
-	{
-		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-	}
+	edict_t *proxyEdict = gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy));
+	if (proxyEdict != NULL)
+		gamehelpers->SetEdictStateChanged(proxyEdict, offset);
 
 	return 0;
 }
@@ -386,14 +365,10 @@ static cell_t GameRules_SetPropEnt(IPluginContext *pContext, const cell_t *param
 	int offset;
 	int bit_count;
 
-	bool sendChange = true;
-	if (params[4] == 0)
-		sendChange = false;
-
 	void *pGameRules = GameRules();
 
 	CBaseEntity *pProxy = NULL;
-	if (sendChange && ((pProxy = GetGameRulesProxyEnt()) == NULL))
+	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
 	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
@@ -423,10 +398,9 @@ static cell_t GameRules_SetPropEnt(IPluginContext *pContext, const cell_t *param
 		hndl.Set(pHandleEnt);
 	}
 
-	if (sendChange)
-	{
-		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-	}
+	edict_t *proxyEdict = gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy));
+	if (proxyEdict != NULL)
+		gamehelpers->SetEdictStateChanged(proxyEdict, offset);
 
 	return 0;
 }
@@ -466,14 +440,10 @@ static cell_t GameRules_SetPropVector(IPluginContext *pContext, const cell_t *pa
 	int offset;
 	int bit_count;
 
-	bool sendChange = true;
-	if (params[4] == 0)
-		sendChange = false;
-
 	void *pGameRules = GameRules();
 
 	CBaseEntity *pProxy = NULL;
-	if (sendChange && ((pProxy = GetGameRulesProxyEnt()) == NULL))
+	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
 	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
@@ -492,10 +462,9 @@ static cell_t GameRules_SetPropVector(IPluginContext *pContext, const cell_t *pa
 	v->y = sp_ctof(vec[1]);
 	v->z = sp_ctof(vec[2]);
 
-	if (sendChange)
-	{
-		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-	}
+	edict_t *proxyEdict = gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy));
+	if (proxyEdict != NULL)
+		gamehelpers->SetEdictStateChanged(proxyEdict, offset);
 
 	return 1;
 }
@@ -563,14 +532,10 @@ static cell_t GameRules_SetPropString(IPluginContext *pContext, const cell_t *pa
 	int offset;
 	int maxlen;
 
-	bool sendChange = true;
-	if (params[3] == 0)
-		sendChange = false;
-
 	void *pGameRules = GameRules();
 
 	CBaseEntity *pProxy = NULL;
-	if (sendChange && ((pProxy = GetGameRulesProxyEnt()) == NULL))
+	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
 	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
@@ -602,10 +567,9 @@ static cell_t GameRules_SetPropString(IPluginContext *pContext, const cell_t *pa
 	pContext->LocalToString(params[2], &src);
 	size_t len = strncopy(dest, src, maxlen);
 
-	if (sendChange)
-	{
-		gamehelpers->SetEdictStateChanged(gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy)), offset);
-	}
+	edict_t *proxyEdict = gamehelpers->EdictOfIndex(gamehelpers->EntityToBCompatRef(pProxy));
+	if (proxyEdict != NULL)
+		gamehelpers->SetEdictStateChanged(proxyEdict, offset);
 
 	return len;
 }

--- a/plugins/include/sdktools_gamerules.inc
+++ b/plugins/include/sdktools_gamerules.inc
@@ -93,7 +93,7 @@ native GameRules_GetProp(const String:prop[], size=4, element=0);
  *						This value is auto-detected, and the size parameter is 
  *						only used as a fallback in case detection fails.
  * @param element		Element # (starting from 0) if property is an array.
- * @param changeState	If true, change will be sent over the network.
+ * @param changeState	This parameter is ignored.
  * @error				Not supported.
  * @noreturn
  */
@@ -115,7 +115,7 @@ native Float:GameRules_GetPropFloat(const String:prop[], element=0);
  * @param prop			Property name.
  * @param value			Value to set.
  * @param element		Element # (starting from 0) if property is an array.
- * @param changeState	If true, change will be sent over the network.
+ * @param changeState	This parameter is ignored.
  * @noreturn
  * @error				Not supported.
  */
@@ -139,7 +139,7 @@ native GameRules_GetPropEnt(const String:prop[], element=0);
  * @param prop			Property name.
  * @param other			Entity index to set, or -1 to unset.
  * @param element		Element # (starting from 0) if property is an array.
- * @param changeState	If true, change will be sent over the network.
+ * @param changeState	This parameter is ignored.
  * @noreturn
  * @error				Not supported.
  */
@@ -162,7 +162,7 @@ native GameRules_GetPropVector(const String:prop[], Float:vec[3], element=0);
  * @param prop			Property name.
  * @param vec			Vector to set.
  * @param element		Element # (starting from 0) if property is an array.
- * @param changeState	If true, change will be sent over the network.
+ * @param changeState	This parameter is ignored.
  * @noreturn
  * @error				Not supported.
  */
@@ -184,7 +184,7 @@ native GameRules_GetPropString(const String:prop[], String:buffer[], maxlen);
  *
  * @param prop			Property to use.
  * @param buffer		String to set.		
- * @param changeState	If true, change will be sent over the network.
+ * @param changeState	This parameter is ignored.
  * @return				Number of non-null bytes written.
  * @error				Not supported.
  */


### PR DESCRIPTION
This is a follow up to https://github.com/alliedmodders/sourcemod/pull/473#issuecomment-179506496.

Essentially, it forces changeState to true for all the GameRules_SetProp* natives. This brings the behavior in line with that of the SetEntProp* natives. I can't find a use case for not marking the offsets as changed. That just means that clients won't see the change until the game logic happens to change another game rules property, calling StateChanged().