### PR TITLE
Suppress logging of "Plugin not runnable" errors in SM 1.8

### DIFF
--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -180,6 +180,13 @@ void DebugReport::ReportError(const IErrorReport &report, IFrameIterator &iter)
 	}
 
 	iter.Reset();
+	
+	// Don't log an error if a function wasn't runnable.	
+	// This is necassary due to the way SM is handling and exposing
+	// scripted functions. It's too late to change that now.
+	// Make sure this error wasn't manually thrown by a plugin.
+	if (!blame && !strcmp(report.Message(), "Plugin not runnable"))
+		return;
 
 	g_Logger.LogError("[SM] Exception reported: %s", report.Message());
 


### PR DESCRIPTION
This is a backport of #558 to the 1.8 branch.

Since we can't really easily change the VM in 1.8 anymore (right?), this does a string comparison against the error message to know what to suppress. Also tries to not suppress errors manually generated by plugins which happen to start with the same phrase.