### PR TITLE
Add LogStackTrace Native (#684)

### DIFF
--- a/core/logic/DebugReporter.h
+++ b/core/logic/DebugReporter.h
@@ -34,6 +34,8 @@
 
 #include "sp_vm_api.h"
 #include "common_logic.h"
+#include <am-vector.h>
+#include <am-string.h>
 
 class DebugReport : 
 	public SMGlobalClass, 
@@ -48,6 +50,7 @@ public:
 	void GenerateError(IPluginContext *ctx, cell_t func_idx, int err, const char *message, ...);
 	void GenerateErrorVA(IPluginContext *ctx, cell_t func_idx, int err, const char *message, va_list ap); 
 	void GenerateCodeError(IPluginContext *ctx, uint32_t code_addr, int err, const char *message, ...);
+	ke::Vector<ke::AString> GetStackTrace(IFrameIterator *iter);
 private:
 	int _GetPluginIndex(IPluginContext *ctx);
 };

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -937,6 +937,27 @@ static cell_t FrameIterator_GetFilePath(IPluginContext *pContext, const cell_t *
 	return 0;
 }
 
+static cell_t LogStackTrace(IPluginContext *pContext, const cell_t *params)
+{
+	char buffer[512];
+
+	g_pSM->FormatString(buffer, sizeof(buffer), pContext, params, 1);
+		
+	IFrameIterator *it = pContext->CreateFrameIterator();
+	ke::Vector<ke::AString> arr = g_DbgReporter.GetStackTrace(it);
+	pContext->DestroyFrameIterator(it);
+
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+
+	g_Logger.LogError("[SM] Stack trace requested: %s", buffer);
+	g_Logger.LogError("[SM] Called from: %s", pPlugin->GetFilename());
+	for (size_t i = 0; i < arr.length(); i)
+	{
+		g_Logger.LogError("%s", arr[i].chars());
+	}
+	return 0;
+}
+
 REGISTER_NATIVES(coreNatives)
 {
 	{"ThrowError",				ThrowError},
@@ -967,6 +988,7 @@ REGISTER_NATIVES(coreNatives)
 	{"StoreToAddress",          StoreToAddress},
 	{"IsNullVector",			IsNullVector},
 	{"IsNullString",			IsNullString},
+	{"LogStackTrace",           LogStackTrace},
 	
 	{"FrameIterator.FrameIterator",				FrameIterator_Create},
 	{"FrameIterator.Next",						FrameIterator_Next},


### PR DESCRIPTION
In order for this to be merged, [this pr](https://github.com/alliedmodders/sourcepawn/pull/140) for sourcepawn must be merged. 

Essentially this adds pull request adds LogStackTrace, which will serve as a debugging function that outputs a stack trace where the native is called, but does not halt execution. For more info: see #684

```cpp
#include <sourcemod>

public void OnPluginStart()
{
	SomeFunction();
}

void SomeFunction()
{
	SomeFunction2();
}

void SomeFunction2()
{
	LogStackTrace("LogStackTrace%i %.2f", 4, 10.0)
	SetFailState("SetFailState %i %.2f", 4, 10.0)
}
```
will output in errors

```
L 09/17/2017 - 15:07:55: [SM] Stack trace requested: LogStackTrace 4 10.00
L 09/17/2017 - 15:07:55: [SM] Call stack trace:
L 09/17/2017 - 15:07:55: [SM]   [0] LogStackTrace
L 09/17/2017 - 15:07:55: [SM]   [1] Line 15, C:\Users\Micha\Desktop\sourcemod\sourcemod\build\package\addons\sourcemod\Test.sp::SomeFunction2
L 09/17/2017 - 15:07:55: [SM]   [2] Line 10, C:\Users\Micha\Desktop\sourcemod\sourcemod\build\package\addons\sourcemod\Test.sp::SomeFunction
L 09/17/2017 - 15:07:55: [SM]   [3] Line 5, C:\Users\Micha\Desktop\sourcemod\sourcemod\build\package\addons\sourcemod\Test.sp::OnPluginStart
L 09/17/2017 - 15:07:55: [SM] Exception reported: SetFailState 4 10.00
L 09/17/2017 - 15:07:55: [SM] Blaming: test.smx
L 09/17/2017 - 15:07:55: [SM] Call stack trace:
L 09/17/2017 - 15:07:55: [SM]   [0] SetFailState
L 09/17/2017 - 15:07:55: [SM]   [1] Line 16, C:\Users\Micha\Desktop\sourcemod\sourcemod\build\package\addons\sourcemod\Test.sp::SomeFunction2
L 09/17/2017 - 15:07:55: [SM]   [2] Line 10, C:\Users\Micha\Desktop\sourcemod\sourcemod\build\package\addons\sourcemod\Test.sp::SomeFunction
L 09/17/2017 - 15:07:55: [SM]   [3] Line 5, C:\Users\Micha\Desktop\sourcemod\sourcemod\build\package\addons\sourcemod\Test.sp::OnPluginStart
```