### PR TITLE
Expose ``KeyValueStack`` to extensions to interact with plugin kv handles

### DIFF
--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -40,6 +40,7 @@ project.sources += [
   'vprof_tool.cpp',
   'smn_commandline.cpp',
   'GameHooks.cpp',
+  'KeyValueStack.cpp',
 ]
 
 for sdk_name in SM.sdks:

--- a/core/KeyValueStack.cpp
+++ b/core/KeyValueStack.cpp
@@ -1,0 +1,233 @@
+/**
+* vim: set ts=4 :
+* =============================================================================
+* SourceMod
+* Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, AlliedModders LLC gives you permission to link the
+* code of this program (as well as its derivative works) to "Half-Life 2," the
+* "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, AlliedModders LLC grants
+* this exception to all derivative works.  AlliedModders LLC defines further
+* exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+* or <http://www.sourcemod.net/license.php>.
+*
+* Version: $Id$
+*/
+
+#include "KeyValueStack.h"
+#include "utlbuffer.h"
+#include <KeyValues.h>
+
+KeyValueStack::KeyValueStack(KeyValues *root)
+{
+	pRoot = root;
+}
+
+KeyValueStack::~KeyValueStack()
+{
+	if (m_bDeleteOnDestroy)
+	{
+		if (pRoot)
+		{
+			GetRootSection()->deleteThis();
+		}
+	}
+}
+
+KeyValues *KeyValueStack::GetRootSection()
+{
+	return pRoot;
+}
+
+KeyValues *KeyValueStack::GetCurrentSection()
+{
+	if (!pCurrentPath.empty())
+	{
+		return pCurrentPath.front();
+	}
+	return GetRootSection();
+}
+
+bool KeyValueStack::JumpToKey(const char * keyName, bool create)
+{
+	KeyValues *pJumpTo = GetCurrentSection()->FindKey(keyName, create);
+	if (!pJumpTo)
+	{
+		return false;
+	}
+	pCurrentPath.push(pJumpTo);
+	return true;
+}
+
+bool KeyValueStack::JumpToKeySymbol(int symbol)
+{
+	KeyValues *pJumpTo = GetCurrentSection()->FindKey(symbol);
+	if (!pJumpTo)
+	{
+		return false;
+	}
+	pCurrentPath.push(pJumpTo);
+	return true;
+}
+
+bool KeyValueStack::GotoNextKey(bool keyOnly)
+{
+	if (pCurrentPath.empty())
+	{
+		// there should only be one root section, no next keys exist
+		return false;
+	}
+	KeyValues *pCurrentSection = GetCurrentSection();
+	KeyValues *pNextKey;
+	if (keyOnly)
+	{
+		// not realy sure why ``GetNextTrueSubKey`` is not supposed
+		// add another level lo the stack, but w/e
+		pNextKey = pCurrentSection->GetNextTrueSubKey();
+	}
+	else
+	{
+		pNextKey = pCurrentSection->GetNextKey();
+	}
+
+	if (!pNextKey)
+	{
+		return false;
+	}
+	pCurrentPath.pop();
+	pCurrentPath.push(pNextKey);
+
+	return true;
+}
+
+bool KeyValueStack::GotoFirstSubKey(bool keyOnly)
+{
+	KeyValues *pCurrentSection = GetCurrentSection();
+	KeyValues *pFirstSubKey;
+	if (keyOnly)
+	{
+		pFirstSubKey = pCurrentSection->GetFirstTrueSubKey();
+	}
+	else
+	{
+		pFirstSubKey = pCurrentSection->GetFirstSubKey();
+	}
+
+	if (!pFirstSubKey)
+	{
+		return false;
+	}
+	pCurrentPath.push(pFirstSubKey);
+
+	return true;
+}
+
+bool KeyValueStack::SavePosition()
+{
+	if (pCurrentPath.empty())
+	{
+		// there's no point on saving the root position if it's already there
+		// and there's only one root key
+		return false;
+	}
+
+	pCurrentPath.push(pCurrentPath.front());
+	return true;
+}
+
+bool KeyValueStack::GoBack()
+{
+	if (pCurrentPath.empty())
+	{
+		return false;
+	}
+	pCurrentPath.pop();
+	return true;
+}
+
+KeyValueStack::DeleteThis_Result KeyValueStack::DeleteThis()
+{
+	if (pCurrentPath.empty())
+	{
+		return DeleteThis_Failed;
+	}
+	KeyValues *pToDelete = GetCurrentSection();
+	KeyValues *pPathCandidate = pCurrentPath.second();
+
+	KeyValues *pSubPathCandidate = pPathCandidate->GetFirstSubKey();
+	while (pSubPathCandidate)
+	{
+		if (pSubPathCandidate == pToDelete)
+		{
+			KeyValues *pJumpTo = pSubPathCandidate->GetNextKey();
+			pPathCandidate->RemoveSubKey(pToDelete);
+			pCurrentPath.pop();
+			pToDelete->deleteThis();
+			if (pJumpTo)
+			{
+				pCurrentPath.push(pJumpTo);
+				return DeleteThis_MovedNext;
+			}
+			else
+			{
+				return DeleteThis_MovedBack;
+			}
+		}
+		pSubPathCandidate = pSubPathCandidate->GetNextKey();
+	}
+
+	return DeleteThis_Failed;
+}
+
+void KeyValueStack::Rewind()
+{
+	pCurrentPath.popall();
+}
+
+size_t KeyValueStack::GetNodeCount()
+{
+	return pCurrentPath.size();
+}
+
+size_t KeyValueStack::CalcSize()
+{
+	return sizeof(*this) + pCurrentPath.size() * sizeof(KeyValues *) + CalcKVSize();
+}
+
+bool KeyValueStack::DeleteKVOnDestroy()
+{
+	return m_bDeleteOnDestroy;
+}
+
+void KeyValueStack::SetDeleteKVOnDestroy(bool deleteOnDestroy)
+{
+	m_bDeleteOnDestroy = deleteOnDestroy;
+}
+
+size_t KeyValueStack::CalcKVSize()
+{
+	CUtlBuffer buf;
+	size_t size;
+
+	GetRootSection()->RecursiveSaveToFile(buf, 0);
+	size = buf.TellMaxPut();
+
+	buf.Purge();
+
+	return size;
+}

--- a/core/KeyValueStack.cpp
+++ b/core/KeyValueStack.cpp
@@ -199,12 +199,12 @@ void KeyValueStack::Rewind()
 	pCurrentPath.popall();
 }
 
-size_t KeyValueStack::GetNodeCount()
+unsigned int KeyValueStack::GetNodeCount()
 {
 	return pCurrentPath.size();
 }
 
-size_t KeyValueStack::CalcSize()
+unsigned int KeyValueStack::CalcSize()
 {
 	return sizeof(*this) + pCurrentPath.size() * sizeof(KeyValues *) + CalcKVSize();
 }
@@ -219,7 +219,7 @@ void KeyValueStack::SetDeleteKVOnDestroy(bool deleteOnDestroy)
 	m_bDeleteOnDestroy = deleteOnDestroy;
 }
 
-size_t KeyValueStack::CalcKVSize()
+unsigned int KeyValueStack::CalcKVSize()
 {
 	CUtlBuffer buf;
 	size_t size;

--- a/core/KeyValueStack.h
+++ b/core/KeyValueStack.h
@@ -52,12 +52,12 @@ public:
 	bool GoBack();
 	DeleteThis_Result DeleteThis();
 	void Rewind();
-	size_t GetNodeCount();
-	size_t CalcSize();
+	unsigned int GetNodeCount();
+	unsigned int CalcSize();
 	bool DeleteKVOnDestroy();
 	void SetDeleteKVOnDestroy(bool deleteOnDestroy);
 private:
-	size_t CalcKVSize();
+	unsigned int CalcKVSize();
 	KeyValues* pRoot;
 	SourceHook::CStack<KeyValues *> pCurrentPath;
 	bool m_bDeleteOnDestroy = true;

--- a/core/KeyValueStack.h
+++ b/core/KeyValueStack.h
@@ -2,7 +2,7 @@
 * vim: set ts=4 :
 * =============================================================================
 * SourceMod
-* Copyright (C) 2004-2015 AlliedModders LLC.  All rights reserved.
+* Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
 * =============================================================================
 *
 * This program is free software; you can redistribute it and/or modify it under
@@ -29,14 +29,38 @@
 * Version: $Id$
 */
 
-#ifndef _INCLUDE_SOURCEMOD_KVWRAPPER_H_
-#define _INCLUDE_SOURCEMOD_KVWRAPPER_H_
+#ifndef _INCLUDE_SOURCEMOD_KEYVALUESTACK_H_
+#define _INCLUDE_SOURCEMOD_KEYVALUESTACK_H_
 
-#include <IHandleSys.h>
 #include <IKeyValueStack.h>
+#include <sh_stack.h>
 
 using namespace SourceMod;
 
-extern HandleType_t g_KeyValueType;
+class KeyValueStack : public IKeyValueStack
+{
+public:
+	KeyValueStack(KeyValues *root);
+	~KeyValueStack();
+	KeyValues *GetRootSection();
+	KeyValues *GetCurrentSection();
+	bool JumpToKey(const char* keyName, bool create = false);
+	bool JumpToKeySymbol(int symbol);
+	bool GotoNextKey(bool keyOnly);
+	bool GotoFirstSubKey(bool keyOnly);
+	bool SavePosition();
+	bool GoBack();
+	DeleteThis_Result DeleteThis();
+	void Rewind();
+	size_t GetNodeCount();
+	size_t CalcSize();
+	bool DeleteKVOnDestroy();
+	void SetDeleteKVOnDestroy(bool deleteOnDestroy);
+private:
+	size_t CalcKVSize();
+	KeyValues* pRoot;
+	SourceHook::CStack<KeyValues *> pCurrentPath;
+	bool m_bDeleteOnDestroy = true;
+};
 
-#endif // _INCLUDE_SOURCEMOD_KVWRAPPER_H_
+#endif

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -47,7 +47,8 @@
 #include "ConsoleDetours.h"
 #include "logic_bridge.h"
 #include <sourcemod_version.h>
-#include "smn_keyvalues.h"
+#include <IKeyValueStack.h>
+#include "sourcemod.h"
 #include "command_args.h"
 #include <bridge/include/IExtensionBridge.h>
 #include <bridge/include/IScriptManager.h>
@@ -1163,12 +1164,10 @@ void PlayerManager::OnClientCommandKeyValues(edict_t *pEntity, KeyValues *pComma
 		RETURN_META(MRES_IGNORED);
 	}
 
-	KeyValueStack *pStk = new KeyValueStack;
-	pStk->pBase = pCommand;
-	pStk->pCurRoot.push(pStk->pBase);
-	pStk->m_bDeleteOnDestroy = false;
+	IKeyValueStack *pKVStack = g_SourceMod.CreateKVStack(pCommand);
+	pKVStack->SetDeleteKVOnDestroy(false);
 
-	Handle_t hndl = handlesys->CreateHandle(g_KeyValueType, pStk, g_pCoreIdent, g_pCoreIdent, NULL);
+	Handle_t hndl = g_SourceMod.CreateHandleFromKVStack(pKVStack, g_pCoreIdent);
 
 	m_bInCCKVHook = true;
 	m_clcommandkv->PushCell(client);
@@ -1208,12 +1207,10 @@ void PlayerManager::OnClientCommandKeyValues_Post(edict_t *pEntity, KeyValues *p
 		return;
 	}
 
-	KeyValueStack *pStk = new KeyValueStack;
-	pStk->pBase = pCommand;
-	pStk->pCurRoot.push(pStk->pBase);
-	pStk->m_bDeleteOnDestroy = false;
+	IKeyValueStack *pKVStack = g_SourceMod.CreateKVStack(pCommand);
+	pKVStack->SetDeleteKVOnDestroy(false);
 
-	Handle_t hndl = handlesys->CreateHandle(g_KeyValueType, pStk, g_pCoreIdent, g_pCoreIdent, NULL);
+	Handle_t hndl = g_SourceMod.CreateHandleFromKVStack(pKVStack, g_pCoreIdent);
 
 	m_bInCCKVHook = true;
 	m_clcommandkv_post->PushCell(client);

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -48,6 +48,7 @@
 #include <bridge/include/IScriptManager.h>
 #include <bridge/include/IProviderCallbacks.h>
 #include <bridge/include/ILogger.h>
+#include "KeyValueStack.h"
 
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);
 SH_DECL_HOOK0_void(IServerGameDLL, LevelShutdown, SH_NOATTRIB, false);
@@ -743,6 +744,16 @@ int SourceModBase::GetShApiVersion()
 bool SourceModBase::IsMapRunning()
 {
 	return g_OnMapStarted;
+}
+
+IKeyValueStack *SourceModBase::CreateKVStack(KeyValues *root)
+{
+	return new KeyValueStack(root);
+}
+
+void SourceModBase::FreeKVStack(IKeyValueStack *kVStack)
+{
+	delete static_cast<KeyValueStack *>(kVStack);
 }
 
 class ConVarRegistrar :

--- a/core/sourcemod.h
+++ b/core/sourcemod.h
@@ -135,6 +135,10 @@ public: // ISourceMod
 	int GetPluginId();
 	int GetShApiVersion();
 	bool IsMapRunning();
+	IKeyValueStack *CreateKVStack(KeyValues *root);
+	void FreeKVStack(IKeyValueStack *kVStack);
+	IKeyValueStack *ReadKVStackFromHandle(Handle_t hndl, IdentityToken_t *owner = NULL, HandleError *err = NULL);
+	Handle_t CreateHandleFromKVStack(IKeyValueStack *kVStack, IdentityToken_t *owner, HandleError *err = NULL);
 private:
 	void ShutdownServices();
 private:

--- a/public/IKeyValueStack.h
+++ b/public/IKeyValueStack.h
@@ -1,0 +1,182 @@
+/**
+* vim: set ts=4 :
+* =============================================================================
+* SourceMod
+* Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* As a special exception, AlliedModders LLC gives you permission to link the
+* code of this program (as well as its derivative works) to "Half-Life 2," the
+* "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+* by the Valve Corporation.  You must obey the GNU General Public License in
+* all respects for all other code used.  Additionally, AlliedModders LLC grants
+* this exception to all derivative works.  AlliedModders LLC defines further
+* exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+* or <http://www.sourcemod.net/license.php>.
+*
+* Version: $Id$
+*/
+
+#ifndef _INCLUDE_SOURCEMOD_INTERFACE_KEYVALUESTACK_H_
+#define _INCLUDE_SOURCEMOD_INTERFACE_KEYVALUESTACK_H_
+
+/**
+* @file IKeyValueStack.h
+* @brief Interface to the data structure that SP uses to interact with KeyValues. 
+* The wrappers for creating these are contained in ISourceMod.h
+*/
+
+/**
+ * @brief Forward declaration of the KeyValues class.
+ */
+class KeyValues;
+
+namespace SourceMod
+{
+	/**
+	 * @brief Defines a KeyValues Stack.
+	 */
+	class IKeyValueStack
+	{
+	public:
+		/**
+		 * @brief Defines possible results that can be returned by ``DeleteThis``.
+		 */
+		enum DeleteThis_Result {
+			DeleteThis_Failed = 0,		/**< Failed to delete the current section */
+			DeleteThis_MovedNext = 1,	/**< Success, moved to next section */
+			DeleteThis_MovedBack = -1,	/**< Success, moved one section back */
+		};
+
+		/**
+		 * Retrieves the root section.
+		 * 
+		 * @return	The root section.
+		 */
+		virtual KeyValues *GetRootSection() = 0;
+
+		/**
+		 * Retrieves the current section, the last node on the path stack. 
+		 * 
+		 * @return	The current section.
+		 */
+		virtual KeyValues *GetCurrentSection() = 0;
+
+		/**
+		 * Sets the current position in the KeyValues tree to the given key.
+		 * 
+		 * @param keyName	Name of the key.
+		 * @param create	If true, and the key does not exist, it will be created.
+		 * @return			True if the key exists, false if it does not and was not created.
+		 */
+		virtual bool JumpToKey(const char* keyName, bool create = false) = 0;
+
+		/**
+		 * Sets the current position in the KeyValues tree to the given key.
+		 * 
+		 * @param symbol	Name of the key.
+		 * @return			True if the key exists, false if it does not.
+		 */
+		virtual bool JumpToKeySymbol(int symbol) = 0;
+		
+		/**
+		 * Sets the current position in the tree to the next sub key.
+		 * 
+		 * @param keyOnly	If false, non-keys will be traversed (values).
+		 * @return			True on success, false if there was no next sub key.
+		 */
+		virtual bool GotoNextKey(bool keyOnly) = 0;
+
+		/**
+		 * Sets the current position in the KeyValues tree to the first sub key.
+		 * 
+		 * @param keyOnly	If false, non-keys will be traversed (values).
+		 * @return			True on success, false if there was no first sub key.
+		 */
+		virtual bool GotoFirstSubKey(bool keyOnly) = 0;
+
+		/**
+		 * Saves the current position in the traversal stack onto the traversal
+		 * stack. This can be useful if you wish to use ``GotoNextKey`` and
+		 * have the previous key saved for backwards traversal.
+		 * 
+		 * @return			False if the current section is the root section.
+		 */
+		virtual bool SavePosition() = 0;
+
+		/**
+		 * Jumps back to the previous position. Returns false if there are no
+		 * previous positions (i.e., at the root node). This should be called
+		 * once for each successful Jump call, in order to return to the top node.
+		 * This function pops one node off the internal traversal stack.
+		 * 
+		 * @return			True on success, false if there is no higher node.
+		 */
+		virtual bool GoBack() = 0;
+
+		/**
+		 * Removes the current sub-key and attempts to set the position
+		 * to the sub-key after the removed one. If no such sub-key exists,
+		 * the position will be the parent key in the traversal stack.
+		 * Given the sub-key having position "N" in the traversal stack, the
+		 * removal will always take place from position "N-1."
+		 * 
+		 * @return			A ``DeleteThis_Result`` value stating the result.
+		 */
+		virtual DeleteThis_Result DeleteThis() = 0;
+
+		/**
+		 * Sets the position back to the top node, emptying the entire node
+		 * traversal history. This can be used instead of looping ``GoBack``
+		 * if recursive iteration is not important.
+		 */
+		virtual void Rewind() = 0;
+
+		/**
+		 * Returns the position in the jump stack; I.e. the number of calls
+		 * required for KvGoBack to return to the root node. If at the root node,
+		 * 0 is returned.
+		 * 
+		 * @return			Number of non-root nodes in the jump stack.
+		 */
+		virtual size_t GetNodeCount() = 0;
+
+		/**
+		 * @brief Returns a computed aproximate size of this object, 
+		 * including the KV object.
+		 * 
+		 * @return			Aproximate size of this structure and the KV object.
+		 */
+		virtual size_t CalcSize() = 0;
+
+		/**
+		 * @brief Returns True if the KeyValues object should be deleted along with
+		 * this object. 
+		 * 
+		 * @return			True if the KV object should be deleted when this gets deleted.
+		 */
+		virtual bool DeleteKVOnDestroy() = 0;
+
+		/**
+		 * @brief Sets whether or not the KeyValues root must be deleted when
+		 * this object gets deleted.
+		 * 
+		 * @param deleteOnDestroy	
+		 */
+		virtual void SetDeleteKVOnDestroy(bool deleteOnDestroy) = 0;
+	};
+}
+
+#endif

--- a/public/IKeyValueStack.h
+++ b/public/IKeyValueStack.h
@@ -151,7 +151,7 @@ namespace SourceMod
 		 * 
 		 * @return			Number of non-root nodes in the jump stack.
 		 */
-		virtual size_t GetNodeCount() = 0;
+		virtual unsigned int GetNodeCount() = 0;
 
 		/**
 		 * @brief Returns a computed aproximate size of this object, 
@@ -159,7 +159,7 @@ namespace SourceMod
 		 * 
 		 * @return			Aproximate size of this structure and the KV object.
 		 */
-		virtual size_t CalcSize() = 0;
+		virtual unsigned int CalcSize() = 0;
 
 		/**
 		 * @brief Returns True if the KeyValues object should be deleted along with

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -41,9 +41,10 @@
 #include <sp_vm_api.h>
 #include <IDataPack.h>
 #include <time.h>
+#include <IKeyValueStack.h>
 
 #define SMINTERFACE_SOURCEMOD_NAME		"ISourceMod"
-#define SMINTERFACE_SOURCEMOD_VERSION	13
+#define SMINTERFACE_SOURCEMOD_VERSION	14
 
 /**
 * @brief Forward declaration of the KeyValues class.
@@ -318,6 +319,43 @@ namespace SourceMod
 		 * @return			True if a map is currently running, otherwise false.
 		 */
 		virtual bool IsMapRunning() = 0;
+
+		/**
+		 * @brief Creates a KeyValues stack object.
+		 * 
+		 * @return			A new IKeyValueStack object.
+		 */
+		virtual IKeyValueStack *CreateKVStack(KeyValues *root) = 0;
+
+		/**
+		 * @brief Removes a KeyValues stack object.
+		 * 
+		 * @return			An IKeyValueStack object to remove.
+		 */
+		virtual void FreeKVStack(IKeyValueStack *kVStack) = 0;
+
+		/**
+		 * @brief Retrieves a IKeyValueStack pointer from a handle.
+		 * 
+		 * @param hndl		Handle_t from which to retrieve contents.
+		 * @param owner		The identity token of the owner of the handle.
+		 * @param err		Optional address to store a possible handle error.
+		 * 
+		 * @return			The IKeyValueStack pointer, or NULL for any error encountered.
+		 */
+		virtual IKeyValueStack *ReadKVStackFromHandle(Handle_t hndl, IdentityToken_t *owner = NULL, HandleError *err = NULL) = 0;
+		
+		/**
+		 * @brief Packs a IKeyValueStack object into a handle as a "KeyValues" type for
+		 * plugins to use. This object gets deleted once the handle is destroyed. 
+		 * 
+		 * @param kVStack	A IKeyValueStack object to pack into the handle.
+		 * @param owner		The identity token of the owner of the handle.
+		 * @param err		Optional address to store a possible handle error.
+		 * 
+		 * @return			The IKeyValueStack object packed into a handle.
+		 */
+		virtual Handle_t CreateHandleFromKVStack(IKeyValueStack *kVStack, IdentityToken_t *owner, HandleError *err = NULL) = 0;
 	};
 }
 


### PR DESCRIPTION
Exposes methods via the sm interface for creating and reading kv handles and adds a new interface for ``KeyValueStack``. This should allow extensions to provide kv handles to plugins and read them when necessary. 