### PR TITLE
Fix case of not calling OnMapTimeLeftChanged in CS:GO

### DIFF
--- a/extensions/cstrike/timeleft.cpp
+++ b/extensions/cstrike/timeleft.cpp
@@ -65,7 +65,11 @@ void TimeLeftEvents::FireGameEvent(IGameEvent *event)
 	}
 	else if (strcmp(name, "round_end") == 0)
 	{
+#if SOURCE_ENGINE == SE_CSGO
+		if (event->GetInt("reason") == 16)
+#else
 		if (event->GetInt("reason") == 15)
+#endif
 		{
 			get_new_timeleft_offset = true;
 		}


### PR DESCRIPTION
Round end reasons in CS:GO are +1 from the ones in CS:S. The
CSRoundEnd_GameStart reason for when the OnMapTimeLeftChanged forward
should be called should be one higher than in CS:S.