### PR TITLE
Added missing information

### DIFF
--- a/configs/cfg/sourcemod.cfg
+++ b/configs/cfg/sourcemod.cfg
@@ -65,6 +65,10 @@ sm_flood_time 0.75
 // no reserved slot access (spectator players are selected first) is kicked to make room. Thus, the reserved
 // slots always remains free. The only situation where the reserved slot(s) can become properly occupied is 
 // if the server is full with reserve slot access clients.
+// 2 : The same as sm_reserve_type 1 except once a certain number of admins have been reached, the reserve slot
+// stops kicking people and anyone can join to fill the server. You can use this to simulate having a large
+// number of reserved slots with sm_reserve_type 0 but with only need to have 1 slot unavailable when there are
+// less admins connected.
 // --
 // Requires: reservedslots.smx
 // Default: 0


### PR DESCRIPTION
There is no information about sm_reserve_type 2 in the cfg file, even though reserve type 2 exists in the plugin and on the wikia.

[https://wiki.alliedmods.net/Reserved_Slots_(SourceMod)](https://wiki.alliedmods.net/Reserved_Slots_(SourceMod))