### PR TITLE
Add natives to check for NULL_VECTOR and NULL_STRING without breaking backwards compatibility

### DIFF
--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -528,10 +528,17 @@ void CForward::_Int_PushArray(cell_t *inarray, unsigned int cells, int flags)
 
 int CForward::PushArray(cell_t *inarray, unsigned int cells, int flags)
 {
-	/* We don't allow this here */
+	/* Push a reference to the NULL_VECTOR pubvar if NULL was passed. */
 	if (!inarray)
 	{
-		return SetError(SP_ERROR_PARAM);
+		/* Make sure this was intentional. */
+		if (cells == 3)
+		{
+			return PushNullVector();
+		} else {
+			/* We don't allow this here */
+			return SetError(SP_ERROR_PARAM);
+		}
 	}
 
 	if (m_curparam < m_numparams)
@@ -568,6 +575,12 @@ void CForward::_Int_PushString(cell_t *inarray, unsigned int cells, int sz_flags
 
 int CForward::PushString(const char *string)
 {
+	/* Push a reference to the NULL_STRING pubvar if NULL was passed. */
+	if (!string)
+	{
+		return PushNullString();
+	}
+
 	if (m_curparam < m_numparams)
 	{
 		if (m_types[m_curparam] == Param_Any)

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -55,8 +55,6 @@ public: //IForward
 	virtual unsigned int GetFunctionCount();
 	virtual ExecType GetExecType();
 	virtual int Execute(cell_t *result, IForwardFilter *filter);
-	virtual int PushNullString();
-	virtual int PushNullVector();
 public: //IChangeableForward
 	virtual bool RemoveFunction(IPluginFunction *func);
 	virtual unsigned int RemoveFunctionsOfPlugin(IPlugin *plugin);
@@ -74,6 +72,8 @@ private:
 	CForward(ExecType et, const char *name,
 	         const ParamType *types, unsigned num_params);
 
+	int PushNullString();
+	int PushNullVector();
 	int _ExecutePushRef(IPluginFunction *func, ParamType type, FwdParamInfo *param);
 	void _Int_PushArray(cell_t *inarray, unsigned int cells, int flags);
 	void _Int_PushString(cell_t *inarray, unsigned int cells, int sz_flags, int cp_flags);

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -55,6 +55,8 @@ public: //IForward
 	virtual unsigned int GetFunctionCount();
 	virtual ExecType GetExecType();
 	virtual int Execute(cell_t *result, IForwardFilter *filter);
+	virtual int PushNullString();
+	virtual int PushNullVector();
 public: //IChangeableForward
 	virtual bool RemoveFunction(IPluginFunction *func);
 	virtual unsigned int RemoveFunctionsOfPlugin(IPlugin *plugin);

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -74,6 +74,7 @@ private:
 	CForward(ExecType et, const char *name,
 	         const ParamType *types, unsigned num_params);
 
+	int _ExecutePushRef(IPluginFunction *func, ParamType type, FwdParamInfo *param);
 	void _Int_PushArray(cell_t *inarray, unsigned int cells, int flags);
 	void _Int_PushString(cell_t *inarray, unsigned int cells, int sz_flags, int cp_flags);
 	inline int SetError(int err)

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -759,6 +759,27 @@ static cell_t StoreToAddress(IPluginContext *pContext, const cell_t *params)
 	return 0;
 }
 
+static cell_t IsNullVector(IPluginContext *pContext, const cell_t *params)
+{
+	cell_t *pNullVec = pContext->GetNullRef(SP_NULL_VECTOR);
+	if (!pNullVec)
+		return 0;
+	
+	cell_t *addr;
+	pContext->LocalToPhysAddr(params[1], &addr);
+
+	return addr == pNullVec;
+}
+
+static cell_t IsNullString(IPluginContext *pContext, const cell_t *params)
+{
+	char *str;
+	if (pContext->LocalToStringNULL(params[1], &str) != SP_ERROR_NONE)
+		return 0;
+
+	return str == nullptr;
+}
+
 REGISTER_NATIVES(coreNatives)
 {
 	{"ThrowError",				ThrowError},
@@ -787,5 +808,7 @@ REGISTER_NATIVES(coreNatives)
 	{"RequireFeature",          RequireFeature},
 	{"LoadFromAddress",         LoadFromAddress},
 	{"StoreToAddress",          StoreToAddress},
+	{"IsNullVector",			IsNullVector},
+	{"IsNullString",			IsNullString},
 	{NULL,						NULL},
 };

--- a/core/logic/smn_fakenatives.cpp
+++ b/core/logic/smn_fakenatives.cpp
@@ -424,6 +424,58 @@ static cell_t FormatNativeString(IPluginContext *pContext, const cell_t *params)
 	return SP_ERROR_NONE;
 }
 
+static cell_t IsNativeParamNullVector(IPluginContext *pContext, const cell_t *params)
+{
+	if (!s_curnative || (s_curnative->ctx != pContext))
+	{
+		return pContext->ThrowNativeError("Not called from inside a native function");
+	}
+
+	cell_t param = params[1];
+	if (param < 1 || param > s_curparams[0])
+	{
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAM, "Invalid parameter number: %d", param);
+	}
+
+	int err;
+	cell_t *addr;
+	if ((err = s_curcaller->LocalToPhysAddr(s_curparams[param], &addr)) != SP_ERROR_NONE)
+	{
+		return err;
+	}
+
+	cell_t *pNullVec = s_curcaller->GetNullRef(SP_NULL_VECTOR);
+	if (!pNullVec)
+	{
+		return 0;
+	}
+
+	return addr == pNullVec ? 1 : 0;
+}
+
+static cell_t IsNativeParamNullString(IPluginContext *pContext, const cell_t *params)
+{
+	if (!s_curnative || (s_curnative->ctx != pContext))
+	{
+		return pContext->ThrowNativeError("Not called from inside a native function");
+	}
+
+	cell_t param = params[1];
+	if (param < 1 || param > s_curparams[0])
+	{
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAM, "Invalid parameter number: %d", param);
+	}
+
+	int err;
+	char *str;
+	if ((err = s_curcaller->LocalToStringNULL(s_curparams[param], &str)) != SP_ERROR_NONE)
+	{
+		return err;
+	}
+
+	return str == nullptr ? 1 : 0;
+}
+
 //tee hee
 REGISTER_NATIVES(nativeNatives)
 {
@@ -439,5 +491,7 @@ REGISTER_NATIVES(nativeNatives)
 	{"SetNativeArray",			SetNativeArray},
 	{"SetNativeCellRef",		SetNativeCellRef},
 	{"SetNativeString",			SetNativeString},
+	{"IsNativeParamNullVector",	IsNativeParamNullVector},
+	{"IsNativeParamNullString",	IsNativeParamNullString},
 	{NULL,						NULL},
 };

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -580,7 +580,7 @@ static cell_t sm_CallPushNullVector(IPluginContext *pContext, const cell_t *para
 	}
 	else if (s_pForward)
 	{
-		err = s_pForward->PushNullVector();
+		err = s_pForward->PushArray(NULL, 3);
 	}
 
 	if (err)
@@ -621,7 +621,7 @@ static cell_t sm_CallPushNullString(IPluginContext *pContext, const cell_t *para
 	}
 	else if (s_pForward)
 	{
-		err = s_pForward->PushNullString();
+		err = s_pForward->PushString(NULL);
 	}
 
 	if (err)

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -552,6 +552,88 @@ static cell_t sm_CallPushStringEx(IPluginContext *pContext, const cell_t *params
 	return 1;
 }
 
+static cell_t sm_CallPushNullVector(IPluginContext *pContext, const cell_t *params)
+{
+	int err = SP_ERROR_NOT_FOUND;
+
+	if (!s_CallStarted)
+	{
+		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
+	}
+
+	if (s_pFunction)
+	{
+		// Find the NULL_VECTOR pubvar in the target plugin and push the local address.
+		IPluginRuntime *runtime = s_pFunction->GetParentRuntime();
+		uint32_t null_vector_idx;
+		err = runtime->FindPubvarByName("NULL_VECTOR", &null_vector_idx);
+		if (err)
+		{
+			return pContext->ThrowNativeErrorEx(err, "Target plugin has no NULL_VECTOR.");
+		}
+
+		cell_t null_vector;
+		err = runtime->GetPubvarAddrs(null_vector_idx, &null_vector, nullptr);
+
+		if (!err)
+			err = s_pCallable->PushCell(null_vector);
+	}
+	else if (s_pForward)
+	{
+		err = s_pForward->PushNullVector();
+	}
+
+	if (err)
+	{
+		s_pCallable->Cancel();
+		ResetCall();
+		return pContext->ThrowNativeErrorEx(err, NULL);
+	}
+
+	return 1;
+}
+
+static cell_t sm_CallPushNullString(IPluginContext *pContext, const cell_t *params)
+{
+	int err = SP_ERROR_NOT_FOUND;
+
+	if (!s_CallStarted)
+	{
+		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
+	}
+
+	if (s_pFunction)
+	{
+		// Find the NULL_STRING pubvar in the target plugin and push the local address.
+		IPluginRuntime *runtime = s_pFunction->GetParentRuntime();
+		uint32_t null_string_idx;
+		err = runtime->FindPubvarByName("NULL_STRING", &null_string_idx);
+		if (err)
+		{
+			return pContext->ThrowNativeErrorEx(err, "Target plugin has no NULL_STRING.");
+		}
+
+		cell_t null_string;
+		err = runtime->GetPubvarAddrs(null_string_idx, &null_string, nullptr);
+
+		if (!err)
+			err = s_pCallable->PushCell(null_string);
+	}
+	else if (s_pForward)
+	{
+		err = s_pForward->PushNullString();
+	}
+
+	if (err)
+	{
+		s_pCallable->Cancel();
+		ResetCall();
+		return pContext->ThrowNativeErrorEx(err, NULL);
+	}
+
+	return 1;
+}
+
 static cell_t sm_CallFinish(IPluginContext *pContext, const cell_t *params)
 {
 	int err = SP_ERROR_NOT_RUNNABLE;
@@ -668,6 +750,8 @@ REGISTER_NATIVES(functionNatives)
 	{"Call_PushArrayEx",		sm_CallPushArrayEx},
 	{"Call_PushString",			sm_CallPushString},
 	{"Call_PushStringEx",		sm_CallPushStringEx},
+	{"Call_PushNullVector",		sm_CallPushNullVector},
+	{"Call_PushNullString",		sm_CallPushNullString},
 	{"Call_Finish",				sm_CallFinish},
 	{"Call_Cancel",				sm_CallCancel},
 	{"RequestFrame",			sm_AddFrameAction},

--- a/plugins/include/core.inc
+++ b/plugins/include/core.inc
@@ -144,6 +144,22 @@ public float NULL_VECTOR[3];		/**< Pass this into certain functions to act as a 
 public const char NULL_STRING[1];	/**< pass this into certain functions to act as a C++ NULL */
 
 /**
+ * Check if the given vector is the NULL_VECTOR.
+ *
+ * @param vec     The vector to test.
+ * @return        True if NULL_VECTOR, false otherwise.
+ */
+native bool IsNullVector(const float vec[3]);
+
+/**
+ * Check if the given string is the NULL_STRING.
+ *
+ * @param str     The string to test.
+ * @return        True if NULL_STRING, false otherwise.
+ */
+native bool IsNullString(const char[] str);
+
+/**
  * Horrible compatibility shim.
  */
 public Extension __ext_core = 

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -466,6 +466,22 @@ native int GetNativeArray(int param, any[] local, int size);
 native int SetNativeArray(int param, const any[] local, int size);
 
 /**
+ * Check if the native parameter is the NULL_VECTOR.
+ *
+ * @param param		Parameter number, starting from 1.
+ * @return        True if NULL_VECTOR, false otherwise.
+ */
+native bool IsNativeParamNullVector(int param);
+
+/**
+ * Check if the native parameter is the NULL_STRING.
+ *
+ * @param param		Parameter number, starting from 1.
+ * @return        True if NULL_STRING, false otherwise.
+ */
+native bool IsNativeParamNullString(int param);
+
+/**
  * Formats a string using parameters from a native.
  *
  * @note All parameter indexes start at 1.

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -291,6 +291,16 @@ native void Call_PushArray(const any[] value, int size);
 native void Call_PushArrayEx(any[] value, int size, int cpflags);
 
 /**
+ * Pushes the NULL_VECTOR onto the current call.
+ * @see IsNullVector
+ *
+ * @note Cannot be used before a call has been started.
+ *
+ * @error					Called before a call has been started.
+ */
+native void Call_PushNullVector();
+
+/**
  * Pushes a string onto the current call.
  *
  * @note Changes to string are not copied back to caller. Use PushStringEx() to do this.
@@ -316,6 +326,16 @@ native void Call_PushString(const char[] value);
  * @error					Called before a call has been started.
  */
 native void Call_PushStringEx(char[] value, int length, int szflags, int cpflags);
+
+/**
+ * Pushes the NULL_STRING onto the current call.
+ * @see IsNullString
+ *
+ * @note Cannot be used before a call has been started.
+ *
+ * @error					Called before a call has been started.
+ */
+native void Call_PushNullString();
 
 /**
  * Completes a call to a function or forward's call list.

--- a/public/IForwardSys.h
+++ b/public/IForwardSys.h
@@ -178,7 +178,8 @@ namespace SourceMod
 		 * @brief Pushes an array of cells onto the current call.  Different rules than ICallable.
 		 * NOTE: On Execute, the pointer passed will be modified according to the copyback rule.
 		 *
-		 * @param inarray	Array to copy.  Cannot be NULL, unlike ICallable's version.
+		 * @param inarray	Array to copy.  If NULL and cells is 3 pushes a reference to the NULL_VECTOR pubvar to each callee.
+		 *                  Pushing other number of cells is not allowed, unlike ICallable's version.
 		 * @param cells		Number of cells to allocate and optionally read from the input array.
 		 * @param flags		Whether or not changes should be copied back to the input array.
 		 * @return			Error code, if any.
@@ -186,20 +187,12 @@ namespace SourceMod
 		virtual int PushArray(cell_t *inarray, unsigned int cells, int flags=0) =0;
 
 		/**
-		 * @brief Pushes the NULL_STRING onto the current call. This will always push the
-		 * correct reference to each function in the forward.
-		 *
-		 * @return			Error code, if any.
-		 */
-		virtual int PushNullString() =0;
-
-		/**
-		 * @brief Pushes the NULL_VECTOR onto the current call. This will always push the
-		 * correct reference to each function in the forward.
-		 *
-		 * @return			Error code, if any.
-		 */
-		virtual int PushNullVector() =0;
+		* @brief Pushes a string onto the current call.
+		*
+		* @param string  String to push.  If NULL pushes a reference to the NULL_STRING pubvar to each callee.
+		* @return      Error code, if any.
+		*/
+		virtual int PushString(const char *string) = 0;
 	};
 
 	/**

--- a/public/IForwardSys.h
+++ b/public/IForwardSys.h
@@ -50,7 +50,7 @@
 using namespace SourcePawn;
 
 #define SMINTERFACE_FORWARDMANAGER_NAME		"IForwardManager"
-#define SMINTERFACE_FORWARDMANAGER_VERSION	3
+#define SMINTERFACE_FORWARDMANAGER_VERSION	4
 
 /*
  * There is some very important documentation at the bottom of this file.
@@ -118,6 +118,7 @@ namespace SourceMod
 		cell_t val;
 		ByrefInfo byref;
 		ParamType pushedas;
+		bool isnull;
 	};
 	
 	class IForwardFilter
@@ -183,6 +184,22 @@ namespace SourceMod
 		 * @return			Error code, if any.
 		 */
 		virtual int PushArray(cell_t *inarray, unsigned int cells, int flags=0) =0;
+
+		/**
+		 * @brief Pushes the NULL_STRING onto the current call. This will always push the
+		 * correct reference to each function in the forward.
+		 *
+		 * @return			Error code, if any.
+		 */
+		virtual int PushNullString() =0;
+
+		/**
+		 * @brief Pushes the NULL_VECTOR onto the current call. This will always push the
+		 * correct reference to each function in the forward.
+		 *
+		 * @return			Error code, if any.
+		 */
+		virtual int PushNullVector() =0;
 	};
 
 	/**


### PR DESCRIPTION
Readds https://github.com/alliedmodders/sourcemod/pull/606 while fixing https://github.com/alliedmodders/sourcemod/pull/647

Unmanaged forwards broke in old extensions after adding `PushNullVector` and `PushNullString` to `IForward`, because `IChangeableForward` inherited from `IForward`. So extensions which were compiled against older SourceMod includes and using private forwards crashed when calling one of the `AddFunction`/`RemoveFunction` methods.

This was fixed by removing the two new functions from `IForward` and just allow passing `NULL` to `PushArray` and `PushString` which get replaced with the corresponding pubvar.