### PR TITLE
Fixed typo on previous PR

### DIFF
--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -268,7 +268,7 @@
 			"game"					"synergy"
 			"game"					"bms"
 			"game"					"KreedzClimbing"
-			"engine"				"csgo"
+			"game"					"csgo"
 		}
 		
 		"Keys"


### PR DESCRIPTION
"engine" doesn't work here. It should be "game". #598