### PR TITLE
Remove spacers from MenuManager when we have control options.

### DIFF
--- a/core/MenuManager.cpp
+++ b/core/MenuManager.cpp
@@ -567,13 +567,8 @@ skip_search:
 		ItemDrawInfo padItem(NULL, ITEMDRAW_SPACER);
 		if (exitButton || (displayNext || displayPrev))
 		{
-			/* If there are no control options,
-			 * Instead just pad with invisible slots.
-			 */
-			if (!displayNext && !displayPrev)
-			{
-				padItem.style = ITEMDRAW_NOTEXT;
-			}
+			padItem.style = ITEMDRAW_NOTEXT;
+
 			/* Add spacers so we can pad to the end */
 			for (unsigned int i=0; i<padding; i++)
 			{


### PR DESCRIPTION
This has been a long standing gripe with SM menus that I forgot about until today.

When I migrated my environment to SM from Mani Admin Plugin (MAP) in 2k9 the one thing that always irk'd me was that SM drew a ton of whitespace if there were control options at the bottom. I meant to get this in for SM 1.5, and then again for 1.6 but always forgot about it...

Turns out this was a feature in SM and might be a "personal change". Screenshots attached.

Before: https://i.imgur.com/vxGvLH5.jpg
After: https://i.imgur.com/TvuCdKt.jpg