### PR TITLE
Add support for retrieving game server Steam Id (bug 6404).

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1398,6 +1398,17 @@ bool CHalfLife2::GetServerSteam3Id(char *pszOut, size_t len) const
 	return true;
 }
 
+#if defined( PLATFORM_WINDOWS )
+#define STEAM_LIB_PREFIX
+#define STEAM_LIB_SUFFIX
+#elif defined( PLATFORM_LINUX )
+#define STEAM_LIB_PREFIX "lib"
+#define STEAM_LIB_SUFFIX ".so"
+#elif defined( PLATFORM_APPLE )
+#define STEAM_LIB_PREFIX "lib"
+#define STEAM_LIB_SUFFIX ".dylib"
+#endif
+
 uint64_t CHalfLife2::GetServerSteamId64() const
 {
 #if SOURCE_ENGINE == SE_BLADE          \
@@ -1421,7 +1432,7 @@ uint64_t CHalfLife2::GetServerSteamId64() const
 	static GetServerSteamIdFn fn = nullptr;
 	if (!fn)
 	{
-		ke::SharedLib steam_api("steam_api");
+		ke::SharedLib steam_api(STEAM_LIB_PREFIX "steam_api" STEAM_LIB_SUFFIX);
 		if (steam_api.valid())
 		{
 			fn = (GetServerSteamIdFn)steam_api.lookup("SteamGameServer_GetSteamID");

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2016 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -1375,3 +1375,64 @@ string_t CHalfLife2::AllocPooledString(const char *pszValue)
 	return newString;
 }
 #endif
+
+bool CHalfLife2::GetServerSteam3Id(char *pszOut, size_t len) const
+{
+	CSteamID sid(GetServerSteamId64());
+
+	switch (sid.GetEAccountType())
+	{
+	case k_EAccountTypeAnonGameServer:
+		ke::SafeSprintf(pszOut, len, "[A:%u:%u:%u]", sid.GetEUniverse(), sid.GetAccountID(), sid.GetUnAccountInstance());
+		break;
+	case k_EAccountTypeGameServer:
+		ke::SafeSprintf(pszOut, len, "[G:%u:%u]", sid.GetEUniverse(), sid.GetAccountID());
+		break;
+	case k_EAccountTypeInvalid:
+		ke::SafeSprintf(pszOut, len, "[I:%u:%u]", sid.GetEUniverse(), sid.GetAccountID());
+		break;
+	default:
+		return false;
+	}
+
+	return true;
+}
+
+uint64_t CHalfLife2::GetServerSteamId64() const
+{
+#if SOURCE_ENGINE == SE_BLADE          \
+	|| SOURCE_ENGINE == SE_BMS         \
+	|| SOURCE_ENGINE == SE_CSGO        \
+	|| SOURCE_ENGINE == SE_CSS         \
+	|| SOURCE_ENGINE == SE_DODS        \
+	|| SOURCE_ENGINE == SE_EYE         \
+	|| SOURCE_ENGINE == SE_HL2DM       \
+	|| SOURCE_ENGINE == SE_INSURGENCY  \
+	|| SOURCE_ENGINE == SE_SDK2013     \
+	|| SOURCE_ENGINE == SE_ALIENSWARM  \
+	|| SOURCE_ENGINE == SE_TF2
+	const CSteamID *sid = engine->GetGameServerSteamID();
+	if (sid)
+	{
+		return sid->ConvertToUint64();
+	}
+#else
+	typedef uint64_t(* GetServerSteamIdFn)(void);
+	static GetServerSteamIdFn fn = nullptr;
+	if (!fn)
+	{
+		ke::SharedLib steam_api("steam_api");
+		if (steam_api.valid())
+		{
+			fn = (GetServerSteamIdFn)steam_api.lookup("SteamGameServer_GetSteamID");
+		}
+	}
+
+	if (fn)
+	{
+		return fn();
+	}
+#endif
+
+	return 1ULL;
+}

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2016 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -194,6 +194,8 @@ public: //IGameHelpers
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	string_t AllocPooledString(const char *pszValue);
 #endif
+	bool GetServerSteam3Id(char *pszOut, size_t len) const override;
+	uint64_t GetServerSteamId64() const override;
 public:
 	void AddToFakeCliCmdQueue(int client, int userid, const char *cmd);
 	void ProcessFakeCliCmdQueue();

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -81,6 +81,7 @@ binary.sources += [
   'RootConsoleMenu.cpp',
   'CDataPack.cpp',
   'frame_tasks.cpp',
+  'smn_halflife.cpp',
 ]
 if builder.target_platform == 'windows':
   binary.sources += ['thread/WinThreads.cpp']

--- a/core/logic/smn_halflife.cpp
+++ b/core/logic/smn_halflife.cpp
@@ -1,0 +1,69 @@
+/**
+* vim: set ts=4 sw=4 tw=99 noet :
+* =============================================================================
+* SourceMod
+* Copyright (C) 2004-2016 AlliedModders LLC.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, AlliedModders LLC gives you permission to link the
+* code of this program (as well as its derivative works) to "Half-Life 2," the
+* "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, AlliedModders LLC grants
+* this exception to all derivative works.  AlliedModders LLC defines further
+* exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+* or <http://www.sourcemod.net/license.php>.
+*
+* Version: $Id$
+*/
+
+#include "common_logic.h"
+#include <IGameHelpers.h>
+#include <am-string.h>
+
+#include <inttypes.h>
+
+static cell_t GetServerAuthId(IPluginContext *pContext, const cell_t *params)
+{
+	cell_t *pOut;
+	pContext->LocalToPhysAddr(params[2], &pOut);
+
+	switch ((AuthIdType)params[1])
+	{
+	case AuthIdType::Steam3:
+		gamehelpers->GetServerSteam3Id((char *)pOut, params[3]);
+		break;
+
+	case AuthIdType::SteamId64:
+		ke::SafeSprintf((char *)pOut, params[3], "%" PRIu64, gamehelpers->GetServerSteamId64());
+		break;
+	default:
+		return pContext->ThrowNativeError("Unsupported AuthIdType (%d) for GetServerAuthId.", params[1]);
+	}
+
+	return 1;
+}
+
+static cell_t GetServerAccountId(IPluginContext *pContext, const cell_t *params)
+{
+	return (cell_t)(gamehelpers->GetServerSteamId64() & 0xFFFFFFFF);
+}
+
+REGISTER_NATIVES(halflifeNatives)
+{
+	{ "GetServerAuthId",			GetServerAuthId },
+	{ "GetServerSteamAccountId",	GetServerAccountId },
+	{ nullptr, 						nullptr }
+};

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -2,7 +2,7 @@
  * vim: set ts=4 sw=4 tw=99 noet :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2016 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -335,15 +335,6 @@ static cell_t sm_GetClientIP(IPluginContext *pCtx, const cell_t *params)
 	pCtx->StringToLocal(params[2], static_cast<size_t>(params[3]), buf);
 	return 1;
 }
-
-// Must match clients.inc
-enum class AuthIdType
-{
-	Engine = 0,
-	Steam2,
-	Steam3,
-	SteamId64,
-};
 
 static cell_t SteamIdToLocal(IPluginContext *pCtx, int index, AuthIdType authType, cell_t local_addr, size_t bytes, bool validate)
 {

--- a/core/sm_globals.h
+++ b/core/sm_globals.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 sw=4 :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2009 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2016 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -63,6 +63,15 @@ enum ConfigSource
 {
 	ConfigSource_File = 0,		/**< Config option was set from config file (core.cfg) */
 	ConfigSource_Console = 1,	/**< Config option was set from console command (sm config) */
+};
+
+// Must match clients.inc
+enum class AuthIdType
+{
+	Engine = 0,
+	Steam2,
+	Steam3,
+	SteamId64,
 };
 
 /** 

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -1,7 +1,7 @@
 /**
  * vim: set ts=4 :
  * =============================================================================
- * SourceMod (C)2004-2008 AlliedModders LLC.  All rights reserved.
+ * SourceMod (C)2004-2016 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This file is part of the SourceMod/SourcePawn SDK.
@@ -692,3 +692,23 @@ enum ClientRangeType
  */
 native int GetClientsInRange(float origin[3], ClientRangeType rangeType, int[] clients, int size);
 
+/**
+ * Retrieves the server's authentication string (SteamID).
+ *
+ * Note: If called before server is connected to Steam, auth id
+ * will be invalid ([I:0:1], 1, etc.)
+ *
+ * @param authType		Auth id type and format to use.
+ * 						(Only AuthId_Steam3 and AuthId_SteamID64 are supported)
+ * @param auth			Buffer to store the server's auth id.
+ * @param maxlen		Maximum length of string buffer (includes NULL terminator).
+ * @error				Invalid AuthIdType given.
+ */
+native void GetServerAuthId(AuthIdType authType, char[] auth, int maxlen);
+
+/**
+ * Returns the server's Steam account ID.
+ *
+ * @return				Steam account ID or 0 if not available.
+ */
+native int GetServerSteamAccountId();

--- a/public/IGameHelpers.h
+++ b/public/IGameHelpers.h
@@ -2,7 +2,7 @@
  * vim: set ts=4 :
  * =============================================================================
  * SourceMod
- * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * Copyright (C) 2004-2016 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -40,7 +40,7 @@
  */
 
 #define SMINTERFACE_GAMEHELPERS_NAME		"IGameHelpers"
-#define SMINTERFACE_GAMEHELPERS_VERSION		10
+#define SMINTERFACE_GAMEHELPERS_VERSION		11
 
 class CBaseEntity;
 class CBaseHandle;
@@ -335,6 +335,23 @@ namespace SourceMod
 		 *						on failure.
 		 */
 		virtual bool FindDataMapInfo(datamap_t *pMap, const char *offset, sm_datatable_info_t *pDataTable) =0;
+
+		/**
+		 * @brief Retrieves the server's rendered Steam3 id.
+		 *
+		 * @param pszOut		Buffer to which id will be copied.
+		 * @param len			Max size of buffer in bytes.
+		 * @return				True on id successfully retrieved and buffer populated
+		 *						(even if id invalid/unset) false on failure (unknown id type).
+		 */
+		virtual bool GetServerSteam3Id(char *pszOut, size_t len) const =0;
+
+		/**
+		 * @brief Retrieves the server's SteamID64.
+		 *
+		 * @return				64-bit server Steam id.
+		 */
+		virtual uint64_t GetServerSteamId64() const =0;
 	};
 }
 


### PR DESCRIPTION
This has been requested a few times and isn't too bad to add.

It could have been done simpler, but this leaves a segue to move more natives to the logic bin.