### PR TITLE
Actual support for milliseconds since epoch

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -152,13 +152,17 @@ void LogAction(Handle_t hndl, int type, int client, int target, const char *mess
 
 static cell_t GetTime(IPluginContext *pContext, const cell_t *params)
 {
-	time_t t = g_pSM->GetAdjustedTime();
+	time_t seconds = g_pSM->GetAdjustedTime();
+	struct timeval timev;
+	gettimeofday(&timev, NULL);
+	long long millis = (long long)seconds * 1000 + timev.tv_usec / 1000;
+
 	cell_t *addr;
 	pContext->LocalToPhysAddr(params[1], &addr);
+	addr[0] = (time_t)(millis >> 31); // Shift left by the length of an int to get the first half.
+	addr[1] = (time_t)(millis - addr[0]); // Subtract the first half to get the second half.
 
-	*(time_t *)addr = t;
-
-	return static_cast<cell_t>(t);
+	return static_cast<cell_t>(seconds);
 }
 
 #if defined SUBPLATFORM_SECURECRT

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -47,6 +47,7 @@
 #include <limits.h>
 #include <unistd.h>
 #include <sys/times.h>
+#include <sys/time.h>
 #endif
 #include <IForwardSys.h>
 #include <ILibrarySys.h>


### PR DESCRIPTION
While it is also valid to use addr[1] = (time_t)(millis % (1 << 31)), it's about 3% slower.
I use long long rather than long because some systems don't require long to be 64 bit. Long long is always at least 64 bits.