### PR TITLE
Keep optional natives optional after reloading

### DIFF
--- a/core/logic/NativeOwner.cpp
+++ b/core/logic/NativeOwner.cpp
@@ -73,7 +73,7 @@ void CNativeOwner::UnbindWeakRef(const WeakNative &ref)
 	pContext->GetRuntime()->UpdateNativeBinding(
 	  ref.idx,
 	  nullptr,
-	  0,
+	  SP_NTVFLAG_OPTIONAL,
 	  nullptr);
 }
 

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -341,6 +341,8 @@ void ShareSystem::BindNativeToPlugin(CPlugin *pPlugin, const sp_native_t *native
 		/* The native is optional, this is a special case */
 		if ((native->flags & SP_NTVFLAG_OPTIONAL) == SP_NTVFLAG_OPTIONAL)
 		{
+			flags |= SP_NTVFLAG_OPTIONAL;
+
 			/* Only add if there is a valid owner. */
 			if (!pEntry->owner)
 				return;


### PR DESCRIPTION
Bug 6518

Starting from no plugins loaded, after the final step of the following,
basetriggers will be marked as errored because mapchooser is missing:

Load basetriggers
Load mapchooser
Unload mapchooser
Load mapchooser
Unload mapchooser

We lose the SP_NTVFLAG_OPTIONAL when removing a WeakNative. The
__pl_mapchooser_SetNTVOptional() is only called in basetriggers when it
is loaded. It adds the OPTIONAL flag to the mapchooser natives the
basetrigger plugin uses.
When mapchooser is loaded, the native is overwritten and the OPTIONAL
flag consumed (WeakNative registered), but not preserved. Later when
mapchooser is unloaded the WeakNative is removed in
CNativeOwner::UnbindWeakRef, but the OPTIONAL flag isn't added again.
The next time mapchooser is loaded, the natives aren't optional anymore
and will cause a real dependency.

The change in ShareSys isn't needed to fix the error, but is included to
keep the SP_NTVFLAG_OPTIONAL flag consistent.