### PR TITLE
Fix (parts of) CS:GO gamedata

### DIFF
--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -208,7 +208,7 @@
 		}
 	}
 	
-	"csgo"
+	"#default"
 	{
 		"Keys"
 		{

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -219,9 +219,9 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"449"
+				"windows"	"450"
 				"linux"		"451"
-				"mac"		"450"
+				"mac"		"451"
 			}
 			"RemovePlayerItem"
 			{
@@ -303,9 +303,9 @@
 			}
 			"GiveAmmo"
 			{
-				"windows"	"275"
+				"windows"	"276"
 				"linux"		"277"
-				"mac"		"276"
+				"mac"		"277"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -255,9 +255,9 @@
 			}
 			"CommitSuicide"
 			{
-				"windows"	"499"
-				"linux"		"499"
-				"mac"		"499"
+				"windows"	"500"
+				"linux"		"500"
+				"mac"		"500"
 			}
 			"GetVelocity"
 			{

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -208,7 +208,7 @@
 		}
 	}
 	
-	"#default"
+	"csgo"
 	{
 		"Keys"
 		{
@@ -220,7 +220,7 @@
 			"GiveNamedItem"
 			{
 				"windows"	"449"
-				"linux"		"450"
+				"linux"		"451"
 				"mac"		"450"
 			}
 			"RemovePlayerItem"
@@ -297,14 +297,14 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"469"
-				"linux"		"470"
-				"mac"		"470"
+				"windows"	"470"
+				"linux"		"471"
+				"mac"		"471"
 			}
 			"GiveAmmo"
 			{
 				"windows"	"275"
-				"linux"		"276"
+				"linux"		"277"
 				"mac"		"276"
 			}
 		}

--- a/gamedata/sm-cstrike.games/game.csgo.txt
+++ b/gamedata/sm-cstrike.games/game.csgo.txt
@@ -11,7 +11,7 @@
 
 "Games"
 {
-	"#default"
+	"csgo"
 	{
 		"Keys"
 		{
@@ -58,7 +58,7 @@
 			"CCSPlayerInventoryOffset"
 			{
 				"windows"	"55"
-				"linux"		"87"
+				"linux"		"97"
 				"mac"		"109"
 			}
 			"GetItemInLoadout"
@@ -97,7 +97,7 @@
 			{
 				"library"		"server"
 				"windows"		"\x2A\x2A\x2A\x2A\x2A\x2A\x81\xEC\x7C\x01\x00\x00\x53\x56\x57\x6A\x00"
-				"linux"			"\x2A\x2A\x2A\x2A\x2A\x2A\x81\xEC\x9C\x01\x00\x00\x0F\xB6\x55\x14"
+				"linux"			"\x2A\x2A\x2A\x2A\x2A\x2A\x0F\xB6\x55\x14\x89\x75\xF8\x8B\x75\x08"
 			}
 			"CSWeaponDrop"//Wildcard first 6 bytes for CS:S DM (kept for backcompat with old SM versions)
 			{
@@ -171,7 +171,7 @@
 		}
 	}
 	
-	"#default"
+	"csgo"
 	{
 		"Keys"
 		{
@@ -189,7 +189,7 @@
 		}
 	}
 	
-	"#default"
+	"csgo"
 	{
 		"Keys"
 		{
@@ -207,7 +207,7 @@
 		}
 	}
 	
-	"#default"
+	"csgo"
 	{
 		"Keys"
 		{

--- a/gamedata/sm-cstrike.games/game.csgo.txt
+++ b/gamedata/sm-cstrike.games/game.csgo.txt
@@ -11,7 +11,7 @@
 
 "Games"
 {
-	"csgo"
+	"#default"
 	{
 		"Keys"
 		{
@@ -171,7 +171,7 @@
 		}
 	}
 	
-	"csgo"
+	"#default"
 	{
 		"Keys"
 		{
@@ -189,7 +189,7 @@
 		}
 	}
 	
-	"csgo"
+	"#default"
 	{
 		"Keys"
 		{
@@ -207,7 +207,7 @@
 		}
 	}
 	
-	"csgo"
+	"#default"
 	{
 		"Keys"
 		{


### PR DESCRIPTION
This should fix the HandleCommand_Buy_Internal detour, as well as most crashes.
GetWeaponInfo is still broken, might need some more work.