### PR TITLE
Renaming multiple players

### DIFF
--- a/plugins/playercommands/rename.sp
+++ b/plugins/playercommands/rename.sp
@@ -174,11 +174,6 @@ public Action Command_Rename(int client, int args)
 			ShowActivity2(client, "[SM] ", "%t", "Renamed target", "_s", target_name);
 		}
 
-		if (target_count > 1) /* We cannot name everyone the same thing. */
-		{
-			randomize = true;
-		}
-
 		for (int i = 0; i < target_count; i++)
 		{
 			if(randomize)
@@ -187,7 +182,10 @@ public Action Command_Rename(int client, int args)
 			}
 			else
 			{
-				Format(g_NewName[target_list[i]], MAX_NAME_LENGTH, "%s", arg2);
+				if(target_count>1)
+					Format(g_NewName[target_list[i]], MAX_NAME_LENGTH, "%s %i", arg2, i+1);
+				else
+					Format(g_NewName[target_list[i]], MAX_NAME_LENGTH, "%s", arg2);
 			}
 			PerformRename(client, target_list[i]);
 		}

--- a/plugins/playercommands/rename.sp
+++ b/plugins/playercommands/rename.sp
@@ -176,16 +176,20 @@ public Action Command_Rename(int client, int args)
 
 		for (int i = 0; i < target_count; i++)
 		{
-			if(randomize)
+			if (randomize)
 			{
 				RandomizeName(target_list[i]);
 			}
 			else
 			{
-				if(target_count>1)
+				if (target_count > 1)
+				{
 					Format(g_NewName[target_list[i]], MAX_NAME_LENGTH, "%s %i", arg2, i+1);
+				}
 				else
+				{
 					Format(g_NewName[target_list[i]], MAX_NAME_LENGTH, "%s", arg2);
+				}
 			}
 			PerformRename(client, target_list[i]);
 		}


### PR DESCRIPTION
**Before the change:**
sm_rename @all "Random Name" - this would rename everyone but the names would be randomized (random characters and numbers)

**After the change:**
sm_rename @all "Random Name" - this would rename everyone to: Random Name 1, Random Name 2, Random Name 3 ...  etc.

**Description:**
sm_rename can only rename 1 player at a time, when you specify a name. If you use this command on multiple players (like sm_rename @bots "A random bot"), their names get randomized(just like when you dont specify a name). So I propose this change, so you can rename multiple people.

**PS:**The funny thing is that there was a comment in the code about not wanting everyone to have a same name, but sm_rename doesnt a have check for this so you could use sm_rename to rename everyone, one by one, using the same name.