### PR TITLE
Expose SourceMods existing Think hook to Pawn

### DIFF
--- a/core/logic/frame_tasks.cpp
+++ b/core/logic/frame_tasks.cpp
@@ -24,6 +24,7 @@
 // this exception to all derivative works.  AlliedModders LLC defines further
 // exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
 // or <http://www.sourcemod.net/license.php>.
+#include "common_logic.h"
 #include "frame_tasks.h"
 #include <am-vector.h>
 
@@ -31,6 +32,19 @@ using namespace SourceMod;
 
 ke::Vector<ke::Lambda<void()>> sNextTasks;
 ke::Vector<ke::Lambda<void()>> sWorkTasks;
+FrameTasks sPawnTasks;
+
+void
+FrameTasks::OnSourceModAllInitialized()
+{
+	m_pOnThink = forwardsys->CreateForward("OnThinkFrame", ET_Ignore, 1, NULL, Param_Cell);
+}
+
+void
+FrameTasks::OnSourceModShutdown()
+{
+	forwardsys->ReleaseForward(m_pOnThink);
+}
 
 void
 SourceMod::ScheduleTaskForNextFrame(ke::Lambda<void()>&& task)
@@ -41,6 +55,12 @@ SourceMod::ScheduleTaskForNextFrame(ke::Lambda<void()>&& task)
 void
 SourceMod::RunScheduledFrameTasks(bool simulating)
 {
+	if (sPawnTasks.pOnThink->GetFunctionCount() != 0)
+	{
+		sPawnTasks.pOnThink->PushCell(simulating);
+		sPawnTasks.pOnThink->Execute(NULL);
+	}
+
 	if (sNextTasks.empty())
 		return;
 

--- a/core/logic/frame_tasks.h
+++ b/core/logic/frame_tasks.h
@@ -29,6 +29,17 @@
 
 #include <am-function.h>
 
+class FrameTasks :
+	public SMGlobalClass
+{
+	friend class SourceMod;
+public: // SMGlobalClass
+	void OnSourceModAllInitialized();
+	void OnSourceModShutdown();
+protected:
+	IForward *m_pOnThink;
+};
+
 namespace SourceMod {
 
 void ScheduleTaskForNextFrame(ke::Lambda<void()>&& task);


### PR DESCRIPTION
SourceMod utilizes Think instead of GameFrame to enable plugins to load/unload while the server is hibernating. As an unfortunate side effect, these plugins can't do much if anything while the server is hibernating. Exposing a forward is a simple, requested for years, feature that helps server operators keep hibernation enabled while utilizing SourceMod.