### PR TITLE
Add Timer Datatype

### DIFF
--- a/core/logic/smn_timers.cpp
+++ b/core/logic/smn_timers.cpp
@@ -361,6 +361,9 @@ REGISTER_NATIVES(timernatives)
 	{"ExtendMapTimeLimit",		smn_ExtendMapTimeLimit},
 	{"IsServerProcessing",		smn_IsServerProcessing},
 	{"GetTickInterval",			smn_GetTickInterval},
+	{"Timer.Timer",				smn_CreateTimer},
+	{"Timer.Kill",				smn_KillTimer},
+	{"Timer.Trigger",			smn_TriggerTimer},
 	{NULL,						NULL}
 };
 

--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -45,7 +45,7 @@
 /**
  * Any of the following prototypes will work for a timed function.
  */
-typeset Timer
+typeset TimerCallback
 {
 	/**
  	 * Called when the timer interval has elapsed.
@@ -77,6 +77,40 @@ typeset Timer
 	function Action(Handle timer);
 };
 
+methodmap Timer < Handle
+{
+	/**
+	 * Creates a basic timer.  Calling delete on a timer handle will end the timer.
+	 *
+	 * @param interval			Interval from the current game time to execute the given function.
+	 * @param func				Function to execute once the given interval has elapsed.
+	 * @param data				Handle or value to pass through to the timer callback function.
+	 * @param flags				Flags to set (such as repeatability or auto-Handle closing).
+	 * @return					Handle to the timer object.  You do not need to call CloseHandle().
+	 *							If the timer could not be created, INVALID_HANDLE will be returned.
+	 */
+	public native Timer(float interval, TimerCallback func, any data=INVALID_HANDLE, int flags=0);
+	
+	/**
+	 * Kills a timer.  Use this instead of delete if you need more options.
+	 *
+	 * @param timer				Timer Handle to kill.
+	 * @param autoClose			If autoClose is true, the data that was passed to CreateTimer() will
+	 *							be closed as a handle if TIMER_DATA_HNDL_CLOSE was not specified.
+	 * @error				Invalid handles will cause a run time error.
+	 */
+	public native void Kill(bool autoClose=false);
+
+	/**
+	 * Manually triggers a timer so its function will be called.
+	 *
+	 * @param timer				Timer Handle to trigger.
+	 * @param reset				If reset is true, the elapsed time counter is reset
+	 *							so the full interval must pass again.
+	 */
+	public native void Trigger(bool reset=false);
+}
+
 /**
  * Creates a basic timer.  Calling CloseHandle() on a timer will end the timer.
  *
@@ -87,7 +121,7 @@ typeset Timer
  * @return					Handle to the timer object.  You do not need to call CloseHandle().
  *							If the timer could not be created, INVALID_HANDLE will be returned.
  */
-native Handle CreateTimer(float interval, Timer func, any data=INVALID_HANDLE, int flags=0);
+native Handle CreateTimer(float interval, TimerCallback func, any data=INVALID_HANDLE, int flags=0);
 
 /**
  * Kills a timer.  Use this instead of CloseHandle() if you need more options.
@@ -201,7 +235,7 @@ native bool IsServerProcessing();
  * @param flags				Timer flags.
  * @return					Handle to the timer object.  You do not need to call CloseHandle().
  */
-stock Handle CreateDataTimer(float interval, Timer func, Handle &datapack, int flags=0)
+stock Handle CreateDataTimer(float interval, TimerCallback func, Handle &datapack, int flags=0)
 {
 	datapack = new DataPack();
 	flags |= TIMER_DATA_HNDL_CLOSE;

--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -55,7 +55,7 @@ typeset TimerCallback
  	 * @return				Plugin_Stop to stop a repeating timer, any other value for
  	 *						default behavior.
  	 */
-	function Action(Handle timer, Handle hndl);
+	function Action(Timer timer, Handle hndl);
 	
 	/**
  	 * Called when the timer interval has elapsed.
@@ -65,7 +65,7 @@ typeset TimerCallback
  	 * @return				Plugin_Stop to stop a repeating timer, any other value for
  	 *						default behavior.
  	 */
-	function Action(Handle timer, any data);
+	function Action(Timer timer, any data);
 	
 	/**
  	 * Called when the timer interval has elapsed.
@@ -74,7 +74,7 @@ typeset TimerCallback
  	 * @return				Plugin_Stop to stop a repeating timer, any other value for
  	 *						default behavior.
  	 */
-	function Action(Handle timer);
+	function Action(Timer timer);
 };
 
 methodmap Timer < Handle
@@ -119,7 +119,7 @@ methodmap Timer < Handle
  * @return					Handle to the timer object.  You do not need to call CloseHandle().
  *							If the timer could not be created, INVALID_HANDLE will be returned.
  */
-native Handle CreateTimer(float interval, TimerCallback func, any data=INVALID_HANDLE, int flags=0);
+native Timer CreateTimer(float interval, TimerCallback func, any data=INVALID_HANDLE, int flags=0);
 
 /**
  * Kills a timer.  Use this instead of CloseHandle() if you need more options.
@@ -233,9 +233,9 @@ native bool IsServerProcessing();
  * @param flags				Timer flags.
  * @return					Handle to the timer object.  You do not need to call CloseHandle().
  */
-stock Handle CreateDataTimer(float interval, TimerCallback func, Handle &datapack, int flags=0)
+stock Timer CreateDataTimer(float interval, TimerCallback func, Handle &datapack, int flags=0)
 {
 	datapack = new DataPack();
 	flags |= TIMER_DATA_HNDL_CLOSE;
-	return CreateTimer(interval, func, datapack, flags);
+	return (new Timer(interval, func, datapack, flags));
 }

--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -233,7 +233,7 @@ native bool IsServerProcessing();
  * @param flags				Timer flags.
  * @return					Handle to the timer object.  You do not need to call CloseHandle().
  */
-stock Timer CreateDataTimer(float interval, TimerCallback func, Handle &datapack, int flags=0)
+stock Timer CreateDataTimer(float interval, TimerCallback func, DataPack &datapack, int flags=0)
 {
 	datapack = new DataPack();
 	flags |= TIMER_DATA_HNDL_CLOSE;

--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -211,7 +211,7 @@ native float GetTickInterval();
 forward void OnMapTimeLeftChanged();
 
 /**
- * Returns whether or not the server is processing frames or not.  
+ * Returns whether or not the server is processing frames.  
  *
  * The server does not process frames until at least one client joins the game.  
  * Once the first player has in, even if that player, leaves, the server's 

--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -94,7 +94,6 @@ methodmap Timer < Handle
 	/**
 	 * Kills a timer.  Use this instead of delete if you need more options.
 	 *
-	 * @param timer				Timer Handle to kill.
 	 * @param autoClose			If autoClose is true, the data that was passed to CreateTimer() will
 	 *							be closed as a handle if TIMER_DATA_HNDL_CLOSE was not specified.
 	 * @error				Invalid handles will cause a run time error.
@@ -104,7 +103,6 @@ methodmap Timer < Handle
 	/**
 	 * Manually triggers a timer so its function will be called.
 	 *
-	 * @param timer				Timer Handle to trigger.
 	 * @param reset				If reset is true, the elapsed time counter is reset
 	 *							so the full interval must pass again.
 	 */


### PR DESCRIPTION
Timers don't have very many functions attributed to the Handle, so this is quite a small methodmap. This is one step towards methodmap completion, though.

This pull request allows for sourcemod plugin creators to make timers like so

```cpp
Timer timer = new Timer(10.0, Timer_Callback);
...
timer.Kill();
```