### PR TITLE
fix generate_headers.py to strip new lines

### DIFF
--- a/tools/buildbot/generate_headers.py
+++ b/tools/buildbot/generate_headers.py
@@ -50,15 +50,11 @@ def output_version_headers():
     count, shorthash, longhash = get_git_version()
 
   with open(os.path.join(SourceFolder, 'product.version')) as fp:
-    contents = fp.read()
+    contents = fp.read().strip()
   m = re.match('(\d+)\.(\d+)\.(\d+)-?(.*)', contents)
   if m == None:
     raise Exception('Could not detremine product version')
   major, minor, release, tag = m.groups()
-  major = major.strip()
-  minir = minor.strip()
-  release = release.strip()
-  tag = tag.strip()
   product = "{0}.{1}.{2}.{3}".format(major, minor, release, count)
   fullstring = product
   if tag != "":

--- a/tools/buildbot/generate_headers.py
+++ b/tools/buildbot/generate_headers.py
@@ -55,6 +55,10 @@ def output_version_headers():
   if m == None:
     raise Exception('Could not detremine product version')
   major, minor, release, tag = m.groups()
+  major = major.strip()
+  minir = minor.strip()
+  release = release.strip()
+  tag = tag.strip()
   product = "{0}.{1}.{2}.{3}".format(major, minor, release, count)
   fullstring = product
   if tag != "":


### PR DESCRIPTION
This is to avoid line breaks in sourcemod_version_auto.h which occur in rare cases when tag is empty.
At least I got this on compiling using Bash on Windows.

Without this fix, I got a sourcemod_version_auto.h which looks like this:
```
#ifndef _SOURCEMOD_AUTO_VERSION_INFORMATION_H_
#define _SOURCEMOD_AUTO_VERSION_INFORMATION_H_

#define SM_BUILD_TAG		"
"
#define SM_BUILD_CSET		"3d461ec"
#define SM_BUILD_MAJOR		"1"
#define SM_BUILD_MINOR		"9"
#define SM_BUILD_RELEASE	"0"
#define SM_BUILD_LOCAL_REV      "6152"

#define SM_BUILD_UNIQUEID       SM_BUILD_LOCAL_REV ":" SM_BUILD_CSET

#define SM_VERSION_STRING	"1.9.0.6152
"
#define SM_VERSION_FILE		1,9,0,6152

#endif /* _SOURCEMOD_AUTO_VERSION_INFORMATION_H_ */ 
```

This, of course, caused compile errors.