### PR TITLE
Ditch C header/Fix build warnings

### DIFF
--- a/core/logic/smn_float.cpp
+++ b/core/logic/smn_float.cpp
@@ -29,7 +29,7 @@
  * Version: $Id$
  */
 
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <stdlib.h>
 #include "common_logic.h"
@@ -287,44 +287,6 @@ static cell_t sm_ArcTangent2(IPluginContext *pCtx, const cell_t *params)
 
 	return sp_ftoc(val1);
 }
-
-#if 0
-static cell_t sm_FloatRound(IPluginContext *pCtx, const cell_t *params)
-{
-	float val = sp_ctof(params[1]);
-
-	switch (params[2])
-	{
-	case 1:
-		{
-			val = floor(val);
-			break;
-		}
-	case 2:
-		{
-			val = ceil(val);
-			break;
-		}
-	case 3:
-		{
-			if (val >= 0.0f)
-			{
-				val = floor(val);
-			} else {
-				val = ceil(val);
-			}
-			break;
-		}
-	default:
-		{
-			val = (float)floor(val + 0.5f);
-			break;
-		}
-	}
-
-	return static_cast<int>(val);
-}
-#endif
 
 class RandomHelpers :
 	public SMGlobalClass,

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -957,7 +957,7 @@ bool SDKHooks::Hook_CanBeAutobalanced()
 			// Only update our new ret if different from original
 			// (so if multiple plugins returning different answers,
 			//  the one(s) that changed it win)
-			if (res != origRet)
+			if ((bool)res != origRet)
 				newRet = !origRet;
 		}
 


### PR DESCRIPTION
Fixing some warnings that were spit out due to unsafe double -> float comparisons, and some other easily-fixable warnings were corrected, as well.


~~Someone please double check that the change in MernsenneTwister.h is safe. The warning was~~ 
~~```\sourcemod\core\logic\MersenneTwister.h(128): warning C4146: unary minus operator applied to unsigned type, result still unsigned```~~

^Redacted from pr