### PR TITLE
Un deprecate FCVAR_PLUGIN

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "ConVarManager.h"
+#include "convar_sm.h"
 #include "HalfLife2.h"
 #include "sm_stringutil.h"
 #include <sh_vector.h>
@@ -392,6 +393,9 @@ Handle_t ConVarManager::CreateConVar(IPluginContext *pContext, const char *name,
 	}
 
 	pInfo->handle = hndl;
+	
+	/* This ConVar was created by a plugin, add the flag. */
+	flags |= FCVAR_PLUGIN;
 
 	/* Since an existing convar (or concmd with the same name) was not found , now we can finally create it */
 	pConVar = new ConVar(sm_strdup(name), sm_strdup(defaultVal), flags, sm_strdup(description), hasMin, min, hasMax, max);

--- a/core/sourcemm_api.cpp
+++ b/core/sourcemm_api.cpp
@@ -63,7 +63,7 @@ int vsp_version = 0;
 
 PLUGIN_EXPOSE(SourceMod, g_SourceMod_Core);
 
-ConVar sourcemod_version("sourcemod_version", SOURCEMOD_VERSION, FCVAR_SPONLY|FCVAR_REPLICATED|FCVAR_NOTIFY, "SourceMod Version");
+ConVar sourcemod_version("sourcemod_version", SOURCEMOD_VERSION, FCVAR_SPONLY|FCVAR_NOTIFY, "SourceMod Version");
 
 bool SourceMod_Core::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool late)
 {

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -59,7 +59,6 @@ enum ReplySource
  * for each constant come directly from the Source SDK.
  */
 
-#pragma deprecated No logic using this flag ever existed in a released game. It only ever appeared in the first hl2sdk.
 #define FCVAR_PLUGIN           0       // Actual value is same as FCVAR_SS_ADDED in Left 4 Dead and later.
 #pragma deprecated Did you mean FCVAR_DEVELOPMENTONLY? (No logic using this flag ever existed in a released game. It only ever appeared in the first hl2sdk.)
 #define FCVAR_LAUNCHER         (1<<1)  // Same value as FCVAR_DEVELOPMENTONLY, which is what most usages of this were intending to use.


### PR DESCRIPTION
Can be useful to know if a plugin actually added the ConVar or not.