### PR TITLE
 Lowercase windows/mac paths to avoid plugin duplicate loadings (Bug #6491)

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -952,7 +952,7 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 	if (m_LoadingLocked)
 		return LoadRes_NeverLoad;
 
-/* For windows, we convert the path to lower-case in order to avoid duplicate plugin loading */
+/* For windows & mac, we convert the path to lower-case in order to avoid duplicate plugin loading */
 #if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
 	ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(path));
 #else 

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -932,7 +932,7 @@ void CPluginManager::LoadPluginsFromDir(const char *basedir, const char *localpa
 	libsys->CloseDirectory(dir);
 }
 
-#ifdef PLATFORM_WINDOWS
+#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
 char *strdup_tolower(const char *input)
 {
 	char *str = strdup(input);
@@ -952,7 +952,7 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 		return LoadRes_NeverLoad;
 
 /* For windows, we convert the path to lower-case in order to avoid duplicate plugin loading */
-#ifdef PLATFORM_WINDOWS
+#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
 	char *finalPath = strdup_tolower(path);
 #else 
 	char *finalPath = strdup(path);

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -953,9 +953,9 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 
 /* For windows, we convert the path to lower-case in order to avoid duplicate plugin loading */
 #ifdef PLATFORM_WINDOWS
-	ke::AString finalPath(strdup_tolower(path));
-#elif 
-	ke::AString finalPath(strdup(path));
+	char *finalPath = strdup_tolower(path);
+#else 
+	char *finalPath = strdup(path);
 #endif
 
 
@@ -963,7 +963,7 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 	 * Does this plugin already exist?
 	 */
 	CPlugin *pPlugin;
-	if (m_LoadLookup.retrieve(finalPath.chars(), &pPlugin))
+	if (m_LoadLookup.retrieve(finalPath, &pPlugin))
 	{
 		/* Check to see if we should try reloading it */
 		if (pPlugin->GetStatus() == Plugin_BadLoad
@@ -976,11 +976,14 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 		{
 			if (aResult)
 				*aResult = pPlugin;
+			
+			free(finalPath);
 			return LoadRes_AlreadyLoaded;
 		}
 	}
 
-	CPlugin *plugin = CompileAndPrep(finalPath.chars());
+	CPlugin *plugin = CompileAndPrep(finalPath);
+	free(finalPath);
 
 	// Assign our outparam so we can return early. It must be set.
 	*aResult = plugin;


### PR DESCRIPTION
Prior to this pull request, plugins could be loaded in twice & have two separate instances of the same plugin running simultaneously. This adds a check for each plugin loaded in, and ensures that the code hash of the new plugin doesn't equal a code hash of a plugin that's already loaded.

Here's the original bug report: https://bugs.alliedmods.net/show_bug.cgi?id=6491