### PR TITLE
Add KeyValues.ExportToString

### DIFF
--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -1140,7 +1140,7 @@ static cell_t smn_KeyValuesToString(IPluginContext *pContext, const cell_t *para
 	size_t maxlen = static_cast<size_t>(params[3]);
 	
 	buffer.GetString(outStr, maxlen);
-	return buffer.TellGet();
+	return buffer.TellPut();
 }
 
 static cell_t smn_KeyValuesExportLength(IPluginContext *pContext, const cell_t *params)
@@ -1165,11 +1165,7 @@ static cell_t smn_KeyValuesExportLength(IPluginContext *pContext, const cell_t *
 
 	kv->RecursiveSaveToFile(buffer, 0);
 	
-	/* In order for TellGet to return the size, we have to GetString atleast once... */
-	char string[2];
-	buffer.GetString(string, sizeof(string));
-
-	return (cell_t)buffer.TellGet();
+	return (cell_t)buffer.TellPut();
 }
 
 static KeyValueNatives s_KeyValueNatives;

--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -1113,7 +1113,6 @@ static cell_t KeyValues_Import(IPluginContext *pContext, const cell_t *params)
 	return smn_CopySubkeys(pContext, new_params);
 }
 
-// int KeyValues.ExportToString(char[] buffer, int maxlen);
 static cell_t smn_KeyValuesToString(IPluginContext *pContext, const cell_t *params)
 {
 	Handle_t hndl = static_cast<Handle_t>(params[1]);
@@ -1144,7 +1143,6 @@ static cell_t smn_KeyValuesToString(IPluginContext *pContext, const cell_t *para
 	return buffer.TellGet(); // output size able to be written
 }
 
-// int KeyValues.ExportLength; 
 static cell_t smn_KeyValuesExportLength(IPluginContext *pContext, const cell_t *params)
 {
 	Handle_t hndl = static_cast<Handle_t>(params[1]);

--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -1131,16 +1131,16 @@ static cell_t smn_KeyValuesToString(IPluginContext *pContext, const cell_t *para
 	KeyValues *kv;
 	CUtlBuffer buffer;
 	
-	kv = pStk->pCurRoot.front(); // grab kv from kvstack
+	kv = pStk->pCurRoot.front();
 
-	kv->RecursiveSaveToFile(buffer, 0); // write kvs to CUtlBuffer
+	kv->RecursiveSaveToFile(buffer, 0);
 	
 	char* outStr;
 	pContext->LocalToString(params[2], &outStr);
 	size_t maxlen = static_cast<size_t>(params[3]);
 	
-	buffer.GetString(outStr, maxlen); // write buffer output to sp str
-	return buffer.TellGet(); // output size able to be written
+	buffer.GetString(outStr, maxlen);
+	return buffer.TellGet();
 }
 
 static cell_t smn_KeyValuesExportLength(IPluginContext *pContext, const cell_t *params)
@@ -1161,15 +1161,15 @@ static cell_t smn_KeyValuesExportLength(IPluginContext *pContext, const cell_t *
 	KeyValues *kv;
 	CUtlBuffer buffer;
 	
-	kv = pStk->pCurRoot.front(); // grab kv from kvstack
+	kv = pStk->pCurRoot.front();
 
-	kv->RecursiveSaveToFile(buffer, 0); // write kvs to CUtlBuffer
+	kv->RecursiveSaveToFile(buffer, 0);
 	
 	/* In order for TellGet to return the size, we have to GetString atleast once... */
 	char string[2];
 	buffer.GetString(string, sizeof(string));
 
-	return (cell_t)buffer.TellGet(); // output size able to be written
+	return (cell_t)buffer.TellGet();
 }
 
 static KeyValueNatives s_KeyValueNatives;

--- a/core/smn_keyvalues.h
+++ b/core/smn_keyvalues.h
@@ -46,6 +46,6 @@ struct KeyValueStack
 	bool m_bDeleteOnDestroy = true;
 };
 
-extern HandleType_t g_KeyValueType;;
+extern HandleType_t g_KeyValueType;
 
 #endif // _INCLUDE_SOURCEMOD_KVWRAPPER_H_

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -72,8 +72,13 @@ methodmap KeyValues < Handle
 	//
 	// @param buffer        Buffer to write to.
 	// @param maxlength		Max length of buffer.
-	// @return              True on success, false otherwise.
-	public native void ExportToString(char[] buffer, int maxlength);
+	// @return              Number of bytes that can be written to buffer.
+	public native int ExportToString(char[] buffer, int maxlength);
+
+	// Amount of bytes written by ExportToFile & ExportToString.
+	property int ExportLength {
+		public native get();
+	}
 
 	// Imports a file in KeyValues format. The file is read into the current
 	// position of the tree.

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -68,6 +68,13 @@ methodmap KeyValues < Handle
 	// @return              True on success, false otherwise.
 	public native bool ExportToFile(const char[] file);
 
+	// Exports a KeyValues tree to a string. The string is dumped from the current position.
+	//
+	// @param buffer        Buffer to write to.
+	// @param maxlength		Max length of buffer.
+	// @return              True on success, false otherwise.
+	public native void ExportToString(char[] buffer, int maxlength);
+
 	// Imports a file in KeyValues format. The file is read into the current
 	// position of the tree.
 	//


### PR DESCRIPTION
Before this pull request, in order for a plugin to get a string version of the KeyValues tree they'd have to export to a file and read it back in. That is the reason this was created. General use of this functionality looks something like this:

```cpp
int length = kv.ExportLength;
char[] buffer = new char[length];
kv.ExportToString(buffer, length);
```