### PR TITLE
Default last_command_client_ to 0 instead of -1.

### DIFF
--- a/core/GameHooks.cpp
+++ b/core/GameHooks.cpp
@@ -51,7 +51,7 @@ SH_DECL_HOOK1_void(IServerGameClients, SetCommandClient, SH_NOATTRIB, false, int
 
 GameHooks::GameHooks()
 	: client_cvar_query_mode_(ClientCvarQueryMode::Unavailable),
-	  last_command_client_(-1)
+	  last_command_client_(0)
 {
 }
 


### PR DESCRIPTION
Over two years ago (!) we changed CommandClient() to return -1 as opposed to 0 if it was uninitialized. This is reproducible by simply going:

```
#pragma semicolon 1
public OnPluginStart()
{
	AddCommandListener(Listener);
}

public Action:Listener(client, const String:sCommand[], argc)
{
	PrintToServer("%N: %s", client, sCommand);
	return Plugin_Continue;
}
```
This may have uncovered a bug, that we never set CommandClient to 0 when commands are invoked by the server. This PR just reverts the behaviour to prior to when this landed for 1.8 as I'm only updating my (ancient) gear now.

Fix from: https://github.com/alliedmodders/sourcemod/commit/fe16e8e47cd854c482ba04f292eaa1e2d4e2e34b
Docs: https://github.com/alliedmodders/hl2sdk/blob/sdk2013/tier1/commandbuffer.cpp#L568