### PR TITLE
Fix UTIL_ReplaceAll not properly tracking length (6472)

### DIFF
--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -83,11 +83,13 @@ unsigned int UTIL_ReplaceAll(char *subject, size_t maxlength, const char *search
 	size_t searchLen = strlen(search);
 	size_t replaceLen = strlen(replace);
 
-	char *ptr = subject;
+	char *newptr, *ptr = subject;
 	unsigned int total = 0;
-	while ((ptr = UTIL_ReplaceEx(ptr, maxlength, search, searchLen, replace, replaceLen, caseSensitive)) != NULL)
+	while ((newptr = UTIL_ReplaceEx(ptr, maxlength, search, searchLen, replace, replaceLen, caseSensitive)) != NULL)
 	{
 		total++;
+		maxlength -= newptr - ptr;
+		ptr = newptr;
 		if (*ptr == '\0')
 		{
 			break;


### PR DESCRIPTION
UTIL_ReplaceEx returns a pointer to the character after the newly-replaced stuff.  While maxlength is the size of the original buffer, the remaining space left needs to get reduced by how far forward we jumped after a replace happens.