### PR TITLE
[1.8] Add support for compiling with VS2015.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -403,6 +403,8 @@ class SMConfig(object):
 
     if compiler.like('msvc'):
       compiler.defines += ['COMPILER_MSVC', 'COMPILER_MSVC32']
+      if compiler.version >= 1900:
+	    compiler.linkflags += ['legacy_stdio_definitions.lib']
     else:
       compiler.defines += ['COMPILER_GCC']
 

--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -73,6 +73,8 @@ for sdk_name in SM.sdks:
       vs_year = ''
       if msvc_ver == 1800:
         vs_year = '2013'
+      elif msvc_ver == 1900:
+	    vs_year = '2015'
       else:
         raise Exception('Cannot find libprotobuf for MSVC version "' + str(compiler.version) + '"')
 

--- a/extensions/mysql/AMBuilder
+++ b/extensions/mysql/AMBuilder
@@ -28,6 +28,9 @@ if SM.mysql_root:
       'wsock32.lib'
     ]
 
+  if binary.compiler.vendor == 'msvc' and binary.compiler.version >= 1900:
+    binary.compiler.linkflags += ['legacy_stdio_definitions.lib', 'legacy_stdio_wide_specifiers.lib']
+
   binary.sources += [
     '../../public/smsdk_ext.cpp',
     'mysql/MyBasicResults.cpp',

--- a/public/sm_platform.h
+++ b/public/sm_platform.h
@@ -44,7 +44,7 @@
 #if !defined WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#if !defined snprintf
+#if !defined snprintf && defined _MSC_VER && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 #if !defined stat


### PR DESCRIPTION
Cherry picked commit 416abd8 from master, which never landed on 1.8-dev. Fixes building SM 1.8 on VS2015 and VS2017.