### PR TITLE
Allow Plugin_Changed return on event PreHooks to not block.

### DIFF
--- a/core/EventManager.cpp
+++ b/core/EventManager.cpp
@@ -424,7 +424,7 @@ bool EventManager::OnFireEvent(IGameEvent *pEvent, bool bDontBroadcast)
 			m_EventCopies.push(gameevents->DuplicateEvent(pEvent));
 		}
 
-		if (res)
+		if (res >= Pl_Handled)
 		{
 			gameevents->FreeEvent(pEvent);
 			RETURN_META_VALUE(MRES_SUPERCEDE, false);


### PR DESCRIPTION
This avoids issues from confusion that users have, returning Plugin_Changed
after altering event data, when Plugin_Changed isn't required and wasn't supported
in that scenario, and instead acted like Plugin_Handled.