### PR TITLE
Change sm_msay behavior to use GetMaxPageItems instead of hardcoded values

### DIFF
--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -407,7 +407,7 @@ void SendPanelToAll(int from, char[] message)
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
 	mSayPanel.DrawText(message);
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
-	int exitkey = 10
+	int exitkey = 10;
 	if(GetEngineVersion() == Engine_CSGO)
 	{
 		exitkey = 9; //fix for CS:GO not showing the exit button.

--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -407,8 +407,12 @@ void SendPanelToAll(int from, char[] message)
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
 	mSayPanel.DrawText(message);
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
-
-	mSayPanel.CurrentKey = 10;
+	int exitkey = 10
+	if(GetEngineVersion() == Engine_CSGO)
+	{
+		exitkey = 9; //fix for CS:GO not showing the exit button.
+	}
+	mSayPanel.CurrentKey = exitkey;
 	mSayPanel.DrawItem("Exit", ITEMDRAW_CONTROL);
 
 	for(int i = 1; i <= MaxClients; i++)

--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -407,12 +407,7 @@ void SendPanelToAll(int from, char[] message)
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
 	mSayPanel.DrawText(message);
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
-	int exitkey = 10;
-	if(GetEngineVersion() == Engine_CSGO)
-	{
-		exitkey = 9; //fix for CS:GO not showing the exit button.
-	}
-	mSayPanel.CurrentKey = exitkey;
+	mSayPanel.CurrentKey = GetMaxPageItems(GetMenuStyleHandle(mSayPanel));
 	mSayPanel.DrawItem("Exit", ITEMDRAW_CONTROL);
 
 	for(int i = 1; i <= MaxClients; i++)

--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -407,7 +407,7 @@ void SendPanelToAll(int from, char[] message)
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
 	mSayPanel.DrawText(message);
 	mSayPanel.DrawItem("", ITEMDRAW_SPACER);
-	mSayPanel.CurrentKey = GetMaxPageItems(GetMenuStyleHandle(mSayPanel));
+	mSayPanel.CurrentKey = GetMaxPageItems(GetPanelStyle(mSayPanel));
 	mSayPanel.DrawItem("Exit", ITEMDRAW_CONTROL);
 
 	for(int i = 1; i <= MaxClients; i++)


### PR DESCRIPTION
Fix for CS:GO not showing the sm_msay exit button

mSayPanel.CurrentKey = 10:
![mSayPanel.CurrentKey = 10](http://i.imgur.com/qxgVoUM.png)

mSayPanel.CurrentKey = 9:
![mSayPanel.CurrentKey = 9](http://i.imgur.com/t8079No.png)