### PR TITLE
Fix typo in menu manager not drawing a spacer

### DIFF
--- a/core/MenuManager.cpp
+++ b/core/MenuManager.cpp
@@ -570,7 +570,7 @@ skip_search:
 			/* If there are no control options,
 			 * Instead just pad with invisible slots.
 			 */
-			if (!displayPrev && !displayPrev)
+			if (!displayNext && !displayPrev)
 			{
 				padItem.style = ITEMDRAW_NOTEXT;
 			}


### PR DESCRIPTION
The "Back" slot was hidden even if the page had a "Next" button. Draw the spacer correctly!