### PR TITLE
Address issue #737

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -948,20 +948,7 @@ void CExtensionManager::OnRootConsoleCommand(const char *cmdname, const ICommand
 			CExtension *pExt;
 			unsigned int num = 1;
 
-			List<CExtension *> required; // List of loaded and required extensions
-			List<CExtension *> optional; // List of non loaded optional extensions
-
-			for (iter = m_Libs.begin(); iter != m_Libs.end(); iter++)
-			{
-				pExt = (*iter);
-
-				if (pExt->IsLoaded() || pExt->IsRequired())
-					required.push_back(pExt);
-				else if (!pExt->IsLoaded() && !pExt->IsRequired())
-					optional.push_back(pExt);
-			}
-
-			switch (required.size())
+			switch (m_Libs.size())
 			{
 			case 1:
 				{
@@ -975,11 +962,11 @@ void CExtensionManager::OnRootConsoleCommand(const char *cmdname, const ICommand
 				}
 			default:
 				{
-					rootmenu->ConsolePrint("[SM] Displaying %d extensions:", required.size());
+					rootmenu->ConsolePrint("[SM] Displaying %d extensions:", m_Libs.size());
 					break;
 				}
 			}
-			for (iter = required.begin(); iter != required.end(); iter++,num++)
+			for (iter = m_Libs.begin(); iter != m_Libs.end(); iter++,num++)
 			{
 				pExt = (*iter);
 				if (pExt->IsLoaded())
@@ -998,32 +985,13 @@ void CExtensionManager::OnRootConsoleCommand(const char *cmdname, const ICommand
 						rootmenu->ConsolePrint("[%02d] %s (%s): %s", num, name, version, descr);
 					}
 				}
-				else
+				else if(pExt->IsRequired() || libsys->PathExists(pExt->GetPath()))
 				{
 					rootmenu->ConsolePrint("[%02d] <FAILED> file \"%s\": %s", num, pExt->GetFilename(), pExt->m_Error.c_str());
 				}
-			}
-			if (optional.size())
-			{
-				num = 1;
-				switch (optional.size())
+				else
 				{
-					case 1:
-					{
-						rootmenu->ConsolePrint("\n[SM] Displaying 1 optional extension not found:");
-						break;
-					}
-					default:
-					{
-						rootmenu->ConsolePrint("\n[SM] Displaying %d optional extensions not found:", optional.size());
-						break;
-					}
-				}
-
-				for (iter = optional.begin(); iter != optional.end(); iter++,num++)
-				{
-					pExt = (*iter);
-					rootmenu->ConsolePrint("[%02d] \"%s\"", num, pExt->GetFilename());
+					rootmenu->ConsolePrint("[%02d] <OPTIONAL> file \"%s\": %s", num, pExt->GetFilename(), pExt->m_Error.c_str());
 				}
 			}
 			return;


### PR DESCRIPTION
After discussing this with both asherkin and psychonic I think this is the best fix for now to the issue.

Example output
```
[SM] Displaying 10 extensions:
[01] CS:GO GNI Econ (1.0.2): Creates EconItemView for items.
[02] BinTools (1.8.0-manual): Low-level C/C++ Calling API
[03] <FAILED> file "game.cstrike.ext.2.csgo.dll": Could not read sm-cstrike.games: File could not be opened: The system cannot find the file specified.

[04] SDK Tools (1.8.0-manual): Source SDK Tools
[05] Top Menus (1.8.0-manual): Creates sorted nested menus
[06] Client Preferences (1.8.0-manual): Saves client preference settings
[07] SQLite (1.8.0-manual): SQLite Driver
[08] CS:S DM (2.1.6-dev): Deathmatch for CS:S
[09] <OPTIONAL> file "SteamWorks.ext.dll": The specified module could not be found.

[10] SDK Hooks (1.8.0-manual): Source SDK Hooks
```

Not sure why it has the extra new line (maybe a windows thing?) but it doesnt appear to be related to this change. The optional tag should only be displayed if the extension is missing, else it will display FAILED.