### PR TITLE
Fix /nominations returning Plugin_Continue on success

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -261,7 +261,7 @@ public Action Command_Nominate(int client, int args)
 	GetClientName(client, name, sizeof(name));
 	PrintToChatAll("[SM] %t", "Map Nominated", name, displayName);
 	
-	return Plugin_Continue;
+	return Plugin_Handled;
 }
 
 void AttemptNominate(int client)


### PR DESCRIPTION
sm_nominate (/nominate and !nominate) was returning Plugin_Continue when a map was successfully nominated.

This should be Plugin_Handled.