### PR TITLE
TF2 Makebleed function param fix

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -45,7 +45,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 	if(!pWrapper)
 	{
 		REGISTER_NATIVE_ADDR("MakeBleed",
-			PassInfo pass[5]; \
+			PassInfo pass[6]; \
 			pass[0].flags = PASSFLAG_BYVAL; \
 			pass[0].size = sizeof(CBaseEntity *); \
 			pass[0].type = PassType_Basic; \
@@ -61,7 +61,10 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 			pass[4].flags = PASSFLAG_BYVAL; \
 			pass[4].size = sizeof(bool); \
 			pass[4].type = PassType_Basic; \
-			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 5))
+			pass[5].flags = PASSFLAG_BYVAL; \
+			pass[5].size = sizeof(int); \
+			pass[5].type = PassType_Basic; \
+			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 6))
 	}
 
 	CBaseEntity *pEntity;
@@ -78,7 +81,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float) + sizeof(int) + sizeof(bool)];
+	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float) + sizeof(int) + sizeof(bool) + sizeof(int)];
 	unsigned char *vptr = vstk;
 
 	*(void **)vptr = obj;
@@ -89,9 +92,11 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 	vptr += sizeof(CBaseEntity *);
 	*(float *)vptr = sp_ctof(params[3]);
 	vptr += sizeof(float);
-	*(int *)vptr = 4;
+	*(int *)vptr = 4;      // Damage amount
 	vptr += sizeof(int);
-	*(bool *)vptr = false;
+	*(bool *)vptr = false; // Permanent
+	vptr += sizeof(bool);
+	*(int *)vptr = 34;     // Custom Damage type (bleeding)
 
 	pWrapper->Execute(vstk, NULL);
 

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -82,8 +82,8 @@
 			{
 				"library" 	"server"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x30\x53\x8B\xD9\x89\x5D\xEC"
-				"linux"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefib"
-				"mac"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefib"
+				"linux"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefibi"
+				"mac"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefibi"
 			}
 			"IsPlayerInDuel"
 			{


### PR DESCRIPTION
Fix the error:
`L 10/21/2017 - 19:05:10: [SM] Exception reported: Failed to locate function
L 10/21/2017 - 19:05:10: [SM] Blaming: sf2.smx
L 10/21/2017 - 19:05:10: [SM] Call stack trace:
L 10/21/2017 - 19:05:10: [SM]   [0] TF2_MakeBleed
`
I don't know if the recent two fix patches changed the signature or you've missed it, but here a fixed linux sig for MakeBleed