### PR TITLE
Fix crash in CloneArray for too large arrays

### DIFF
--- a/core/logic/CellArray.h
+++ b/core/logic/CellArray.h
@@ -186,6 +186,12 @@ public:
 		array->m_AllocSize = m_AllocSize;
 		array->m_Size = m_Size;
 		array->m_Data = (cell_t *)malloc(sizeof(cell_t) * m_BlockSize * m_AllocSize);
+		if (!array->m_Data)
+		{
+			delete array;
+			return NULL;
+		}
+		
 		memcpy(array->m_Data, m_Data, sizeof(cell_t) * m_BlockSize * m_Size);
 		return array;
 	}

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -503,6 +503,10 @@ static cell_t CloneArray(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ICellArray *array = oldArray->clone();
+	if (!array)
+	{
+		return pContext->ThrowNativeError("Failed to clone array. Out of memory.");
+	}
 
 	Handle_t hndl = handlesys->CreateHandle(htCellArray, array, pContext->GetIdentity(), g_pCoreIdent, NULL);
 	if (!hndl)


### PR DESCRIPTION
If there is not enough memory to clone an array, throw an error instead
of crashing the server.