### PR TITLE
[HashMap] Adds new IntHashMap and IntMap natives.

### DIFF
--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -41,7 +41,7 @@
 #include <IAdminSystem.h>
 #include "concmd_cleaner.h"
 #include "GameHooks.h"
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <am-utility.h>
 #include <am-inlinelist.h>
 #include <am-linkedlist.h>

--- a/core/ConsoleDetours.h
+++ b/core/ConsoleDetours.h
@@ -34,7 +34,7 @@
 #include "sm_globals.h"
 #include "sourcemm_api.h"
 #include <IForwardSys.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 
 namespace SourceMod {
 class ICommandArgs;

--- a/core/CoreConfig.h
+++ b/core/CoreConfig.h
@@ -36,7 +36,7 @@
 #include <ITextParsers.h>
 #include <IRootConsoleMenu.h>
 #include <am-string.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 
 using namespace SourceMod;
 

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -38,7 +38,7 @@
 #include <am-utility.h>
 #include <am-hashset.h>
 #include <am-hashmap.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <sm_namehashset.h>
 #include "sm_globals.h"
 #include "sm_queue.h"

--- a/core/UserMessages.h
+++ b/core/UserMessages.h
@@ -34,7 +34,7 @@
 
 #include <IUserMessages.h>
 #include "sourcemm_api.h"
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include "sm_stringutil.h"
 #include "CellRecipientFilter.h"
 #include "sm_globals.h"

--- a/core/logic/ADTFactory.h
+++ b/core/logic/ADTFactory.h
@@ -34,7 +34,7 @@
 
 #include <IADTFactory.h>
 #include "common_logic.h"
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 
 using namespace SourceMod;
 

--- a/core/logic/AdminCache.h
+++ b/core/logic/AdminCache.h
@@ -39,7 +39,7 @@
 #include <sh_list.h>
 #include <sh_string.h>
 #include <IForwardSys.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <sm_namehashset.h>
 
 using namespace SourceHook;

--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -36,7 +36,7 @@
 #include <IGameConfigs.h>
 #include <ITextParsers.h>
 #include <am-refcounting.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <sm_namehashset.h>
 
 using namespace SourceMod;

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -44,7 +44,7 @@
 #include <sh_string.h>
 #include "common_logic.h"
 #include <IRootConsoleMenu.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <sm_namehashset.h>
 #include "ITranslator.h"
 #include "IGameConfigs.h"

--- a/core/logic/ShareSys.h
+++ b/core/logic/ShareSys.h
@@ -38,7 +38,7 @@
 #include <am-utility.h>
 #include <am-refcounting.h>
 #include <sh_list.h>
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <sm_namehashset.h>
 #include "common_logic.h"
 #include "Native.h"

--- a/core/logic/Translator.h
+++ b/core/logic/Translator.h
@@ -33,7 +33,7 @@
 #define _INCLUDE_SOURCEMOD_TRANSLATOR_H_
 
 #include "common_logic.h"
-#include <sm_stringhashmap.h>
+#include <sm_hashmap.h>
 #include <sh_string.h>
 #include <sh_vector.h>
 #include "sm_memtable.h"

--- a/plugins/include/adt_trie.inc
+++ b/plugins/include/adt_trie.inc
@@ -273,22 +273,6 @@ methodmap IntMapSnapshot < Handle
 native StringMap CreateTrie();
 
 /**
- * Creates a hash map. A hash map is a container that can map integers (called
- * "keys") to arbitrary values (cells, arrays, or strings). Keys in a hash map
- * are unique. That is, there is at most one entry in the map for a given key.
- *
- * Insertion, deletion, and lookup in a hash map are all considered to be fast
- * operations, amortized to O(1), or constant time.
- *
- * The word "Trie" in this API is historical. As of SourceMod 1.6, tries have
- * been internally replaced with hash tables, which have O(1) insertion time
- * instead of O(n).
- *
- * @return 			New Map Handle, which must be freed via CloseHandle().
- */
-native IntMap CreateIntTrie();
-
-/**
  * Sets a value in a hash map, either inserting a new entry or replacing an old one.
  *
  * @param map		Map Handle.
@@ -299,18 +283,6 @@ native IntMap CreateIntTrie();
  * @error			Invalid Handle.
  */
 native bool SetTrieValue(Handle map, const char[] key, any value, bool replace=true);
-
-/**
- * Sets a value in a hash map, either inserting a new entry or replacing an old one.
- *
- * @param map		Map Handle.
- * @param key		Key integer.
- * @param value		Value to store at this key.
- * @param replace	If false, operation will fail if the key is already set.
- * @return			True on success, false on failure.
- * @error			Invalid Handle.
- */
-native bool SetIntTrieValue(Handle map, const int key, any value, bool replace=true);
 
 /**
  * Sets an array value in a Map, either inserting a new entry or replacing an old one.
@@ -326,19 +298,6 @@ native bool SetIntTrieValue(Handle map, const int key, any value, bool replace=t
 native bool SetTrieArray(Handle map, const char[] key, const any[] array, int num_items, bool replace=true);
 
 /**
- * Sets an array value in a Map, either inserting a new entry or replacing an old one.
- *
- * @param map		Map Handle.
- * @param key		Key integer.
- * @param array		Array to store.
- * @param num_items	Number of items in the array.
- * @param replace	If false, operation will fail if the key is already set.
- * @return			True on success, false on failure.
- * @error			Invalid Handle.
- */
-native bool SetIntTrieArray(Handle map, const int key, const any[] array, int num_items, bool replace=true);
-
-/**
  * Sets a string value in a Map, either inserting a new entry or replacing an old one.
  *
  * @param map		Map Handle.
@@ -351,18 +310,6 @@ native bool SetIntTrieArray(Handle map, const int key, const any[] array, int nu
 native bool SetTrieString(Handle map, const char[] key, const char[] value, bool replace=true);
 
 /**
- * Sets a string value in a Map, either inserting a new entry or replacing an old one.
- *
- * @param map		Map Handle.
- * @param key		Key integer.
- * @param value		String to store.
- * @param replace	If false, operation will fail if the key is already set.
- * @return			True on success, false on failure.
- * @error			Invalid Handle.
- */
-native bool SetIntTrieString(Handle map, const int key, const char[] value, bool replace=true);
-
-/**
  * Retrieves a value in a Map.
  *
  * @param map		Map Handle.
@@ -373,18 +320,6 @@ native bool SetIntTrieString(Handle map, const int key, const char[] value, bool
  * @error			Invalid Handle.
  */
 native bool GetTrieValue(Handle map, const char[] key, any &value);
-
-/**
- * Retrieves a value in a Map.
- *
- * @param map		Map Handle.
- * @param key		Key integer.
- * @param value		Variable to store value.
- * @return			True on success.  False if the key is not set, or the key is set 
- *					as an array or string (not a value).
- * @error			Invalid Handle.
- */
-native bool GetIntTrieValue(Handle map, const int key, any &value);
 
 /**
  * Retrieves an array in a Map.
@@ -401,20 +336,6 @@ native bool GetIntTrieValue(Handle map, const int key, any &value);
 native bool GetTrieArray(Handle map, const char[] key, any[] array, int max_size, int &size=0);
 
 /**
- * Retrieves an array in a Map.
- *
- * @param map		Map Handle.
- * @param key		Key integer.
- * @param array		Buffer to store array.
- * @param max_size	Maximum size of array buffer.
- * @param size		Optional parameter to store the number of elements written to the buffer.
- * @return			True on success.  False if the key is not set, or the key is set 
- *					as a value or string (not an array).
- * @error			Invalid Handle.
- */
-native bool GetIntTrieArray(Handle map, const int key, any[] array, int max_size, int &size=0);
-
-/**
  * Retrieves a string in a Map.
  *
  * @param map		Map Handle.
@@ -429,20 +350,6 @@ native bool GetIntTrieArray(Handle map, const int key, any[] array, int max_size
 native bool GetTrieString(Handle map, const char[] key, char[] value, int max_size, int &size=0);
 
 /**
- * Retrieves a string in a Map.
- *
- * @param map		Map Handle.
- * @param key		Key integer.
- * @param value		Buffer to store value.
- * @param max_size	Maximum size of string buffer.
- * @param size		Optional parameter to store the number of bytes written to the buffer.
- * @return			True on success.  False if the key is not set, or the key is set 
- *					as a value or array (not a string).
- * @error			Invalid Handle.
- */
-native bool GetIntTrieString(Handle map, const int key, char[] value, int max_size, int &size=0);
-
-/**
  * Removes a key entry from a Map.
  *
  * @param map		Map Handle.
@@ -453,30 +360,12 @@ native bool GetIntTrieString(Handle map, const int key, char[] value, int max_si
 native bool RemoveFromTrie(Handle map, const char[] key);
 
 /**
- * Removes a key entry from a Map.
- *
- * @param map		Map Handle.
- * @param key		Key integer
- * @return			True on success, false if the value was never set.
- * @error			Invalid Handle.
- */
-native bool RemoveFromIntTrie(Handle map, const int key);
-
-/**
  * Clears all entries from a Map.
  *
  * @param map		Map Handle.
  * @error			Invalid Handle.
  */
 native void ClearTrie(Handle map);
-
-/**
- * Clears all entries from a Map.
- *
- * @param map		Map Handle.
- * @error			Invalid Handle.
- */
-native void ClearIntTrie(Handle map);
 
 /**
  * Retrieves the number of elements in a map.
@@ -486,15 +375,6 @@ native void ClearIntTrie(Handle map);
  * @error			Invalid Handle.
  */
 native int GetTrieSize(Handle map);
-
-/**
- * Retrieves the number of elements in a map.
- *
- * @param map		Map Handle.
- * @return			Number of elements in the trie.
- * @error			Invalid Handle.
- */
-native int GetIntTrieSize(Handle map);
 
 /**
  * Creates a snapshot of all keys in the map. If the map is changed after this
@@ -507,16 +387,6 @@ native int GetIntTrieSize(Handle map);
 native Handle CreateTrieSnapshot(Handle map);
 
 /**
- * Creates a snapshot of all keys in the map. If the map is changed after this
- * call, the changes are not reflected in the snapshot. Keys are not sorted.
- *
- * @param map       Map Handle.
- * @return			New Map Snapshot Handle, which must be closed via CloseHandle().
- * @error			Invalid Handle.
- */
-native Handle CreateIntTrieSnapshot(Handle map);
-
-/**
  * Returns the number of keys in a map snapshot. Note that this may be
  * different from the size of the map, since the map can change after the
  * snapshot of its keys was taken.
@@ -526,17 +396,6 @@ native Handle CreateIntTrieSnapshot(Handle map);
  * @error			Invalid Handle.
  */
 native int TrieSnapshotLength(Handle snapshot);
-
-/**
- * Returns the number of keys in a map snapshot. Note that this may be
- * different from the size of the map, since the map can change after the
- * snapshot of its keys was taken.
- *
- * @param snapshot	Map snapshot.
- * @return			Number of keys.
- * @error			Invalid Handle.
- */
-native int IntTrieSnapshotLength(Handle snapshot);
 
 /**
  * Returns the buffer size required to store a given key. That is, it returns
@@ -560,13 +419,3 @@ native int TrieSnapshotKeyBufferSize(Handle snapshot, int index);
  * @error			Invalid Handle or index out of range.
  */
 native int GetTrieSnapshotKey(Handle snapshot, int index, char[] buffer, int maxlength);
-
-/**
- * Retrieves the key string of a given key in a map snapshot.
- *
- * @param snapshot	Map snapshot.
- * @param index		Key index (starting from 0).
- * @return			The key interger.
- * @error			Invalid Handle or index out of range.
- */
-native int GetIntTrieSnapshotKey(Handle snapshot, int index);

--- a/plugins/include/adt_trie.inc
+++ b/plugins/include/adt_trie.inc
@@ -87,7 +87,6 @@ methodmap StringMap < Handle
 
 	// Retrieves an array in a Map.
 	//
-	// @param map        Map Handle.
 	// @param key        Key string.
 	// @param array      Buffer to store array.
 	// @param max_size   Maximum size of array buffer.
@@ -124,6 +123,93 @@ methodmap StringMap < Handle
 	}
 };
 
+methodmap IntMap < Handle
+{
+	// Creates a hash map. A hash map is a container that can map integers (called
+	// "keys") to arbitrary values (cells, arrays, or strings). Keys in a hash map
+	// are unique. That is, there is at most one entry in the map for a given key.
+	//
+	// Insertion, deletion, and lookup in a hash map are all considered to be fast
+	// operations, amortized to O(1), or constant time.
+	//
+	// The word "Trie" in this API is historical. As of SourceMod 1.6, tries have
+	// been internally replaced with hash tables, which have O(1) insertion time
+	// instead of O(n).
+	//
+	// The IntMap must be freed via delete or CloseHandle().
+	public native IntMap();
+
+	// Sets a value in a hash map, either inserting a new entry or replacing an old one.
+	//
+	// @param key        Key integer.
+	// @param value      Value to store at this key.
+	// @param replace    If false, operation will fail if the key is already set.
+	// @return           True on success, false on failure.
+	public native bool SetValue(const int key, any value, bool replace=true);
+
+	// Sets an array value in a Map, either inserting a new entry or replacing an old one.
+	//
+	// @param key        Key integer.
+	// @param array      Array to store.
+	// @param num_items  Number of items in the array.
+	// @param replace    If false, operation will fail if the key is already set.
+	// @return           True on success, false on failure.
+	public native bool SetArray(const int key, const any[] array, int num_items, bool replace=true);
+
+	// Sets a string value in a Map, either inserting a new entry or replacing an old one.
+	//
+	// @param key        Key integer.
+	// @param value      String to store.
+	// @param replace    If false, operation will fail if the key is already set.
+	// @return           True on success, false on failure.
+	public native bool SetString(const int key, const char[] value, bool replace=true);
+
+	// Retrieves a value in a Map.
+	//
+	// @param key        Key integer.
+	// @param value      Variable to store value.
+	// @return           True on success.  False if the key is not set, or the key is set 
+	//                   as an array or string (not a value).
+	public native bool GetValue(const int key, any &value);
+
+	// Retrieves an array in a Map.
+	//
+	// @param key        Key integer.
+	// @param array      Buffer to store array.
+	// @param max_size   Maximum size of array buffer.
+	// @param size       Optional parameter to store the number of elements written to the buffer.
+	// @return           True on success.  False if the key is not set, or the key is set 
+	//                   as a value or string (not an array).
+	public native bool GetArray(const int key, any[] array, int max_size, int &size=0);
+
+	// Retrieves a string in a Map.
+	//
+	// @param key        Key integer.
+	// @param value      Buffer to store value.
+	// @param max_size   Maximum size of string buffer.
+	// @param size       Optional parameter to store the number of bytes written to the buffer.
+	// @return           True on success.  False if the key is not set, or the key is set 
+	//                   as a value or array (not a string).
+	public native bool GetString(const int key, char[] value, int max_size, int &size=0);
+
+	// Removes a key entry from a Map.
+	//
+	// @param key        Key integer.
+	// @return           True on success, false if the value was never set.
+	public native bool Remove(const int key);
+
+	// Clears all entries from a Map.
+	public native void Clear();
+
+	// Create a snapshot of the map's keys. See IntMapSnapshot.
+	public native IntMapSnapshot Snapshot();
+
+	// Retrieves the number of elements in a map.
+	property int Size {
+		public native get();
+	}
+};
+
 // A StringMapSnapshot is created via StringMap.Snapshot(). It captures the
 // keys on a map so they can be read. Snapshots must be freed with delete or
 // CloseHandle().
@@ -152,6 +238,24 @@ methodmap StringMapSnapshot < Handle
 	public native int GetKey(int index, char[] buffer, int maxlength);
 };
 
+// A IntMapSnapshot is created via IntMap.Snapshot(). It captures the
+// keys on a map so they can be read. Snapshots must be freed with delete or
+// CloseHandle().
+methodmap IntMapSnapshot < Handle
+{
+	// Returns the number of keys in the map snapshot.
+	property int Length {
+		public native get();
+	}
+
+	// Retrieves the key integer of a given key in a map snapshot.
+	// 
+	// @param index      Key index (starting from 0).
+	// @return           The key integer
+	// @error            Index out of range.
+	public native int GetKey(int index);
+};
+
 /**
  * Creates a hash map. A hash map is a container that can map strings (called
  * "keys") to arbitrary values (cells, arrays, or strings). Keys in a hash map
@@ -169,6 +273,22 @@ methodmap StringMapSnapshot < Handle
 native StringMap CreateTrie();
 
 /**
+ * Creates a hash map. A hash map is a container that can map integers (called
+ * "keys") to arbitrary values (cells, arrays, or strings). Keys in a hash map
+ * are unique. That is, there is at most one entry in the map for a given key.
+ *
+ * Insertion, deletion, and lookup in a hash map are all considered to be fast
+ * operations, amortized to O(1), or constant time.
+ *
+ * The word "Trie" in this API is historical. As of SourceMod 1.6, tries have
+ * been internally replaced with hash tables, which have O(1) insertion time
+ * instead of O(n).
+ *
+ * @return 			New Map Handle, which must be freed via CloseHandle().
+ */
+native IntMap CreateIntTrie();
+
+/**
  * Sets a value in a hash map, either inserting a new entry or replacing an old one.
  *
  * @param map		Map Handle.
@@ -179,6 +299,18 @@ native StringMap CreateTrie();
  * @error			Invalid Handle.
  */
 native bool SetTrieValue(Handle map, const char[] key, any value, bool replace=true);
+
+/**
+ * Sets a value in a hash map, either inserting a new entry or replacing an old one.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer.
+ * @param value		Value to store at this key.
+ * @param replace	If false, operation will fail if the key is already set.
+ * @return			True on success, false on failure.
+ * @error			Invalid Handle.
+ */
+native bool SetIntTrieValue(Handle map, const int key, any value, bool replace=true);
 
 /**
  * Sets an array value in a Map, either inserting a new entry or replacing an old one.
@@ -194,6 +326,19 @@ native bool SetTrieValue(Handle map, const char[] key, any value, bool replace=t
 native bool SetTrieArray(Handle map, const char[] key, const any[] array, int num_items, bool replace=true);
 
 /**
+ * Sets an array value in a Map, either inserting a new entry or replacing an old one.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer.
+ * @param array		Array to store.
+ * @param num_items	Number of items in the array.
+ * @param replace	If false, operation will fail if the key is already set.
+ * @return			True on success, false on failure.
+ * @error			Invalid Handle.
+ */
+native bool SetIntTrieArray(Handle map, const int key, const any[] array, int num_items, bool replace=true);
+
+/**
  * Sets a string value in a Map, either inserting a new entry or replacing an old one.
  *
  * @param map		Map Handle.
@@ -206,6 +351,18 @@ native bool SetTrieArray(Handle map, const char[] key, const any[] array, int nu
 native bool SetTrieString(Handle map, const char[] key, const char[] value, bool replace=true);
 
 /**
+ * Sets a string value in a Map, either inserting a new entry or replacing an old one.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer.
+ * @param value		String to store.
+ * @param replace	If false, operation will fail if the key is already set.
+ * @return			True on success, false on failure.
+ * @error			Invalid Handle.
+ */
+native bool SetIntTrieString(Handle map, const int key, const char[] value, bool replace=true);
+
+/**
  * Retrieves a value in a Map.
  *
  * @param map		Map Handle.
@@ -216,6 +373,18 @@ native bool SetTrieString(Handle map, const char[] key, const char[] value, bool
  * @error			Invalid Handle.
  */
 native bool GetTrieValue(Handle map, const char[] key, any &value);
+
+/**
+ * Retrieves a value in a Map.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer.
+ * @param value		Variable to store value.
+ * @return			True on success.  False if the key is not set, or the key is set 
+ *					as an array or string (not a value).
+ * @error			Invalid Handle.
+ */
+native bool GetIntTrieValue(Handle map, const int key, any &value);
 
 /**
  * Retrieves an array in a Map.
@@ -232,6 +401,20 @@ native bool GetTrieValue(Handle map, const char[] key, any &value);
 native bool GetTrieArray(Handle map, const char[] key, any[] array, int max_size, int &size=0);
 
 /**
+ * Retrieves an array in a Map.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer.
+ * @param array		Buffer to store array.
+ * @param max_size	Maximum size of array buffer.
+ * @param size		Optional parameter to store the number of elements written to the buffer.
+ * @return			True on success.  False if the key is not set, or the key is set 
+ *					as a value or string (not an array).
+ * @error			Invalid Handle.
+ */
+native bool GetIntTrieArray(Handle map, const int key, any[] array, int max_size, int &size=0);
+
+/**
  * Retrieves a string in a Map.
  *
  * @param map		Map Handle.
@@ -246,6 +429,20 @@ native bool GetTrieArray(Handle map, const char[] key, any[] array, int max_size
 native bool GetTrieString(Handle map, const char[] key, char[] value, int max_size, int &size=0);
 
 /**
+ * Retrieves a string in a Map.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer.
+ * @param value		Buffer to store value.
+ * @param max_size	Maximum size of string buffer.
+ * @param size		Optional parameter to store the number of bytes written to the buffer.
+ * @return			True on success.  False if the key is not set, or the key is set 
+ *					as a value or array (not a string).
+ * @error			Invalid Handle.
+ */
+native bool GetIntTrieString(Handle map, const int key, char[] value, int max_size, int &size=0);
+
+/**
  * Removes a key entry from a Map.
  *
  * @param map		Map Handle.
@@ -256,12 +453,30 @@ native bool GetTrieString(Handle map, const char[] key, char[] value, int max_si
 native bool RemoveFromTrie(Handle map, const char[] key);
 
 /**
+ * Removes a key entry from a Map.
+ *
+ * @param map		Map Handle.
+ * @param key		Key integer
+ * @return			True on success, false if the value was never set.
+ * @error			Invalid Handle.
+ */
+native bool RemoveFromIntTrie(Handle map, const int key);
+
+/**
  * Clears all entries from a Map.
  *
  * @param map		Map Handle.
  * @error			Invalid Handle.
  */
 native void ClearTrie(Handle map);
+
+/**
+ * Clears all entries from a Map.
+ *
+ * @param map		Map Handle.
+ * @error			Invalid Handle.
+ */
+native void ClearIntTrie(Handle map);
 
 /**
  * Retrieves the number of elements in a map.
@@ -271,6 +486,15 @@ native void ClearTrie(Handle map);
  * @error			Invalid Handle.
  */
 native int GetTrieSize(Handle map);
+
+/**
+ * Retrieves the number of elements in a map.
+ *
+ * @param map		Map Handle.
+ * @return			Number of elements in the trie.
+ * @error			Invalid Handle.
+ */
+native int GetIntTrieSize(Handle map);
 
 /**
  * Creates a snapshot of all keys in the map. If the map is changed after this
@@ -283,6 +507,16 @@ native int GetTrieSize(Handle map);
 native Handle CreateTrieSnapshot(Handle map);
 
 /**
+ * Creates a snapshot of all keys in the map. If the map is changed after this
+ * call, the changes are not reflected in the snapshot. Keys are not sorted.
+ *
+ * @param map       Map Handle.
+ * @return			New Map Snapshot Handle, which must be closed via CloseHandle().
+ * @error			Invalid Handle.
+ */
+native Handle CreateIntTrieSnapshot(Handle map);
+
+/**
  * Returns the number of keys in a map snapshot. Note that this may be
  * different from the size of the map, since the map can change after the
  * snapshot of its keys was taken.
@@ -292,6 +526,17 @@ native Handle CreateTrieSnapshot(Handle map);
  * @error			Invalid Handle.
  */
 native int TrieSnapshotLength(Handle snapshot);
+
+/**
+ * Returns the number of keys in a map snapshot. Note that this may be
+ * different from the size of the map, since the map can change after the
+ * snapshot of its keys was taken.
+ *
+ * @param snapshot	Map snapshot.
+ * @return			Number of keys.
+ * @error			Invalid Handle.
+ */
+native int IntTrieSnapshotLength(Handle snapshot);
 
 /**
  * Returns the buffer size required to store a given key. That is, it returns
@@ -315,3 +560,13 @@ native int TrieSnapshotKeyBufferSize(Handle snapshot, int index);
  * @error			Invalid Handle or index out of range.
  */
 native int GetTrieSnapshotKey(Handle snapshot, int index, char[] buffer, int maxlength);
+
+/**
+ * Retrieves the key string of a given key in a map snapshot.
+ *
+ * @param snapshot	Map snapshot.
+ * @param index		Key index (starting from 0).
+ * @return			The key interger.
+ * @error			Invalid Handle or index out of range.
+ */
+native int GetIntTrieSnapshotKey(Handle snapshot, int index);

--- a/plugins/testsuite/tries.sp
+++ b/plugins/testsuite/tries.sp
@@ -13,6 +13,7 @@ public Plugin:myinfo =
 public OnPluginStart()
 {
   RegServerCmd("test_maps", RunTests);
+  RegServerCmd("test_int_maps", RunIntTest);
 }
 
 public Action:RunTests(argc)
@@ -148,6 +149,147 @@ public Action:RunTests(argc)
         found[2] = true;
       else
         ThrowError("unexpected key: %s", buffer);
+    }
+
+    if (!found[0] || !found[1] || !found[2])
+      ThrowError("did not find all keys");
+  }
+  delete keys;
+
+  PrintToServer("All tests passed!");
+
+  delete map;
+  return Plugin_Handled;
+}
+
+public Action:RunIntTests(argc)
+{
+  IntMap map = new IntMap();
+
+  for (new i = 0; i < 64; i++) {
+    if (!map.SetValue(i, i))
+      ThrowError("set map to %d failed", i);
+
+    new value;
+    if (!map.GetValue(buffer, value))
+      ThrowError("get map %d", i);
+    if (value != i)
+      ThrowError("get map %d == %d", i, i);
+  }
+
+  // Setting 17 without replace should fail.
+  new value;
+  if (map.SetValue(17, 999, false))
+    ThrowError("set map 17 should fail");
+  if (!map.GetValue(17, value) || value != 17)
+    ThrowError("value at 17 not correct");
+  if (!map.SetValue(17, 999))
+    ThrowError("set map 17 = 999 should succeed");
+  if (!map.GetValue(17, value) || value != 999)
+    ThrowError("value at 17 not correct");
+
+  // Check size is 64.
+  if (map.Size != 64)
+    ThrowError("map size not 64");
+
+  // Check 100 is not found.
+  int array[64];
+  char string[64];
+  if (map.GetValue(100, value) ||
+      map.GetArray(100, array, sizeof(array)) ||
+      map.GetString(100, string, sizeof(string)))
+  {
+    ThrowError("map should not have 100");
+  }
+
+  // Check that 17 is not a string or array.
+  if (map.GetArray(17, array, sizeof(array)) ||
+      map.GetString(17, string, sizeof(string)))
+  {
+    ThrowError("entry 17 should not be an array or string");
+  }
+
+  // Strings.
+  if (!map.SetString(17, "hellokitty"))
+    ThrowError("17 should be string");
+  if (!map.GetString(17, string, sizeof(string)) ||
+      strcmp(string, "hellokitty") != 0)
+  {
+    ThrowError("17 should be hellokitty");
+  }
+  if (map.GetValue(17, value) ||
+      map.GetArray("17", array, sizeof(array)))
+  {
+    ThrowError("entry 17 should not be an array or string");
+  }
+
+  // Arrays.
+  new data[5] = { 93, 1, 2, 3, 4 };
+  if (!map.SetArray(17, data, 5))
+    ThrowError("17 should be string");
+  if (!map.GetArray(17, array, sizeof(array)))
+    ThrowError("17 should be hellokitty");
+  for (new i = 0; i < 5; i++) {
+    if (data[i] != array[i])
+      ThrowError("17 slot %d should be %d, got %d", i, data[i], array[i]);
+  }
+  if (map.GetValue(17, value) ||
+      map.GetString(17, string, sizeof(string)))
+  {
+    ThrowError("entry 17 should not be an array or string");
+  }
+
+  if (!map.SetArray(17, data, 1))
+    ThrowError("couldn't set 17 to 1-entry array");
+  // Check that we fixed an old bug where 1-entry arrays where cells
+  if (!map.GetArray(17, array, sizeof(array), value))
+    ThrowError("couldn't fetch 1-entry array");
+  if (value != 1)
+    ThrowError("array size mismatch (%d, expected %d)", value, 1);
+  // Check that we maintained backward compatibility.
+  if (!map.GetValue(17, value))
+    ThrowError("backwards compatibility failed");
+  if (value != data[0])
+    ThrowError("wrong value (%d, expected %d)", value, data[0]);
+
+  // Remove "17".
+  if (!map.Remove(17))
+    ThrowError("17 should have been removed");
+  if (map.Remove(17))
+    ThrowError("17 should not exist");
+  if (map.GetValue(17, value) ||
+      map.GetArray(17, array, sizeof(array)) ||
+      map.GetString(17, string, sizeof(string)))
+  {
+    ThrowError("map should not have a 17");
+  }
+
+  map.Clear();
+
+  if (map.Size)
+    ThrowError("size should be 0");
+
+  map.SetString(42, "time!");
+  map.SetString(84, "bees");
+  map.SetString(126, "egg");
+
+  IntMapSnapshot keys = map.Snapshot();
+  {
+    if (keys.Length != 3)
+      ThrowError("map snapshot length should be 3");
+
+    bool found[3];
+    for (new i = 0; i < keys.Length; i++) {
+      decl key = keys.GetKey(i);
+
+      if (key == 42)
+        found[0] = true;
+      else if (key == 84)
+        found[1] = true;
+      else if (key == 126)
+        found[2] = true;
+      else
+        ThrowError("unexpected key: %d", key);
     }
 
     if (!found[0] || !found[1] || !found[2])

--- a/public/sm_hashmap.h
+++ b/public/sm_hashmap.h
@@ -37,7 +37,7 @@
  *
  * @brief Generic Key -> Value map class, based on a hash table. The Key, in
  * this case, is always an ASCII string or Int, and the value type is a template
- * parameter. This class is intended as a drop-in replacement for KTrie
+ * parameter. This class is intended as a drop-in replacement for KeyLookupTyperie
  * (though the retrieve() signature has been improved).
  *
  * If your Value type already contains the key string, consider using
@@ -136,10 +136,10 @@ namespace detail
 	};
 }
 
-template <typename T, typename K, typename P, typename C, typename KT>
+template <typename T, typename KeyStoreType, typename Policy, typename ContainerType, typename KeyLookupType>
 class HashMap
 {
-	typedef ke::HashMap<K, T, P> Internal;
+	typedef ke::HashMap<KeyStoreType, T, Policy> Internal;
 
 public:
 	HashMap()
@@ -154,10 +154,10 @@ public:
 	typedef typename Internal::Insert Insert;
 	typedef typename Internal::iterator iterator;
 
-	// Some KTrie-like helper functions.
-	bool retrieve(KT aKey, T *aResult = NULL)
+	// Some KeyLookupTyperie-like helper functions.
+	bool retrieve(KeyLookupType aKey, T *aResult = NULL)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		Result r = internal_.find(key);
 		if (!r.found())
 			return false;
@@ -166,22 +166,22 @@ public:
 		return true;
 	}
 
-	Result find(KT aKey)
+	Result find(KeyLookupType aKey)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		return internal_.find(key);
 	}
 
-	bool contains(KT aKey)
+	bool contains(KeyLookupType aKey)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		Result r = internal_.find(key);
 		return r.found();
 	}
 
-	bool replace(KT aKey, const T &value)
+	bool replace(KeyLookupType aKey, const T &value)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		Insert i = internal_.findForAdd(key);
 		if (!i.found())
 		{
@@ -194,9 +194,9 @@ public:
 		return true;
 	}
 
-	bool insert(KT aKey, const T &value)
+	bool insert(KeyLookupType aKey, const T &value)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		Insert i = internal_.findForAdd(key);
 		if (i.found())
 			return false;
@@ -208,9 +208,9 @@ public:
 		return true;
 	}
 
-	bool remove(KT aKey)
+	bool remove(KeyLookupType aKey)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		Result r = internal_.find(key);
 		if (!r.found())
 			return false;
@@ -245,9 +245,9 @@ public:
 	}
 
 
-	Insert findForAdd(KT aKey)
+	Insert findForAdd(KeyLookupType aKey)
 	{
-		C key(aKey);
+		ContainerType key(aKey);
 		return internal_.findForAdd(key);
 	}
 
@@ -260,7 +260,7 @@ public:
 	}
 
 	// Only value needs to be set after.
-	bool add(Insert &i, KT aKey)
+	bool add(Insert &i, KeyLookupType aKey)
 	{
 		if (!internal_.add(i))
 			return false;

--- a/public/sm_hashmap.h
+++ b/public/sm_hashmap.h
@@ -97,41 +97,13 @@ namespace detail
 		}
 	};
 
-	class IntHash
-	{
-	 public:
-	  IntHash(const int v)
-	  	: value_(v)
-	  {
-	  	/* Credit: Thomas Mueller @ http://stackoverflow.com/questions/664014 */
-	  	hash_ = v;
-	  	hash_ = ((hash_ >> 16) ^ hash_) * 0x45d9f3b;
-	  	hash_ = ((hash_ >> 16) ^ hash_) * 0x45d9f3b;
-	  	hash_ = (hash_ >> 16) ^ hash_;
-	  }
-
-	  uint32_t hash() const {
-	  	return hash_;
-	  }
-	  const int value() const {
-	  	return value_;
-	  }
-	  size_t length() const {
-	  	return sizeof(int);
-	  }
-
-	 private:
-	  const int value_;
-	  uint32_t hash_;
-	};
-
 	struct IntHashMapPolicy
 	{
-		static inline bool matches(const IntHash &lookup, const int compare) {
-			return lookup.value() == compare;
+		static inline bool matches(const int32_t lookup, const int32_t compare) {
+			return lookup == compare;
 		}
-		static inline uint32_t hash(const IntHash &key) {
-			return key.hash();
+		static inline uint32_t hash(const int32_t key) {
+			return ke::HashInt32(key);
 		}
 	};
 }
@@ -277,7 +249,7 @@ template <typename T>
 using StringHashMap = HashMap<T, ke::AString, detail::StringHashMapPolicy, detail::CharsAndLength, const char *>;
 
 template <typename T>
-using IntHashMap = HashMap<T, int, detail::IntHashMapPolicy, detail::IntHash, const int>;
+using IntHashMap = HashMap<T, int32_t, detail::IntHashMapPolicy, const int32_t, const int32_t>;
 
 }
 

--- a/public/sm_hashmap.h
+++ b/public/sm_hashmap.h
@@ -37,7 +37,7 @@
  *
  * @brief Generic Key -> Value map class, based on a hash table. The Key, in
  * this case, is always an ASCII string or Int, and the value type is a template
- * parameter. This class is intended as a drop-in replacement for KeyLookupTyperie
+ * parameter. This class is intended as a drop-in replacement for KTrie
  * (though the retrieve() signature has been improved).
  *
  * If your Value type already contains the key string, consider using
@@ -126,7 +126,7 @@ public:
 	typedef typename Internal::Insert Insert;
 	typedef typename Internal::iterator iterator;
 
-	// Some KeyLookupTyperie-like helper functions.
+	// Some KTrie-like helper functions.
 	bool retrieve(KeyLookupType aKey, T *aResult = NULL)
 	{
 		ContainerType key(aKey);

--- a/public/sm_hashmap.h
+++ b/public/sm_hashmap.h
@@ -55,10 +55,10 @@ namespace SourceMod
 
 namespace detail
 {
-	class CharHash
+	class CharsAndLength
 	{
 	 public:
-	  CharHash(const char *str)
+	  CharsAndLength(const char *str)
 		: str_(str),
 		  length_(0)
 	  {
@@ -88,11 +88,11 @@ namespace detail
 
 	struct StringHashMapPolicy
 	{
-		static inline bool matches(const CharHash &lookup, const ke::AString &key) {
+		static inline bool matches(const CharsAndLength &lookup, const ke::AString &key) {
 			return lookup.length() == key.length() &&
 				   memcmp(lookup.chars(), key.chars(), key.length()) == 0;
 		}
-		static inline uint32_t hash(const CharHash &key) {
+		static inline uint32_t hash(const CharsAndLength &key) {
 			return key.hash();
 		}
 	};
@@ -274,7 +274,7 @@ private:
 };
 
 template <typename T>
-using StringHashMap = HashMap<T, ke::AString, detail::StringHashMapPolicy, detail::CharHash, const char *>;
+using StringHashMap = HashMap<T, ke::AString, detail::StringHashMapPolicy, detail::CharsAndLength, const char *>;
 
 template <typename T>
 using IntHashMap = HashMap<T, int, detail::IntHashMapPolicy, detail::IntHash, const int>;

--- a/public/sm_memtable.h
+++ b/public/sm_memtable.h
@@ -166,5 +166,55 @@ private:
 	BaseMemTable m_table;
 };
 
+class BaseIntTable
+{
+public:
+	BaseIntTable(unsigned int init_size) : m_table(init_size)
+	{
+	}
+public:
+	/** 
+	 * Adds a int to the int table and returns its index.
+	 */
+	int AddInt(const int x)
+	{
+		int idx;
+		int *addr;
+
+		idx = m_table.CreateMem(sizeof(int), (void **)&addr);
+		*addr = x;
+		return idx;
+	}
+
+	/**
+	 * Given an index into the int table, returns the associated int.
+	 */
+	inline const int GetInt(int index)
+	{
+		return *(const int *)m_table.GetAddress(index);
+	}
+
+	/**
+	 * Scraps the int table. For caching purposes, the memory
+	 * is not freed, however subsequent calls to AddInt() will 
+	 * begin at the first index again.
+	 */
+	void Reset()
+	{
+		m_table.Reset();
+	}
+
+	/**
+	 * Returns the parent BaseMemTable that this int table uses.
+	 */
+	inline BaseMemTable *GetMemTable()
+	{
+		return &m_table;
+	}
+private:
+	BaseMemTable m_table;
+};
+
+
 #endif //_INCLUDE_SOURCEMOD_CORE_STRINGTABLE_H_
 

--- a/public/sm_namehashset.h
+++ b/public/sm_namehashset.h
@@ -59,7 +59,7 @@ namespace SourceMod
 template <typename T, typename KeyPolicy = T>
 class NameHashSet : public ke::SystemAllocatorPolicy
 {
-	typedef detail::CharHash CharHash;
+	typedef detail::CharsAndLength CharsAndLength;
 
 	// Default policy type: the two types are different. Use them directly.
 	template <typename KeyType, typename KeyPolicyType>
@@ -67,12 +67,12 @@ class NameHashSet : public ke::SystemAllocatorPolicy
 	{
 		typedef KeyType Payload;
 
-		static uint32_t hash(const CharHash &key)
+		static uint32_t hash(const CharsAndLength &key)
 		{
 			return key.hash();
 		}
 
-		static bool matches(const CharHash &key, const KeyType &value)
+		static bool matches(const CharsAndLength &key, const KeyType &value)
 		{
 			return KeyPolicyType::matches(key.chars(), value);
 		}
@@ -85,12 +85,12 @@ class NameHashSet : public ke::SystemAllocatorPolicy
 	{
 		typedef KeyType *Payload;
 
-		static uint32_t hash(const detail::CharHash &key)
+		static uint32_t hash(const detail::CharsAndLength &key)
 		{
 			return key.hash();
 		}
 
-		static bool matches(const CharHash &key, const KeyType *value)
+		static bool matches(const CharsAndLength &key, const KeyType *value)
 		{
 			return KeyType::matches(key.chars(), value);
 		}
@@ -127,7 +127,7 @@ public:
 
 	bool retrieve(const char *aKey, T *value)
 	{
-		CharHash key(aKey);
+		CharsAndLength key(aKey);
 		Result r = table_.find(aKey);
 		if (!r.found())
 			return false;
@@ -138,7 +138,7 @@ public:
 	template <typename U>
 	bool insert(const char *aKey, U &&value)
 	{
-		CharHash key(aKey);
+		CharsAndLength key(aKey);
 		Insert i = table_.findForAdd(key);
 		if (i.found())
 			return false;
@@ -147,14 +147,14 @@ public:
 
 	bool contains(const char *aKey)
 	{
-		CharHash key(aKey);
+		CharsAndLength key(aKey);
 		Result r = table_.find(aKey);
 		return r.found();
 	}
 
 	bool remove(const char *aKey)
 	{
-		CharHash key(aKey);
+		CharsAndLength key(aKey);
 		Result r = table_.find(key);
 		if (!r.found())
 			return false;

--- a/public/sm_namehashset.h
+++ b/public/sm_namehashset.h
@@ -43,7 +43,7 @@
 #include <am-allocator-policies.h>
 #include <am-hashmap.h>
 #include <am-string.h>
-#include "sm_stringhashmap.h"
+#include "sm_hashmap.h"
 
 namespace SourceMod
 {
@@ -59,7 +59,7 @@ namespace SourceMod
 template <typename T, typename KeyPolicy = T>
 class NameHashSet : public ke::SystemAllocatorPolicy
 {
-	typedef detail::CharsAndLength CharsAndLength;
+	typedef detail::CharHash CharHash;
 
 	// Default policy type: the two types are different. Use them directly.
 	template <typename KeyType, typename KeyPolicyType>
@@ -67,12 +67,12 @@ class NameHashSet : public ke::SystemAllocatorPolicy
 	{
 		typedef KeyType Payload;
 
-		static uint32_t hash(const CharsAndLength &key)
+		static uint32_t hash(const CharHash &key)
 		{
 			return key.hash();
 		}
 
-		static bool matches(const CharsAndLength &key, const KeyType &value)
+		static bool matches(const CharHash &key, const KeyType &value)
 		{
 			return KeyPolicyType::matches(key.chars(), value);
 		}
@@ -85,12 +85,12 @@ class NameHashSet : public ke::SystemAllocatorPolicy
 	{
 		typedef KeyType *Payload;
 
-		static uint32_t hash(const detail::CharsAndLength &key)
+		static uint32_t hash(const detail::CharHash &key)
 		{
 			return key.hash();
 		}
 
-		static bool matches(const CharsAndLength &key, const KeyType *value)
+		static bool matches(const CharHash &key, const KeyType *value)
 		{
 			return KeyType::matches(key.chars(), value);
 		}
@@ -127,7 +127,7 @@ public:
 
 	bool retrieve(const char *aKey, T *value)
 	{
-		CharsAndLength key(aKey);
+		CharHash key(aKey);
 		Result r = table_.find(aKey);
 		if (!r.found())
 			return false;
@@ -138,7 +138,7 @@ public:
 	template <typename U>
 	bool insert(const char *aKey, U &&value)
 	{
-		CharsAndLength key(aKey);
+		CharHash key(aKey);
 		Insert i = table_.findForAdd(key);
 		if (i.found())
 			return false;
@@ -147,14 +147,14 @@ public:
 
 	bool contains(const char *aKey)
 	{
-		CharsAndLength key(aKey);
+		CharHash key(aKey);
 		Result r = table_.find(aKey);
 		return r.found();
 	}
 
 	bool remove(const char *aKey)
 	{
-		CharsAndLength key(aKey);
+		CharHash key(aKey);
 		Result r = table_.find(key);
 		if (!r.found())
 			return false;


### PR DESCRIPTION
This patch makes the following changes
  * Refactors StringHashMap to a generic HashMap template
  * Adds the IntHashMap class
  * Adds new IntMap natives
  * Adds IntMap tests to the tries test suite

This does not change the existing Trie API in any way so as to retain backwards compatibility, and all existing and new test suite tests pass.