### PR TITLE
Increase topmenu display buffer size

### DIFF
--- a/extensions/topmenus/TopMenu.cpp
+++ b/extensions/topmenus/TopMenu.cpp
@@ -36,7 +36,7 @@
 struct obj_by_name_t
 {
 	unsigned int obj_index;
-	char name[64];
+	char name[TOPMENU_DISPLAY_BUFFER_SIZE];
 };
 
 int _SortObjectNamesDescending(const void *ptr1, const void *ptr2);
@@ -667,7 +667,7 @@ unsigned int TopMenu::OnMenuDisplayItem(IBaseMenu *menu,
 		return 0;
 
 	/* Ask the object to render the text for this client */
-	char renderbuf[64];
+	char renderbuf[TOPMENU_DISPLAY_BUFFER_SIZE];
 	obj->callbacks->OnTopMenuDisplayOption(this, client, obj->object_id, renderbuf, sizeof(renderbuf));
 
 	/* Build the new draw info */

--- a/extensions/topmenus/TopMenu.h
+++ b/extensions/topmenus/TopMenu.h
@@ -42,6 +42,8 @@
 using namespace SourceHook;
 using namespace SourceMod;
 
+#define TOPMENU_DISPLAY_BUFFER_SIZE 128
+
 struct config_category_t
 {
 	int name;


### PR DESCRIPTION
The buffer for menu options was 64 chars. That limit can easily be
reached by some utf8 string which would get truncated. Double the buffer
size to 128 chars.