### PR TITLE
Disable SQL_(Un)LockDatabase and always lock/unlock on blocking queries.

### DIFF
--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -800,7 +800,9 @@ static cell_t SQL_Query(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToString(params[2], &query);
 
 	IQuery *qr;
-	
+
+	db->LockForFullAtomicOperation();
+
 	if (params[0] >= 3 && params[3] != -1)
 	{
 		qr = db->DoQueryEx(query, params[3]);
@@ -809,6 +811,8 @@ static cell_t SQL_Query(IPluginContext *pContext, const cell_t *params)
 	{
 		qr = db->DoQuery(query);
 	}
+
+	db->UnlockFromFullAtomicOperation();
 
 	if (!qr)
 	{
@@ -887,8 +891,6 @@ static cell_t SQL_LockDatabase(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid database Handle %x (error: %d)", params[1], err);
 	}
 
-	db->LockForFullAtomicOperation();
-
 	return 1;
 }
 
@@ -902,8 +904,6 @@ static cell_t SQL_UnlockDatabase(IPluginContext *pContext, const cell_t *params)
 	{
 		return pContext->ThrowNativeError("Invalid database Handle %x (error: %d)", params[1], err);
 	}
-
-	db->UnlockFromFullAtomicOperation();
 
 	return 1;
 }

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -941,30 +941,15 @@ native void SQL_BindParamString(Handle statement, int param, const char[] value,
 native bool SQL_Execute(Handle statement);
 
 /**
- * Locks a database so threading operations will not interrupt.
- * 
- * If you are using a database Handle for both threading and non-threading,
- * this MUST be called before doing any set of non-threading DB operations.
- * Otherwise you risk corrupting the database driver's memory or network
- * connection.
- * 
- * Leaving a lock on a database and then executing a threaded query results
- * in a dead lock! Make sure to call SQL_UnlockDatabase()!
- *
- * If the lock cannot be acquired, the main thread will pause until the 
- * threaded operation has concluded.
- *
- * @param database		A database Handle.
- * @error				Invalid database Handle.
+ * @deprecated Functionality removed.
  */
+#pragma deprecated Use SQL_Query() normally.
 native void SQL_LockDatabase(Handle database);
 
 /**
- * Unlocks a database so threading operations may continue.
- *
- * @param database		A database Handle.
- * @error				Invalid database Handle.
+ * @deprecated Functionality removed.
  */
+#pragma deprecated Use SQL_Query() normally.
 native void SQL_UnlockDatabase(Handle database);
 
 // General callback for threaded SQL stuff.


### PR DESCRIPTION
This is too hard for people to use and is a ghost from the past https://forums.alliedmods.net/showpost.php?p=1406603&postcount=16 .

I've seen weird things in accelerator, there's issues like https://github.com/alliedmodders/sourcemod/issues/700 every couple months. Doubling down on this, if someone locks the DB and encounters a plugin error; they get into the weird state of having the database locked without being able to check if it's actually locked. Instead of this, every blocking query we should just lock/unlock for them. If there's no contention, they get the lock pretty darn quickly, and if there is contention, they should have taken the mutex anyways.