### PR TITLE
add support for SourceMod libraries in GameConfig files

### DIFF
--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -89,6 +89,7 @@ public:
 	void *          serverFactory;
 	void *          engineFactory;
 	void *          matchmakingDSFactory;
+	void *          jitFactory;
 	SMGlobalClass *	listeners;
 
 	// ConVar functions.

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -556,6 +556,12 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 				addrInBase = bridge->engineFactory;
 			} else if (strcmp(s_TempSig.library, "matchmaking_ds") == 0) {
 				addrInBase = bridge->matchmakingDSFactory;
+			} else if (strcmp(s_TempSig.library, "sourcemod") == 0) {
+				addrInBase = bridge;
+			} else if (strcmp(s_TempSig.library, "sourcemod.logic") == 0) {
+				addrInBase = &g_GameConfigs;
+			} else if (strcmp(s_TempSig.library, "sourcepawn.jit") == 0) {
+				addrInBase = bridge->jitFactory;
 			}
 			void *final_addr = NULL;
 			if (addrInBase == NULL)

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -657,6 +657,16 @@ void CoreProviderImpl::InitializeBridge()
 		this->matchmakingDSFactory =
 		  mmlib->get<decltype(sCoreProviderImpl.matchmakingDSFactory)>("CreateInterface");
 	}
+
+	ke::path::Format(path, sizeof(path),
+	                 "%s/bin/sourcepawn.jit.x86.%s",
+	                 g_SourceMod.GetSourceModPath(),
+	                 PLATFORM_LIB_EXT);
+
+	if (ke::RefPtr<ke::SharedLib> jitlib = ke::SharedLib::Open(path, NULL, 0)) {
+		this->jitFactory =
+			jitlib->get<decltype(sCoreProviderImpl.jitFactory)>("GetSourcePawnFactory");
+	}
 	
 	logic_init_(this, &logicore);
 


### PR DESCRIPTION
Adds support for further SourceMod libraries in GameConfig files.
Supported libraries included:
- `sourcemod` (SourceMod core)
- `sourcemod.logic` (SourceMod core/logic)
- `sourcepawn.jit` (SourcePawn JIT)

I need this for a current project and would be happy if this makes it into the master.