### PR TITLE
Add support for sending gameevent to specific client.

### DIFF
--- a/core/EventManager.cpp
+++ b/core/EventManager.cpp
@@ -31,6 +31,8 @@
 
 #include "EventManager.h"
 #include "sm_stringutil.h"
+#include "PlayerManager.h"
+
 #include "logic_bridge.h"
 #include <bridge/include/IScriptManager.h>
 
@@ -358,6 +360,13 @@ void EventManager::FireEvent(EventInfo *pInfo, bool bDontBroadcast)
 
 	/* Add EventInfo struct to free event stack */
 	m_FreeEvents.push(pInfo);
+}
+
+void EventManager::FireEventToClient(EventInfo *pInfo, IClient *pClient)
+{
+	// The IClient vtable is +4 from the IGameEventListener2 (CBaseClient) vtable due to multiple inheritance.
+	IGameEventListener2 *pGameClient = (IGameEventListener2 *)((intptr_t)pClient - 4);
+	pGameClient->FireGameEvent(pInfo->pEvent);
 }
 
 void EventManager::CancelCreatedEvent(EventInfo *pInfo)

--- a/core/EventManager.h
+++ b/core/EventManager.h
@@ -41,6 +41,8 @@
 #include <IForwardSys.h>
 #include <IPluginSys.h>
 
+class IClient;
+
 using namespace SourceHook;
 
 struct EventInfo
@@ -126,6 +128,7 @@ public:
 	EventHookError UnhookEvent(const char *name, IPluginFunction *pFunction, EventHookMode mode=EventHookMode_Post);
 	EventInfo *CreateEvent(IPluginContext *pContext, const char *name, bool force=false);
 	void FireEvent(EventInfo *pInfo, bool bDontBroadcast=false);
+	void FireEventToClient(EventInfo *pInfo, IClient *pClient);
 	void CancelCreatedEvent(EventInfo *pInfo);
 private: // IGameEventManager2 hooks
 	bool OnFireEvent(IGameEvent *pEvent, bool bDontBroadcast);

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -48,6 +48,8 @@
 
 using namespace SourceHook;
 
+class IClient;
+
 #define PLAYER_LIFE_UNKNOWN	0
 #define PLAYER_LIFE_ALIVE	1
 #define PLAYER_LIFE_DEAD	2
@@ -104,6 +106,9 @@ public:
 	void DoBasicAdminChecks();
 	void MarkAsBeingKicked();
 	int GetLifeState();
+
+	// This can be NULL for fakeclients due to limitations in our impl
+	IClient *GetIClient() const;
 private:
 	void Initialize(const char *name, const char *ip, edict_t *pEntity);
 	void Connect();

--- a/core/smn_events.cpp
+++ b/core/smn_events.cpp
@@ -187,7 +187,7 @@ static cell_t sm_FireEventToClient(IPluginContext *pContext, const cell_t *param
 	IClient *pClient = pPlayer->GetIClient();
 	if (!pClient)
 	{
-		return pContext->ThrowNativeError("Sending events to fakeclints is not supported on this game (client %d)", client);
+		return pContext->ThrowNativeError("Sending events to fakeclients is not supported on this game (client %d)", client);
 	}
 
 	g_EventManager.FireEventToClient(pInfo, pClient);

--- a/core/smn_events.cpp
+++ b/core/smn_events.cpp
@@ -32,6 +32,7 @@
 #include "sm_globals.h"
 #include "sourcemm_api.h"
 #include "EventManager.h"
+#include "PlayerManager.h"
 #include "logic_bridge.h"
 
 static cell_t sm_HookEvent(IPluginContext *pContext, const cell_t *params)
@@ -142,6 +143,54 @@ static cell_t sm_FireEvent(IPluginContext *pContext, const cell_t *params)
 
 	/* Free handle on game event */
 	handlesys->FreeHandle(hndl, &sec);
+
+	return 1;
+}
+
+static cell_t sm_FireEventToClient(IPluginContext *pContext, const cell_t *params)
+{
+	Handle_t hndl = static_cast<Handle_t>(params[1]);
+	HandleError err;
+	EventInfo *pInfo;
+	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
+
+	if ((err = handlesys->ReadHandle(hndl, g_EventManager.GetHandleType(), &sec, (void **)&pInfo))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid game event handle %x (error %d)", hndl, err);
+	}
+
+	/* If identities do not match, don't fire event */
+	if (pContext->GetIdentity() != pInfo->pOwner)
+	{
+		return pContext->ThrowNativeError("Game event \"%s\" could not be fired because it was not created by this plugin", pInfo->pEvent->GetName());
+	}
+
+	if (pInfo->bDontBroadcast)
+	{
+		return pContext->ThrowNativeError("Game event \"%s\" is set to not be broadcasted to clients", pInfo->pEvent->GetName());
+	}
+
+	int client = params[2];
+	CPlayer *pPlayer = g_Players.GetPlayerByIndex(client);
+
+	if (!pPlayer)
+	{
+		return pContext->ThrowNativeError("Client index %d is invalid", client);
+	}
+
+	if (!pPlayer->IsConnected())
+	{
+		return pContext->ThrowNativeError("Client %d is not connected", client);
+	}
+
+	IClient *pClient = pPlayer->GetIClient();
+	if (!pClient)
+	{
+		return pContext->ThrowNativeError("Sending events to fakeclints is not supported on this game (client %d)", client);
+	}
+
+	g_EventManager.FireEventToClient(pInfo, pClient);
 
 	return 1;
 }
@@ -421,6 +470,7 @@ REGISTER_NATIVES(gameEventNatives)
 
 	// Transitional syntax support.
 	{"Event.Fire",			sm_FireEvent},
+	{"Event.FireToClient",	sm_FireEventToClient},
 	{"Event.Cancel",		sm_CancelCreatedEvent},
 	{"Event.GetName",		sm_GetEventName},
 	{"Event.GetBool",		sm_GetEventBool},

--- a/plugins/include/events.inc
+++ b/plugins/include/events.inc
@@ -79,6 +79,13 @@ methodmap Event < Handle
 	//
 	// @param dontBroadcast Optional boolean that determines if event should be broadcast to clients.
 	public native void Fire(bool dontBroadcast=false);
+	
+	// Fires a game event to only the specified client.
+	//
+	// Unlike Fire, this function DOES NOT close the event Handle.
+	//
+	// @param client		Index of client to receive the event..
+	public native void FireToClient(int client);
 
 	// Cancels a previously created game event that has not been fired. This
 	// is necessary to avoid leaking memory when an event isn't fired.


### PR DESCRIPTION
I also initially planned on adding support for blocking existing events, per client on-the-fly, but API was getting complex and potentially inefficient. (This can still be added at some point). The net effect of that can still be achieved by blocking existing events with a prehook, saving event data, and then resending to the desired clients (not ideal, but doable).

Only tested on TF2 in Windows