### PR TITLE
Ignore replay and sourcetv in @spec targeting.

### DIFF
--- a/extensions/sdktools/extension.cpp
+++ b/extensions/sdktools/extension.cpp
@@ -448,7 +448,7 @@ bool SDKTools::ProcessCommandTarget(cmd_target_info_t *info)
 		for (int i = 1; i <= playerhelpers->GetMaxClients(); i++)
 		{
 			IGamePlayer *player = playerhelpers->GetGamePlayer(i);
-			if (player == NULL || !player->IsInGame())
+			if (player == NULL || !player->IsInGame() || player->IsSourceTV() || player->IsReplay())
 				continue;
 			IPlayerInfo *plinfo = player->GetPlayerInfo();
 			if (plinfo == NULL)


### PR DESCRIPTION
This makes it so sm_kick @spec and other commands don't target replay and sourcetv. This is a side effect from a change to calling disconnect for bots instead of kickid.