### PR TITLE
Prevent use of primitive float operation functions

### DIFF
--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -394,7 +394,7 @@ void VoteMenuClose()
 
 float GetVotePercent(int votes, int totalVotes)
 {
-	return FloatDiv(float(votes),float(totalVotes));
+	return float(votes) / float(totalVotes);
 }
 
 bool TestVoteDelay(int client)

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -313,7 +313,7 @@ void VoteMenuClose()
 
 float GetVotePercent(int votes, int totalVotes)
 {
-	return FloatDiv(float(votes),float(totalVotes));
+	return float(votes) / float(totalVotes);
 }
 
 bool TestVoteDelay(int client)

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -260,6 +260,12 @@ stock int RoundFloat(float value)
 #if !defined __sourcepawn2__
 #pragma rational Float
 
+// Internal aliases for backwards compatability.
+native float __FLOAT_MUL__(float a, float b) = FloatMul;
+native float __FLOAT_DIV__(float a, float b) = FloatDiv;
+native float __FLOAT_ADD__(float a, float b) = FloatAdd;
+native float __FLOAT_SUB__(float a, float b) = FloatSub;
+
 native bool __FLOAT_GT__(float a, float b);
 native bool __FLOAT_GE__(float a, float b);
 native bool __FLOAT_LT__(float a, float b);
@@ -268,10 +274,10 @@ native bool __FLOAT_EQ__(float a, float b);
 native bool __FLOAT_NE__(float a, float b);
 native bool __FLOAT_NOT__(float a);
 
-native float operator*(float oper1, float oper2) = FloatMul;
-native float operator/(float oper1, float oper2) = FloatDiv;
-native float operator+(float oper1, float oper2) = FloatAdd;
-native float operator-(float oper1, float oper2) = FloatSub;
+native float operator*(float oper1, float oper2) = __FLOAT_MUL__;
+native float operator/(float oper1, float oper2) = __FLOAT_DIV__;
+native float operator+(float oper1, float oper2) = __FLOAT_ADD__;
+native float operator-(float oper1, float oper2) = __FLOAT_SUB__;
 native bool operator!(float oper1) = __FLOAT_NOT__;
 native bool operator>(float oper1, float oper2) = __FLOAT_GT__;
 native bool operator>=(float oper1, float oper2) = __FLOAT_GE__;
@@ -297,32 +303,32 @@ stock float operator-(float oper)
 
 stock float operator*(float oper1, int oper2)
 {
-	return FloatMul(oper1, float(oper2));			/* "*" is commutative */
+	return __FLOAT_MUL__(oper1, float(oper2));			/* "*" is commutative */
 }
 
 stock float operator/(float oper1, int oper2)
 {
-	return FloatDiv(oper1, float(oper2));
+	return __FLOAT_DIV__(oper1, float(oper2));
 }
 
 stock float operator/(int oper1, float oper2)
 {
-	return FloatDiv(float(oper1), oper2);
+	return __FLOAT_DIV__(float(oper1), oper2);
 }
 
 stock float operator+(float oper1, int oper2)
 {
-	return FloatAdd(oper1, float(oper2));			/* "+" is commutative */
+	return __FLOAT_ADD__(oper1, float(oper2));			/* "+" is commutative */
 }
 
 stock float operator-(float oper1, int oper2)
 {
-	return FloatSub(oper1, float(oper2));
+	return __FLOAT_SUB__(oper1, float(oper2));
 }
 
 stock float operator-(int oper1, float oper2)
 {
-	return FloatSub(float(oper1), oper2);
+	return __FLOAT_SUB__(float(oper1), oper2);
 }
 
 stock bool operator==(float oper1, int oper2)

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -48,45 +48,49 @@ native float float(int value);
 /**
  * Multiplies two floats together.
  *
- * Note: This native only exists to be overloaded. For multiplication use the '*' operator.
+ * Note: This native is internal implementation. For multiplication use the '*' operator.
  *
  * @param oper1			First value.
  * @param oper2			Second value.
  * @return				oper1*oper2.
  */
+#pragma deprecated This native is internal implementation. For multiplication use the '*' operator.
 native float FloatMul(float oper1, float oper2);
 
 /**
  * Divides the dividend by the divisor.
  *
- * Note: This native only exists to be overloaded. For division use the '/' operator.
+ * Note: This native is internal implementation. For division use the '/' operator.
  *
  * @param dividend		First value.
  * @param divisor		Second value.
  * @return				dividend/divisor.
  */
+#pragma deprecated This native is internal implementation. For division use the '/' operator.
 native float FloatDiv(float dividend, float divisor);
 
 /**
  * Adds two floats together.
  *
- * Note: This native only exists to be overloaded. For addition use the '+' operator.
+ * Note: This native is internal implementation. For addition use the '+' operator.
  *
  * @param oper1			First value.
  * @param oper2			Second value.
  * @return				oper1+oper2.
  */
+#pragma deprecated This native is internal implementation. For addition use the '+' operator.
 native float FloatAdd(float oper1, float oper2);
 
 /**
  * Subtracts oper2 from oper1.
  *
- * Note: This native only exists to be overloaded. For subtraction use the '-' operator.
+ * Note: This native is internal implementation. For subtraction use the '-' operator.
  *
  * @param oper1			First value.
  * @param oper2			Second value.
  * @return				oper1-oper2.
  */
+#pragma deprecated This native is internal implementation. For subtraction use the '-' operator.
 native float FloatSub(float oper1, float oper2);
 
 /**

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -48,6 +48,8 @@ native float float(int value);
 /**
  * Multiplies two floats together.
  *
+ * Note: This native only exists to be overloaded. For multiplication use the '*' operator.
+ *
  * @param oper1			First value.
  * @param oper2			Second value.
  * @return				oper1*oper2.
@@ -56,6 +58,8 @@ native float FloatMul(float oper1, float oper2);
 
 /**
  * Divides the dividend by the divisor.
+ *
+ * Note: This native only exists to be overloaded. For division use the '/' operator.
  *
  * @param dividend		First value.
  * @param divisor		Second value.
@@ -66,6 +70,8 @@ native float FloatDiv(float dividend, float divisor);
 /**
  * Adds two floats together.
  *
+ * Note: This native only exists to be overloaded. For addition use the '+' operator.
+ *
  * @param oper1			First value.
  * @param oper2			Second value.
  * @return				oper1+oper2.
@@ -74,6 +80,8 @@ native float FloatAdd(float oper1, float oper2);
 
 /**
  * Subtracts oper2 from oper1.
+ *
+ * Note: This native only exists to be overloaded. For subtraction use the '-' operator.
  *
  * @param oper1			First value.
  * @param oper2			Second value.

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -301,6 +301,8 @@ stock float operator-(float oper)
 	return oper^view_as<float>(cellmin);				/* IEEE values are sign/magnitude */
 }
 
+// The stocks below are int->float converting versions of the above natives.
+
 stock float operator*(float oper1, int oper2)
 {
 	return __FLOAT_MUL__(oper1, float(oper2));			/* "*" is commutative */

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -274,10 +274,10 @@ native bool __FLOAT_EQ__(float a, float b);
 native bool __FLOAT_NE__(float a, float b);
 native bool __FLOAT_NOT__(float a);
 
-native float operator*(float oper1, float oper2) = __FLOAT_MUL__;
-native float operator/(float oper1, float oper2) = __FLOAT_DIV__;
-native float operator+(float oper1, float oper2) = __FLOAT_ADD__;
-native float operator-(float oper1, float oper2) = __FLOAT_SUB__;
+native float operator*(float oper1, float oper2) = FloatMul;
+native float operator/(float oper1, float oper2) = FloatDiv;
+native float operator+(float oper1, float oper2) = FloatAdd;
+native float operator-(float oper1, float oper2) = FloatSub;
 native bool operator!(float oper1) = __FLOAT_NOT__;
 native bool operator>(float oper1, float oper2) = __FLOAT_GT__;
 native bool operator>=(float oper1, float oper2) = __FLOAT_GE__;


### PR DESCRIPTION
Apparently people use the float natives for actual float arithmetic; they're not _really_ intended to be used directly. I've added a note to deter people from using these instead of their respective operators.