### PR TITLE
Fix erroneous () in DebugReport:: printouts.

### DIFF
--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -185,7 +185,7 @@ void DebugReport::ReportError(const IErrorReport &report, IFrameIterator &iter)
 
 	if (blame) 
 	{
-		g_Logger.LogError("[SM] Blaming: %s()", blame);
+		g_Logger.LogError("[SM] Blaming: %s", blame);
 	}
 
 	if (!iter.Done()) 
@@ -211,7 +211,7 @@ void DebugReport::ReportError(const IErrorReport &report, IFrameIterator &iter)
 				{
 					file = "<unknown>";
 				}
-				g_Logger.LogError("[SM]   [%d] Line %d, %s::%s()",
+				g_Logger.LogError("[SM]   [%d] Line %d, %s::%s",
 						index,
 						iter.LineNumber(),
 						file,


### PR DESCRIPTION
This fixes a hard blocker for 1.8 from https://github.com/alliedmodders/sourcemod/pull/448.