### PR TITLE
Switch to AMBuild 2.1 API.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -104,7 +104,7 @@ class SMConfig(object):
 
     for sdk_name in PossibleSDKs:
       sdk = PossibleSDKs[sdk_name]
-      if builder.target_platform in sdk.platform:
+      if builder.target.platform in sdk.platform:
         if builder.options.hl2sdk_root:
           sdk_path = os.path.join(builder.options.hl2sdk_root, sdk.folder)
         else:
@@ -148,11 +148,11 @@ class SMConfig(object):
   def configure(self):
     builder.AddConfigureFile('pushbuild.txt')
 
-    cxx = builder.DetectCompilers()
+    cxx = builder.DetectCxx()
 
     if cxx.like('gcc'):
       self.configure_gcc(cxx)
-    elif cxx.vendor == 'msvc':
+    elif cxx.family == 'msvc':
       self.configure_msvc(cxx)
 
     # Optimizaiton
@@ -164,11 +164,11 @@ class SMConfig(object):
       cxx.defines += ['DEBUG', '_DEBUG']
 
     # Platform-specifics
-    if builder.target_platform == 'linux':
+    if builder.target.platform == 'linux':
       self.configure_linux(cxx)
-    elif builder.target_platform == 'mac':
+    elif builder.target.platform == 'mac':
       self.configure_mac(cxx)
-    elif builder.target_platform == 'windows':
+    elif builder.target.platform == 'windows':
       self.configure_windows(cxx)
 
     # Finish up.
@@ -217,10 +217,12 @@ class SMConfig(object):
     ]
     cxx.linkflags += ['-m32']
 
-    have_gcc = cxx.vendor == 'gcc'
-    have_clang = cxx.vendor == 'clang'
-    if cxx.version >= 'clang-3.6':
+    have_gcc = cxx.family == 'gcc'
+    have_clang = cxx.family == 'clang'
+    if cxx.version >= 'clang-3.6' or cxx.version >= 'apple-clang-7.0':
       cxx.cxxflags += ['-Wno-inconsistent-missing-override']
+    if cxx.version >= 'clang-2.9' or cxx.version >= 'apple-clang-3.0':
+      cxx.cxxflags += ['-Wno-null-dereference']
     if have_clang or (cxx.version >= 'gcc-4.6'):
       cxx.cflags += ['-Wno-narrowing']
     if have_clang or (cxx.version >= 'gcc-4.7'):
@@ -292,9 +294,9 @@ class SMConfig(object):
   def configure_linux(self, cxx):
     cxx.defines += ['_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
     cxx.linkflags += ['-Wl,--exclude-libs,ALL', '-lm']
-    if cxx.vendor == 'gcc':
+    if cxx.family == 'gcc':
       cxx.linkflags += ['-static-libgcc']
-    elif cxx.vendor == 'clang':
+    elif cxx.family == 'clang':
       cxx.linkflags += ['-lgcc_eh']
 
   def configure_mac(self, cxx):
@@ -312,7 +314,7 @@ class SMConfig(object):
     cxx.defines += ['WIN32', '_WINDOWS']
 
   def AddVersioning(self, binary):
-    if builder.target_platform == 'windows':
+    if builder.target.platform == 'windows':
       binary.sources += ['version.rc']
       binary.compiler.rcdefines += [
         'BINARY_NAME="{0}"'.format(binary.outputFile),
@@ -320,7 +322,7 @@ class SMConfig(object):
       ]
       if self.use_auto_versioning():
         binary.compiler.rcdefines += ['SM_GENERATED_BUILD']
-    elif builder.target_platform == 'mac':
+    elif builder.target.platform == 'mac':
       if binary.type == 'library':
         binary.compiler.postlink += [
           '-compatibility_version', '1.0.0',
@@ -330,18 +332,42 @@ class SMConfig(object):
       binary.compiler.linkflags += [self.versionlib]
       binary.compiler.sourcedeps += SM.generated_headers
     return binary
-
-  def Library(self, context, name):
-    binary = context.compiler.Library(name)
+    
+  def LibraryBuilder(self, compiler, name):
+    binary = compiler.Library(name)
+    self.AddVersioning(binary)
     if binary.compiler.like('msvc'):
       binary.compiler.linkflags += ['/SUBSYSTEM:WINDOWS']
-    return self.AddVersioning(binary)
+    return binary
 
-  def Program(self, context, name):
-    binary = context.compiler.Program(name)
+  def ProgramBuilder(self, compiler, name):
+    binary = compiler.Program(name)
+    self.AddVersioning(binary)
+    if '-static-libgcc' in binary.compiler.linkflags:
+      binary.compiler.linkflags.remove('-static-libgcc')
+    if '-lgcc_eh' in binary.compiler.linkflags:
+      binary.compiler.linkflags.remove('-lgcc_eh')
+    if binary.compiler.like('gcc'):
+      binary.compiler.linkflags += ['-lstdc++']
     if binary.compiler.like('msvc'):
       binary.compiler.linkflags += ['/SUBSYSTEM:CONSOLE']
-    return self.AddVersioning(binary)
+    return binary
+    
+  def StaticLibraryBuilder(self, compiler, name):
+    binary = compiler.StaticLibrary(name)
+    return binary;
+
+  def Library(self, context, name):
+    compiler = context.cxx.clone()
+    return self.LibraryBuilder(compiler, name)
+
+  def Program(self, context, name):
+    compiler = context.cxx.clone()
+    return self.ProgramBuilder(compiler, name)
+    
+  def StaticLibrary(self, context, name):
+    compiler = context.cxx.clone()
+    return self.StaticLibraryBuilder(compiler, name)
 
   def ConfigureForExtension(self, context, compiler):
     compiler.cxxincludes += [
@@ -355,9 +381,9 @@ class SMConfig(object):
     return compiler
 
   def ExtLibrary(self, context, name):
-    binary = context.compiler.Library(name)
+    binary = self.Library(context, name)
     self.ConfigureForExtension(context, binary.compiler)
-    return self.AddVersioning(binary)
+    return binary
 
   def ConfigureForHL2(self, binary, sdk):
     compiler = binary.compiler
@@ -409,29 +435,29 @@ class SMConfig(object):
       compiler.defines += ['NETWORK_VARS_ENABLED']
 
     if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2']:
-      if builder.target_platform in ['linux', 'mac']:
+      if builder.target.platform in ['linux', 'mac']:
         compiler.defines += ['NO_HOOK_MALLOC', 'NO_MALLOC_OVERRIDE']
 
-    if sdk.name == 'csgo' and builder.target_platform == 'linux':
+    if sdk.name == 'csgo' and builder.target.platform == 'linux':
       compiler.linkflags += ['-lstdc++']
 
     for path in paths:
       compiler.cxxincludes += [os.path.join(sdk.path, *path)]
 
-    if builder.target_platform == 'linux':
+    if builder.target.platform == 'linux':
       if sdk.name == 'episode1':
         lib_folder = os.path.join(sdk.path, 'linux_sdk')
       elif sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'linux32')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'linux')
-    elif builder.target_platform == 'mac':
+    elif builder.target.platform == 'mac':
       if sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'osx32')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'mac')
 
-    if builder.target_platform in ['linux', 'mac']:
+    if builder.target.platform in ['linux', 'mac']:
       if sdk.name in ['sdk2013', 'bms']:
         compiler.postlink += [
           compiler.Dep(os.path.join(lib_folder, 'tier1.a')),
@@ -446,20 +472,18 @@ class SMConfig(object):
       if sdk.name in ['blade', 'insurgency', 'csgo']:
         compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces_i486.a'))]
 
-    self.AddVersioning(binary)
-
     dynamic_libs = []
-    if builder.target_platform == 'linux':
+    if builder.target.platform == 'linux':
       if sdk.name in ['css', 'hl2dm', 'dods', 'tf2', 'sdk2013', 'bms', 'nucleardawn', 'l4d2', 'insurgency']:
         dynamic_libs = ['libtier0_srv.so', 'libvstdlib_srv.so']
       elif sdk.name in ['l4d', 'blade', 'insurgency', 'csgo']:
         dynamic_libs = ['libtier0.so', 'libvstdlib.so']
       else:
         dynamic_libs = ['tier0_i486.so', 'vstdlib_i486.so']
-    elif builder.target_platform == 'mac':
+    elif builder.target.platform == 'mac':
       compiler.linkflags.append('-liconv')
       dynamic_libs = ['libtier0.dylib', 'libvstdlib.dylib']
-    elif builder.target_platform == 'windows':
+    elif builder.target.platform == 'windows':
       libs = ['tier0', 'tier1', 'vstdlib', 'mathlib']
       if sdk.name in ['swarm', 'blade', 'insurgency', 'csgo']:
         libs.append('interfaces')
@@ -483,17 +507,18 @@ class SMConfig(object):
     return binary
 
   def HL2Library(self, context, name, sdk):
-    binary = context.compiler.Library(name)
+    binary = self.Library(context, name)
     self.ConfigureForExtension(context, binary.compiler)
     return self.ConfigureForHL2(binary, sdk)
 
   def HL2Project(self, context, name):
-    project = context.compiler.LibraryProject(name)
+    project = context.cxx.LibraryProject(name)
     self.ConfigureForExtension(context, project.compiler)
     return project
 
   def HL2Config(self, project, name, sdk):
     binary = project.Configure(name, '{0} - {1}'.format(self.tag, sdk.name))
+    self.AddVersioning(binary)
     return self.ConfigureForHL2(binary, sdk)
 
 SM = SMConfig()
@@ -502,23 +527,21 @@ SM.detectSDKs()
 SM.configure()
 
 if SM.use_auto_versioning():
-  SM.generated_headers = builder.RunScript(
+  SM.generated_headers = builder.Build(
     'tools/buildbot/Versioning',
     { 'SM': SM }
   )
-  SM.versionlib = builder.RunScript(
+  SM.versionlib = builder.Build(
     'versionlib/AMBuilder',
     { 'SM': SM }
   )
 
 # Build SourcePawn externally.
-SourcePawn = builder.RunScript('sourcepawn/AMBuildScript', {})
-SP = SourcePawn(
-  root = SM,
-  amtl = os.path.join(builder.sourcePath, 'public', 'amtl'),
-)
-SP.BuildSpcomp()
-SP.BuildVM()
+SP = builder.Build('sourcepawn/AMBuildScript', {
+  'external_root': SM,
+  'external_amtl': os.path.join(builder.sourcePath, 'public', 'amtl'),
+  'external_build': ['core'],
+})
 SM.spcomp = SP.spcomp
 SM.binaries += [
   SP.libsourcepawn
@@ -549,7 +572,7 @@ if builder.backend == 'amb2':
     'tools/buildbot/PackageScript',
   ]
 
-builder.RunBuildScripts(BuildScripts, { 'SM': SM })
+builder.Build(BuildScripts, { 'SM': SM })
 
 if builder.options.breakpad_dump:
-  builder.RunScript('tools/buildbot/BreakpadSymbols', { 'SM': SM })
+  builder.Build('tools/buildbot/BreakpadSymbols', { 'SM': SM })

--- a/configure.py
+++ b/configure.py
@@ -1,7 +1,7 @@
 # vim: set ts=2 sw=2 tw=99 noet:
 import sys
 try:
-	from ambuild2 import run
+	from ambuild2 import run, util
 except:
 	try:
 		import ambuild
@@ -12,25 +12,29 @@ except:
 		sys.stderr.write('http://www.alliedmods.net/ambuild\n')
 	sys.exit(1)
 
-run = run.PrepareBuild(sourcePath=sys.path[0])
-run.default_build_folder = 'obj-' + run.target_platform
-run.options.add_option('--hl2sdk-root', type=str, dest='hl2sdk_root', default=None,
+def make_objdir_name(p):
+    return 'obj-' + util.Platform() + '-' + p.target_arch
+
+parser = run.BuildParser(sourcePath=sys.path[0], api='2.1')
+parser.default_arch = 'x86'
+parser.default_build_folder = make_objdir_name
+parser.options.add_option('--hl2sdk-root', type=str, dest='hl2sdk_root', default=None,
 		                   help='Root search folder for HL2SDKs')
-run.options.add_option('--mysql-path', type=str, dest='mysql_path', default=None,
+parser.options.add_option('--mysql-path', type=str, dest='mysql_path', default=None,
 		                   help='Path to MySQL 5')
-run.options.add_option('--mms-path', type=str, dest='mms_path', default=None,
+parser.options.add_option('--mms-path', type=str, dest='mms_path', default=None,
                        help='Path to Metamod:Source')
-run.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
+parser.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
                        help='Enable debugging symbols')
-run.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
+parser.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
                        help='Enable optimization')
-run.options.add_option('--no-mysql', action='store_false', default=True, dest='hasMySql',
+parser.options.add_option('--no-mysql', action='store_false', default=True, dest='hasMySql',
                        help='Disable building MySQL extension')
-run.options.add_option('-s', '--sdks', default='all', dest='sdks',
+parser.options.add_option('-s', '--sdks', default='all', dest='sdks',
                        help='Build against specified SDKs; valid args are "all", "present", or '
                             'comma-delimited list of engine names (default: %default)')
-run.options.add_option('--breakpad-dump', action='store_true', dest='breakpad_dump',
+parser.options.add_option('--breakpad-dump', action='store_true', dest='breakpad_dump',
 											 default=False, help='Dump and upload breakpad symbols')
-run.options.add_option('--disable-auto-versioning', action='store_true', dest='disable_auto_versioning',
+parser.options.add_option('--disable-auto-versioning', action='store_true', dest='disable_auto_versioning',
                        default=False, help='Disable the auto versioning script')
-run.Configure()
+parser.Configure()

--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -60,15 +60,15 @@ for sdk_name in SM.sdks:
       os.path.join(sdk.path, 'public', 'game', 'shared', 'csgo', 'protobuf')
     ]
 
-  if builder.target_platform == 'linux':
+  if builder.target.platform == 'linux':
     compiler.postlink += ['-lpthread', '-lrt']
 
   if sdk.name == 'csgo':
-    if builder.target_platform == 'linux':
+    if builder.target.platform == 'linux':
       lib_path = os.path.join(sdk.path, 'lib', 'linux32', 'release', 'libprotobuf.a')
-    elif builder.target_platform == 'mac':
+    elif builder.target.platform == 'mac':
       lib_path = os.path.join(sdk.path, 'lib', 'osx32', 'release', 'libprotobuf.a')
-    elif builder.target_platform == 'windows':
+    elif builder.target.platform == 'windows':
       msvc_ver = compiler.version
       vs_year = ''
       if msvc_ver == 1800:

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -16,15 +16,15 @@ binary.compiler.defines += [
   'SM_LOGIC'
 ]
   
-if builder.target_platform == 'linux':
+if builder.target.platform == 'linux':
   binary.compiler.postlink += ['-lpthread', '-lrt']
-elif builder.target_platform == 'mac':
+elif builder.target.platform == 'mac':
   binary.compiler.cflags += ['-Wno-deprecated-declarations']
   binary.compiler.postlink += ['-framework', 'CoreServices']
 
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
 binary.sources += [
@@ -83,7 +83,7 @@ binary.sources += [
   'frame_tasks.cpp',
   'smn_halflife.cpp',
 ]
-if builder.target_platform == 'windows':
+if builder.target.platform == 'windows':
   binary.sources += ['thread/WinThreads.cpp']
 else:
   binary.sources += ['thread/PosixThreads.cpp']

--- a/extensions/bintools/AMBuilder
+++ b/extensions/bintools/AMBuilder
@@ -8,9 +8,9 @@ binary.compiler.cxxincludes += [
   os.path.join(builder.sourcePath, 'public', 'jit'),
   os.path.join(builder.sourcePath, 'public', 'jit', 'x86'),
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
 binary.sources += [

--- a/extensions/clientprefs/AMBuilder
+++ b/extensions/clientprefs/AMBuilder
@@ -5,9 +5,9 @@ binary = SM.ExtLibrary(builder, 'clientprefs.ext')
 binary.compiler.cxxincludes += [
   os.path.join(SM.mms_root, 'core', 'sourcehook'),
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
 binary.sources += [

--- a/extensions/curl/AMBuilder
+++ b/extensions/curl/AMBuilder
@@ -1,21 +1,21 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python : 
 import os
 
-libcurl = builder.RunScript('curl-src/lib/AMBuilder')
+libcurl = builder.Build('curl-src/lib/AMBuilder')
 
 binary = SM.ExtLibrary(builder, 'webternet.ext')
 binary.compiler.includes += [
   os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'include')
 ]
 binary.compiler.defines += ['CURL_STATICLIB']
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 binary.compiler.postlink += [libcurl.binary]
-if builder.target_platform == 'linux':
+if builder.target.platform == 'linux':
   binary.compiler.postlink += ['-lrt']
-elif builder.target_platform == 'windows':
+elif builder.target.platform == 'windows':
   binary.compiler.postlink += ['ws2_32.lib']
 
 binary.sources += [

--- a/extensions/curl/curl-src/lib/AMBuilder
+++ b/extensions/curl/curl-src/lib/AMBuilder
@@ -3,24 +3,24 @@ import os, platform
 
 builder.SetBuildFolder('libcurl')
 
-binary = builder.compiler.StaticLibrary('curl')
+binary = SM.StaticLibrary(builder, 'curl')
 binary.compiler.includes += [
   os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'lib'),
   os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'include')
 ]
 
-if builder.target_platform == 'mac':
+if builder.target.platform == 'mac':
   mac_version, ignore, ignore = platform.mac_ver()
   mac_tuple = mac_version.split('.')
   if int(mac_tuple[0]) >= 10 and int(mac_tuple[1]) >= 9:
     binary.compiler.defines += ['BUILTIN_STRLCAT']
-elif builder.target_platform == 'windows':
+elif builder.target.platform == 'windows':
   binary.compiler.defines += [
     'BUILDING_LIBCURL',
     'CURL_STATICLIB',
     'CURL_DISABLE_LDAP',
   ]
-elif builder.target_platform == 'linux':
+elif builder.target.platform == 'linux':
   binary.compiler.defines += ['_GNU_SOURCE']
 
 if binary.compiler.vendor == 'clang':

--- a/extensions/geoip/AMBuilder
+++ b/extensions/geoip/AMBuilder
@@ -2,11 +2,11 @@
 import os
 
 binary = SM.ExtLibrary(builder, 'geoip.ext')
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
-if builder.target_platform == 'windows':
+if builder.target.platform == 'windows':
   binary.compiler.postlink += ['wsock32.lib']
 
 binary.sources += [

--- a/extensions/mysql/AMBuilder
+++ b/extensions/mysql/AMBuilder
@@ -7,21 +7,21 @@ if SM.mysql_root:
     os.path.join(SM.mysql_root, 'include'),
     os.path.join(SM.mms_root, 'core', 'sourcehook')
   ]
-  if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
     binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.vendor == 'msvc':
+  elif binary.compiler.family == 'msvc':
     binary.compiler.cxxflags += ['/GR-']
 
-  if builder.target_platform == 'linux' or builder.target_platform == 'mac':
+  if builder.target.platform == 'linux' or builder.target.platform == 'mac':
     binary.compiler.postlink += [
       os.path.join(SM.mysql_root, 'lib', 'libmysqlclient_r.a'),
       '-lz',
       '-lpthread',
       '-lm',
     ]
-  if builder.target_platform == 'linux':
+  if builder.target.platform == 'linux':
     binary.compiler.postlink += ['-lrt']
-  elif builder.target_platform == 'windows':
+  elif builder.target.platform == 'windows':
     binary.compiler.postlink += [
       os.path.join(SM.mysql_root, 'lib', 'opt', 'mysqlclient.lib'),
       os.path.join(SM.mysql_root, 'lib', 'opt', 'zlib.lib'),
@@ -38,7 +38,7 @@ if SM.mysql_root:
     'extension.cpp'
   ]
   
-  if binary.compiler.vendor == 'msvc' and binary.compiler.version >= 1900:
+  if binary.compiler.family == 'msvc' and binary.compiler.version >= 1900:
     binary.sources += [ 'msvc15hack.c' ]
     binary.compiler.linkflags += ['legacy_stdio_definitions.lib', 'legacy_stdio_wide_specifiers.lib']
 

--- a/extensions/regex/AMBuilder
+++ b/extensions/regex/AMBuilder
@@ -5,16 +5,16 @@ binary = SM.ExtLibrary(builder, 'regex.ext')
 binary.compiler.cxxincludes += [
   os.path.join(SM.mms_root, 'core', 'sourcehook'),
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
-if builder.target_platform == 'linux':
+if builder.target.platform == 'linux':
   path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux', 'libpcre.a')
-elif builder.target_platform == 'windows':
+elif builder.target.platform == 'windows':
   path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_win', 'pcre.lib')
-elif builder.target_platform == 'mac':
+elif builder.target.platform == 'mac':
   path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin', 'libpcre.a')
 binary.compiler.postlink += [binary.Dep(path)]
 

--- a/extensions/sdkhooks/AMBuilder
+++ b/extensions/sdkhooks/AMBuilder
@@ -17,7 +17,7 @@ for sdk_name in SM.sdks:
   binary.compiler.cxxincludes += [
     os.path.join(sdk.path, 'game', 'shared')
   ]
-  if binary.compiler.cxx.behavior == 'gcc':
+  if binary.compiler.behavior == 'gcc':
     binary.compiler.cxxflags += ['-Wno-invalid-offsetof']
 
 SM.extensions += builder.Add(project)

--- a/extensions/sdktools/AMBuilder
+++ b/extensions/sdktools/AMBuilder
@@ -42,7 +42,7 @@ for sdk_name in SM.sdks:
   if sdk.name != 'episode1':
     binary.compiler.defines += ['HOOKING_ENABLED']
 
-  if binary.compiler.cxx.behavior == 'gcc':
+  if binary.compiler.behavior == 'gcc':
     binary.compiler.cxxflags += ['-Wno-invalid-offsetof']
 
 SM.extensions += builder.Add(project)

--- a/extensions/sqlite/AMBuilder
+++ b/extensions/sqlite/AMBuilder
@@ -5,9 +5,9 @@ binary = SM.ExtLibrary(builder, 'dbi.sqlite.ext')
 binary.compiler.cxxincludes += [
   os.path.join(SM.mms_root, 'core', 'sourcehook'),
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
 binary.compiler.defines += [
@@ -16,7 +16,7 @@ binary.compiler.defines += [
   'SQLITE_USE_URI',
   'SQLITE_ALLOW_URI_AUTHORITY',
 ]
-if builder.target_platform == 'linux':
+if builder.target.platform == 'linux':
   binary.compiler.postlink += ['-ldl', '-lpthread']
 
 binary.sources += [

--- a/extensions/topmenus/AMBuilder
+++ b/extensions/topmenus/AMBuilder
@@ -5,9 +5,9 @@ binary = SM.ExtLibrary(builder, 'topmenus.ext')
 binary.compiler.cxxincludes += [
   os.path.join(SM.mms_root, 'core', 'sourcehook'),
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
 binary.sources += [

--- a/extensions/updater/AMBuilder
+++ b/extensions/updater/AMBuilder
@@ -5,9 +5,9 @@ binary = SM.ExtLibrary(builder, 'updater.ext')
 binary.compiler.cxxincludes += [
   os.path.join(SM.mms_root, 'core', 'sourcehook'),
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 
 binary.sources += [

--- a/loader/AMBuilder
+++ b/loader/AMBuilder
@@ -1,10 +1,10 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os.path
 
-if builder.target_platform in ['windows', 'mac']:
+if builder.target.platform in ['windows', 'mac']:
   name = 'sourcemod_mm'
   extra_ldflags = []
-elif builder.target_platform == 'linux':
+elif builder.target.platform == 'linux':
   name = 'sourcemod_mm_i486'
   extra_ldflags = ['-ldl']
 
@@ -13,9 +13,9 @@ binary.compiler.cxxincludes += [
   os.path.join(SM.mms_root, 'core'),
   os.path.join(SM.mms_root, 'sourcehook')
 ]
-if binary.compiler.vendor == 'gcc' or binary.compiler.vendor == 'clang':
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
   binary.compiler.cxxflags += ['-fno-rtti']
-elif binary.compiler.vendor == 'msvc':
+elif binary.compiler.family == 'msvc':
   binary.compiler.cxxflags += ['/GR-']
 binary.compiler.linkflags += extra_ldflags
 binary.sources = [

--- a/tools/buildbot/PackageScript
+++ b/tools/buildbot/PackageScript
@@ -474,7 +474,7 @@ CopyFiles('plugins/playercommands', 'addons/sourcemod/scripting/playercommands',
   ]
 )
 
-if builder.target_platform == 'windows':
+if builder.target.platform == 'windows':
   CopyFiles('tools/batchtool', 'addons/sourcemod/scripting', ['compile.exe'])
 else:
   CopyFiles('plugins', 'addons/sourcemod/scripting', ['compile.sh'])

--- a/versionlib/AMBuilder
+++ b/versionlib/AMBuilder
@@ -1,7 +1,7 @@
 # vim: sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-lib = builder.compiler.StaticLibrary('version')
+lib = SM.StaticLibrary(builder, 'version')
 lib.compiler.includes += [
   os.path.join(builder.sourcePath, 'public')
 ]


### PR DESCRIPTION
SourcePawn's build scripts were recently updated to the 2.1 API and SourceMod needs the same treatment to stay compatible.