### PR TITLE
Suppress logging of "Plugin not runnable" errors

### DIFF
--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -157,6 +157,12 @@ int DebugReport::_GetPluginIndex(IPluginContext *ctx)
 
 void DebugReport::ReportError(const IErrorReport &report, IFrameIterator &iter)
 {
+	// Don't log an error if a function wasn't runnable.
+	// This is necassary due to the way SM is handling and exposing
+	// scripted functions. It's too late to change that now.
+	if (report.Code() == SP_ERROR_NOT_RUNNABLE)
+		return;
+
 	const char *blame = nullptr;
 	if (report.Blame()) 
 	{


### PR DESCRIPTION
SourceMod itself and thirdparty extensions call functions in plugins
without making sure it is runnable. The plugin pausing feature isn't
supported anymore and is set to get nuked #438 which will reduce the
amount of not-runnable error reports.

We can't fix every third party extension, so suppressing the error from
the logs will stop the spam until pausing is removed.

#489 can be reverted after this.