### PR TITLE
Add GameData methodmap

### DIFF
--- a/core/logic/smn_gameconfigs.cpp
+++ b/core/logic/smn_gameconfigs.cpp
@@ -67,7 +67,10 @@ static cell_t smn_LoadGameConfigFile(IPluginContext *pCtx, const cell_t *params)
 		return pCtx->ThrowNativeError("Unable to open %s: %s", filename, error);
 	}
 
-	return handlesys->CreateHandle(g_GameConfigsType, gc, pCtx->GetIdentity(), g_pCoreIdent, NULL);
+	Handle_t hndl = handlesys->CreateHandle(g_GameConfigsType, gc, pCtx->GetIdentity(), g_pCoreIdent, NULL);
+	if (hndl == BAD_HANDLE)
+		g_GameConfigs.CloseGameConfigFile(gc);
+	return hndl;
 }
 
 static cell_t smn_GameConfGetOffset(IPluginContext *pCtx, const cell_t *params)
@@ -167,5 +170,11 @@ REGISTER_NATIVES(gameconfignatives)
 	{"GameConfGetOffset",			smn_GameConfGetOffset},
 	{"GameConfGetKeyValue",			smn_GameConfGetKeyValue},
 	{"GameConfGetAddress",			smn_GameConfGetAddress},
+
+	// Transitional syntax support.
+	{"GameData.GameData",			smn_LoadGameConfigFile},
+	{"GameData.GetOffset",			smn_GameConfGetOffset},
+	{"GameData.GetKeyValue",		smn_GameConfGetKeyValue},
+	{"GameData.GetAddress",			smn_GameConfGetAddress},
 	{NULL,							NULL}
 };

--- a/plugins/funcommands.sp
+++ b/plugins/funcommands.sp
@@ -181,60 +181,60 @@ void HookEvents()
 
 public void OnMapStart()
 {
-	Handle gameConfig = LoadGameConfigFile("funcommands.games");
+	GameData gameConfig = new GameData("funcommands.games");
 	if (gameConfig == null)
 	{
 		SetFailState("Unable to load game config funcommands.games");
 		return;
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SoundBlip", g_BlipSound, sizeof(g_BlipSound)) && g_BlipSound[0])
+	if (gameConfig.GetKeyValue("SoundBlip", g_BlipSound, sizeof(g_BlipSound)) && g_BlipSound[0])
 	{
 		PrecacheSound(g_BlipSound, true);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SoundBeep", g_BeepSound, sizeof(g_BeepSound)) && g_BeepSound[0])
+	if (gameConfig.GetKeyValue("SoundBeep", g_BeepSound, sizeof(g_BeepSound)) && g_BeepSound[0])
 	{
 		PrecacheSound(g_BeepSound, true);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SoundFinal", g_FinalSound, sizeof(g_FinalSound)) && g_FinalSound[0])
+	if (gameConfig.GetKeyValue("SoundFinal", g_FinalSound, sizeof(g_FinalSound)) && g_FinalSound[0])
 	{
 		PrecacheSound(g_FinalSound, true);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SoundBoom", g_BoomSound, sizeof(g_BoomSound)) && g_BoomSound[0])
+	if (gameConfig.GetKeyValue("SoundBoom", g_BoomSound, sizeof(g_BoomSound)) && g_BoomSound[0])
 	{
 		PrecacheSound(g_BoomSound, true);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SoundFreeze", g_FreezeSound, sizeof(g_FreezeSound)) && g_FreezeSound[0])
+	if (gameConfig.GetKeyValue("SoundFreeze", g_FreezeSound, sizeof(g_FreezeSound)) && g_FreezeSound[0])
 	{
 		PrecacheSound(g_FreezeSound, true);
 	}
 	
 	char buffer[PLATFORM_MAX_PATH];
-	if (GameConfGetKeyValue(gameConfig, "SpriteBeam", buffer, sizeof(buffer)) && buffer[0])
+	if (gameConfig.GetKeyValue("SpriteBeam", buffer, sizeof(buffer)) && buffer[0])
 	{
 		g_BeamSprite = PrecacheModel(buffer);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SpriteBeam2", buffer, sizeof(buffer)) && buffer[0])
+	if (gameConfig.GetKeyValue("SpriteBeam2", buffer, sizeof(buffer)) && buffer[0])
 	{
 		g_BeamSprite2 = PrecacheModel(buffer);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SpriteExplosion", buffer, sizeof(buffer)) && buffer[0])
+	if (gameConfig.GetKeyValue("SpriteExplosion", buffer, sizeof(buffer)) && buffer[0])
 	{
 		g_ExplosionSprite = PrecacheModel(buffer);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SpriteGlow", buffer, sizeof(buffer)) && buffer[0])
+	if (gameConfig.GetKeyValue("SpriteGlow", buffer, sizeof(buffer)) && buffer[0])
 	{
 		g_GlowSprite = PrecacheModel(buffer);
 	}
 	
-	if (GameConfGetKeyValue(gameConfig, "SpriteHalo", buffer, sizeof(buffer)) && buffer[0])
+	if (gameConfig.GetKeyValue("SpriteHalo", buffer, sizeof(buffer)) && buffer[0])
 	{
 		g_HaloSprite = PrecacheModel(buffer);
 	}

--- a/plugins/include/entity_prop_stocks.inc
+++ b/plugins/include/entity_prop_stocks.inc
@@ -206,9 +206,9 @@ stock MoveType GetEntityMoveType(int entity)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_MoveType", datamap, sizeof(datamap));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_MoveType", datamap, sizeof(datamap));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -235,9 +235,9 @@ stock void SetEntityMoveType(int entity, MoveType mt)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_MoveType", datamap, sizeof(datamap));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_MoveType", datamap, sizeof(datamap));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -264,9 +264,9 @@ stock RenderMode GetEntityRenderMode(int entity)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_nRenderMode", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_nRenderMode", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -293,9 +293,9 @@ stock void SetEntityRenderMode(int entity, RenderMode mode)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_nRenderMode", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_nRenderMode", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -322,9 +322,9 @@ stock RenderFx GetEntityRenderFx(int entity)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_nRenderFX", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_nRenderFX", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -351,9 +351,9 @@ stock void SetEntityRenderFx(int entity, RenderFx fx)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_nRenderFX", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_nRenderFX", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -383,9 +383,9 @@ stock void GetEntityRenderColor(int entity, int &r, int &g, int &b, int &a)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_clrRender", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_clrRender", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -425,9 +425,9 @@ stock void SetEntityRenderColor(int entity, int r=255, int g=255, int b=255, int
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_clrRender", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_clrRender", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -464,9 +464,9 @@ stock float GetEntityGravity(int entity)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_flGravity", datamap, sizeof(datamap));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_flGravity", datamap, sizeof(datamap));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -493,9 +493,9 @@ stock void SetEntityGravity(int entity, float amount)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_flGravity", datamap, sizeof(datamap));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_flGravity", datamap, sizeof(datamap));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -522,9 +522,9 @@ stock void SetEntityHealth(int entity, int amount)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_iHealth", prop, sizeof(prop));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_iHealth", prop, sizeof(prop));
+		delete gc;
 		
 		if (!exists)
 		{
@@ -578,9 +578,9 @@ stock int GetClientButtons(int client)
 	
 	if (!gotconfig)
 	{
-		Handle gc = LoadGameConfigFile("core.games");
-		bool exists = GameConfGetKeyValue(gc, "m_nButtons", datamap, sizeof(datamap));
-		CloseHandle(gc);
+		GameData gc = new GameData("core.games");
+		bool exists = gc.GetKeyValue("m_nButtons", datamap, sizeof(datamap));
+		delete gc;
 		
 		if (!exists)
 		{

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -84,6 +84,37 @@ enum APLRes
 	APLRes_SilentFailure	/**< Plugin shouldn't load but do so silently */
 };
 
+methodmap GameData < Handle
+{
+	// Loads a game config file.
+	//
+	// @param file		File to load.  The path must be relative to the 'gamedata' folder under the config folder 
+	//					and the extension should be omitted.
+	// @return			A handle to the game config file or null on failure.
+	public native GameData(const char[] file);
+
+	// Returns an offset value.
+	//
+	// @param key		Key to retrieve from the offset section.
+	// @return			An offset, or -1 on failure.
+	public native int GetOffset(const char[] key);
+
+	// Gets the value of a key from the "Keys" section.
+	//
+	// @param key		Key to retrieve from the Keys section.
+	// @param buffer	Destination string buffer.
+	// @param maxlen	Maximum length of output string buffer.
+	// @return			True if key existed, false otherwise.
+	public native bool GetKeyValue(const char[] key, char[] buffer, int maxlen);
+
+	// Finds an address calculation in a GameConfig file,
+	// performs LoadFromAddress on it as appropriate, then returns the final address.
+	//
+	// @param name		Name of the property to find.
+	// @return			An address calculated on success, or 0 on failure.
+	public native Address GetAddress(const char[] name);
+};
+
 /**
  * Called when the plugin is fully initialized and all known external references 
  * are resolved. This is only called once in the lifetime of the plugin, and is 
@@ -339,9 +370,9 @@ native void FormatTime(char[] buffer, int maxlength, const char[] format, int st
  *
  * @param file			File to load.  The path must be relative to the 'gamedata' folder under the config folder 
  *					and the extension should be omitted.
- * @return			A handle to the game config file or INVALID_HANDLE in failure.
+ * @return			A handle to the game config file or INVALID_HANDLE on failure.
  */
-native Handle LoadGameConfigFile(const char[] file);
+native GameData LoadGameConfigFile(const char[] file);
 
 /**
  * Returns an offset value.
@@ -367,7 +398,7 @@ native bool GameConfGetKeyValue(Handle gc, const char[] key, char[] buffer, int 
  * Finds an address calculation in a GameConfig file,
  * performs LoadFromAddress on it as appropriate, then returns the final address.
  *
- * @param gameconf      GameConfig Handle, or INVALID_HANDLE to use sdktools.games.txt.
+ * @param gameconf      Game config handle.
  * @param name          Name of the property to find.
  * @return              An address calculated on success, or 0 on failure.
  */


### PR DESCRIPTION
Wrap gamedata natives in a pretty methodmap and update stock plugins/includes to use it.

This fixes bad documentation on `GameConfGetAddress` and not closing the gameconfig file if handle creation fails as well.