### PR TITLE
Fix memory leak in Regex extension.

### DIFF
--- a/extensions/regex/extension.cpp
+++ b/extensions/regex/extension.cpp
@@ -91,7 +91,16 @@ static cell_t CompileRegex(IPluginContext *pCtx, const cell_t *params)
 		return 0;
 	}
 
-	return g_pHandleSys->CreateHandle(g_RegexHandle, (void*)x, pCtx->GetIdentity(), myself->GetIdentity(), NULL);
+	HandleError error = HandleError_None;
+	Handle_t regexHandle = g_pHandleSys->CreateHandle(g_RegexHandle, (void*)x, pCtx->GetIdentity(), myself->GetIdentity(), &error);
+	if (!regexHandle || error != HandleError_None)
+	{
+		delete x;
+		pCtx->ReportError("Allocation of regex handkle failed, error code #%d", error);
+		return 0;
+	}
+	
+	return regexHandle;
 }
 
 

--- a/extensions/regex/extension.cpp
+++ b/extensions/regex/extension.cpp
@@ -96,7 +96,7 @@ static cell_t CompileRegex(IPluginContext *pCtx, const cell_t *params)
 	if (!regexHandle || error != HandleError_None)
 	{
 		delete x;
-		pCtx->ReportError("Allocation of regex handkle failed, error code #%d", error);
+		pCtx->ReportError("Allocation of regex handle failed, error code #%d", error);
 		return 0;
 	}
 	

--- a/extensions/regex/extension.cpp
+++ b/extensions/regex/extension.cpp
@@ -87,6 +87,7 @@ static cell_t CompileRegex(IPluginContext *pCtx, const cell_t *params)
 		const char *err = x->mError;
 		*eOff = x->mErrorOffset;
 		pCtx->StringToLocal(params[3], params[4], err ? err:"unknown");
+		delete x;
 		return 0;
 	}
 


### PR DESCRIPTION
"x" is never deleted when compile fails.