### PR TITLE
Add a note for FindConVar

### DIFF
--- a/plugins/include/convars.inc
+++ b/plugins/include/convars.inc
@@ -84,6 +84,9 @@ native ConVar CreateConVar(
 
 // Searches for a console variable.
 //
+// Note: A lookup is performed when FindConVar is called,
+// and should be considered expensive.
+//
 // @param name			Name of convar to find.
 // @return				A ConVar object if found; null otherwise.
 native ConVar FindConVar(const char[] name);

--- a/plugins/include/convars.inc
+++ b/plugins/include/convars.inc
@@ -85,7 +85,7 @@ native ConVar CreateConVar(
 // Searches for a console variable.
 //
 // Note: A lookup is performed when FindConVar is called,
-// and should be considered expensive.
+// so it should be considered expensive.
 //
 // @param name			Name of convar to find.
 // @return				A ConVar object if found; null otherwise.


### PR DESCRIPTION
FindConVar should be cached whenever it's used often, or more than once consecutively. This comment will hopefully remind people to cache it. I see code like this way too often.

```cpp
	if(GetConVarFloat(FindConVar("sm_ghost_time")) > 0.0 && !bWarmUp)
		CreateTimer(GetConVarFloat(FindConVar("sm_ghost_time")), KillGhost, m_unEnt);
	
	if(GetConVarFloat(FindConVar("sm_ghost_warmup_time")) > 0.0 && bWarmUp)
		CreateTimer(GetConVarFloat(FindConVar("sm_ghost_warmup_time")), KillGhost, m_unEnt);
```