### PR TITLE
Fix regression with GetEntPropEnt always returning -1

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -1190,6 +1190,7 @@ inline int MatchTypeDescAsInteger(_fieldtypes type, int flags)
 			// Variant, read as int32.
 			return 32;
 		}
+		break;
 	case FIELD_SHORT:
 		return 16;
 	case FIELD_CHARACTER:
@@ -1722,7 +1723,7 @@ static cell_t GetEntPropEnt(IPluginContext *pContext, const cell_t *params)
 
 			CBaseEntity *pHandleEntity = g_HL2.ReferenceToEntity(hndl->GetEntryIndex());
 
-			if (!pHandleEntity || hndl != &reinterpret_cast<IHandleEntity *>(pHandleEntity)->GetRefEHandle())
+			if (!pHandleEntity || *hndl != reinterpret_cast<IHandleEntity *>(pHandleEntity)->GetRefEHandle())
 				return -1;
 
 			return g_HL2.EntityToBCompatRef(pHandleEntity);


### PR DESCRIPTION
Regression in #583

The `CBaseHandle *` was compared to a `IHandleEntity **` always failing
instead of comparing the actual base handles.

Fixes a small typo in MatchTypeDescAsInteger too, where a FIELD_CUSTOM
could fall through badly.