### PR TITLE
Individualize NameHashSet Hashing & Revisit #709

### DIFF
--- a/core/ConVarManager.h
+++ b/core/ConVarManager.h
@@ -43,6 +43,7 @@
 #include <compat_wrappers.h>
 #include "concmd_cleaner.h"
 #include "PlayerManager.h"
+#include <sm_stringhashmap.h>
 
 using namespace SourceHook;
 
@@ -66,6 +67,10 @@ struct ConVarInfo
 	static inline bool matches(const char *name, const ConVarInfo *info)
 	{
 		return strcmp(name, info->pVar->GetName()) == 0;
+	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
 	}
 };
 

--- a/core/EventManager.h
+++ b/core/EventManager.h
@@ -77,6 +77,10 @@ struct EventHook
 	{
 		return strcmp(name, hook->name.chars()) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 enum EventHookMode

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -68,13 +68,21 @@ struct DataTableInfo
 		{
 			return strcmp(name, info.prop->GetName()) == 0;
 		}
+		static inline uint32_t hash(const detail::CharsAndLength &key)
+		{
+			return key.hash();
+		}
 	};
 
 	static inline bool matches(const char *name, const DataTableInfo *info)
 	{
 		return strcmp(name, info->sc->GetName()) == 0;
 	}
-
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
+	
 	DataTableInfo(ServerClass *sc)
 		: sc(sc)
 	{
@@ -89,6 +97,10 @@ struct DataMapCachePolicy
 	static inline bool matches(const char *name, const sm_datatable_info_t &info)
 	{
 		return strcmp(name, info.prop->fieldName) == 0;
+	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
 	}
 };
 

--- a/core/logic/AdminCache.h
+++ b/core/logic/AdminCache.h
@@ -82,6 +82,10 @@ struct AuthMethod
 	{
 		return strcmp(name, method->name.c_str()) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 struct UserAuth

--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -72,6 +72,10 @@ public: //NameHashSet
 	{
 		return strcmp(key, value->m_File) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 private:
 	char m_File[PLATFORM_MAX_PATH];
 	char m_CurFile[PLATFORM_MAX_PATH];

--- a/core/logic/HandleSys.h
+++ b/core/logic/HandleSys.h
@@ -110,6 +110,10 @@ struct QHandleType
 	{
 		return type->name && type->name->compare(key) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 typedef ke::Lambda<void(const char *)> HandleReporter;

--- a/core/logic/Native.h
+++ b/core/logic/Native.h
@@ -36,6 +36,7 @@
 #include <am-string.h>
 #include <am-utility.h>
 #include <am-refcounting.h>
+#include <sm_stringhashmap.h>
 #include "common_logic.h"
 
 class CNativeOwner;
@@ -92,6 +93,10 @@ struct Native : public ke::Refcounted<Native>
 	static inline bool matches(const char *name, const ke::RefPtr<Native> &entry)
 	{
 		return strcmp(name, entry->name()) == 0;
+	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
 	}
 };
 

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1855,7 +1855,12 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				const char *ext = libsys->GetFileExtension(arg) ? "" : ".smx";
 				g_pSM->BuildPath(Path_None, pluginfile, sizeof(pluginfile), "%s%s", arg, ext);
 
-				if (!m_LoadLookup.retrieve(pluginfile, &pl))
+#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
+				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(pluginfile));
+#else 
+				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(pluginfile));
+#endif
+				if (!m_LoadLookup.retrieve(finalPath.get(), &pl))
 				{
 					rootmenu->ConsolePrint("[SM] Plugin %s is not loaded.", pluginfile);
 					return;
@@ -1945,7 +1950,12 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				const char *ext = libsys->GetFileExtension(arg) ? "" : ".smx";
 				g_pSM->BuildPath(Path_None, pluginfile, sizeof(pluginfile), "%s%s", arg, ext);
 
-				if (!m_LoadLookup.retrieve(pluginfile, &pl))
+#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
+				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(pluginfile));
+#else 
+				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(pluginfile));
+#endif
+				if (!m_LoadLookup.retrieve(finalPath.get(), &pl))
 				{
 					rootmenu->ConsolePrint("[SM] Plugin %s is not loaded.", pluginfile);
 					return;
@@ -2030,7 +2040,12 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				const char *ext = libsys->GetFileExtension(arg) ? "" : ".smx";
 				g_pSM->BuildPath(Path_None, pluginfile, sizeof(pluginfile), "%s%s", arg, ext);
 
-				if (!m_LoadLookup.retrieve(pluginfile, &pl))
+#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
+				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(pluginfile));
+#else 
+				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(pluginfile));
+#endif
+				if (!m_LoadLookup.retrieve(finalPath.get(), &pl))
 				{
 					rootmenu->ConsolePrint("[SM] Plugin %s is not loaded.", pluginfile);
 					return;

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -31,7 +31,6 @@
 
 #include <stdio.h>
 #include <stdarg.h>
-#include <ctype.h>
 #include "PluginSys.h"
 #include "ShareSys.h"
 #include <ILibrarySys.h>
@@ -47,7 +46,6 @@
 #include "frame_tasks.h"
 #include <amtl/am-string.h>
 #include <amtl/am-linkedlist.h>
-#include <amtl/am-uniqueptr.h>
 #include <bridge/include/IVEngineServerBridge.h>
 #include <bridge/include/CoreProvider.h>
 
@@ -934,38 +932,16 @@ void CPluginManager::LoadPluginsFromDir(const char *basedir, const char *localpa
 	libsys->CloseDirectory(dir);
 }
 
-#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-char *strdup_tolower(const char *input)
-{
-	char *str = strdup(input);
-	
-	for (char *c = str; *c; c++)
-	{
-		*c = tolower((unsigned char)*c);
-	}
-	
-	return str;
-}
-#endif
-
 LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool debug, PluginType type)
 {
 	if (m_LoadingLocked)
 		return LoadRes_NeverLoad;
 
-/* For windows & mac, we convert the path to lower-case in order to avoid duplicate plugin loading */
-#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-	ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(path));
-#else 
-	ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(path));
-#endif
-
-
 	/**
 	 * Does this plugin already exist?
 	 */
 	CPlugin *pPlugin;
-	if (m_LoadLookup.retrieve(finalPath.get(), &pPlugin))
+	if (m_LoadLookup.retrieve(path, &pPlugin))
 	{
 		/* Check to see if we should try reloading it */
 		if (pPlugin->GetStatus() == Plugin_BadLoad
@@ -978,12 +954,11 @@ LoadRes CPluginManager::LoadPlugin(CPlugin **aResult, const char *path, bool deb
 		{
 			if (aResult)
 				*aResult = pPlugin;
-			
 			return LoadRes_AlreadyLoaded;
 		}
 	}
 
-	CPlugin *plugin = CompileAndPrep(finalPath.get());
+	CPlugin *plugin = CompileAndPrep(path);
 
 	// Assign our outparam so we can return early. It must be set.
 	*aResult = plugin;
@@ -1855,12 +1830,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				const char *ext = libsys->GetFileExtension(arg) ? "" : ".smx";
 				g_pSM->BuildPath(Path_None, pluginfile, sizeof(pluginfile), "%s%s", arg, ext);
 
-#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(pluginfile));
-#else 
-				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(pluginfile));
-#endif
-				if (!m_LoadLookup.retrieve(finalPath.get(), &pl))
+				if (!m_LoadLookup.retrieve(pluginfile, &pl))
 				{
 					rootmenu->ConsolePrint("[SM] Plugin %s is not loaded.", pluginfile);
 					return;
@@ -1950,12 +1920,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				const char *ext = libsys->GetFileExtension(arg) ? "" : ".smx";
 				g_pSM->BuildPath(Path_None, pluginfile, sizeof(pluginfile), "%s%s", arg, ext);
 
-#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(pluginfile));
-#else 
-				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(pluginfile));
-#endif
-				if (!m_LoadLookup.retrieve(finalPath.get(), &pl))
+				if (!m_LoadLookup.retrieve(pluginfile, &pl))
 				{
 					rootmenu->ConsolePrint("[SM] Plugin %s is not loaded.", pluginfile);
 					return;
@@ -2040,12 +2005,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				const char *ext = libsys->GetFileExtension(arg) ? "" : ".smx";
 				g_pSM->BuildPath(Path_None, pluginfile, sizeof(pluginfile), "%s%s", arg, ext);
 
-#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup_tolower(pluginfile));
-#else 
-				ke::UniquePtr<char> finalPath = ke::UniquePtr<char>(strdup(pluginfile));
-#endif
-				if (!m_LoadLookup.retrieve(finalPath.get(), &pl))
+				if (!m_LoadLookup.retrieve(pluginfile, &pl))
 				{
 					rootmenu->ConsolePrint("[SM] Plugin %s is not loaded.", pluginfile);
 					return;

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -503,25 +503,7 @@ private:
 		static inline bool matches(const char *file, const CPlugin *plugin)
 		{
 			const char *pluginFile = const_cast<CPlugin*>(plugin)->GetFilename();
-#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-			size_t fileLen = strlen(file);
-			if (fileLen != strlen(pluginFile))
-			{
-				return false;
-			}
-			
-			for (size_t i = 0; i < fileLen; ++i)
-			{
-				if (tolower(file[i]) != tolower(pluginFile[i]))
-				{
-					return false;
-				}
-			}
-			
-			return true;
-#else
-			return strcmp(pluginFile, file) == 0;
-#endif
+			return (detail::CharsAndLength(file).hash() == detail::CharsAndLength(pluginFile).hash());
 		}
 	};
 	NameHashSet<CPlugin *, CPluginPolicy> m_LoadLookup;

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -484,17 +484,10 @@ private:
 		{
 /* For windows & mac, we convert the path to lower-case in order to avoid duplicate plugin loading */
 #if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
-			const char *original = key.chars();
-			char *copy = strdup(original);
+			ke::AString original(key.chars());
+			ke::AString lower = original.lowercase();
 			
-			for (size_t i = 0; copy[i]; ++i)
-			{
-				copy[i] = tolower(copy[i]);
-			}
-			
-			uint32_t hash = detail::CharsAndLength(copy).hash();
-			free(copy);
-			return hash;
+			return detail::CharsAndLength(lower.chars()).hash();
 #else
 			return key.hash();
 #endif
@@ -502,8 +495,15 @@ private:
 		
 		static inline bool matches(const char *file, const CPlugin *plugin)
 		{
-			const char *pluginFile = const_cast<CPlugin*>(plugin)->GetFilename();
-			return (detail::CharsAndLength(file).hash() == detail::CharsAndLength(pluginFile).hash());
+			const char *pluginFileChars = const_cast<CPlugin*>(plugin)->GetFilename();
+#if defined PLATFORM_WINDOWS || defined PLATFORM_APPLE
+			ke::AString pluginFile = ke::AString(pluginFileChars).lowercase();
+			ke::AString input = ke::AString(file).lowercase();
+			
+			return pluginFile == input;
+#else
+			return strcmp(pluginFileChars, file) == 0;
+#endif
 		}
 	};
 	NameHashSet<CPlugin *, CPluginPolicy> m_LoadLookup;

--- a/core/logic/RootConsoleMenu.h
+++ b/core/logic/RootConsoleMenu.h
@@ -46,6 +46,10 @@ struct ConsoleEntry
 	{
 		return strcmp(name, entry->command.c_str()) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 class RootConsoleMenu : 

--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -58,6 +58,10 @@ struct maplist_info_t
 	{
 		return strcmp(value->name, key) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 #define MAPLIST_FLAG_MAPSFOLDER		(1<<0)		/**< On failure, use all maps in the maps folder. */

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -184,6 +184,10 @@ private:
 		{
 			return strcmp(name, base->GetName()) == 0;
 		}
+		static inline uint32_t hash(const detail::CharsAndLength &key)
+		{
+			return key.hash();
+		}
 	};
 	NameHashSet<ConCommandBase *, ConCommandPolicy> m_CmdFlags;
 } s_CommandFlagsHelper;

--- a/extensions/clientprefs/cookie.h
+++ b/extensions/clientprefs/cookie.h
@@ -96,6 +96,10 @@ struct Cookie
 	{
 		return strcmp(name, cookie->name) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 class CookieManager : public IClientListener, public IPluginsListener

--- a/extensions/topmenus/TopMenu.h
+++ b/extensions/topmenus/TopMenu.h
@@ -77,6 +77,10 @@ struct topmenu_object_t
 	{
 		return strcmp(name, topmenu->name) == 0;
 	}
+	static inline uint32_t hash(const detail::CharsAndLength &key)
+	{
+		return key.hash();
+	}
 };
 
 struct topmenu_category_t

--- a/public/sm_namehashset.h
+++ b/public/sm_namehashset.h
@@ -48,10 +48,12 @@
 namespace SourceMod
 {
 
-// The HashPolicy type must have this method:
+// The HashPolicy type must have these methods:
 // 		static bool matches(const char *key, const T &value);
+// 		static uint32_t hash(const CharsAndLength &key);
 //
-// Depending on what lookup types are used.
+// Depending on what lookup types are used, and how hashing should be done.
+// Most of the time, key hashing will just call the key's hash() method.
 //
 // If these members are available on T, then the HashPolicy type can be left
 // default. It is okay to use |T *|, the functions will still be looked up
@@ -69,7 +71,7 @@ class NameHashSet : public ke::SystemAllocatorPolicy
 
 		static uint32_t hash(const CharsAndLength &key)
 		{
-			return key.hash();
+			return KeyPolicyType::hash(key);
 		}
 
 		static bool matches(const CharsAndLength &key, const KeyType &value)
@@ -85,9 +87,9 @@ class NameHashSet : public ke::SystemAllocatorPolicy
 	{
 		typedef KeyType *Payload;
 
-		static uint32_t hash(const detail::CharsAndLength &key)
+		static uint32_t hash(const CharsAndLength &key)
 		{
-			return key.hash();
+			return KeyType::hash(key);
 		}
 
 		static bool matches(const CharsAndLength &key, const KeyType *value)


### PR DESCRIPTION
On #709, we forgot to convert the `NameHashSet<CPlugin *>`'s lookups to be lowercase. This will fix some casing issues people were experiencing trying to unload their (case-edited) plugins.

EDIT (12/27/17): 
Upon asherkin’s message below, I reverted the first commit of this PR & the #709 commit. The new solution to this entire problem, including the one #709 tried to solve, is to change the way `NameHashSet` hashes the key by forcing policies to also implement a `hash` method which will be used instead of the blanket implementation of `hash` that existed before.

Edit (6/17/2018):
Fixes #831