### PR TITLE
Add missing parameter to DataPack.IsReadable

### DIFF
--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -97,7 +97,7 @@ methodmap DataPack < Handle
 	//  position to the end can be read.
 	//
 	// @param bytes		Number of bytes to simulate reading.
-	public native bool IsReadable();
+	public native bool IsReadable(int bytes);
 	
 	// The read or write position in a data pack.
 	property DataPackPos Position {


### PR DESCRIPTION
The `int bytes` parameter is mentioned in the docs but was missing from the prototype.
Copy&Paste heros!