### PR TITLE
fix CloseHandle signature

### DIFF
--- a/plugins/include/handles.inc
+++ b/plugins/include/handles.inc
@@ -52,9 +52,10 @@ enum Handle // Tag disables introducing "Handle" as a symbol.
  *       sure you read the documentation on whatever provided the Handle.
  *
  * @param hndl		Handle to close.
+ * @return			True on success, false if Handle does not exists or on Handle access violation.
  * @error			Invalid handles will cause a run time error.
  */
-native void CloseHandle(Handle hndl);
+native bool CloseHandle(Handle hndl);
 
 /**
  * Clones a Handle.  When passing handles in between plugins, caching handles


### PR DESCRIPTION
[`CloseHandle` returns `bool`](https://github.com/alliedmodders/sourcemod/blob/0c8e6e29184bf58851954019a2060d84f0c556f9/core/logic/smn_handles.cpp#L58-L71). This PR updates its signature and docstring

