### PR TITLE
Added AutoExecConfig to each plugin that has its own ConVars

### DIFF
--- a/configs/cfg/sourcemod.cfg
+++ b/configs/cfg/sourcemod.cfg
@@ -50,68 +50,6 @@ sm_immunity_mode 1
 // Default: 0
 sm_time_adjustment 0
 
-// Specifies the amount of time that is allowed between chat messages.  This
-// includes the say and say_team commands.  If a client sends a message faster
-// than this time, they receive a flood token.  When the client has accumulated
-// 3 or more tokens, a warning message is shown instead of the chat message.
-// --
-// Requires: antiflood.smx
-// Default: 0.75
-sm_flood_time 0.75
-
-// Specifies how the reserved slots plugin operates. Valid values are:
-// 0 : Public slots are used in preference to reserved slots. Reserved slots are freed before public slots.
-// 1 : If someone with reserve access joins into a reserved slot, the player with the highest latency and 
-// no reserved slot access (spectator players are selected first) is kicked to make room. Thus, the reserved
-// slots always remains free. The only situation where the reserved slot(s) can become properly occupied is 
-// if the server is full with reserve slot access clients.
-// 2 : The same as sm_reserve_type 1 except once a certain number of admins have been reached, the reserve slot
-// stops kicking people and anyone can join to fill the server. You can use this to simulate having a large
-// number of reserved slots with sm_reserve_type 0 but with only need to have 1 slot unavailable when there are
-// less admins connected.
-// --
-// Requires: reservedslots.smx
-// Default: 0
-sm_reserve_type 0
-
-// Specifies the number of reserved player slots.  Users with the reservation
-// admin flag set will be able to join the server when there are no public slots
-// remaining. If someone does not have this flag, they will be kicked.
-// (Public slots are defined as: maxplayers - number of reserved slots)
-// --
-// Requires: reservedslots.smx
-// Default: 0
-sm_reserved_slots 0
-
-// Specifies whether or not reserved slots will be hidden (subtracted from max
-// slot count). Valid values are 0 (Visible) or 1 (Hidden).
-// --
-// Requires: reservedslots.smx
-// Default: 0
-sm_hide_slots 0
-
-// Specifies whether or not non-admins can send messages to admins using
-// say_team @<message>. Valid values are 0 (Disabled) or 1 (Enabled)
-// --
-// Requires: basechat.smx
-// Default: 1
-sm_chat_mode 1
-
-// Specifies whether or not "timeleft" will automatically be triggered every
-// x seconds. Valid values are 0 (Disabled) to 1800 seconds.
-// --
-// Requires: basetriggers.smx
-// Default: 0
-sm_timeleft_interval 0
-
-// Specifies whether or not chat triggers are broadcast to the server or just
-// the player who requested the info trigger. Valid values are 0 (Disabled) or
-// 1 (Enabled)
-// --
-// Requires: basetriggers.smx
-// Default: 0
-sm_trigger_show 0
-
 // Specifies whether or not to display vote progress to clients in the
 // "hint" box (near the bottom of the screen in most games).
 // Valid values are 0 (Disabled) or 1 (Enabled).

--- a/plugins/antiflood.sp
+++ b/plugins/antiflood.sp
@@ -54,6 +54,8 @@ ConVar sm_flood_time;									/* Handle to sm_flood_time convar */
 public void OnPluginStart()
 {
 	sm_flood_time = CreateConVar("sm_flood_time", "0.75", "Amount of time allowed between chat messages");
+	
+	AutoExecConfig(true, "antiflood");
 }
 
 public void OnClientPutInServer(int client)

--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -76,6 +76,8 @@ public void OnPluginStart()
 	RegAdminCmd("sm_chat", Command_SmChat, ADMFLAG_CHAT, "sm_chat <message> - sends message to admins");
 	RegAdminCmd("sm_psay", Command_SmPsay, ADMFLAG_CHAT, "sm_psay <name or #userid> <message> - sends private message");
 	RegAdminCmd("sm_msay", Command_SmMsay, ADMFLAG_CHAT, "sm_msay <message> - sends message as a menu panel");
+	
+	AutoExecConfig(true, "basechat");
 }
 
 public Action OnClientSayCommand(int client, const char[] command, const char[] sArgs)

--- a/plugins/basecomm.sp
+++ b/plugins/basecomm.sp
@@ -89,7 +89,9 @@ public void OnPluginStart()
 	RegAdminCmd("sm_unmute", Command_Unmute, ADMFLAG_CHAT, "sm_unmute <player> - Restores a player's ability to use voice.");
 	RegAdminCmd("sm_ungag", Command_Ungag, ADMFLAG_CHAT, "sm_ungag <player> - Restores a player's ability to use chat.");
 	RegAdminCmd("sm_unsilence", Command_Unsilence, ADMFLAG_CHAT, "sm_unsilence <player> - Restores a player's ability to use voice and chat.");	
-	
+
+	AutoExecConfig(true, "basecomm");
+
 	g_Cvar_Deadtalk.AddChangeHook(ConVarChange_Deadtalk);
 	g_Cvar_Alltalk.AddChangeHook(ConVarChange_Alltalk);
 	

--- a/plugins/basetriggers.sp
+++ b/plugins/basetriggers.sp
@@ -81,7 +81,9 @@ public void OnPluginStart()
 	RegConsoleCmd("nextmap", Command_Nextmap);
 	RegConsoleCmd("motd", Command_Motd);
 	RegConsoleCmd("ff", Command_FriendlyFire);
-	
+
+	AutoExecConfig(true, "basetriggers");
+
 	g_Cvar_TimeleftInterval.AddChangeHook(ConVarChange_TimeleftInterval);
 
 	char folder[64];   	 

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -76,6 +76,8 @@ public void OnPluginStart()
 	
 	RegAdminCmd("sm_nominate_addmap", Command_Addmap, ADMFLAG_CHANGEMAP, "sm_nominate_addmap <mapname> - Forces a map to be on the next mapvote.");
 	
+	AutoExecConfig(true, "nominations");
+	
 	g_mapTrie = new StringMap();
 }
 

--- a/plugins/reservedslots.sp
+++ b/plugins/reservedslots.sp
@@ -71,10 +71,12 @@ public void OnPluginStart()
 	sm_reserved_slots = CreateConVar("sm_reserved_slots", "0", "Number of reserved player slots", 0, true, 0.0);
 	sm_hide_slots = CreateConVar("sm_hide_slots", "0", "If set to 1, reserved slots will hidden (subtracted from the max slot count)", 0, true, 0.0, true, 1.0);
 	sv_visiblemaxplayers = FindConVar("sv_visiblemaxplayers");
-	sm_reserve_type = CreateConVar("sm_reserve_type", "0", "Method of reserving slots", 0, true, 0.0, true, 2.0);
+	sm_reserve_type = CreateConVar("sm_reserve_type", "0", "Method of reserving slots: 0-Public slots are used in preference to reserved slots, 1-If someone with reserve access joins into a reserved slot, a player with no reserved slot access is kicked, 2-Same as method 1 except once a certain number of admins has been reached, the reserve slot stops kicking people", 0, true, 0.0, true, 2.0);
 	sm_reserve_maxadmins = CreateConVar("sm_reserve_maxadmins", "1", "Maximum amount of admins to let in the server with reserve type 2", 0, true, 0.0);
-	sm_reserve_kicktype = CreateConVar("sm_reserve_kicktype", "0", "How to select a client to kick (if appropriate)", 0, true, 0.0, true, 2.0);
-	
+	sm_reserve_kicktype = CreateConVar("sm_reserve_kicktype", "0", "How to select a client to kick (if appropriate): 0-Highest ping, 1-Longest connection time, 2-Random choice", 0, true, 0.0, true, 2.0);
+
+	AutoExecConfig(true, "reservedslots");
+
 	sm_reserved_slots.AddChangeHook(SlotCountChanged);
 	sm_hide_slots.AddChangeHook(SlotHideChanged);
 }


### PR DESCRIPTION
Removed each ConVar that requires a plugin from sourcemod.cfg, so the console doesnt print Unknown command for ConVars from plugins that aren't loaded.
Added AutoExecConfig to each plugin that has its own ConVars.
Expanded description for 2 reservedslots ConVars.
