### PR TITLE
Fix crash when accessing gamerules during mapchange

### DIFF
--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -70,7 +70,8 @@ static CBaseEntity* GetGameRulesProxyEnt()
 	if (proxyEntRef == -1 || (pProxy = gamehelpers->ReferenceToEntity(proxyEntRef)) == NULL)
 	{
 		pProxy = FindEntityByNetClass(playerhelpers->GetMaxClients(), g_szGameRulesProxy);
-		proxyEntRef = gamehelpers->EntityToReference(pProxy);
+		if (pProxy)
+			proxyEntRef = gamehelpers->EntityToReference(pProxy);
 	}
 	
 	return pProxy;


### PR DESCRIPTION
If the gamerules proxy entity doesn't exist, don't try to generate the reference for it.

https://forums.alliedmods.net/showthread.php?t=294762