### PR TITLE
Fix crash when database transaction fails (bug 6531)

### DIFF
--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -1726,7 +1726,7 @@ public:
 		{
 			HandleSecurity sec(ident_, g_pCoreIdent);
 
-			ke::AutoPtr<cell_t[]> data = ke::MakeUnique<cell_t[]>(results_.length());
+			ke::AutoPtr<cell_t[]> data = ke::MakeUnique<cell_t[]>(txn_->entries.length());
 			for (size_t i = 0; i < txn_->entries.length(); i++)
 				data[i] = txn_->entries[i].data;
 


### PR DESCRIPTION
If one of the queries fails in a transaction, the DBI system would only
allocate an array of the size of the amount of all the successful
queries before the failed one.
It writes data for all the queries though effectively writing past the
array bounds leading to heap corruption.

Create the right sized array!