### PR TITLE
Add command argument autocompletion for plugins

### DIFF
--- a/bridge/include/BridgeAPI.h
+++ b/bridge/include/BridgeAPI.h
@@ -35,7 +35,7 @@ namespace SourceMod {
 
 // Add 1 to the RHS of this expression to bump the intercom file
 // This is to prevent mismatching core/logic binaries
-static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 55;
+static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 56;
 
 } // namespace SourceMod
 

--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -31,6 +31,8 @@
 #include <stdint.h>
 #include <IAdminSystem.h>
 #include <amtl/am-function.h>
+#include <amtl/am-vector.h>
+#include <amtl/am-string.h>
 
 namespace SourcePawn {
 class ISourcePawnEngine;
@@ -68,6 +70,7 @@ class IPlayerInfoBridge;
 class ICommandArgs;
 
 typedef ke::Lambda<bool(int client, const ICommandArgs*)> CommandFunc;
+typedef ke::Lambda<int(const char *, ke::Vector<ke::AString> &)> AutoCompleteFunc;
 
 class CoreProvider
 {
@@ -97,7 +100,7 @@ public:
 	virtual bool GetCvarBool(ConVar* cvar) = 0;
 
 	// Command functions.
-	virtual void DefineCommand(const char *cmd, const char *help, const CommandFunc &callback) = 0;
+	virtual void DefineCommand(const char *cmd, const char *help, const CommandFunc &callback, const AutoCompleteFunc &autocompleter = nullptr) = 0;
 
 	// Game description functions.
 	virtual bool GetGameName(char *buffer, size_t maxlength) = 0;

--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -70,7 +70,7 @@ class IPlayerInfoBridge;
 class ICommandArgs;
 
 typedef ke::Lambda<bool(int client, const ICommandArgs*)> CommandFunc;
-typedef ke::Lambda<int(const char *, ke::Vector<ke::AString> &)> AutoCompleteFunc;
+typedef ke::Lambda<int(const ICommandArgs*, ke::Vector<ke::AString> &)> AutoCompleteFunc;
 
 class CoreProvider
 {

--- a/bridge/include/LogicProvider.h
+++ b/bridge/include/LogicProvider.h
@@ -65,6 +65,7 @@ struct sm_logic_t
 	unsigned int	(*ReplaceAll)(char*, size_t, const char *, const char *, bool);
 	char            *(*ReplaceEx)(char *, size_t, const char *, size_t, const char *, size_t, bool);
 	size_t          (*DecodeHexString)(unsigned char *, size_t, const char *);
+	int				(*BreakString)(const char *, char *, size_t);
 	IGameConfig *   (*GetCoreGameConfig)();
 	IDebugListener   *debugger;
 	void			(*GenerateError)(IPluginContext *, cell_t, int, const char *, ...);

--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -304,7 +304,7 @@ bool ConCmdManager::InternalDispatch(int client, const ICommandArgs *args)
 int CommandCompletionCallback(char const *partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH])
 {
 	ke::Vector<ke::AString> suggestions;
-	int count = g_ConCmds.InternalCommandCompletionCallback(partial, suggestions, 0);
+	int count = g_ConCmds.InternalCommandCompletionCallback(partial, suggestions);
 
 	// Put the suggestions into the engine's buffer.
 	if (count > COMMAND_COMPLETION_MAXITEMS)
@@ -317,8 +317,9 @@ int CommandCompletionCallback(char const *partial, char commands[COMMAND_COMPLET
 	return count;
 }
 
-int ConCmdManager::InternalCommandCompletionCallback(char const *partial, ke::Vector<ke::AString> &suggestions, int size)
+int ConCmdManager::InternalCommandCompletionCallback(char const *partial, ke::Vector<ke::AString> &suggestions)
 {
+	int size = suggestions.length();
 	ConCmdInfo *pInfo = FindCommandFromPartial(partial);
 	if (!pInfo)
 		return size;
@@ -623,7 +624,7 @@ void ConCmdManager::RemoveConCmd(ConCmdInfo *info, const char *name, bool untrac
 
 	/* Remove the autocomplete forward. */
 	if (info->autocompleter)
-		logicore.forwardsys->ReleaseForward(info->autocompleter);
+		forwardsys->ReleaseForward(info->autocompleter);
 	
 	/* Remove from list */
 	m_CmdList.remove(info);
@@ -687,8 +688,8 @@ ConCmdInfo *ConCmdManager::AddOrFindCommand(const char *name, const char *descri
 			pInfo->sh_hook = sCoreProviderImpl.AddCommandHook(pCmd, callback);
 
 			// Add AutoCompleteSuggest and CanAutoComplete hooks
-			CommandAutoCompleteHook::Callback auto_complete = [this](char const *partial, ke::Vector<ke::AString> &suggestions, size_t size) -> int {
-				return this->InternalCommandCompletionCallback(partial, suggestions, size);
+			CommandAutoCompleteHook::Callback auto_complete = [this](char const *partial, ke::Vector<ke::AString> &suggestions) -> int {
+				return this->InternalCommandCompletionCallback(partial, suggestions);
 			};
 			pInfo->sh_autocomplete_hook = sCoreProviderImpl.AddCommandAutoCompleteHook(pCmd, auto_complete);
 		}

--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -368,6 +368,7 @@ int ConCmdManager::InternalCommandCompletionCallback(const ICommandArgs *args, k
 	{
 		// Call the plugin functions
 		AutoEnterCommand autoEnterCommand(args);
+		pInfo->autocompleter->PushString(cmd);
 		pInfo->autocompleter->PushCell(args->ArgC());
 		pInfo->autocompleter->PushCell(hndl);
 		pInfo->autocompleter->Execute(nullptr);
@@ -448,7 +449,7 @@ bool ConCmdManager::AddAdminCommand(IPluginFunction *pFunction,
 	if (pAutoCompleteFunction)
 	{
 		if (!pInfo->autocompleter)
-			pInfo->autocompleter = forwardsys->CreateForwardEx(NULL, ET_Ignore, 2, NULL, Param_Cell, Param_Cell);
+			pInfo->autocompleter = forwardsys->CreateForwardEx(NULL, ET_Ignore, 3, NULL, Param_String, Param_Cell, Param_Cell);
 		pInfo->autocompleter->AddFunction(pAutoCompleteFunction);
 	}
 
@@ -494,7 +495,7 @@ bool ConCmdManager::AddServerCommand(IPluginFunction *pFunction,
 	if (pAutoCompleteFunction)
 	{
 		if (!pInfo->autocompleter)
-			pInfo->autocompleter = forwardsys->CreateForwardEx(NULL, ET_Ignore, 2, NULL, Param_Cell, Param_Cell);
+			pInfo->autocompleter = forwardsys->CreateForwardEx(NULL, ET_Ignore, 3, NULL, Param_String, Param_Cell, Param_Cell);
 		pInfo->autocompleter->AddFunction(pAutoCompleteFunction);
 	}
 

--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -331,7 +331,8 @@ int ConCmdManager::InternalCommandCompletionCallback(const ICommandArgs *args, k
 		pInfo = *item;
 	}
 
-	if (!pInfo->autocompleter)
+	// No plugins listening at the moment. Ignore.
+	if (!pInfo->autocompleter || pInfo->autocompleter->GetFunctionCount() == 0)
 		return size;
 
 	HandleType_t htCellArray;

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -94,32 +94,19 @@ struct CmdHook : public ke::InlineListNode<CmdHook>
 
 typedef ke::InlineList<CmdHook> CmdHookList;
 
-struct CmdAutoCompleteSuggest : public ke::InlineListNode<CmdAutoCompleteSuggest>
-{
-	CmdAutoCompleteSuggest(ConCmdInfo *cmd, IPluginFunction *fun)
-		: info(cmd),
-		pf(fun)
-	{
-	}
-
-	ConCmdInfo *info;
-	IPluginFunction *pf;
-};
-
-typedef ke::InlineList<CmdAutoCompleteSuggest> CmdAutoCompleteSuggestList;
-
 struct ConCmdInfo
 {
 	ConCmdInfo()
 	{
 		sourceMod = false;
 		pCmd = NULL;
+		autocompleter = nullptr;
 		eflags = 0;
 	}
 	bool sourceMod;					/**< Determines whether or not concmd was created by a SourceMod plugin */
 	ConCommand *pCmd;				/**< Pointer to the command itself */
 	CmdHookList hooks;				/**< Hook list */
-	CmdAutoCompleteSuggestList autocompleters; /**< AutoComplete list */
+	IChangeableForward *autocompleter; /**< AutoComplete forward */
 	FlagBits eflags;				/**< Effective admin flags */
 	ke::RefPtr<CommandHook> sh_hook;   /**< SourceHook Dispatch hook, if any. */
 	ke::RefPtr<CommandAutoCompleteHook> sh_autocomplete_hook; /**< SourceHook AutoCompleteSuggest hook, if any. */

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -149,10 +149,9 @@ public:
 	bool LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags);
 private:
 	bool InternalDispatch(int client, const ICommandArgs *args);
-	int InternalCommandCompletionCallback(char const *partial, ke::Vector<ke::AString> &suggestions);
+	int InternalCommandCompletionCallback(const ICommandArgs *args, ke::Vector<ke::AString> &suggestions);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
 	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
-	ConCmdInfo *FindCommandFromPartial(const char *partial);
 	void AddToCmdList(ConCmdInfo *info);
 	void RemoveConCmd(ConCmdInfo *info, const char *cmd, bool untrack);
 	bool CheckAccess(int client, const char *cmd, AdminCmdInfo *pAdmin);

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -149,7 +149,7 @@ public:
 	bool LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags);
 private:
 	bool InternalDispatch(int client, const ICommandArgs *args);
-	int InternalCommandCompletionCallback(char const *partial, ke::Vector<ke::AString> &suggestions, int size);
+	int InternalCommandCompletionCallback(char const *partial, ke::Vector<ke::AString> &suggestions);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
 	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
 	ConCmdInfo *FindCommandFromPartial(const char *partial);

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -162,7 +162,7 @@ public:
 	bool LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags);
 private:
 	bool InternalDispatch(int client, const ICommandArgs *args);
-	int InternalCommandCompletionCallback(char const *partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH], int size);
+	int InternalCommandCompletionCallback(char const *partial, ke::Vector<ke::AString> &suggestions, int size);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
 	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
 	ConCmdInfo *FindCommandFromPartial(const char *partial);

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -211,7 +211,7 @@ int CommandAutoCompleteHook::AutoCompleteSuggest(AUTOCOMPLETESUGGEST_ARGS)
 		suggestions.append(commands[i]);
 	}
 
-	count = callback_(partial, suggestions, count);
+	count = callback_(partial, suggestions);
 
 	// Put the suggestions back into the expected structure for the engine.
 #if defined AUTOCOMPLETESUGGEST_NEWARGS

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -44,12 +44,12 @@ SH_DECL_HOOK5_void(IServerPluginCallbacks, OnQueryCvarValueFinished, SH_NOATTRIB
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 SH_DECL_HOOK1_void(ConCommand, Dispatch, SH_NOATTRIB, false, const CCommand &);
 SH_DECL_HOOK2(ConCommand, AutoCompleteSuggest, SH_NOATTRIB, false, int, const char *, CUtlVector< CUtlString > &);
+SH_DECL_HOOK0(ConCommand, CanAutoComplete, SH_NOATTRIB, false, bool);
 #else
 SH_DECL_HOOK0_void(ConCommand, Dispatch, SH_NOATTRIB, false);
-SH_DECL_HOOK2(ConCommand, AutoCompleteSuggest, SH_NOATTRIB, false, int, char const *, char **);
+// sourcehook for ep1 doesn't support the argument..
+//SH_DECL_HOOK2(ConCommand, AutoCompleteSuggest, SH_NOATTRIB, false, int, char const *, char **);
 #endif
-
-SH_DECL_HOOK0(ConCommand, CanAutoComplete, SH_NOATTRIB, false, bool);
 
 SH_DECL_HOOK1_void(IServerGameClients, SetCommandClient, SH_NOATTRIB, false, int);
 
@@ -185,8 +185,10 @@ CommandAutoCompleteHook::CommandAutoCompleteHook(ConCommand *cmd, const Callback
 	can_hook_id_(0),
 	callback_(callback)
 {
+#if SOURCE_ENGINE >= SE_ORANGEBOX
 	suggest_hook_id_ = SH_ADD_HOOK(ConCommand, AutoCompleteSuggest, cmd, SH_MEMBER(this, &CommandAutoCompleteHook::AutoCompleteSuggest), true);
 	can_hook_id_ = SH_ADD_HOOK(ConCommand, CanAutoComplete, cmd, SH_MEMBER(this, &CommandAutoCompleteHook::CanAutoComplete), false);
+#endif
 }
 
 CommandAutoCompleteHook::~CommandAutoCompleteHook()

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -44,12 +44,14 @@ SH_DECL_HOOK5_void(IServerPluginCallbacks, OnQueryCvarValueFinished, SH_NOATTRIB
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 SH_DECL_HOOK1_void(ConCommand, Dispatch, SH_NOATTRIB, false, const CCommand &);
 SH_DECL_HOOK2(ConCommand, AutoCompleteSuggest, SH_NOATTRIB, false, int, const char *, CUtlVector< CUtlString > &);
-SH_DECL_HOOK0(ConCommand, CanAutoComplete, SH_NOATTRIB, false, bool);
 #else
 SH_DECL_HOOK0_void(ConCommand, Dispatch, SH_NOATTRIB, false);
-// sourcehook for ep1 doesn't support the argument..
-//SH_DECL_HOOK2(ConCommand, AutoCompleteSuggest, SH_NOATTRIB, false, int, char const *, char **);
+
+typedef char(*AutoCompleteArray)[COMMAND_COMPLETION_ITEM_LENGTH];
+SH_DECL_HOOK2(ConCommand, AutoCompleteSuggest, SH_NOATTRIB, false, int, char const *, AutoCompleteArray);
 #endif
+
+SH_DECL_HOOK0(ConCommand, CanAutoComplete, SH_NOATTRIB, false, bool);
 
 SH_DECL_HOOK1_void(IServerGameClients, SetCommandClient, SH_NOATTRIB, false, int);
 
@@ -185,10 +187,8 @@ CommandAutoCompleteHook::CommandAutoCompleteHook(ConCommand *cmd, const Callback
 	can_hook_id_(0),
 	callback_(callback)
 {
-#if SOURCE_ENGINE >= SE_ORANGEBOX
 	suggest_hook_id_ = SH_ADD_HOOK(ConCommand, AutoCompleteSuggest, cmd, SH_MEMBER(this, &CommandAutoCompleteHook::AutoCompleteSuggest), true);
 	can_hook_id_ = SH_ADD_HOOK(ConCommand, CanAutoComplete, cmd, SH_MEMBER(this, &CommandAutoCompleteHook::CanAutoComplete), false);
-#endif
 }
 
 CommandAutoCompleteHook::~CommandAutoCompleteHook()

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -211,7 +211,8 @@ int CommandAutoCompleteHook::AutoCompleteSuggest(AUTOCOMPLETESUGGEST_ARGS)
 		suggestions.append(commands[i]);
 	}
 
-	count = callback_(partial, suggestions);
+	ArgsFromString args(partial);
+	count = callback_(&args, suggestions);
 
 	// Put the suggestions back into the expected structure for the engine.
 #if defined AUTOCOMPLETESUGGEST_NEWARGS

--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -215,7 +215,7 @@ int CommandAutoCompleteHook::AutoCompleteSuggest(AUTOCOMPLETESUGGEST_ARGS)
 	count = callback_(&args, suggestions);
 
 	// Put the suggestions back into the expected structure for the engine.
-#if defined AUTOCOMPLETESUGGEST_NEWARGS
+#if SOURCE_ENGINE >= SE_ORANGEBOX
 	commands.Purge();
 	for (int i = 0; i < count; i++)
 	{

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -87,7 +87,7 @@ private:
 class CommandAutoCompleteHook : public ke::Refcounted<CommandAutoCompleteHook>
 {
 public:
-	typedef ke::Lambda<int(const char *, ke::Vector<ke::AString> &)> Callback;
+	typedef ke::Lambda<int(const ICommandArgs *, ke::Vector<ke::AString> &)> Callback;
 
 public:
 	CommandAutoCompleteHook(ConCommand *cmd, const Callback &callback);

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -34,6 +34,7 @@
 #include <iserverplugin.h>
 #include <amtl/am-refcounting.h>
 #include <amtl/am-vector.h>
+#include <amtl/am-string.h>
 #include <amtl/am-function.h>
 
 class ConVar;
@@ -50,11 +51,9 @@ struct CCommandContext;
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 # define AUTOCOMPLETESUGGEST_NEWARGS
-# define AUTOCOMPLETESUGGEST_TYPES     const char *, CUtlVector< CUtlString > &
 # define AUTOCOMPLETESUGGEST_ARGS      const char *partial, CUtlVector< CUtlString > &commands
 #else
-//# define AUTOCOMPLETESUGGEST_TYPES      char const *, char *
-# define AUTOCOMPLETESUGGEST_ARGS      char const *partial, char oldCommands[ COMMAND_COMPLETION_MAXITEMS ][ COMMAND_COMPLETION_ITEM_LENGTH ]
+# define AUTOCOMPLETESUGGEST_ARGS      char const *partial, char commands[ COMMAND_COMPLETION_MAXITEMS ][ COMMAND_COMPLETION_ITEM_LENGTH ]
 #endif
 
 namespace SourceMod {
@@ -88,7 +87,7 @@ private:
 class CommandAutoCompleteHook : public ke::Refcounted<CommandAutoCompleteHook>
 {
 public:
-	typedef ke::Lambda<int(AUTOCOMPLETESUGGEST_ARGS, size_t)> Callback;
+	typedef ke::Lambda<int(const char *, ke::Vector<ke::AString> &, size_t)> Callback;
 
 public:
 	CommandAutoCompleteHook(ConCommand *cmd, const Callback &callback);

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -50,7 +50,6 @@ struct CCommandContext;
 #endif
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX
-# define AUTOCOMPLETESUGGEST_NEWARGS
 # define AUTOCOMPLETESUGGEST_ARGS      const char *partial, CUtlVector< CUtlString > &commands
 #else
 # define AUTOCOMPLETESUGGEST_ARGS      char const *partial, char commands[ COMMAND_COMPLETION_MAXITEMS ][ COMMAND_COMPLETION_ITEM_LENGTH ]

--- a/core/GameHooks.h
+++ b/core/GameHooks.h
@@ -87,7 +87,7 @@ private:
 class CommandAutoCompleteHook : public ke::Refcounted<CommandAutoCompleteHook>
 {
 public:
-	typedef ke::Lambda<int(const char *, ke::Vector<ke::AString> &, size_t)> Callback;
+	typedef ke::Lambda<int(const char *, ke::Vector<ke::AString> &)> Callback;
 
 public:
 	CommandAutoCompleteHook(ConCommand *cmd, const Callback &callback);

--- a/core/command_args.h
+++ b/core/command_args.h
@@ -54,28 +54,6 @@ public:
 		return engine->Cmd_Args();
 	}
 };
-#else
-class EngineArgs : public ICommandArgs
-{
-	const CCommand *cmd;
-public:
-	EngineArgs(const CCommand& _cmd) : cmd(&_cmd)
-	{
-	}
-	const char *Arg(int n) const
-	{
-		return cmd->Arg(n);
-	}
-	int ArgC() const
-	{
-		return cmd->ArgC();
-	}
-	const char *ArgS() const
-	{
-		return cmd->ArgS();
-	}
-};
-#endif
 
 class ArgsFromString : public ICommandArgs
 {
@@ -93,14 +71,17 @@ public:
 		while ((pos = logicore.BreakString(arg_pos, arg, arglen)) != -1)
 		{
 			args_.append(arg);
-			
+
 			// Skip the command name in the argument string.
 			if (!arg_string_)
 				arg_string_ = &args[pos];
 
 			arg_pos += pos;
 		}
-		args_.append(arg);
+
+		// Add the last argument as well.
+		if (strlen(arg) > 0)
+			args_.append(arg);
 
 		// No arguments?
 		if (!arg_string_)
@@ -129,5 +110,51 @@ private:
 	ke::Vector<ke::AString> args_;
 	const char *arg_string_;
 };
+#else
+class EngineArgs : public ICommandArgs
+{
+	const CCommand *cmd;
+public:
+	EngineArgs(const CCommand& _cmd) : cmd(&_cmd)
+	{
+	}
+	const char *Arg(int n) const
+	{
+		return cmd->Arg(n);
+	}
+	int ArgC() const
+	{
+		return cmd->ArgC();
+	}
+	const char *ArgS() const
+	{
+		return cmd->ArgS();
+	}
+};
+
+class ArgsFromString : public ICommandArgs
+{
+public:
+	ArgsFromString(const char *args)
+	{
+		cmd.Tokenize(args);
+	}
+	const char *Arg(int n) const
+	{
+		return cmd.Arg(n);
+	}
+	int ArgC() const
+	{
+		return cmd.ArgC();
+	}
+	const char *ArgS() const
+	{
+		return cmd.ArgS();
+	}
+
+private:
+	CCommand cmd;
+};
+#endif
 
 #endif // _INCLUDE_SOURCEMOD_CCOMMANDARGS_IMPL_H_

--- a/core/command_args.h
+++ b/core/command_args.h
@@ -68,7 +68,7 @@ public:
 		// Break all the arguments including the command name at whitespace.
 		size_t pos = 0;
 		const char *arg_pos = args;
-		while ((pos = logicore.BreakString(arg_pos, arg, arglen)) != -1)
+		while ((pos = logicore.BreakString(arg_pos, arg, arglen + 1)) != -1)
 		{
 			args_.append(arg);
 
@@ -87,7 +87,7 @@ public:
 		if (!arg_string_)
 			arg_string_ = &args[arglen];
 
-		delete arg;
+		delete [] arg;
 	}
 
 	const char *Arg(int n) const

--- a/core/logic/common_logic.cpp
+++ b/core/logic/common_logic.cpp
@@ -141,6 +141,7 @@ static sm_logic_t logic =
 	UTIL_ReplaceAll,
 	UTIL_ReplaceEx,
 	UTIL_DecodeHexString,
+	UTIL_BreakString,
 	GetCoreGameConfig,
 	&g_DbgReporter,
 	GenerateError,

--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -251,7 +251,6 @@ static cell_t sm_vformat(IPluginContext *pContext, const cell_t *params)
 	return total;
 }
 
-/* :TODO: make this UTF8 safe */
 static cell_t BreakString(IPluginContext *pContext, const cell_t *params)
 {
 	const char *input;
@@ -263,81 +262,7 @@ static cell_t BreakString(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToString(params[2], &out);
 	outMax = params[3];
 
-	const char *inptr = input;
-	/* Eat up whitespace */
-	while (*inptr != '\0' && textparsers->IsWhitespace(inptr))
-	{
-		inptr++;
-	}
-
-	if (*inptr == '\0')
-	{
-		if (outMax)
-		{
-			*out = '\0';
-		}
-		return -1;
-	}
-
-	const char *start, *end = NULL;
-
-	bool quoted = (*inptr == '"');
-	if (quoted)
-	{
-		inptr++;
-		start = inptr;
-		/* Read input until we reach a quote. */
-		while (*inptr != '\0' && *inptr != '"')
-		{
-			/* Update the end point, increment the stream. */
-			end = inptr++;
-		}
-		/* Read one more token if we reached an end quote */
-		if (*inptr == '"')
-		{
-			inptr++;
-		}
-	} else {
-		start = inptr;
-		/* Read input until we reach a space */
-		while (*inptr != '\0' && !textparsers->IsWhitespace(inptr))
-		{
-			/* Update the end point, increment the stream. */
-			end = inptr++;
-		}
-	}
-
-	/* Copy the string we found, if necessary */
-	if (end == NULL)
-	{
-		if (outMax)
-		{
-			*out = '\0';
-		}
-	} else if (outMax) {
-		char *outptr = out;
-		outMax--;
-		for (const char *ptr=start;
-			(ptr <= end) && ((unsigned)(outptr - out) < (outMax));
-			ptr++, outptr++)
-			{
-			*outptr = *ptr;
-		}
-		*outptr = '\0';
-	}
-
-	/* Consume more of the string until we reach non-whitespace */
-	while (*inptr != '\0' && textparsers->IsWhitespace(inptr))
-	{
-		inptr++;
-	}
-
-	if (*inptr == '\0')
-	{
-		return -1;
-	}
-
-	return inptr - input;
+	return UTIL_BreakString(input, out, outMax);
 }
 
 static cell_t GetCharBytes(IPluginContext *pContext, const cell_t *params)

--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -365,6 +365,88 @@ char *UTIL_TrimWhitespace(char *str, size_t &len)
 	return str;
 }
 
+/* :TODO: make this UTF8 safe */
+int UTIL_BreakString(const char *input, char *output, size_t maxlen)
+{
+	const char *inptr = input;
+	/* Eat up whitespace */
+	while (*inptr != '\0' && textparsers->IsWhitespace(inptr))
+	{
+		inptr++;
+	}
+
+	if (*inptr == '\0')
+	{
+		if (maxlen)
+		{
+			*output = '\0';
+		}
+		return -1;
+	}
+
+	const char *start, *end = NULL;
+
+	bool quoted = (*inptr == '"');
+	if (quoted)
+	{
+		inptr++;
+		start = inptr;
+		/* Read input until we reach a quote. */
+		while (*inptr != '\0' && *inptr != '"')
+		{
+			/* Update the end point, increment the stream. */
+			end = inptr++;
+		}
+		/* Read one more token if we reached an end quote */
+		if (*inptr == '"')
+		{
+			inptr++;
+		}
+	}
+	else {
+		start = inptr;
+		/* Read input until we reach a space */
+		while (*inptr != '\0' && !textparsers->IsWhitespace(inptr))
+		{
+			/* Update the end point, increment the stream. */
+			end = inptr++;
+		}
+	}
+
+	/* Copy the string we found, if necessary */
+	if (end == NULL)
+	{
+		if (maxlen)
+		{
+			*output = '\0';
+		}
+	}
+	else if (maxlen) {
+		char *outptr = output;
+		maxlen--;
+		for (const char *ptr = start;
+			(ptr <= end) && ((unsigned)(outptr - output) < (maxlen));
+			ptr++, outptr++)
+		{
+			*outptr = *ptr;
+		}
+		*outptr = '\0';
+	}
+
+	/* Consume more of the string until we reach non-whitespace */
+	while (*inptr != '\0' && textparsers->IsWhitespace(inptr))
+	{
+		inptr++;
+	}
+
+	if (*inptr == '\0')
+	{
+		return -1;
+	}
+
+	return inptr - input;
+}
+
 class StaticCharBuf
 {
     char *buffer;

--- a/core/logic/stringutil.h
+++ b/core/logic/stringutil.h
@@ -42,6 +42,7 @@ size_t UTIL_DecodeHexString(unsigned char *buffer, size_t maxlength, const char 
 
 void UTIL_StripExtension(const char *in, char *out, int outSize);
 char *UTIL_TrimWhitespace(char *str, size_t &len);
+int UTIL_BreakString(const char *input, char *output, size_t maxlen);
 
 // Internal copying Format helper, expects (char[] buffer, int maxlength, const char[] format, any ...) starting at |start|
 // i.e. you can stuff your own params before |buffer|.

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -748,9 +748,10 @@ CoreProviderImpl::AddCommandAutoCompleteHook(ConCommand *cmd, const CommandAutoC
 	return hooks_.AddCommandAutocompleteHook(cmd, callback);
 }
 
-CoreProviderImpl::CommandImpl::CommandImpl(ConCommand *cmd, CommandHook *hook)
+CoreProviderImpl::CommandImpl::CommandImpl(ConCommand *cmd, CommandHook *hook, CommandAutoCompleteHook *autocompleter)
 : cmd_(cmd),
-  hook_(hook)
+  hook_(hook),
+  autocompleter_(autocompleter)
 {
 }
 
@@ -765,7 +766,7 @@ CoreProviderImpl::CommandImpl::~CommandImpl()
 }
 
 void
-CoreProviderImpl::DefineCommand(const char *name, const char *help, const CommandFunc &callback)
+CoreProviderImpl::DefineCommand(const char *name, const char *help, const CommandFunc &callback, const AutoCompleteFunc &autocompleter)
 {
 	char *new_name = sm_strdup(name);
 	char *new_help = sm_strdup(help);
@@ -777,7 +778,12 @@ CoreProviderImpl::DefineCommand(const char *name, const char *help, const Comman
 	ConCommand *cmd = new ConCommand(new_name, ignore_callback, new_help, flags);
 	ke::RefPtr<CommandHook> hook = AddCommandHook(cmd, callback);
 
-	ke::RefPtr<CommandImpl> impl = new CommandImpl(cmd, hook);
+
+	ke::RefPtr<CommandAutoCompleteHook> autocompleter_hook;
+	if (autocompleter)
+		autocompleter_hook = AddCommandAutoCompleteHook(cmd, autocompleter);
+
+	ke::RefPtr<CommandImpl> impl = new CommandImpl(cmd, hook, autocompleter_hook);
 	commands_.append(impl);
 }
 

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -741,6 +741,13 @@ CoreProviderImpl::AddPostCommandHook(ConCommand *cmd, const CommandHook::Callbac
 	return hooks_.AddPostCommandHook(cmd, callback);
 }
 
+ke::RefPtr<CommandAutoCompleteHook>
+CoreProviderImpl::AddCommandAutoCompleteHook(ConCommand *cmd, const CommandAutoCompleteHook::Callback &callback)
+{
+
+	return hooks_.AddCommandAutocompleteHook(cmd, callback);
+}
+
 CoreProviderImpl::CommandImpl::CommandImpl(ConCommand *cmd, CommandHook *hook)
 : cmd_(cmd),
   hook_(hook)

--- a/core/provider.h
+++ b/core/provider.h
@@ -69,6 +69,7 @@ public:
 
 	ke::RefPtr<CommandHook> AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 	ke::RefPtr<CommandHook> AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
+	ke::RefPtr<CommandAutoCompleteHook> AddCommandAutoCompleteHook(ConCommand *cmd, const CommandAutoCompleteHook::Callback &callback);
 
 	int CommandClient() const {
 		return hooks_.CommandClient();

--- a/core/provider.h
+++ b/core/provider.h
@@ -65,7 +65,7 @@ public:
 	void UnloadMMSPlugin(int id) override;
 	int QueryClientConVar(int client, const char *cvar) override;
 	bool IsClientConVarQueryingSupported() override;
-	void DefineCommand(const char *cmd, const char *help, const SourceMod::CommandFunc &callback) override;
+	void DefineCommand(const char *cmd, const char *help, const SourceMod::CommandFunc &callback, const AutoCompleteFunc &autocompleter = nullptr) override;
 
 	ke::RefPtr<CommandHook> AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 	ke::RefPtr<CommandHook> AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
@@ -83,12 +83,13 @@ private:
 	struct CommandImpl : public ke::Refcounted<CommandImpl>
 	{
 	public:
-		CommandImpl(ConCommand *cmd, CommandHook *hook);
+		CommandImpl(ConCommand *cmd, CommandHook *hook, CommandAutoCompleteHook *autocompleter);
 		~CommandImpl();
 
 	private:
 		ConCommand *cmd_;
 		ke::RefPtr<CommandHook> hook_;
+		ke::RefPtr<CommandAutoCompleteHook> autocompleter_;
 	};
 	ke::Vector<ke::RefPtr<CommandImpl>> commands_;
 };

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -688,8 +688,8 @@ static cell_t sm_QueryClientConVar(IPluginContext *pContext, const cell_t *param
 
 static cell_t sm_RegServerCmd(IPluginContext *pContext, const cell_t *params)
 {
-	char *name,*help;
-	IPluginFunction *pFunction;
+	char *name, *help;
+	IPluginFunction *pFunction, *pAutoCompleteFunction = nullptr;
 
 	pContext->LocalToString(params[1], &name);
 
@@ -706,7 +706,16 @@ static cell_t sm_RegServerCmd(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid function id (%X)", params[2]);
 	}
 
-	if (!g_ConCmds.AddServerCommand(pFunction, name, help, params[4]))
+	if (params[0] > 4 && params[5] != -1)
+	{
+		pAutoCompleteFunction = pContext->GetFunctionById(params[5]);
+		if (!pAutoCompleteFunction)
+		{
+			return pContext->ThrowNativeError("Invalid auto complete function id (%X)", params[5]);
+		}
+	}
+
+	if (!g_ConCmds.AddServerCommand(pFunction, name, help, params[4], pAutoCompleteFunction))
 	{
 		return pContext->ThrowNativeError("Command \"%s\" could not be created. A convar with the same name already exists.", name);
 	}
@@ -717,7 +726,7 @@ static cell_t sm_RegServerCmd(IPluginContext *pContext, const cell_t *params)
 static cell_t sm_RegConsoleCmd(IPluginContext *pContext, const cell_t *params)
 {
 	char *name,*help;
-	IPluginFunction *pFunction;
+	IPluginFunction *pFunction, *pAutoCompleteFunction = nullptr;
 
 	pContext->LocalToString(params[1], &name);
 
@@ -734,9 +743,18 @@ static cell_t sm_RegConsoleCmd(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid function id (%X)", params[2]);
 	}
 
+	if (params[0] > 4 && params[5] != -1)
+	{
+		pAutoCompleteFunction = pContext->GetFunctionById(params[5]);
+		if (!pAutoCompleteFunction)
+		{
+			return pContext->ThrowNativeError("Invalid auto complete function id (%X)", params[5]);
+		}
+	}
+
 	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
 	const char *group = pPlugin->GetFilename();
-	if (!g_ConCmds.AddAdminCommand(pFunction, name, group, 0, help, params[4]))
+	if (!g_ConCmds.AddAdminCommand(pFunction, name, group, 0, help, params[4], pAutoCompleteFunction))
 	{
 		return pContext->ThrowNativeError("Command \"%s\" could not be created. A convar with the same name already exists.", name);
 	}
@@ -748,7 +766,7 @@ static cell_t sm_RegAdminCmd(IPluginContext *pContext, const cell_t *params)
 {
 	char *name,*help;
 	const char *group;
-	IPluginFunction *pFunction;
+	IPluginFunction *pFunction, *pAutoCompleteFunction = nullptr;
 	FlagBits flags = params[3];
 	int cmdflags = params[6];
 
@@ -774,7 +792,16 @@ static cell_t sm_RegAdminCmd(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid function id (%X)", params[2]);
 	}
 
-	if (!g_ConCmds.AddAdminCommand(pFunction, name, group, flags, help, cmdflags))
+	if (params[0] > 6 && params[7] != -1)
+	{
+		pAutoCompleteFunction = pContext->GetFunctionById(params[7]);
+		if (!pAutoCompleteFunction)
+		{
+			return pContext->ThrowNativeError("Invalid auto complete function id (%X)", params[7]);
+		}
+	}
+
+	if (!g_ConCmds.AddAdminCommand(pFunction, name, group, flags, help, cmdflags, pAutoCompleteFunction))
 	{
 		return pContext->ThrowNativeError("Command \"%s\" could not be created. A convar with the same name already exists.", name);
 	}

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -323,17 +323,17 @@ typedef SrvCmd = function Action (int args);
 /**
  * Called when the server operator typed "some_command <tab>" in the server console.
  * Provide and change argument autocompletion suggestions for the command.
+ * Use the GetCmdArg* natives to access the command and (incomplete) arguments.
  *
  * If there is only one suggestion for the arguments, the command line string
  * is replaced with the suggestion.
  *
- * @param command      The name of the command to generate argument suggestions for.
- * @param partial      The whole command line string typed yet (including the command name).
+ * @param args         Number of arguments that are in the argument string.
  * @param suggestions  ArrayList holding all suggestions for the command arguments.
  *                     The suggestions should include the full command line with the 
                        command name itself.
  */
-typedef CommandCompletionCallback = function void (const char[] command, const char[] partial, ArrayList suggestions);
+typedef CommandCompletionCallback = function void (int args, ArrayList suggestions);
 
 /**
  * Creates a server-only console command, or hooks an already existing one.  

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -321,6 +321,21 @@ native bool FormatActivitySource(int client, int target, const char[] namebuf, i
 typedef SrvCmd = function Action (int args);
 
 /**
+ * Called when the server operator typed "some_command <tab>" in the server console.
+ * Provide and change argument autocompletion suggestions for the command.
+ *
+ * If there is only one suggestion for the arguments, the command line string
+ * is replaced with the suggestion.
+ *
+ * @param command      The name of the command to generate argument suggestions for.
+ * @param partial      The whole command line string typed yet (including the command name).
+ * @param suggestions  ArrayList holding all suggestions for the command arguments.
+ *                     The suggestions should include the full command line with the 
+                       command name itself.
+ */
+typedef CommandCompletionCallback = function void (const char[] command, const char[] partial, ArrayList suggestions);
+
+/**
  * Creates a server-only console command, or hooks an already existing one.  
  *
  * Server commands are case sensitive.
@@ -329,9 +344,10 @@ typedef SrvCmd = function Action (int args);
  * @param callback		A function to use as a callback for when the command is invoked.
  * @param description	Optional description to use for command creation.
  * @param flags			Optional flags to use for command creation.
+ * @param autocomplete	Optional callback to provide or alter argument autocomplete suggestions.
  * @error				Command name is the same as an existing convar.
  */
-native void RegServerCmd(const char[] cmd, SrvCmd callback, const char[] description="", int flags=0);
+native void RegServerCmd(const char[] cmd, SrvCmd callback, const char[] description="", int flags=0, CommandCompletionCallback autocomplete=INVALID_FUNCTION);
 
 /**
  * Called when a generic console command is invoked.
@@ -354,9 +370,10 @@ typedef ConCmd = function Action (int client, int args);
  * @param callback		A function to use as a callback for when the command is invoked.
  * @param description	Optional description to use for command creation.
  * @param flags			Optional flags to use for command creation.
+ * @param autocomplete	Optional callback to provide or alter argument autocomplete suggestions.
  * @error				Command name is the same as an existing convar.
  */
-native void RegConsoleCmd(const char[] cmd, ConCmd callback, const char[] description="", int flags=0);
+native void RegConsoleCmd(const char[] cmd, ConCmd callback, const char[] description="", int flags=0, CommandCompletionCallback autocomplete=INVALID_FUNCTION);
 
 /**
  * Creates a console command as an administrative command.  If the command does not exist,
@@ -372,6 +389,7 @@ native void RegConsoleCmd(const char[] cmd, ConCmd callback, const char[] descri
  * @param group			String containing the command group to use.  If empty,
  * 						the plugin's filename will be used instead.
  * @param flags			Optional console flags.
+ * @param autocomplete	Optional callback to provide or alter argument autocomplete suggestions.
  * @error				Command name is the same as an existing convar.
  */
 native void RegAdminCmd(const char[] cmd,
@@ -379,7 +397,8 @@ native void RegAdminCmd(const char[] cmd,
 					int adminflags,
 					const char[] description="",
 					const char[] group="",
-					int flags=0);
+					int flags=0,
+					CommandCompletionCallback autocomplete=INVALID_FUNCTION);
 					
 /**
  * Returns the number of arguments from the current console or server command.

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -328,12 +328,13 @@ typedef SrvCmd = function Action (int args);
  * If there is only one suggestion for the arguments, the command line string
  * is replaced with the suggestion.
  *
+ * @param cmd          The command to suggest arguments for.
  * @param args         Number of arguments that are in the argument string.
  * @param suggestions  ArrayList holding all suggestions for the command arguments.
  *                     The suggestions should include the full command line with the 
                        command name itself.
  */
-typedef CommandCompletionCallback = function void (int args, ArrayList suggestions);
+typedef CommandCompletionCallback = function void (const char[] cmd, int args, ArrayList suggestions);
 
 /**
  * Creates a server-only console command, or hooks an already existing one.  

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -432,6 +432,16 @@ native int GetCmdArg(int argnum, char[] buffer, int maxlength);
 native int GetCmdArgString(char[] buffer, int maxlength);
 
 /**
+ * Returns the autocomplete suggestions for the given input.
+ * This is the same as typing "command <tab>".
+ * ArrayList handle has to be closed after use.
+ *
+ * @param partial  The console command with optional additional partial arguments.
+ * @return         An ArrayList of all suggestions or INVALID_HANDLE if no suggestions / error.
+ */
+native ArrayList GetCmdAutoCompleteSuggestions(const char[] partial);
+
+/**
  * Gets a command iterator.  Must be freed with CloseHandle().
  *
  * @return				A new command iterator.


### PR DESCRIPTION
Add an additional callback argument to Reg*Cmd natives to provide suggestions for possible arguments.
Currently only the SRCDS windows GUI supports the autocompletion feature properly. You need a [seperate extension](https://forums.alliedmods.net/showthread.php?t=286937) to enable it on the command line versions. This only works in the server console.

In the callback

``` sourcepawn
typedef CommandCompletionCallback = function void (const char[] cmd, int args, ArrayList suggestions);
```

plugin authors can use the `GetCmdArg*` natives to get the (partial) arguments just like in the normal command callback and add possible arguments to the `suggestions` array.

There is a new native to get the argument suggestions for arbitary commands too.

``` sourcepawn
native ArrayList GetCmdAutoCompleteSuggestions(const char[] partial);
```

The autocompletion capability is exposed to logic too through the bridge. A future PR might add argument autocompletion for the rootmenu.

~~At the moment `episode1` and `darkm` engine branches aren't supported when trying to hook autocompletion for existing commands due to a limitation in SourceHook and fixed-size array parameters.~~
