### PR TITLE
Add ``RequestThink`` and ``OnServerThink``

### DIFF
--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -244,9 +244,9 @@ void TimerSystem::GameFrame(bool simulating)
 	}
 }
 
-void TimerSystem::Think(bool FinalTick)
+void TimerSystem::Think(bool finalTick)
 {
-	RunThinkHooks(FinalTick);
+	RunThinkHooks(finalTick);
 
 	if (m_pOnServerThink->GetFunctionCount())
 	{

--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -242,6 +242,11 @@ void TimerSystem::GameFrame(bool simulating)
 	}
 }
 
+void TimerSystem::Think(bool FinalTick)
+{
+	RunThinkHooks(FinalTick);
+}
+
 void TimerSystem::RunFrame()
 {
 	ITimer *pTimer;

--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -183,6 +183,7 @@ void TimerSystem::OnSourceModAllInitialized()
 	sharesys->AddInterface(NULL, this);
 	m_pOnGameFrame = forwardsys->CreateForward("OnGameFrame", ET_Ignore, 0, NULL);
 	m_pOnMapTimeLeftChanged = forwardsys->CreateForward("OnMapTimeLeftChanged", ET_Ignore, 0, NULL);
+	m_pOnServerThink = forwardsys->CreateForward("OnServerThink", ET_Ignore, 0, NULL);
 }
 
 void TimerSystem::OnSourceModGameInitialized()
@@ -200,6 +201,7 @@ void TimerSystem::OnSourceModShutdown()
 	SetMapTimer(NULL);
 	forwardsys->ReleaseForward(m_pOnGameFrame);
 	forwardsys->ReleaseForward(m_pOnMapTimeLeftChanged);
+	forwardsys->ReleaseForward(m_pOnServerThink);
 }
 
 void TimerSystem::OnSourceModLevelEnd()
@@ -245,6 +247,11 @@ void TimerSystem::GameFrame(bool simulating)
 void TimerSystem::Think(bool FinalTick)
 {
 	RunThinkHooks(FinalTick);
+
+	if (m_pOnServerThink->GetFunctionCount())
+	{
+		m_pOnServerThink->Execute(NULL);
+	}
 }
 
 void TimerSystem::RunFrame()

--- a/core/TimerSys.h
+++ b/core/TimerSys.h
@@ -99,6 +99,7 @@ private:
 
 	IForward *m_pOnGameFrame;
 	IForward *m_pOnMapTimeLeftChanged;
+	IForward *m_pOnServerThink;
 };
 
 time_t GetAdjustedTime(time_t *buf = NULL);

--- a/core/TimerSys.h
+++ b/core/TimerSys.h
@@ -83,6 +83,7 @@ public:
 	void RunFrame();
 	void RemoveMapChangeTimers();
 	void GameFrame(bool simulating);
+	void Think(bool FinalTick);
 private:
 	List<ITimer *> m_SingleTimers;
 	List<ITimer *> m_LoopTimers;

--- a/core/TimerSys.h
+++ b/core/TimerSys.h
@@ -83,7 +83,7 @@ public:
 	void RunFrame();
 	void RemoveMapChangeTimers();
 	void GameFrame(bool simulating);
-	void Think(bool FinalTick);
+	void Think(bool finalTick);
 private:
 	List<ITimer *> m_SingleTimers;
 	List<ITimer *> m_LoopTimers;

--- a/core/frame_hooks.cpp
+++ b/core/frame_hooks.cpp
@@ -152,7 +152,7 @@ void AddThinkAction(const FrameAction & action)
 	think_mutex->Unlock();
 }
 
-void RunThinkHooks(bool FinalTick)
+void RunThinkHooks(bool finalTick)
 {
 	/* It's okay if this check races. */
 	if (think_queue->size())
@@ -174,4 +174,5 @@ void RunThinkHooks(bool FinalTick)
 			item.action(item.data);
 		}
 	}
+	g_SourceMod.ProcessServerThinkHooks(finalTick);
 }

--- a/core/frame_hooks.h
+++ b/core/frame_hooks.h
@@ -51,6 +51,6 @@ void AddFrameAction(const FrameAction & action);
 void RunFrameHooks(bool simulating);
 
 void AddThinkAction(const FrameAction & action);
-void RunThinkHooks(bool FinalTick);
+void RunThinkHooks(bool finalTick);
 
 #endif //_INCLUDE_SOURCEMOD_FRAME_HOOKS_H_

--- a/core/frame_hooks.h
+++ b/core/frame_hooks.h
@@ -50,4 +50,7 @@ extern bool g_PendingInternalPush;
 void AddFrameAction(const FrameAction & action);
 void RunFrameHooks(bool simulating);
 
+void AddThinkAction(const FrameAction & action);
+void RunThinkHooks(bool FinalTick);
+
 #endif //_INCLUDE_SOURCEMOD_FRAME_HOOKS_H_

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -645,7 +645,15 @@ static cell_t sm_AddFrameAction(IPluginContext *pContext, const cell_t *params)
 	pForward->AddFunction(pFunction);
 
 	SMFrameActionData *pData = new SMFrameActionData(Handle, pPlugin->GetMyHandle(), params[2]);
-	g_pSM->AddFrameAction(PawnFrameAction, pData);
+	if (params[0] >= 3)	//for backwards compatibility
+	{
+		if (params[3]) { g_pSM->AddThinkAction(PawnFrameAction, pData); }
+		else { g_pSM->AddFrameAction(PawnFrameAction, pData); }
+	}
+	else
+	{
+		g_pSM->AddFrameAction(PawnFrameAction, pData);
+	}
 	return 1;
 }
 

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -699,6 +699,36 @@ void SourceModBase::ProcessGameFrameHooks(bool simulating)
 	}
 }
 
+void SourceModBase::AddServerThinkHook(GAME_FRAME_HOOK hook)
+{
+	m_think_hooks.push_back(hook);
+}
+
+void SourceModBase::RemoveServerThinkHook(GAME_FRAME_HOOK hook)
+{
+	for (size_t i = 0; i < m_think_hooks.size(); i++)
+	{
+		if (m_think_hooks[i] == hook)
+		{
+			m_think_hooks.erase(m_think_hooks.iterAt(i));
+			return;
+		}
+	}
+}
+
+void SourceModBase::ProcessServerThinkHooks(bool finalTick)
+{
+	if (m_think_hooks.size() == 0)
+	{
+		return;
+	}
+
+	for (size_t i = 0; i < m_think_hooks.size(); i++)
+	{
+		m_think_hooks[i](finalTick);
+	}
+}
+
 size_t SourceModBase::Format(char *buffer, size_t maxlength, const char *fmt, ...)
 {
 	size_t len;

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -254,6 +254,7 @@ void SourceModBase::StartSourceMod(bool late)
 {
 	SH_ADD_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
 	SH_ADD_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
+	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 
 	enginePatch = SH_GET_CALLCLASS(engine);
 	gamedllPatch = SH_GET_CALLCLASS(gamedll);
@@ -543,6 +544,7 @@ void SourceModBase::ShutdownServices()
 
 	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
 	SH_REMOVE_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
+	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
@@ -720,6 +722,11 @@ size_t SourceModBase::FormatArgs(char *buffer,
 void SourceModBase::AddFrameAction(FRAMEACTION fn, void *data)
 {
 	::AddFrameAction(FrameAction(fn, data));
+}
+
+void SourceModBase::AddThinkAction(FRAMEACTION fn, void *data)
+{
+	::AddThinkAction(FrameAction(fn, data));
 }
 
 const char *SourceModBase::GetCoreConfigValue(const char *key)

--- a/core/sourcemod.h
+++ b/core/sourcemod.h
@@ -128,6 +128,9 @@ public: // ISourceMod
 	void AddGameFrameHook(GAME_FRAME_HOOK hook);
 	void RemoveGameFrameHook(GAME_FRAME_HOOK hook);
 	void ProcessGameFrameHooks(bool simulating);
+	void AddServerThinkHook(GAME_FRAME_HOOK hook);
+	void RemoveServerThinkHook(GAME_FRAME_HOOK hook);
+	void ProcessServerThinkHooks(bool finalTick);
 	size_t Format(char *buffer, size_t maxlength, const char *fmt, ...);
 	size_t FormatArgs(char *buffer, size_t maxlength, const char *fmt, va_list ap);
 	void AddFrameAction(FRAMEACTION fn, void *data);
@@ -148,6 +151,7 @@ private:
 	unsigned int m_target;
 	bool m_GotBasePath;
 	CVector<GAME_FRAME_HOOK> m_frame_hooks;
+	CVector<GAME_FRAME_HOOK> m_think_hooks;
 };
 
 void UTIL_ConsolePrintVa(const char *fmt, va_list ap);

--- a/core/sourcemod.h
+++ b/core/sourcemod.h
@@ -131,6 +131,7 @@ public: // ISourceMod
 	size_t Format(char *buffer, size_t maxlength, const char *fmt, ...);
 	size_t FormatArgs(char *buffer, size_t maxlength, const char *fmt, va_list ap);
 	void AddFrameAction(FRAMEACTION fn, void *data);
+	void AddThinkAction(FRAMEACTION fn, void *data);
 	const char *GetCoreConfigValue(const char *key);
 	int GetPluginId();
 	int GetShApiVersion();

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -498,10 +498,20 @@ typedef RequestFrameCallback = function void (any data);
 
 /**
  * Creates a single use Next Frame hook.
+ * @note If you need to queue an action even when the server is hibernating,
+ * Use RequestFrame instead
  *
  * @param Function	Function to call on the next frame.
  * @param data		Value to be passed on the invocation of the Function.
- * @param HookThink	Enable this flag if you want your function to be called 
- *					even if the server is hibernating.
  */
-native void RequestFrame(RequestFrameCallback Function, any data=0, bool HookThink=false);
+native void RequestFrame(RequestFrameCallback Function, any data=0);
+
+/**
+ * Creates a single use Next Think hook.
+ * @note This is guaranteed to work even when the server is hibernating,
+ * ideal when working with network-driven events.
+ *
+ * @param Function	Function to call on the next server's think call.
+ * @param data		Value to be passed on the invocation of the Function.
+ */
+native void RequestThink(RequestFrameCallback Function, any data=0);

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -498,8 +498,8 @@ typedef RequestFrameCallback = function void (any data);
 
 /**
  * Creates a single use Next Frame hook.
- * @note If you need to queue an action even when the server is hibernating,
- * Use RequestFrame instead
+ * @note If you need to queue an action even when the server is hibernating
+ * use RequestThink instead.
  *
  * @param Function	Function to call on the next frame.
  * @param data		Value to be passed on the invocation of the Function.

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -500,6 +500,8 @@ typedef RequestFrameCallback = function void (any data);
  * Creates a single use Next Frame hook.
  *
  * @param Function	Function to call on the next frame.
- * @param data			Value to be passed on the invocation of the Function.
+ * @param data		Value to be passed on the invocation of the Function.
+ * @param HookThink	Enable this flag if you want your function to be called 
+ *					even if the server is hibernating.
  */
-native void RequestFrame(RequestFrameCallback Function, any data=0);
+native void RequestFrame(RequestFrameCallback Function, any data=0, bool HookThink=false);

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -146,6 +146,16 @@ forward void OnPluginPauseChange(bool pause);
 forward void OnGameFrame();
 
 /**
+ * Called before every server think. Note that you should avoid
+ * doing expensive computations or declaring large local arrays.
+ *
+ * @note In contrast with OnGameFrame, this forward is triggered
+ * even if no level was loaded yet. This is useful when working
+ * with network bound events.
+ */
+forward void OnServerThink();
+
+/**
  * Called when the map is loaded.
  *
  * @note This used to be OnServerLoad(), which is now deprecated.

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -43,7 +43,7 @@
 #include <time.h>
 
 #define SMINTERFACE_SOURCEMOD_NAME		"ISourceMod"
-#define SMINTERFACE_SOURCEMOD_VERSION	13
+#define SMINTERFACE_SOURCEMOD_VERSION	14
 
 /**
 * @brief Forward declaration of the KeyValues class.

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -289,16 +289,6 @@ namespace SourceMod
 		virtual void AddFrameAction(FRAMEACTION fn, void *data) = 0;
 
 		/**
-		* @brief Adds an action to be executed on the next available think call.
-		*
-		* This function is thread safe.
-		*
-		* @param fn			Function to execute.
-		* @param data		Data to pass to function.
-		*/
-		virtual void AddThinkAction(FRAMEACTION fn, void *data) = 0;
-
-		/**
 		 * @brief Retrieves a core.cfg configuration value.
 		 *
 		 * @param key		Core.cfg key phrase.
@@ -328,6 +318,16 @@ namespace SourceMod
 		 * @return			True if a map is currently running, otherwise false.
 		 */
 		virtual bool IsMapRunning() = 0;
+
+		/**
+		* @brief Adds an action to be executed on the next available think call.
+		*
+		* This function is thread safe.
+		*
+		* @param fn			Function to execute.
+		* @param data		Data to pass to function.
+		*/
+		virtual void AddThinkAction(FRAMEACTION fn, void *data) = 0;
 	};
 }
 

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -289,6 +289,16 @@ namespace SourceMod
 		virtual void AddFrameAction(FRAMEACTION fn, void *data) = 0;
 
 		/**
+		* @brief Adds an action to be executed on the next available think call.
+		*
+		* This function is thread safe.
+		*
+		* @param fn			Function to execute.
+		* @param data		Data to pass to function.
+		*/
+		virtual void AddThinkAction(FRAMEACTION fn, void *data) = 0;
+
+		/**
 		 * @brief Retrieves a core.cfg configuration value.
 		 *
 		 * @param key		Core.cfg key phrase.

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -328,6 +328,20 @@ namespace SourceMod
 		* @param data		Data to pass to function.
 		*/
 		virtual void AddThinkAction(FRAMEACTION fn, void *data) = 0;
+
+		/**
+		* @brief Adds a function to be called each server think.
+		*
+		* @param hook		Hook function.
+		*/
+		virtual void AddServerThinkHook(GAME_FRAME_HOOK hook) = 0;
+
+		/**
+		* @brief Removes one server think hook matching the given function.
+		*
+		* @param hook		Hook function.
+		*/
+		virtual void RemoveServerThinkHook(GAME_FRAME_HOOK hook) = 0;
 	};
 }
 


### PR DESCRIPTION
Added AddThinkAction to the sm interface and a flag to RequestFrame on pawn to specify a Think hook instead of a GameFrame one. This allows plguins to schedule actions to be executed on the next think call, even if the server is hibernating.

Status: the branch builds no problem but it generates a runtime error while trying to load the sdktools and sdkhooks extensions ("Unable to load extension "sdkhooks.ext": undefined symbol: Warning" and "Unable to load extension "sdktools.ext": undefined symbol: Warning") any help would be appreciated.
