### PR TITLE
Added repeating param to end of OnPlayerRunCmd and OnPlayerRunCmdPost

### DIFF
--- a/core/sourcemm_api.cpp
+++ b/core/sourcemm_api.cpp
@@ -63,7 +63,7 @@ int vsp_version = 0;
 
 PLUGIN_EXPOSE(SourceMod, g_SourceMod_Core);
 
-ConVar sourcemod_version("sourcemod_version", SOURCEMOD_VERSION, FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY, "SourceMod Version");
+ConVar sourcemod_version("sourcemod_version", SOURCEMOD_VERSION, FCVAR_SPONLY|FCVAR_NOTIFY, "SourceMod Version");
 
 bool SourceMod_Core::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool late)
 {

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -230,19 +230,24 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
-	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
+	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.z && weaponselect[client] == ucmd->weaponselect \
 	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->mousedx \
 	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;
 	impulse[client] = ucmd->impulse;
-	vel[client][3] = {sp_ftoc(ucmd->forwardmove), sp_ftoc(ucmd->sidemove), sp_ftoc(ucmd->upmove)};
-	angles[client][3] = {sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z)};
+	vel[client][0] = ucmd->forwardmove;
+	vel[client][1] = ucmd->sidemove;
+	vel[client][2] = ucmd->upmove;
+	angles[client][0] = ucmd->viewangles.x;
+	angles[client][1] = ucmd->viewangles.y;
+	angles[client][2] = ucmd->viewangles.z;
 	weaponselect[client] = ucmd->weaponselect;
 	weaponsubtype[client] = ucmd->weaponsubtype;
 	command_number[client] = ucmd->command_number;
 	random_seed[client] = ucmd->random_seed;
-	mouse[client][2] = {ucmd->mousedx, ucmd->mousedy};
+	mouse[client][0] = ucmd->mousedx;
+	mouse[client][1] = ucmd->mousedy;
 	
 	m_usercmdsFwd->PushCell(client);
 	m_usercmdsFwd->PushCellByRef(&buttons[client]);
@@ -312,19 +317,24 @@ void CHookManager::PlayerRunCmdPost(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
-	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
+	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.z && weaponselect[client] == ucmd->weaponselect \
 	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->mousedx \
 	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;
 	impulse[client] = ucmd->impulse;
-	vel[client][3] = {sp_ftoc(ucmd->forwardmove), sp_ftoc(ucmd->sidemove), sp_ftoc(ucmd->upmove)};
-	angles[client][3] = {sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z)};
+	vel[client][0] = ucmd->forwardmove;
+	vel[client][1] = ucmd->sidemove;
+	vel[client][2] = ucmd->upmove;
+	angles[client][0] = ucmd->viewangles.x;
+	angles[client][1] = ucmd->viewangles.y;
+	angles[client][2] = ucmd->viewangles.z;
 	weaponselect[client] = ucmd->weaponselect;
 	weaponsubtype[client] = ucmd->weaponsubtype;
 	command_number[client] = ucmd->command_number;
 	random_seed[client] = ucmd->random_seed;
-	mouse[client][2] = {ucmd->mousedx, ucmd->mousedy};
+	mouse[client][0] = ucmd->mousedx;
+	mouse[client][1] = ucmd->mousedy;
 
 	m_usercmdsPostFwd->PushCell(client);
 	m_usercmdsPostFwd->PushCell(buttons[client]);

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -103,7 +103,7 @@ void CHookManager::Initialize()
 		Param_Array,		// mouse[2]
 		Param_Cell);		// repeating
 
-	m_usercmdsPostFwd = forwards->CreateForward("OnPlayerRunCmdPost", ET_Ignore, 11, NULL,
+	m_usercmdsPostFwd = forwards->CreateForward("OnPlayerRunCmdPost", ET_Ignore, 12, NULL,
 		Param_Cell,			// client
 		Param_Cell,			// buttons
 		Param_Cell,			// impulse

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -231,8 +231,8 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
 	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
-	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[0] == ucmd->ucmd->mousedx \
-	&& mouse[1] == ucmd->mousedy;
+	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
+	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;
 	impulse[client] = ucmd->impulse;
@@ -249,11 +249,11 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	m_usercmdsFwd->PushCellByRef(&impulse[client]);
 	m_usercmdsFwd->PushArray(vel[client], 3, SM_PARAM_COPYBACK);
 	m_usercmdsFwd->PushArray(angles[client], 3, SM_PARAM_COPYBACK);
-	m_usercmdsFwd->PushCellByRef(weaponselect[client]);
-	m_usercmdsFwd->PushCellByRef(weaponsubtype[client]);
-	m_usercmdsFwd->PushCellByRef(command_number[client]);
+	m_usercmdsFwd->PushCellByRef(&weaponselect[client]);
+	m_usercmdsFwd->PushCellByRef(&weaponsubtype[client]);
+	m_usercmdsFwd->PushCellByRef(&command_number[client]);
 	m_usercmdsFwd->PushCellByRef(&ucmd->tick_count);
-	m_usercmdsFwd->PushCellByRef(random_seed[client]);
+	m_usercmdsFwd->PushCellByRef(&random_seed[client]);
 	m_usercmdsFwd->PushArray(mouse[client], 2, SM_PARAM_COPYBACK);
 	m_usercmdsFwd->PushCell(repeating);
 	m_usercmdsFwd->Execute(&result);
@@ -314,8 +314,8 @@ void CHookManager::PlayerRunCmdPost(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
 	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
-	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[0] == ucmd->ucmd->mousedx \
-	&& mouse[1] == ucmd->mousedy;
+	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
+	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;
 	impulse[client] = ucmd->impulse;

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -231,7 +231,7 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
 	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
-	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
+	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->mousedx \
 	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;
@@ -313,7 +313,7 @@ void CHookManager::PlayerRunCmdPost(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
 	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
-	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
+	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->mousedx \
 	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -89,7 +89,7 @@ void CHookManager::Initialize()
 	plsys->AddPluginsListener(this);
 	sharesys->AddCapabilityProvider(myself, this, FEATURECAP_PLAYERRUNCMD_11PARAMS);
 
-	m_usercmdsFwd = forwards->CreateForward("OnPlayerRunCmd", ET_Event, 11, NULL,
+	m_usercmdsFwd = forwards->CreateForward("OnPlayerRunCmd", ET_Event, 12, NULL,
 		Param_Cell,			// client
 		Param_CellByRef,	// buttons
 		Param_CellByRef,	// impulse
@@ -100,7 +100,8 @@ void CHookManager::Initialize()
 		Param_CellByRef,	// cmdnum
 		Param_CellByRef,	// tickcount
 		Param_CellByRef,	// seed
-		Param_Array);		// mouse[2]
+		Param_Array,		// mouse[2]
+		Param_Cell);		// repeating
 
 	m_usercmdsPostFwd = forwards->CreateForward("OnPlayerRunCmdPost", ET_Ignore, 11, NULL,
 		Param_Cell,			// client
@@ -113,7 +114,8 @@ void CHookManager::Initialize()
 		Param_Cell,			// cmdnum
 		Param_Cell,			// tickcount
 		Param_Cell,			// seed
-		Param_Array);		// mouse[2]
+		Param_Array,		// mouse[2]
+		Param_Cell);		// repeating
 }
 
 void CHookManager::Shutdown()
@@ -211,39 +213,62 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	}
 
 	int client = IndexOfEdict(pEdict);
-
-
+	bool repeating = false;
+	
 	cell_t result = 0;
+	
+	static cell_t buttons[MAXPLAYERS + 1];
 	/* Impulse is a byte so we copy it back manually */
-	cell_t impulse = ucmd->impulse;
-	cell_t vel[3] = {sp_ftoc(ucmd->forwardmove), sp_ftoc(ucmd->sidemove), sp_ftoc(ucmd->upmove)};
-	cell_t angles[3] = {sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z)};
-	cell_t mouse[2] = {ucmd->mousedx, ucmd->mousedy};
-
+	static cell_t impulse[MAXPLAYERS + 1];
+	static cell_t vel[MAXPLAYERS + 1][3];
+	static cell_t angles[MAXPLAYERS + 1][3];
+	static cell_t weaponselect[MAXPLAYERS + 1];
+	static cell_t weaponsubtype[MAXPLAYERS + 1];
+	static cell_t command_number[MAXPLAYERS + 1];
+	static cell_t random_seed[MAXPLAYERS + 1];
+	static cell_t mouse[MAXPLAYERS + 1][2];
+	
+	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
+	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
+	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
+	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[0] == ucmd->ucmd->mousedx \
+	&& mouse[1] == ucmd->mousedy;
+	
+	buttons[client] = ucmd->buttons;
+	impulse[client] = ucmd->impulse;
+	vel[client][3] = {sp_ftoc(ucmd->forwardmove), sp_ftoc(ucmd->sidemove), sp_ftoc(ucmd->upmove)};
+	angles[client][3] = {sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z)};
+	weaponselect[client] = ucmd->weaponselect;
+	weaponsubtype[client] = ucmd->weaponsubtype;
+	command_number[client] = ucmd->command_number;
+	random_seed[client] = ucmd->random_seed;
+	mouse[client][2] = {ucmd->mousedx, ucmd->mousedy};
+	
 	m_usercmdsFwd->PushCell(client);
-	m_usercmdsFwd->PushCellByRef(&ucmd->buttons);
-	m_usercmdsFwd->PushCellByRef(&impulse);
-	m_usercmdsFwd->PushArray(vel, 3, SM_PARAM_COPYBACK);
-	m_usercmdsFwd->PushArray(angles, 3, SM_PARAM_COPYBACK);
-	m_usercmdsFwd->PushCellByRef(&ucmd->weaponselect);
-	m_usercmdsFwd->PushCellByRef(&ucmd->weaponsubtype);
-	m_usercmdsFwd->PushCellByRef(&ucmd->command_number);
+	m_usercmdsFwd->PushCellByRef(&buttons[client]);
+	m_usercmdsFwd->PushCellByRef(&impulse[client]);
+	m_usercmdsFwd->PushArray(vel[client], 3, SM_PARAM_COPYBACK);
+	m_usercmdsFwd->PushArray(angles[client], 3, SM_PARAM_COPYBACK);
+	m_usercmdsFwd->PushCellByRef(weaponselect[client]);
+	m_usercmdsFwd->PushCellByRef(weaponsubtype[client]);
+	m_usercmdsFwd->PushCellByRef(command_number[client]);
 	m_usercmdsFwd->PushCellByRef(&ucmd->tick_count);
-	m_usercmdsFwd->PushCellByRef(&ucmd->random_seed);
-	m_usercmdsFwd->PushArray(mouse, 2, SM_PARAM_COPYBACK);
+	m_usercmdsFwd->PushCellByRef(random_seed[client]);
+	m_usercmdsFwd->PushArray(mouse[client], 2, SM_PARAM_COPYBACK);
+	m_usercmdsFwd->PushCell(repeating);
 	m_usercmdsFwd->Execute(&result);
 
-	ucmd->impulse = impulse;
-	ucmd->forwardmove = sp_ctof(vel[0]);
-	ucmd->sidemove = sp_ctof(vel[1]);
-	ucmd->upmove = sp_ctof(vel[2]);
-	ucmd->viewangles.x = sp_ctof(angles[0]);
-	ucmd->viewangles.y = sp_ctof(angles[1]);
-	ucmd->viewangles.z = sp_ctof(angles[2]);
-	ucmd->mousedx = mouse[0];
-	ucmd->mousedy = mouse[1];
-
-
+	ucmd->buttons = buttons[client];
+	ucmd->impulse = impulse[client];
+	ucmd->forwardmove = sp_ctof(vel[client][0]);
+	ucmd->sidemove = sp_ctof(vel[client][1]);
+	ucmd->upmove = sp_ctof(vel[client][2]);
+	ucmd->viewangles.x = sp_ctof(angles[client][0]);
+	ucmd->viewangles.y = sp_ctof(angles[client][1]);
+	ucmd->viewangles.z = sp_ctof(angles[client][2]);
+	ucmd->mousedx = mouse[client][0];
+	ucmd->mousedy = mouse[client][1];
+	
 	if (result == Pl_Handled)
 	{
 		RETURN_META(MRES_SUPERCEDE);
@@ -274,21 +299,46 @@ void CHookManager::PlayerRunCmdPost(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	}
 
 	int client = IndexOfEdict(pEdict);
-	cell_t vel[3] = { sp_ftoc(ucmd->forwardmove), sp_ftoc(ucmd->sidemove), sp_ftoc(ucmd->upmove) };
-	cell_t angles[3] = { sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z) };
-	cell_t mouse[2] = { ucmd->mousedx, ucmd->mousedy };
+	bool repeating = false;
+	
+	static cell_t buttons[MAXPLAYERS + 1];
+	static cell_t impulse[MAXPLAYERS + 1];
+	static cell_t vel[MAXPLAYERS + 1][3];
+	static cell_t angles[MAXPLAYERS + 1][3];
+	static cell_t weaponselect[MAXPLAYERS + 1];
+	static cell_t weaponsubtype[MAXPLAYERS + 1];
+	static cell_t command_number[MAXPLAYERS + 1];
+	static cell_t random_seed[MAXPLAYERS + 1];
+	static cell_t mouse[MAXPLAYERS + 1][2];
+	
+	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
+	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
+	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
+	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[0] == ucmd->ucmd->mousedx \
+	&& mouse[1] == ucmd->mousedy;
+	
+	buttons[client] = ucmd->buttons;
+	impulse[client] = ucmd->impulse;
+	vel[client][3] = {sp_ftoc(ucmd->forwardmove), sp_ftoc(ucmd->sidemove), sp_ftoc(ucmd->upmove)};
+	angles[client][3] = {sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z)};
+	weaponselect[client] = ucmd->weaponselect;
+	weaponsubtype[client] = ucmd->weaponsubtype;
+	command_number[client] = ucmd->command_number;
+	random_seed[client] = ucmd->random_seed;
+	mouse[client][2] = {ucmd->mousedx, ucmd->mousedy};
 
 	m_usercmdsPostFwd->PushCell(client);
-	m_usercmdsPostFwd->PushCell(ucmd->buttons);
-	m_usercmdsPostFwd->PushCell(ucmd->impulse);
-	m_usercmdsPostFwd->PushArray(vel, 3);
-	m_usercmdsPostFwd->PushArray(angles, 3);
-	m_usercmdsPostFwd->PushCell(ucmd->weaponselect);
-	m_usercmdsPostFwd->PushCell(ucmd->weaponsubtype);
-	m_usercmdsPostFwd->PushCell(ucmd->command_number);
+	m_usercmdsPostFwd->PushCell(buttons[client]);
+	m_usercmdsPostFwd->PushCell(impulse[client]);
+	m_usercmdsPostFwd->PushArray(vel[client], 3);
+	m_usercmdsPostFwd->PushArray(angles[client], 3);
+	m_usercmdsPostFwd->PushCell(weaponselect[client]);
+	m_usercmdsPostFwd->PushCell(weaponsubtype[client]);
+	m_usercmdsPostFwd->PushCell(command_number[client]);
 	m_usercmdsPostFwd->PushCell(ucmd->tick_count);
-	m_usercmdsPostFwd->PushCell(ucmd->random_seed);
-	m_usercmdsPostFwd->PushArray(mouse, 2);
+	m_usercmdsPostFwd->PushCell(random_seed[client]);
+	m_usercmdsPostFwd->PushArray(mouse[client], 2);
+	m_usercmdsPostFwd->PushCell(repeating);
 	m_usercmdsPostFwd->Execute();
 
 	RETURN_META(MRES_IGNORED);

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -231,7 +231,7 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
 	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
-	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
+	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
 	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;
@@ -258,7 +258,6 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	m_usercmdsFwd->PushCell(repeating);
 	m_usercmdsFwd->Execute(&result);
 
-	ucmd->buttons = buttons[client];
 	ucmd->impulse = impulse[client];
 	ucmd->forwardmove = sp_ctof(vel[client][0]);
 	ucmd->sidemove = sp_ctof(vel[client][1]);
@@ -314,7 +313,7 @@ void CHookManager::PlayerRunCmdPost(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
 	&& angles[client][0] == ucmd->viewangles.x && angles[client][1] == ucmd->viewangles.y && angles[client][2] == ucmd->viewangles.y && weaponselect[client] == ucmd->weaponselect \
-	&& weaponsubtype[client] == ucmd->weaponselect && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
+	&& weaponsubtype[client] == ucmd->weaponsubtype && command_number[client] == ucmd->command_number && random_seed[client] == ucmd->random_seed && mouse[client][0] == ucmd->ucmd->mousedx \
 	&& mouse[client][1] == ucmd->mousedy;
 	
 	buttons[client] = ucmd->buttons;

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -217,16 +217,16 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	
 	cell_t result = 0;
 	
-	static cell_t buttons[MAXPLAYERS + 1];
+	static cell_t buttons[SM_MAXPLAYERS + 1];
 	/* Impulse is a byte so we copy it back manually */
-	static cell_t impulse[MAXPLAYERS + 1];
-	static cell_t vel[MAXPLAYERS + 1][3];
-	static cell_t angles[MAXPLAYERS + 1][3];
-	static cell_t weaponselect[MAXPLAYERS + 1];
-	static cell_t weaponsubtype[MAXPLAYERS + 1];
-	static cell_t command_number[MAXPLAYERS + 1];
-	static cell_t random_seed[MAXPLAYERS + 1];
-	static cell_t mouse[MAXPLAYERS + 1][2];
+	static cell_t impulse[SM_MAXPLAYERS + 1];
+	static cell_t vel[SM_MAXPLAYERS + 1][3];
+	static cell_t angles[SM_MAXPLAYERS + 1][3];
+	static cell_t weaponselect[SM_MAXPLAYERS + 1];
+	static cell_t weaponsubtype[SM_MAXPLAYERS + 1];
+	static cell_t command_number[SM_MAXPLAYERS + 1];
+	static cell_t random_seed[SM_MAXPLAYERS + 1];
+	static cell_t mouse[SM_MAXPLAYERS + 1][2];
 	
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \
@@ -301,15 +301,15 @@ void CHookManager::PlayerRunCmdPost(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	int client = IndexOfEdict(pEdict);
 	bool repeating = false;
 	
-	static cell_t buttons[MAXPLAYERS + 1];
-	static cell_t impulse[MAXPLAYERS + 1];
-	static cell_t vel[MAXPLAYERS + 1][3];
-	static cell_t angles[MAXPLAYERS + 1][3];
-	static cell_t weaponselect[MAXPLAYERS + 1];
-	static cell_t weaponsubtype[MAXPLAYERS + 1];
-	static cell_t command_number[MAXPLAYERS + 1];
-	static cell_t random_seed[MAXPLAYERS + 1];
-	static cell_t mouse[MAXPLAYERS + 1][2];
+	static cell_t buttons[SM_MAXPLAYERS + 1];
+	static cell_t impulse[SM_MAXPLAYERS + 1];
+	static cell_t vel[SM_MAXPLAYERS + 1][3];
+	static cell_t angles[SM_MAXPLAYERS + 1][3];
+	static cell_t weaponselect[SM_MAXPLAYERS + 1];
+	static cell_t weaponsubtype[SM_MAXPLAYERS + 1];
+	static cell_t command_number[SM_MAXPLAYERS + 1];
+	static cell_t random_seed[SM_MAXPLAYERS + 1];
+	static cell_t mouse[SM_MAXPLAYERS + 1][2];
 	
 	// Check if the UserCmd is repeating, we won't check the tickcount as that always increments regardless.
 	repeating = buttons[client] == ucmd->buttons && impulse[client] == ucmd->impulse && vel[client][0] == ucmd->forwardmove && vel[client][1] == ucmd->sidemove && vel[client][2] == ucmd->upmove \

--- a/plugins/include/sdktools_hooks.inc
+++ b/plugins/include/sdktools_hooks.inc
@@ -57,7 +57,7 @@
  * @note			To see if all 12 params are available, use FeatureType_Capability and
  *					FEATURECAP_PLAYERRUNCMD_11PARAMS.
  */
-forward Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2]);
+forward Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2], bool repeating);
 
 /**
  * @brief Called after a clients movement buttons were processed.
@@ -75,7 +75,7 @@ forward Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[
  * @param mouse		Mouse direction (x, y).
  * @param repeating	Whether the UserCmd is being repeated by server or not (true/false).
  */
-forward void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float vel[3], const float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, const int mouse[2]);
+forward void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float vel[3], const float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, const int mouse[2], bool repeating);
 
 /**
  * @brief Called when a client requests a file from the server.

--- a/plugins/include/sdktools_hooks.inc
+++ b/plugins/include/sdktools_hooks.inc
@@ -51,9 +51,10 @@
  * @param tickcount	Tick count. A client's prediction based on the server's GetGameTickCount value.
  * @param seed		Random seed. Used to determine weapon recoil, spread, and other predicted elements.
  * @param mouse		Mouse direction (x, y).
+ * @param repeating	Whether the UserCmd is being repeated by server or not (true/false).
  * @return 			Plugin_Handled to block the commands from being processed, Plugin_Continue otherwise.
  *
- * @note			To see if all 11 params are available, use FeatureType_Capability and
+ * @note			To see if all 12 params are available, use FeatureType_Capability and
  *					FEATURECAP_PLAYERRUNCMD_11PARAMS.
  */
 forward Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2]);
@@ -72,6 +73,7 @@ forward Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[
  * @param tickcount	Tick count. A client's prediction based on the server's GetGameTickCount value.
  * @param seed		Random seed. Used to determine weapon recoil, spread, and other predicted elements.
  * @param mouse		Mouse direction (x, y).
+ * @param repeating	Whether the UserCmd is being repeated by server or not (true/false).
  */
 forward void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float vel[3], const float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, const int mouse[2]);
 


### PR DESCRIPTION
This will allow people to determine if the UserCmd is truly being sent from the client or if its previous command being repeated by the server.

You can read more information about this here: https://list.valvesoftware.com/pipermail/csgo_servers/2015-July/011465.html

The parameter was added for more flexibility rather than just not firing the forward at all.
This is a none breaking change as the parameter has been added to the end, you can optionally adjust your plugins otherwise they will continue working as before.