### PR TITLE
Fix workshop/ and workshop\ not always working with GetMapDisplayName

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1253,14 +1253,10 @@ bool CHalfLife2::GetMapDisplayName(const char *pMapName, char *pDisplayname, siz
 	}
 
 #if SOURCE_ENGINE == SE_CSGO
-	// In CSGO, the path separator is used in workshop maps.
-	char workshop[10];
-	ke::SafeSprintf(workshop, SM_ARRAYSIZE(workshop), "%s%c", "workshop", PLATFORM_SEP_CHAR);
-
 	char *lastSlashPos;
 	// In CSGO, workshop maps show up as workshop/123456789/mapname or workshop\123456789\mapname depending on OS
 	// As on sometime in 2016, CS:GO for Windows now recognizes both / and \ so we need to check for both
-	if (strncmp(pDisplayname, workshop, 9) == 0 && ((lastSlashPos = strrchr(pDisplayname, '/')) != NULL || (lastSlashPos = strrchr(pDisplayname, '\\')) != NULL))
+	if (strncmp(pDisplayname, "workshop", 8) == 0 && ((lastSlashPos = strrchr(pDisplayname, '/')) != NULL || (lastSlashPos = strrchr(pDisplayname, '\\')) != NULL))
 	{
 		ke::SafeStrcpy(pDisplayname, nMapNameMax, &lastSlashPos[1]);
 		return true;


### PR DESCRIPTION
The previous patch had a bug where the first slash was always required to be the same as the OS separator path.

This time, the fix has been tested using plugins/testsuite/mapdisplayname.sp on CS:GO Windows:

    test_mapdisplayname workshop\125488374\de_dust2_se
    GetMapDisplayName says "de_dust2_se" for "workshop\125488374\de_dust2_se"
    test_mapdisplayname workshop/125488374/de_dust2_se
    GetMapDisplayName says "de_dust2_se" for "workshop/125488374/de_dust2_se"

There is one caveat with this patch:  
It does not check for the presence of a slash immediately after workshop.  So, if you pass it `workshopblahblabh/de_dust` it will return `de_dust`

Then again, it isn't really checking the entire format anyway, only that it starts with `workshop` and has a `/` or `\` somewhere in it.
