### PR TITLE
Allow support for running on filesystems that use 64-bit inodes on Linux.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -291,7 +291,7 @@ class SMConfig(object):
     cxx.cflags += ['/Oy-']
 
   def configure_linux(self, cxx):
-    cxx.defines += ['_LINUX', 'POSIX']
+    cxx.defines += ['_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
     cxx.linkflags += ['-Wl,--exclude-libs,ALL', '-lm']
     if cxx.vendor == 'gcc':
       cxx.linkflags += ['-static-libgcc']


### PR DESCRIPTION
Most supported games don't even support this case, but at least CS:GO does. WIthout
this fix, some filesystem calls can fail, or in the case of readdir, fail to return all/any files.
This was first observed when using an XFS-formatted volume on CentOS 7 x64.

@asherkin 