### PR TITLE
improved CharToUpper and CharToLower

### DIFF
--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -400,7 +400,9 @@ native bool StripQuotes(char[] text);
  */
 stock int CharToUpper(int chr)
 {
-	return chr & '_';
+	if (IsCharLower(chr))	
+		return chr & '_';
+	return chr;
 }
 
 /**
@@ -412,7 +414,9 @@ stock int CharToUpper(int chr)
  */
 stock int CharToLower(int chr)
 {
-	return chr | ' ';
+	if (IsCharUpper(chr))	
+		return chr | ' ';
+	return chr;
 }
 
 /**

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -400,11 +400,7 @@ native bool StripQuotes(char[] text);
  */
 stock int CharToUpper(int chr)
 {
-	if (IsCharLower(chr))
-	{
-		return (chr & ~(1<<5));
-	}
-	return chr;
+	return chr & '_';
 }
 
 /**
@@ -416,11 +412,7 @@ stock int CharToUpper(int chr)
  */
 stock int CharToLower(int chr)
 {
-	if (IsCharUpper(chr))
-	{
-		return (chr | (1<<5));
-	}
-	return chr;
+	return chr | ' ';
 }
 
 /**


### PR DESCRIPTION
for CharToUpper, using bitwise AND with an underscore always returns an upper case letter, even if it's already upper case! `'c' & '_' == 'C'` likewise, `'C' & '_' == 'C'`

for CharToLower, using bitwise OR with space literal always yields a lower case letter, even if the letter is already lower case. `'c' | ' ' == 'c'` likewise, `'C' | ' ' == 'c'`

simple bitwise operation that does the same thing more efficiently rather than having to require an if statement to catch exceptional chars and convert them.