### PR TITLE
Make CS:GO recognize both / and \ for GetMapDisplayName

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1259,7 +1259,8 @@ bool CHalfLife2::GetMapDisplayName(const char *pMapName, char *pDisplayname, siz
 
 	char *lastSlashPos;
 	// In CSGO, workshop maps show up as workshop/123456789/mapname or workshop\123456789\mapname depending on OS
-	if (strncmp(pDisplayname, workshop, 9) == 0 && (lastSlashPos = strrchr(pDisplayname, PLATFORM_SEP_CHAR)) != NULL)
+	// As on sometime in 2016, CS:GO for Windows now recognizes both / and \ so we need to check for both
+	if (strncmp(pDisplayname, workshop, 9) == 0 && ((lastSlashPos = strrchr(pDisplayname, '/')) != NULL || (lastSlashPos = strrchr(pDisplayname, '\\')) != NULL))
 	{
 		ke::SafeStrcpy(pDisplayname, nMapNameMax, &lastSlashPos[1]);
 		return true;


### PR DESCRIPTION
Sometime during 2016, CS:GO was updated so that the long form of workshop paths work on Windows using either `/` or `\`  i.e.

    changelevel workshop/125499116/de_inferno_se

will properly change to Inferno SE on a Windows machine, assuming the map is downloaded.

I haven't checked to see if `pHelperCmd->AutoCompleteSuggest` (called from FindMap) is also affected by this change, although it shouldn't actually matter.

This pull request changes GetMapDisplayName to stop looking just for the system's path separator.  Now it looks for / first and if that fails, looks for \ instead.

Side note: As I no longer have a Linux machine and only have VS2015 and 2017RC installed, I had no way to actually compile this to test it.  However, it's not a very complex change as it's just changing `(blah) != NULL` into `((blah) != NULL || (blah2) != NULL)`