### PR TITLE
Allow different values per platform in "Keys" gamedata section

### DIFF
--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -86,6 +86,7 @@ private:
 	char m_Prop[64];
 	char m_offset[64];
 	char m_Game[256];
+	char m_Key[64];
 	bool bShouldBeReadingDefault;
 	bool had_game;
 	bool matched_game;


### PR DESCRIPTION
This adds support for platform specific custom key values in the `Keys` section in game config files. Now you can have different values for the same key per platform.

Previously you could only add general key values in gamedata files that were the same on all platforms like
```
"Keys"
{
	"key"	"value"
}
```

This patch allows you to set the value per platform in a subsection like
```
"Keys"
{
	"key"
	{
		"windows"	"value1"
		"linux"	"value2"
		"mac"	"value3"
	}
}
```

Looking up the `key` will return the value matching the host platform.