### PR TITLE
Kick fixes

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1967,6 +1967,13 @@ void CPlayer::Initialize(const char *name, const char *ip, edict_t *pEntity)
 	|| SOURCE_ENGINE == SE_BMS   \
 	|| SOURCE_ENGINE == SE_INSURGENCY
 	m_pIClient = engine->GetIServer()->GetClient(m_iIndex - 1);
+#elif SOURCE_ENGINE == SE_SDK2013
+	// Source SDK 2013 mods that ship on Steam can be using older engine binaries
+	static IVEngineServer *engine22 = (IVEngineServer *)(g_SMAPI->GetEngineFactory()("VEngineServer022", nullptr));
+	if (engine22)
+	{
+		m_pIClient = engine22->GetIServer()->GetClient(m_iIndex - 1);
+	}
 #else
 	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(m_iIndex));
 	if (pNetChan)

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1960,6 +1960,21 @@ void CPlayer::Initialize(const char *name, const char *ip, edict_t *pEntity)
 	}
 	m_IpNoPort.assign(ip2);
 
+#if SOURCE_ENGINE == SE_TF2      \
+	|| SOURCE_ENGINE == SE_CSS   \
+	|| SOURCE_ENGINE == SE_DODS  \
+	|| SOURCE_ENGINE == SE_HL2DM \
+	|| SOURCE_ENGINE == SE_BMS   \
+	|| SOURCE_ENGINE == SE_INSURGENCY
+	m_pIClient = engine->GetIServer()->GetClient(m_iIndex - 1);
+#else
+	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(m_iIndex));
+	if (pNetChan)
+	{
+		m_pIClient = static_cast<IClient *>(pNetChan->GetMsgHandler());
+	}
+#endif
+
 	UpdateAuthIds();
 }
 
@@ -2550,22 +2565,7 @@ int CPlayer::GetLifeState()
 
 IClient *CPlayer::GetIClient() const
 {
-#if SOURCE_ENGINE == SE_TF2      \
-	|| SOURCE_ENGINE == SE_CSS   \
-	|| SOURCE_ENGINE == SE_DODS  \
-	|| SOURCE_ENGINE == SE_HL2DM \
-	|| SOURCE_ENGINE == SE_BMS   \
-	|| SOURCE_ENGINE == SE_INSURGENCY
-	return engine->GetIServer()->GetClient(m_iIndex - 1);
-#else
-	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(m_iIndex));
-	if (pNetChan)
-	{
-		return static_cast<IClient *>(pNetChan->GetMsgHandler());
-	}
-
-	return nullptr;
-#endif
+	return m_pIClient;
 }
 
 unsigned int CPlayer::GetSerial()

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1974,11 +1974,14 @@ void CPlayer::Initialize(const char *name, const char *ip, edict_t *pEntity)
 	{
 		m_pIClient = engine22->GetIServer()->GetClient(m_iIndex - 1);
 	}
+	else
 #else
-	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(m_iIndex));
-	if (pNetChan)
 	{
-		m_pIClient = static_cast<IClient *>(pNetChan->GetMsgHandler());
+		INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(m_iIndex));
+		if (pNetChan)
+		{
+			m_pIClient = static_cast<IClient *>(pNetChan->GetMsgHandler());
+		}
 	}
 #endif
 

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -49,7 +49,6 @@
 #include <sourcemod_version.h>
 #include "smn_keyvalues.h"
 #include "command_args.h"
-#include <ITranslator.h>
 #include <bridge/include/IExtensionBridge.h>
 #include <bridge/include/IScriptManager.h>
 #include <bridge/include/ILogger.h>
@@ -1936,25 +1935,8 @@ bool PlayerManager::HandleConVarQuery(QueryCvarCookie_t cookie, int client, EQue
 
 CPlayer::CPlayer()
 {
-	m_IsConnected = false;
-	m_IsInGame = false;
-	m_IsAuthorized = false;
-	m_pEdict = NULL;
-	m_Admin = INVALID_ADMIN_ID;
-	m_TempAdmin = false;
-	m_Info = NULL;
-	m_bAdminCheckSignalled = false;
-	m_UserId = -1;
-	m_bIsInKickQueue = false;
 	m_LastPassword.clear();
-	m_LangId = SOURCEMOD_LANGUAGE_ENGLISH;
-	m_bFakeClient = false;
-	m_bIsSourceTV = false;
-	m_bIsReplay = false;
 	m_Serial.value = -1;
-#if SOURCE_ENGINE == SE_CSGO
-	m_LanguageCookie = InvalidQueryCvarCookie;
-#endif
 }
 
 void CPlayer::Initialize(const char *name, const char *ip, edict_t *pEntity)

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -138,6 +138,7 @@ private:
 	bool m_TempAdmin = false;
 	edict_t *m_pEdict = nullptr;
 	IPlayerInfo *m_Info = nullptr;
+	IClient *m_pIClient = nullptr;
 	String m_LastPassword;
 	bool m_bAdminCheckSignalled = false;
 	int m_iIndex;

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -38,6 +38,7 @@
 #include <IForwardSys.h>
 #include <IPlayerHelpers.h>
 #include <IAdminSystem.h>
+#include <ITranslator.h>
 #include <sh_string.h>
 #include <sh_list.h>
 #include <sh_vector.h>
@@ -123,32 +124,32 @@ private:
 	bool SetEngineString();
 	bool SetCSteamID();
 private:
-	bool m_IsConnected;
-	bool m_IsInGame;
-	bool m_IsAuthorized;
-	bool m_bIsInKickQueue;
+	bool m_IsConnected = false;
+	bool m_IsInGame = false;
+	bool m_IsAuthorized = false;
+	bool m_bIsInKickQueue = false;
 	String m_Name;
 	String m_Ip;
 	String m_IpNoPort;
 	ke::AString m_AuthID;
 	ke::AString m_Steam2Id;
 	ke::AString m_Steam3Id;
-	AdminId m_Admin;
-	bool m_TempAdmin;
-	edict_t *m_pEdict;
-	IPlayerInfo *m_Info;
+	AdminId m_Admin = INVALID_ADMIN_ID;
+	bool m_TempAdmin = false;
+	edict_t *m_pEdict = nullptr;
+	IPlayerInfo *m_Info = nullptr;
 	String m_LastPassword;
-	bool m_bAdminCheckSignalled;
+	bool m_bAdminCheckSignalled = false;
 	int m_iIndex;
-	unsigned int m_LangId;
-	int m_UserId;
-	bool m_bFakeClient;
-	bool m_bIsSourceTV;
-	bool m_bIsReplay;
+	unsigned int m_LangId = SOURCEMOD_LANGUAGE_ENGLISH;
+	int m_UserId = -1;
+	bool m_bFakeClient = false;
+	bool m_bIsSourceTV = false;
+	bool m_bIsReplay = false;
 	serial_t m_Serial;
 	CSteamID m_SteamId;
 #if SOURCE_ENGINE == SE_CSGO
-	QueryCvarCookie_t m_LanguageCookie;
+	QueryCvarCookie_t m_LanguageCookie = InvalidQueryCvarCookie;
 #endif
 };
 

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -1361,14 +1361,6 @@ static cell_t KickClient(IPluginContext *pContext, const cell_t *params)
 			return 0;
 	}
 
-	if (pPlayer->IsFakeClient())
-	{
-		// Kick uses the kickid command for bots. It is already delayed
-		// until the next frame unless someone flushes command buffer
-		pPlayer->Kick(buffer);
-		return 1;
-	}
-
 	gamehelpers->AddDelayedKick(client, pPlayer->GetUserId(), buffer);
 
 	return 1;


### PR DESCRIPTION
Cache IClient pointer on clients, since it's also used for per-client events, not just when kicking.

Support bot IClient lookups for SDK 2013 mods that are on latest engine.

Remove unsafe kick queue bypass for bots.