### PR TITLE
Migrate CDataPack from a Compact Cassette tape.

### DIFF
--- a/bridge/include/BridgeAPI.h
+++ b/bridge/include/BridgeAPI.h
@@ -35,7 +35,7 @@ namespace SourceMod {
 
 // Add 1 to the RHS of this expression to bump the intercom file
 // This is to prevent mismatching core/logic binaries
-static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 55;
+static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 56;
 
 } // namespace SourceMod
 

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -198,10 +198,20 @@ bool CDataPack::IsReadable(size_t bytes) const
 const char *CDataPack::ReadString(size_t *len) const
 {
 	if (!this->IsReadable())
+	{
+		if (len)
+			*len = 0;
+
 		return "";
+	}
 
 	if (this->elements[this->position].type != CDataPackType::String)
+	{
+		if (len)
+			*len = 0;
+
 		return "";
+	}
 
 	const ke::AString &val = *static_cast<ke::AString *>(this->elements[this->position++].pData.vval);
 	if (len)

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -46,7 +46,7 @@ CDataPack::~CDataPack()
 
 static ke::Vector<ke::AutoPtr<CDataPack>> sDataPackCache;
 
-IDataPack * CDataPack::New()
+IDataPack *CDataPack::New()
 {
   if (sDataPackCache.empty())
     return new CDataPack();
@@ -205,20 +205,21 @@ const char *CDataPack::ReadString(size_t *len) const
 
 void *CDataPack::GetMemory() const
 {
-	if (!IsReadable() || elements[position].type != CDataPackType::Raw)
-		return nullptr;
-
-	return &(reinterpret_cast<size_t *>(elements[position].pData.vval)[1]);
+	return nullptr;
 }
 
 void *CDataPack::ReadMemory(size_t *size) const
 {
-	void *ptr = GetMemory();
-	if (ptr != nullptr)
-		++position;
-	
+	void *ptr = nullptr;
+	if (!IsReadable() || elements[position].type != CDataPackType::Raw)
+		return ptr;
+
+	size_t *val = reinterpret_cast<size_t *>(elements[position].pData.vval);
+	ptr = &(val[1]);
+	++position;
+
 	if (size)
-		*size = (reinterpret_cast<size_t *>(ptr)[-1]); /* Egor!!!! */
+		*size = val[0]; /* Egor!!!! */
 
 	return ptr;
 }

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -33,25 +33,19 @@
 #include <string.h>
 #include "CDataPack.h"
 #include <amtl/am-autoptr.h>
-#include <amtl/am-vector.h>
-
-using namespace ke;
-
-#define DATAPACK_INITIAL_SIZE 64
+#include <amtl/am-string.h>
 
 CDataPack::CDataPack()
 {
-	m_pBase = (char *)malloc(DATAPACK_INITIAL_SIZE);
-	m_capacity = DATAPACK_INITIAL_SIZE;
-	Initialize();
+	this->Initialize();
 }
 
 CDataPack::~CDataPack()
 {
-	free(m_pBase);
+	this->Initialize();
 }
 
-static Vector<AutoPtr<CDataPack>> sDataPackCache;
+static ke::Vector<ke::AutoPtr<CDataPack>> sDataPackCache;
 
 IDataPack * CDataPack::New()
 {
@@ -72,286 +66,171 @@ CDataPack::Free(IDataPack *pack)
 
 void CDataPack::Initialize()
 {
-	m_curptr = m_pBase;
-	m_size = 0;
-}
-
-void CDataPack::CheckSize(size_t typesize)
-{
-	if (m_curptr - m_pBase + typesize <= m_capacity)
+	for (size_t iter = 0; iter < this->elements.length(); ++iter)
 	{
-		return;
+		switch (this->elements[iter].type)
+		{
+			case CDataPackType::Raw:
+			{
+				delete static_cast<uint8_t *>(this->elements[iter].pData.vval);
+				this->elements.remove(iter--);
+				break;
+			}
+
+			case CDataPackType::String:
+			{
+				delete static_cast<ke::AString *>(this->elements[iter].pData.vval);
+				this->elements.remove(iter--);
+				break;
+			}
+		}
 	}
 
-	size_t pos = m_curptr - m_pBase;
-	do
-	{
-		m_capacity *= 2;
-	} while (pos + typesize > m_capacity);
-	
-	m_pBase = (char *)realloc(m_pBase, m_capacity);
-	m_curptr = m_pBase + pos;
+	this->elements.clear();
+	this->position = 0;
 }
 
 void CDataPack::ResetSize()
 {
-	m_size = 0;
+	this->Initialize();
 }
 
 size_t CDataPack::CreateMemory(size_t size, void **addr)
 {
-	CheckSize(sizeof(char) + sizeof(size_t) + size);
-	size_t pos = m_curptr - m_pBase;
+	InternalPack val;
+	val.type = CDataPackType::Raw;
+	val.pData.vval = new uint8_t[size + 1];
+	this->elements.insert(this->position, val);
 
-	*(char *)m_curptr = Raw;
-	m_curptr += sizeof(char);
-
-	*(size_t *)m_curptr = size;
-	m_curptr += sizeof(size_t);
-
-	if (addr)
-	{
-		*addr = m_curptr;
-	}
-
-	m_curptr += size;
-	m_size += sizeof(char) + sizeof(size_t) + size;
-
-	return pos;
+	return this->position++;
 }
 
 void CDataPack::PackCell(cell_t cell)
 {
-	CheckSize(sizeof(char) + sizeof(size_t) + sizeof(cell_t));
-
-	*(char *)m_curptr = Cell;
-	m_curptr += sizeof(char);
-
-	*(size_t *)m_curptr = sizeof(cell_t);
-	m_curptr += sizeof(size_t);
-
-	*(cell_t *)m_curptr = cell;
-	m_curptr += sizeof(cell_t);
-
-	m_size += sizeof(char) + sizeof(size_t) + sizeof(cell_t);
+	InternalPack val;
+	val.type = CDataPackType::Cell;
+	val.pData.cval = cell;
+	this->elements.insert(this->position++, val);
 }
 
-void CDataPack::PackFloat(float val)
+void CDataPack::PackFunction(cell_t function)
 {
-	CheckSize(sizeof(char) + sizeof(size_t) + sizeof(float));
+	InternalPack val;
+	val.type = CDataPackType::Function;
+	val.pData.cval = function;
+	this->elements.insert(this->position++, val);
+}
 
-	*(char *)m_curptr = Float;
-	m_curptr += sizeof(char);
-
-	*(size_t *)m_curptr = sizeof(float);
-	m_curptr += sizeof(size_t);
-
-	*(float *)m_curptr = val;
-	m_curptr += sizeof(float);
-
-	m_size += sizeof(char) + sizeof(size_t) + sizeof(float);
+void CDataPack::PackFloat(float floatval)
+{
+	InternalPack val;
+	val.type = CDataPackType::Float;
+	val.pData.fval = floatval;
+	this->elements.insert(this->position++, val);
 }
 
 void CDataPack::PackString(const char *string)
 {
-	size_t len = strlen(string);
-	size_t maxsize = sizeof(char) + sizeof(size_t) + len + 1;
-	CheckSize(maxsize);
-
-	*(char *)m_curptr = String;
-	m_curptr += sizeof(char);
-
-	// Pack the string length first for buffer overrun checking.
-	*(size_t *)m_curptr = len;
-	m_curptr += sizeof(size_t);
-
-	// Now pack the string.
-	memcpy(m_curptr, string, len);
-	m_curptr[len] = '\0';
-	m_curptr += len + 1;
-
-	m_size += maxsize;
+	InternalPack val;
+	val.type = CDataPackType::String;
+	ke::AString *sval = new ke::AString(string);
+	val.pData.vval = static_cast<void *>(sval);
+	this->elements.insert(this->position++, val);
 }
 
 void CDataPack::Reset() const
 {
-	m_curptr = m_pBase;
+	this->position = 0;
 }
 
 size_t CDataPack::GetPosition() const
 {
-	return static_cast<size_t>(m_curptr - m_pBase);
+	return this->position;
 }
 
 bool CDataPack::SetPosition(size_t pos) const
 {
-	if (pos > m_size)
-	{
+	if (pos > this->elements.length())
 		return false;
-	}
-	m_curptr = m_pBase + pos;
 
+	this->position = pos;
 	return true;
 }
 
 cell_t CDataPack::ReadCell() const
 {
-	if (!IsReadable(sizeof(char) + sizeof(size_t) + sizeof(cell_t)))
-	{
+	if (!this->IsReadable())
 		return 0;
-	}
-	if (*reinterpret_cast<char *>(m_curptr) != Cell)
-	{
+
+	if (this->elements[this->position].type != CDataPackType::Cell)
 		return 0;
-	}
-	m_curptr += sizeof(char);
-
-	if (*reinterpret_cast<size_t *>(m_curptr) != sizeof(cell_t))
-	{
-		return 0;
-	}
-
-	m_curptr += sizeof(size_t);
-
-	cell_t val = *reinterpret_cast<cell_t *>(m_curptr);
-	m_curptr += sizeof(cell_t);
-	return val;
-}
-
-float CDataPack::ReadFloat() const
-{
-	if (!IsReadable(sizeof(char) + sizeof(size_t) + sizeof(float)))
-	{
-		return 0;
-	}
-	if (*reinterpret_cast<char *>(m_curptr) != Float)
-	{
-		return 0;
-	}
-	m_curptr += sizeof(char);
-
-	if (*reinterpret_cast<size_t *>(m_curptr) != sizeof(float))
-	{
-		return 0;
-	}
-
-	m_curptr += sizeof(size_t);
-
-	float val = *reinterpret_cast<float *>(m_curptr);
-	m_curptr += sizeof(float);
-	return val;
-}
-
-bool CDataPack::IsReadable(size_t bytes) const
-{
-	return (bytes + (m_curptr - m_pBase) > m_size) ? false : true;
-}
-
-const char *CDataPack::ReadString(size_t *len) const
-{
-	if (!IsReadable(sizeof(char) + sizeof(size_t)))
-	{
-		return NULL;
-	}
-	if (*reinterpret_cast<char *>(m_curptr) != String)
-	{
-		return NULL;
-	}
-	m_curptr += sizeof(char);
-
-	size_t real_len = *(size_t *)m_curptr;
-
-	m_curptr += sizeof(size_t);
-	char *str = (char *)m_curptr;
-
-	if ((strlen(str) != real_len) || !(IsReadable(real_len+1)))
-	{
-		return NULL;
-	}
-
-	if (len)
-	{
-		*len = real_len;
-	}
-
-	m_curptr += real_len + 1;
-
-	return str;
-}
-
-void *CDataPack::GetMemory() const
-{
-	return m_curptr;
-}
-
-void *CDataPack::ReadMemory(size_t *size) const
-{
-	if (!IsReadable(sizeof(size_t)))
-	{
-		return NULL;
-	}
-	if (*reinterpret_cast<char *>(m_curptr) != Raw)
-	{
-		return NULL;
-	}
-	m_curptr += sizeof(char);
-
-	size_t bytecount = *(size_t *)m_curptr;
-	m_curptr += sizeof(size_t);
-
-	if (!IsReadable(bytecount))
-	{
-		return NULL;
-	}
-
-	void *ptr = m_curptr;
-
-	if (size)
-	{
-		*size = bytecount;
-	}
-
-	m_curptr += bytecount;
-
-	return ptr;
-}
-
-void CDataPack::PackFunction(cell_t function)
-{
-	CheckSize(sizeof(char) + sizeof(size_t) + sizeof(cell_t));
-
-	*(char *)m_curptr = Function;
-	m_curptr += sizeof(char);
-
-	*(size_t *)m_curptr = sizeof(cell_t);
-	m_curptr += sizeof(size_t);
-
-	*(cell_t *)m_curptr = function;
-	m_curptr += sizeof(cell_t);
-
-	m_size += sizeof(char) + sizeof(size_t) + sizeof(cell_t);
+	
+	return this->elements[this->position++].pData.cval;
 }
 
 cell_t CDataPack::ReadFunction() const
 {
-	if (!IsReadable(sizeof(char) + sizeof(size_t) + sizeof(cell_t)))
-	{
+	if (!this->IsReadable())
 		return 0;
-	}
-	if (*reinterpret_cast<char *>(m_curptr) != Function)
-	{
+
+	if (this->elements[this->position].type != CDataPackType::Function)
 		return 0;
-	}
-	m_curptr += sizeof(char);
+	
+	return this->elements[this->position++].pData.cval;
+}
 
-	if (*reinterpret_cast<size_t *>(m_curptr) != sizeof(cell_t))
-	{
+float CDataPack::ReadFloat() const
+{
+	if (!this->IsReadable())
 		return 0;
+
+	if (this->elements[this->position].type != CDataPackType::Float)
+		return 0;
+	
+	return this->elements[this->position++].pData.fval;
+}
+
+bool CDataPack::IsReadable(size_t bytes) const
+{
+	return (this->position < this->elements.length());
+}
+
+const char *CDataPack::ReadString(size_t *len) const
+{
+	if (!this->IsReadable())
+		return "";
+
+	if (this->elements[this->position].type != CDataPackType::String)
+		return "";
+
+	const ke::AString &val = *static_cast<ke::AString *>(this->elements[this->position++].pData.vval);
+	if (len)
+	{
+		*len = val.length();
 	}
 
-	m_curptr += sizeof(size_t);
+	return val.chars();
+}
 
-	cell_t val = *reinterpret_cast<cell_t *>(m_curptr);
-	m_curptr += sizeof(cell_t);
-	return val;
+void *CDataPack::GetMemory() const
+{
+	if (!this->IsReadable())
+		return nullptr;
+	
+	if (this->elements[this->position].type != CDataPackType::Raw)
+		return nullptr;
+
+	return this->elements[this->position].pData.vval;
+}
+
+void *CDataPack::ReadMemory(size_t *size) const
+{
+	void *ptr = this->GetMemory();
+	if (ptr != nullptr)
+		++this->position;
+	
+	if (size)
+		*size = (ptr != nullptr); /* Egor!!!! */
+
+	return ptr;
 }

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -34,6 +34,7 @@
 
 #include <IDataPack.h>
 #include <amtl/am-vector.h>
+#include <amtl/am-string.h>
 
 using namespace SourceMod;
 
@@ -80,7 +81,8 @@ private:
 	typedef union {
 		cell_t cval;
 		float fval;
-		void *vval;
+		uint8_t *vval;
+		ke::AString *sval;
 	} InternalPackValue;
 	
 	typedef struct {

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -33,8 +33,17 @@
 #define _INCLUDE_SOURCEMOD_CDATAPACK_H_
 
 #include <IDataPack.h>
+#include <amtl/am-vector.h>
 
 using namespace SourceMod;
+
+enum CDataPackType {
+	Raw,
+	Cell,
+	Float,
+	String,
+	Function
+};
 
 class CDataPack : public IDataPack
 {
@@ -50,7 +59,7 @@ public: //IDataReader
 	bool SetPosition(size_t pos) const;
 	cell_t ReadCell() const;
 	float ReadFloat() const;
-	bool IsReadable(size_t bytes) const;
+	bool IsReadable(size_t bytes = 0) const;
 	const char *ReadString(size_t *len) const;
 	void *GetMemory() const;
 	void *ReadMemory(size_t *size) const;
@@ -64,22 +73,23 @@ public: //IDataPack
 	void PackFunction(cell_t function);
 public:
 	void Initialize();
-	inline size_t GetCapacity() const { return m_capacity; }
+	inline size_t GetCapacity() const { return this->elements.length(); };
+	CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
 private:
-	void CheckSize(size_t sizetype);
-private:
-	char *m_pBase;
-	mutable char *m_curptr;
-	size_t m_capacity;
-	size_t m_size;
 
-	enum DataPackType {
-		Raw,
-		Cell,
-		Float,
-		String,
-		Function
-	};
+	typedef union {
+		cell_t cval;
+		float fval;
+		void *vval;
+	} InternalPackValue;
+	
+	typedef struct {
+		InternalPackValue pData;
+		CDataPackType type;
+	} InternalPack;
+
+	ke::Vector<InternalPack> elements;
+	mutable size_t position;
 };
 
 #endif //_INCLUDE_SOURCEMOD_CDATAPACK_H_

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -75,7 +75,7 @@ public: //IDataPack
 public:
 	void Initialize();
 	inline size_t GetCapacity() const { return this->elements.length(); };
-	CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
+	inline CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
 private:
 
 	typedef union {

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -96,7 +96,7 @@ static cell_t smn_WritePackCell(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	pDataPack->PackCell(params[2]);
@@ -117,7 +117,7 @@ static cell_t smn_WritePackFloat(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	pDataPack->PackFloat(sp_ctof(params[2]));
@@ -138,7 +138,7 @@ static cell_t smn_WritePackString(IPluginContext *pContext, const cell_t *params
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	char *str;
@@ -161,7 +161,7 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 	if ((herr = handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	pDataPack->PackFunction(params[2]);
@@ -182,17 +182,17 @@ static cell_t smn_ReadPackCell(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	if (!pDataPack->IsReadable())
 	{
-		return pContext->ThrowNativeError("DataPack operation is out of bounds.");
+		return pContext->ThrowNativeError("Data pack operation is out of bounds.");
 	}
 
 	if (pDataPack->GetCurrentType() != CDataPackType::Cell)
 	{
-		return pContext->ThrowNativeError("Invalid Datapack Type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Cell);
+		return pContext->ThrowNativeError("Invalid data pack type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Cell);
 	}
 
 	return pDataPack->ReadCell();
@@ -211,17 +211,17 @@ static cell_t smn_ReadPackFloat(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	if (!pDataPack->IsReadable())
 	{
-		return pContext->ThrowNativeError("DataPack operation is out of bounds.");
+		return pContext->ThrowNativeError("Data pack operation is out of bounds.");
 	}
 
 	if (pDataPack->GetCurrentType() != CDataPackType::Float)
 	{
-		return pContext->ThrowNativeError("Invalid Datapack Type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Float);
+		return pContext->ThrowNativeError("Invalid data pack type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Float);
 	}
 
 	return sp_ftoc(pDataPack->ReadFloat());
@@ -240,17 +240,17 @@ static cell_t smn_ReadPackString(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	if (!pDataPack->IsReadable())
 	{
-		return pContext->ThrowNativeError("DataPack operation is out of bounds.");
+		return pContext->ThrowNativeError("Data pack operation is out of bounds.");
 	}
 
 	if (pDataPack->GetCurrentType() != CDataPackType::String)
 	{
-		return pContext->ThrowNativeError("Invalid Datapack Type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::String);
+		return pContext->ThrowNativeError("Invalid data pack type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::String);
 	}
 
 	const char *str = pDataPack->ReadString(NULL);
@@ -272,17 +272,17 @@ static cell_t smn_ReadPackFunction(IPluginContext *pContext, const cell_t *param
 	if ((herr = handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	if (!pDataPack->IsReadable())
 	{
-		return pContext->ThrowNativeError("DataPack operation is out of bounds.");
+		return pContext->ThrowNativeError("Data pack operation is out of bounds.");
 	}
 
 	if (pDataPack->GetCurrentType() != CDataPackType::Function)
 	{
-		return pContext->ThrowNativeError("Invalid Datapack Type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Function);
+		return pContext->ThrowNativeError("Invalid data pack type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Function);
 	}
 
 	return pDataPack->ReadFunction();
@@ -301,7 +301,7 @@ static cell_t smn_ResetPack(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	if (params[2])
@@ -329,7 +329,7 @@ static cell_t smn_GetPackPosition(IPluginContext *pContext, const cell_t *params
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	return static_cast<cell_t>(pDataPack->GetPosition());
@@ -348,12 +348,12 @@ static cell_t smn_SetPackPosition(IPluginContext *pContext, const cell_t *params
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	if (!pDataPack->SetPosition(params[2]))
 	{
-		return pContext->ThrowNativeError("Invalid DataPack position, %d is out of bounds (%d)", params[2], pDataPack->GetCapacity());
+		return pContext->ThrowNativeError("Invalid data pack position, %d is out of bounds (%d)", params[2], pDataPack->GetCapacity());
 	}
 
 	return 1;
@@ -372,7 +372,7 @@ static cell_t smn_IsPackReadable(IPluginContext *pContext, const cell_t *params)
 	if ((herr=handlesys->ReadHandle(hndl, g_DataPackType, &sec, (void **)&pDataPack))
 		!= HandleError_None)
 	{
-		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
+		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
 	return pDataPack->IsReadable(params[2]) ? 1 : 0;

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -214,7 +214,7 @@ static cell_t smn_ReadPackFloat(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d)", hndl, herr);
 	}
 
-	if (!pDataPack->IsReadable(sizeof(char) + sizeof(size_t) + sizeof(float)))
+	if (!pDataPack->IsReadable())
 	{
 		return pContext->ThrowNativeError("DataPack operation is out of bounds.");
 	}

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -619,7 +619,7 @@ unsigned int SourceModBase::GetGlobalTarget() const
 
 IDataPack *SourceModBase::CreateDataPack()
 {
-	return logicore.CreateDataPack();
+	return nullptr;
 }
 
 void SourceModBase::FreeDataPack(IDataPack *pack)

--- a/public/IDataPack.h
+++ b/public/IDataPack.h
@@ -38,6 +38,7 @@
  * @file IDataPack.h
  * @brief Contains functions for packing data abstractly to/from plugins.  The wrappers
  * for creating these are contained in ISourceMod.h
+ * @deprecated Deprecated. Does nothing.
  */
 
 namespace SourceMod


### PR DESCRIPTION
This lift and shifts CDataPack from a linear datatype to something using a vector with type mixed in. Iterators will change (again), so plugins manually using SetPackPosition without ReadPackPosition (against the API) will experience breakage; if this even builds.