### PR TITLE
Fix incomplete TextMsg packet

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -574,6 +574,10 @@ bool CHalfLife2::TextMsg(int client, int dest, const char *msg)
 
 	pBitBuf->WriteByte(dest);
 	pBitBuf->WriteString(msg);
+	pBitBuf->WriteString("");
+	pBitBuf->WriteString("");
+	pBitBuf->WriteString("");
+	pBitBuf->WriteString("");
 #endif
 
 	g_UserMsgs.EndMessage();


### PR DESCRIPTION
The source 2013 handler for TextMsg expects five strings in the message here: https://github.com/ValveSoftware/source-sdk-2013/blob/master/mp/src/game/client/hud_chat.cpp#L124

Because sourcemod doesn't send the last four strings along each message sent from sourcemod triggers an assert in tier1/bitbuf.cpp if the game is not built with RELEASE.