### PR TITLE
Fix KeyValues.SetUInt64 truncating value (#635).

### DIFF
--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -189,7 +189,7 @@ static cell_t smn_KvSetUInt64(IPluginContext *pCtx, const cell_t *params)
 	pCtx->LocalToStringNULL(params[2], &key);
 	pCtx->LocalToPhysAddr(params[3], &addr);
 
-	value = static_cast<uint64>(*addr);
+	value = *reinterpret_cast<uint64 *>(addr);
 	pStk->pCurRoot.front()->SetUint64(key, value);
 
 	return 1;


### PR DESCRIPTION
In KeyValues.SetUint64, when reading the uint64 value from SP, we were only reading a cell_t worth of data, and then casting that as a uint64. 