### PR TITLE
Fix core config values not being cached

### DIFF
--- a/core/CoreConfig.cpp
+++ b/core/CoreConfig.cpp
@@ -277,7 +277,7 @@ SMCResult CoreConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key,
 
 ConfigResult CoreConfig::SetConfigOption(const char *option, const char *value, ConfigSource source, char *error, size_t maxlength)
 {
-	ConfigResult result;
+	ConfigResult result = ConfigResult_Ignore;
 
 	/* Notify! */
 	SMGlobalClass *pBase = SMGlobalClass::head;
@@ -285,7 +285,7 @@ ConfigResult CoreConfig::SetConfigOption(const char *option, const char *value, 
 	{
 		if ((result = pBase->OnSourceModConfigChanged(option, value, source, error, maxlength)) != ConfigResult_Ignore)
 		{
-			return result;
+			break;
 		}
 		pBase = pBase->m_pGlobalClassNext;
 	}
@@ -293,7 +293,7 @@ ConfigResult CoreConfig::SetConfigOption(const char *option, const char *value, 
 	ke::AString vstr(value);
 	m_KeyValues.replace(option, ke::Move(vstr));
 
-	return ConfigResult_Ignore;
+	return result;
 }
 
 const char *CoreConfig::GetCoreConfigValue(const char *key)

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -171,13 +171,16 @@ ConfigResult CHalfLife2::OnSourceModConfigChanged(const char *key, const char *v
 		if (strcasecmp(value, "no") == 0)
 		{
 			m_bFollowCSGOServerGuidelines = false;
+			return ConfigResult_Accept;
 		}
 		else if (strcasecmp(value, "yes") == 0)
 		{
 			m_bFollowCSGOServerGuidelines = true;
+			return ConfigResult_Accept;
 		}
 		else
 		{
+			ke::SafeSprintf(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
 			return ConfigResult_Reject;
 		}
 #endif


### PR DESCRIPTION
Valid core config options aren't cached to be retrieved using `GetCoreConfigValue` after they've been loaded from core.cfg or set through the `sm config` root console menu.

E.g. `sm config ServerLang` would return `[SM] No such config option "ServerLang" exists.` all the time.

Stop notifying other listeners if the config key was consumed, but don't skip adding it to the cache.

Also fix `FollowCSGOServerGuidelines` always showing as unhandled command when being changed through `sm config FollowCSGOServerGuidelines yes`.