### PR TITLE
Change the message displayed when a map isn’t in the nominations maplist

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -145,7 +145,7 @@ public Action Command_Addmap(int client, int args)
 	int status;
 	if (!g_mapTrie.GetValue(resolvedMap, status))
 	{
-		ReplyToCommand(client, "%t", "Map was not found", displayName);
+		ReplyToCommand(client, "%t", "Map Not In Pool", displayName);
 		return Plugin_Handled;		
 	}
 	
@@ -304,7 +304,7 @@ void AttemptNominate(int client, const char[] map, int size)
 	int status;
 	if (!g_mapTrie.GetValue(mapname, status))
 	{
-		ReplyToCommand(client, "%t", "Map was not found", displayName);
+		ReplyToCommand(client, "%t", "Map Not In Pool", displayName);
 		return;		
 	}
 	

--- a/translations/nominations.phrases.txt
+++ b/translations/nominations.phrases.txt
@@ -68,4 +68,10 @@
 	{
 		"en"			"Nominated"
 	}
+
+	"Map Not In Pool"
+	{
+		"#format"		"{1:s}"
+		"en"			"Map '{1}' is not in the nominations pool."
+	}
 }


### PR DESCRIPTION
New English text is “Map ‘%s’ is not in the nominations pool.”

Split off from #588 due to the pending discussion on how i18n requests will work under the new setup.