### PR TITLE
Fix "Exception reported: Client 12 is not in game"

### DIFF
--- a/plugins/adminhelp.sp
+++ b/plugins/adminhelp.sp
@@ -58,7 +58,7 @@ public void OnPluginStart()
 
 public Action HelpCmd(int client, int args)
 {
-	if(client != 0 && !IsClientInGame(client))
+	if (client && !IsClientInGame(client))
 	{
 		return Plugin_Handled;
 	}

--- a/plugins/adminhelp.sp
+++ b/plugins/adminhelp.sp
@@ -58,7 +58,10 @@ public void OnPluginStart()
 
 public Action HelpCmd(int client, int args)
 {
-	if(!IsClientInGame(client)) return Plugin_Handled;
+	if(client != 0 && !IsClientInGame(client))
+	{
+		return Plugin_Handled;
+	}
 	
 	char arg[64], CmdName[20];
 	int PageNum = 1;

--- a/plugins/adminhelp.sp
+++ b/plugins/adminhelp.sp
@@ -58,6 +58,8 @@ public void OnPluginStart()
 
 public Action HelpCmd(int client, int args)
 {
+	if(!IsClientInGame(client)) return Plugin_Handled;
+	
 	char arg[64], CmdName[20];
 	int PageNum = 1;
 	bool DoSearch;


### PR DESCRIPTION
L 11/19/2017 - 16:37:02: [SM] Exception reported: Client 12 is not in game
L 11/19/2017 - 16:37:02: [SM] Blaming: adminhelp.smx
L 11/19/2017 - 16:37:02: [SM] Call stack trace:
L 11/19/2017 - 16:37:02: [SM]   [0] PrintToConsole
L 11/19/2017 - 16:37:02: [SM]   [1] Line 105, /home/builds/sourcemod/linux-1.9/build/plugins/adminhelp.sp::HelpCmd