### PR TITLE
Add ADT array blocksize getter

### DIFF
--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -580,6 +580,21 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	return -1;
 }
 
+static cell_t GetArrayBlockSize(IPluginContext *pContext, const cell_t *params)
+{
+	CellArray *array;
+	HandleError err;
+	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
+
+	if ((err = handlesys->ReadHandle(params[1], htCellArray, &sec, (void **)&array))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
+	}
+
+	return array->blocksize();
+}
+
 REGISTER_NATIVES(cellArrayNatives)
 {
 	{"ClearArray",					ClearArray},
@@ -601,6 +616,7 @@ REGISTER_NATIVES(cellArrayNatives)
 	{"CloneArray",					CloneArray},
 	{"FindStringInArray",			FindStringInArray},
 	{"FindValueInArray",			FindValueInArray},
+	{"GetArrayBlockSize",			GetArrayBlockSize},
 
 	// Transitional syntax support.
 	{"ArrayList.ArrayList",			CreateArray},
@@ -622,6 +638,7 @@ REGISTER_NATIVES(cellArrayNatives)
 	{"ArrayList.Clone",				CloneArray},
 	{"ArrayList.FindString",		FindStringInArray},
 	{"ArrayList.FindValue",			FindValueInArray},
+	{"ArrayList.BlockSize.get",		GetArrayBlockSize},
 
 	{NULL,							NULL},
 };

--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -369,6 +369,21 @@ static cell_t ArrayStack_PopArray(IPluginContext *pContext, const cell_t *params
 	return 0;
 }
 
+static cell_t GetStackBlockSize(IPluginContext *pContext, const cell_t *params)
+{
+	HandleError err;
+	CellArray *array;
+	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
+
+	if ((err = handlesys->ReadHandle(params[1], htCellStack, &sec, (void **)&array))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
+	}
+
+	return array->blocksize();
+}
+
 REGISTER_NATIVES(cellStackNatives)
 {
 	{"CreateStack",					CreateStack},
@@ -379,6 +394,7 @@ REGISTER_NATIVES(cellStackNatives)
 	{"PushStackArray",				PushStackArray},
 	{"PushStackCell",				PushStackCell},
 	{"PushStackString",				PushStackString},
+	{"GetStackBlockSize",			GetStackBlockSize},
 
 	// Transitional syntax support.
 	{"ArrayStack.ArrayStack",		CreateStack},
@@ -389,6 +405,7 @@ REGISTER_NATIVES(cellStackNatives)
 	{"ArrayStack.PushString",		PushStackString},
 	{"ArrayStack.PushArray",		PushStackArray},
 	{"ArrayStack.Empty.get",		IsStackEmpty},
+	{"ArrayStack.BlockSize.get",	GetStackBlockSize},
 
 	{NULL,							NULL},
 };

--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -212,6 +212,11 @@ methodmap ArrayList < Handle {
 	property int Length {
 		public native get();
 	}
+	
+	// Retrieve the blocksize the array was created with.
+	property int BlockSize {
+		public native get();
+	}
 };
 
 /**
@@ -439,3 +444,12 @@ native int FindStringInArray(Handle array, const char[] item);
  * @error				Invalid Handle or invalid block
  */
 native int FindValueInArray(Handle array, any item, int block=0);
+
+/**
+ * Returns the blocksize the array was created with.
+ *
+ * @param array			Array Handle.
+ * @return 				The blocksize of the array.
+ * @error				Invalid Handle
+ */
+native int GetArrayBlockSize(Handle array);

--- a/plugins/include/adt_stack.inc
+++ b/plugins/include/adt_stack.inc
@@ -109,6 +109,11 @@ methodmap ArrayStack < Handle
 	property bool Empty {
 		public native get();
 	}
+	
+	// Retrieve the blocksize the stack was created with.
+	property int BlockSize {
+		public native get();
+	}
 };
 
 /**
@@ -224,3 +229,12 @@ stock bool PopStack(Handle stack)
 	int value;
 	return PopStackCell(stack, value);
 }
+
+/**
+ * Returns the blocksize the stack was created with.
+ *
+ * @param stack			Stack Handle.
+ * @return 				The blocksize of the stack.
+ * @error				Invalid Handle
+ */
+native int GetStackBlockSize(Handle stack);


### PR DESCRIPTION
Add GetArrayBlockSize and GetStackBlockSize and equivalent properties to
the methodmaps to get the blocksize the array or stack was created with.

Useful when getting array handles from other plugins you didn't create
yourself.