### PR TITLE
Replace ke::SafeSprintf with ke::SafeStrcpy

### DIFF
--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -317,7 +317,7 @@ bool ConCmdManager::CheckAccess(int client, const char *cmd, AdminCmdInfo *pAdmi
 	char buffer[128];
 	if (!logicore.CoreTranslate(buffer, sizeof(buffer), "%T", 2, NULL, "No Access", &client))
 	{
-		ke::SafeSprintf(buffer, sizeof(buffer), "You do not have access to this command");
+		ke::SafeStrcpy(buffer, sizeof(buffer), "You do not have access to this command");
 	}
 
 	unsigned int replyto = g_ChatTriggers.GetReplyTo();

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -181,7 +181,7 @@ ConfigResult CHalfLife2::OnSourceModConfigChanged(const char *key, const char *v
 		}
 		else
 		{
-			ke::SafeSprintf(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
+			ke::SafeStrcpy(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
 			return ConfigResult_Reject;
 		}
 #endif
@@ -851,7 +851,7 @@ void CHalfLife2::AddDelayedKick(int client, int userid, const char *msg)
 
 	kick.client = client;
 	kick.userid = userid;
-	ke::SafeSprintf(kick.buffer, sizeof(kick.buffer), "%s", msg);
+	ke::SafeStrcpy(kick.buffer, sizeof(kick.buffer), msg);
 
 	m_DelayedKicks.push(kick);
 }

--- a/core/MenuStyle_Radio.cpp
+++ b/core/MenuStyle_Radio.cpp
@@ -458,9 +458,8 @@ void CRadioMenuPlayer::Radio_Init(int keys, const char *title, const char *text)
 	}
 	else
 	{
-		display_len = ke::SafeSprintf(display_pkt, 
+		display_len = ke::SafeStrcpy(display_pkt, 
 			sizeof(display_pkt), 
-			"%s", 
 			text);
 	}
 	display_keys = keys;

--- a/core/NextMap.cpp
+++ b/core/NextMap.cpp
@@ -138,8 +138,8 @@ void NextMapManager::HookChangeLevel(const char *map, const char *unknown, const
 
 	logger->LogMessage("[SM] Changed map to \"%s\"", newmap);
 
-	ke::SafeSprintf(m_tempChangeInfo.m_mapName, sizeof(m_tempChangeInfo.m_mapName), newmap);
-	ke::SafeSprintf(m_tempChangeInfo.m_changeReason, sizeof(m_tempChangeInfo.m_changeReason), "Normal level change");
+	ke::SafeStrcpy(m_tempChangeInfo.m_mapName, sizeof(m_tempChangeInfo.m_mapName), newmap);
+	ke::SafeStrcpy(m_tempChangeInfo.m_changeReason, sizeof(m_tempChangeInfo.m_changeReason), "Normal level change");
 
 #if SOURCE_ENGINE != SE_DARKMESSIAH
 	RETURN_META_NEWPARAMS(MRES_IGNORED, &IVEngineServer::ChangeLevel, (newmap, unknown));
@@ -184,14 +184,14 @@ void NextMapManager::OnSourceModLevelChange( const char *mapName )
 	m_tempChangeInfo.m_mapName[0] ='\0';
 	m_tempChangeInfo.m_changeReason[0] = '\0';
 	m_tempChangeInfo.startTime = time(NULL);
-	ke::SafeSprintf(lastMap, sizeof(lastMap), "%s", mapName);
+	ke::SafeStrcpy(lastMap, sizeof(lastMap), mapName);
 }
 
 void NextMapManager::ForceChangeLevel( const char *mapName, const char* changeReason )
 {
 	/* Store the mapname and reason */
-	ke::SafeSprintf(m_tempChangeInfo.m_mapName, sizeof(m_tempChangeInfo.m_mapName), "%s", mapName);
-	ke::SafeSprintf(m_tempChangeInfo.m_changeReason, sizeof(m_tempChangeInfo.m_changeReason), "%s", changeReason);
+	ke::SafeStrcpy(m_tempChangeInfo.m_mapName, sizeof(m_tempChangeInfo.m_mapName), mapName);
+	ke::SafeStrcpy(m_tempChangeInfo.m_changeReason, sizeof(m_tempChangeInfo.m_changeReason), changeReason);
 
 	/* Change level and skip our hook */
 	g_forcedChange = true;
@@ -221,7 +221,7 @@ void CmdChangeLevelCallback()
 
 	if (g_NextMap.m_tempChangeInfo.m_mapName[0] == '\0')
 	{
-		ke::SafeSprintf(g_NextMap.m_tempChangeInfo.m_mapName, sizeof(g_NextMap.m_tempChangeInfo.m_mapName), command.Arg(1));
-		ke::SafeSprintf(g_NextMap.m_tempChangeInfo.m_changeReason, sizeof(g_NextMap.m_tempChangeInfo.m_changeReason), "changelevel Command");
+		ke::SafeStrcpy(g_NextMap.m_tempChangeInfo.m_mapName, sizeof(g_NextMap.m_tempChangeInfo.m_mapName), command.Arg(1));
+		ke::SafeStrcpy(g_NextMap.m_tempChangeInfo.m_changeReason, sizeof(g_NextMap.m_tempChangeInfo.m_changeReason), "changelevel Command");
 	}
 }

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -272,7 +272,7 @@ ConfigResult PlayerManager::OnSourceModConfigChanged(const char *key,
 		} else if (strcasecmp(value, "off") == 0) {
 			m_QueryLang = false;
 		} else {
-			ke::SafeSprintf(error, maxlength, "Invalid value: must be \"on\" or \"off\"");
+			ke::SafeStrcpy(error, maxlength, "Invalid value: must be \"on\" or \"off\"");
 			return ConfigResult_Reject;
 		}
 		return ConfigResult_Accept;
@@ -283,7 +283,7 @@ ConfigResult PlayerManager::OnSourceModConfigChanged(const char *key,
 		} else if ( strcasecmp(value, "no") == 0) {
 			m_bAuthstringValidation = false;
 		} else {
-			ke::SafeSprintf(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
+			ke::SafeStrcpy(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
 			return ConfigResult_Reject;
 		}
 		return ConfigResult_Accept;

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -575,7 +575,7 @@ void CExtensionManager::TryAutoload()
 		}
 
 		char file[PLATFORM_MAX_PATH];
-		len = ke::SafeSprintf(file, sizeof(file), "%s", lfile);
+		len = ke::SafeStrcpy(file, sizeof(file), lfile);
 		strcpy(&file[len - 9], ".ext");
 
 		LoadAutoExtension(file);
@@ -591,7 +591,7 @@ IExtension *CExtensionManager::LoadAutoExtension(const char *path, bool bErrorOn
 	if (strcmp(ext, PLATFORM_LIB_EXT) == 0)
 	{
 		char path2[PLATFORM_MAX_PATH];
-		ke::SafeSprintf(path2, sizeof(path2), "%s", path);
+		ke::SafeStrcpy(path2, sizeof(path2), path);
 		path2[strlen(path) - strlen(PLATFORM_LIB_EXT) - 1] = '\0';
 		return LoadAutoExtension(path2, bErrorOnMissing);
 	}
@@ -683,7 +683,7 @@ IExtension *CExtensionManager::LoadExtension(const char *file, char *error, size
 	if (strcmp(ext, PLATFORM_LIB_EXT) == 0)
 	{
 		char path2[PLATFORM_MAX_PATH];
-		ke::SafeSprintf(path2, sizeof(path2), "%s", file);
+		ke::SafeStrcpy(path2, sizeof(path2), file);
 		path2[strlen(file) - strlen(PLATFORM_LIB_EXT) - 1] = '\0';
 		return LoadExtension(path2, error, maxlength);
 	}

--- a/core/logic/LibrarySys.cpp
+++ b/core/logic/LibrarySys.cpp
@@ -230,7 +230,7 @@ void LibrarySystem::GetPlatformErrorEx(int code, char *error, size_t maxlength)
 		const char *ae = strerror_r(code, error, maxlength);
 		if (ae != error)
 		{
-			ke::SafeSprintf(error, maxlength, "%s", ae);
+			ke::SafeStrcpy(error, maxlength, ae);
 		}
 #elif defined PLATFORM_POSIX
 		strerror_r(code, error, maxlength);
@@ -309,12 +309,12 @@ size_t LibrarySystem::GetFileFromPath(char *buffer, size_t maxlength, const char
 #endif
 			)
 		{
-			return ke::SafeSprintf(buffer, maxlength, "%s", &path[i+1]);
+			return ke::SafeStrcpy(buffer, maxlength, &path[i+1]);
 		}
 	}
 
 	/* We scanned and found no path separator */
-	return ke::SafeSprintf(buffer, maxlength, "%s", path);
+	return ke::SafeStrcpy(buffer, maxlength, path);
 }
 
 bool LibrarySystem::FileTime(const char *path, FileTimeType type, time_t *pTime)

--- a/core/logic/Logger.cpp
+++ b/core/logic/Logger.cpp
@@ -56,7 +56,7 @@ ConfigResult Logger::OnSourceModConfigChanged(const char *key,
 		} else if (strcasecmp(value, "off") == 0) {
 			state = false;
 		} else {
-			ke::SafeSprintf(error, maxlength, "Invalid value: must be \"on\" or \"off\"");
+			ke::SafeStrcpy(error, maxlength, "Invalid value: must be \"on\" or \"off\"");
 			return ConfigResult_Reject;
 		}
 
@@ -77,7 +77,7 @@ ConfigResult Logger::OnSourceModConfigChanged(const char *key,
 		} else if (strcasecmp(value, "game") == 0) {
 			m_Mode = LoggingMode_Game;
 		} else {
-			ke::SafeSprintf(error, maxlength, "Invalid value: must be [daily|map|game]");
+			ke::SafeStrcpy(error, maxlength, "Invalid value: must be [daily|map|game]");
 			return ConfigResult_Reject;
 		}
 

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -77,7 +77,7 @@ CPlugin::CPlugin(const char *file)
 	m_serial = ++MySerial;
 	m_errormsg[0] = '\0';
 	m_DateTime[0] = '\0';
-	ke::SafeSprintf(m_filename, sizeof(m_filename), "%s", file);
+	ke::SafeStrcpy(m_filename, sizeof(m_filename), file);
 
 	memset(&m_info, 0, sizeof(m_info));
 
@@ -907,7 +907,7 @@ void CPluginManager::LoadPluginsFromDir(const char *basedir, const char *localpa
 			if (localpath == NULL)
 			{
 				/* If no path yet, don't add a former slash */
-				ke::SafeSprintf(new_local, sizeof(new_local), "%s", dir->GetEntryName());
+				ke::SafeStrcpy(new_local, sizeof(new_local), dir->GetEntryName());
 			} else {
 				libsys->PathFormat(new_local, sizeof(new_local), "%s/%s", localpath, dir->GetEntryName());
 			}
@@ -922,7 +922,7 @@ void CPluginManager::LoadPluginsFromDir(const char *basedir, const char *localpa
 				char plugin[PLATFORM_MAX_PATH];
 				if (localpath == NULL)
 				{
-					ke::SafeSprintf(plugin, sizeof(plugin), "%s", name);
+					ke::SafeStrcpy(plugin, sizeof(plugin), name);
 				} else {
 					libsys->PathFormat(plugin, sizeof(plugin), "%s/%s", localpath, name);
 				}
@@ -1019,9 +1019,9 @@ IPlugin *CPluginManager::LoadPlugin(const char *path, bool debug, PluginType typ
 
 	if (res == LoadRes_NeverLoad) {
 		if (m_LoadingLocked)
-			ke::SafeSprintf(error, maxlength, "There is a global plugin loading lock in effect");
+			ke::SafeStrcpy(error, maxlength, "There is a global plugin loading lock in effect");
 		else
-			ke::SafeSprintf(error, maxlength, "This plugin is blocked from loading (see plugin_settings.cfg)");
+			ke::SafeStrcpy(error, maxlength, "This plugin is blocked from loading (see plugin_settings.cfg)");
 		return NULL;
 	}
 
@@ -1302,7 +1302,7 @@ bool CPluginManager::MalwareCheckPass(CPlugin *pPlugin)
 	unsigned char *pCodeHash = pPlugin->GetRuntime()->GetCodeHash();
 
 	char codeHashBuf[40];
-	ke::SafeSprintf(codeHashBuf, 40, "plugin_");
+	ke::SafeStrcpy(codeHashBuf, sizeof(codeHashBuf), "plugin_");
 	for (int i = 0; i < 16; i++)
 		ke::SafeSprintf(codeHashBuf + 7 + (i * 2), 3, "%02x", pCodeHash[i]);
 
@@ -1632,7 +1632,7 @@ ConfigResult CPluginManager::OnSourceModConfigChanged(const char *key,
 		} else if (strcasecmp(value, "no") == 0) {
 			m_bBlockBadPlugins = false;
 		} else {
-			ke::SafeSprintf(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
+			ke::SafeStrcpy(error, maxlength, "Invalid value: must be \"yes\" or \"no\"");
 			return ConfigResult_Reject;
 		}
 		return ConfigResult_Accept;
@@ -1758,7 +1758,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 				if (pl->GetStatus() < Plugin_Created || pl->GetStatus() == Plugin_Evicted)
 				{
 					if (pl->IsSilentlyFailed())
-						len += ke::SafeSprintf(&buffer[len], sizeof(buffer)-len, " Disabled:");
+						len += ke::SafeStrcpy(&buffer[len], sizeof(buffer)-len, " Disabled:");
 					len += ke::SafeSprintf(&buffer[len], sizeof(buffer)-len, " \"%s\"", (IS_STR_FILLED(info->name)) ? info->name : pl->GetFilename());
 					if (IS_STR_FILLED(info->version))
 					{
@@ -1867,11 +1867,11 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 			if (pl->GetStatus() < Plugin_Created)
 			{
 				const sm_plugininfo_t *info = pl->GetPublicInfo();
-				ke::SafeSprintf(name, sizeof(name), (IS_STR_FILLED(info->name)) ? info->name : pl->GetFilename());
+				ke::SafeStrcpy(name, sizeof(name), (IS_STR_FILLED(info->name)) ? info->name : pl->GetFilename());
 			}
 			else
 			{
-				ke::SafeSprintf(name, sizeof(name), "%s", pl->GetFilename());
+				ke::SafeStrcpy(name, sizeof(name), pl->GetFilename());
 			}
 
 			if (UnloadPlugin(pl))

--- a/core/logic/RootConsoleMenu.cpp
+++ b/core/logic/RootConsoleMenu.cpp
@@ -256,7 +256,7 @@ static bool sm_dump_handles(int client, const ICommandArgs *args)
 		auto write_handles_to_game = [] (const char *str) -> void
 		{
 			char buffer[1024];
-			size_t len = ke::SafeSprintf(buffer, sizeof(buffer)-2, "%s", str);
+			size_t len = ke::SafeStrcpy(buffer, sizeof(buffer)-2, str);
 
 			buffer[len] = '\n';
 			buffer[len+1] = '\0';

--- a/core/logic/TextParsers.cpp
+++ b/core/logic/TextParsers.cpp
@@ -144,7 +144,7 @@ SMCError TextParsers::ParseSMCFile(const char *file,
 	fclose(fp);
 
 	errstr = GetSMCErrorString(result);
-	ke::SafeSprintf(buffer, maxsize, "%s", errstr != NULL ? errstr : "Unknown error");
+	ke::SafeStrcpy(buffer, maxsize, errstr != NULL ? errstr : "Unknown error");
 
 	return result;
 }
@@ -195,7 +195,7 @@ SMCError TextParsers::ParseSMCStream(const char *stream,
 	result = ParseStream_SMC(&rs, RawStreamReader, smc_listener, states);
 
 	const char *errstr = GetSMCErrorString(result);
-	ke::SafeSprintf(buffer, maxsize, "%s", errstr != NULL ? errstr : "Unknown error");
+	ke::SafeStrcpy(buffer, maxsize, errstr != NULL ? errstr : "Unknown error");
 
 	return result;
 }

--- a/core/logic/Translator.cpp
+++ b/core/logic/Translator.cpp
@@ -940,7 +940,7 @@ bool Translator::AddLanguage(const char *langcode, const char *description)
 		Language *pLanguage = new Language;
 		idx = m_Languages.size();
 
-		ke::SafeSprintf(pLanguage->m_code2, sizeof(pLanguage->m_code2), "%s", langcode);
+		ke::SafeStrcpy(pLanguage->m_code2, sizeof(pLanguage->m_code2), langcode);
 		pLanguage->m_CanonicalName = m_pStringTab->AddString(lower);
 
 		m_LCodeLookup.insert(langcode, idx);

--- a/core/logic/smn_lang.cpp
+++ b/core/logic/smn_lang.cpp
@@ -68,7 +68,7 @@ static cell_t sm_LoadTranslations(IPluginContext *pCtx, const cell_t *params)
 	IPlugin *pl = pluginsys->FindPluginByContext(pCtx->GetContext());
 
 	pCtx->LocalToString(params[1], &filename);
-	ke::SafeSprintf(buffer, sizeof(buffer), "%s", filename);
+	ke::SafeStrcpy(buffer, sizeof(buffer), filename);
 
 	/* Make sure there is no extension */
 	if ((ext = strstr(buffer, ".txt")) != NULL

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -1171,18 +1171,12 @@ reswitch:
 					int userid;
 					if (!bridge->DescribePlayer(*value, &name, &auth, &userid))
 						return pCtx->ThrowNativeError("Client index %d is invalid (arg %d)", *value, arg);
-					ke::SafeSprintf(buffer, 
-						sizeof(buffer), 
-						"%s<%d><%s><>", 
-						name,
-						userid,
-						auth);
+					
+					ke::SafeSprintf(buffer, sizeof(buffer), "%s<%d><%s><>", name, userid, auth);
 				}
 				else
 				{
-					ke::SafeSprintf(buffer,
-						sizeof(buffer),
-						"Console<0><Console><Console>");
+					ke::SafeStrcpy(buffer, sizeof(buffer), "Console<0><Console><Console>");
 				}
 				if (!AddString(&buf_p, llen, buffer, width, prec, flags))
 					return pCtx->ThrowNativeError("Escaped string would be truncated (arg %d)", arg);

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -704,7 +704,7 @@ bool CoreProviderImpl::LoadBridge(char *error, size_t maxlength)
 	LogicLoadFunction llf = logic_->get<decltype(llf)>("logic_load");
 	if (!llf) {
 		logic_ = nullptr;
-		ke::SafeSprintf(error, maxlength, "could not find logic_load function");
+		ke::SafeStrcpy(error, maxlength, "could not find logic_load function");
 		return false;
 	}
 
@@ -713,7 +713,7 @@ bool CoreProviderImpl::LoadBridge(char *error, size_t maxlength)
 
 	logic_init_ = llf(SM_LOGIC_MAGIC);
 	if (!logic_init_) {
-		ke::SafeSprintf(error, maxlength, "component version mismatch");
+		ke::SafeStrcpy(error, maxlength, "component version mismatch");
 		return false;
 	}
 	return true;

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -107,7 +107,7 @@ ConfigResult SourceModBase::OnSourceModConfigChanged(const char *key,
 	{
 		if (source == ConfigSource_Console)
 		{
-			ke::SafeSprintf(error, maxlength, "Cannot be set at runtime");
+			ke::SafeStrcpy(error, maxlength, "Cannot be set at runtime");
 			return ConfigResult_Reject;
 		}
 
@@ -207,7 +207,7 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 
 	if (!factoryFn) {
 		if (error && maxlength)
-			snprintf(error, maxlength, "SourcePawn library is out of date");
+			ke::SafeStrcpy(error, maxlength, "SourcePawn library is out of date");
 		ShutdownJIT();
 		return false;
 	}
@@ -215,7 +215,7 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 	ISourcePawnFactory *factory = factoryFn(SOURCEPAWN_API_VERSION);
 	if (!factory) {
 		if (error && maxlength)
-			snprintf(error, maxlength, "SourcePawn library is out of date");
+			ke::SafeStrcpy(error, maxlength, "SourcePawn library is out of date");
 		ShutdownJIT();
 		return false;
 	}
@@ -223,7 +223,7 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 	g_pPawnEnv = factory->NewEnvironment();
 	if (!g_pPawnEnv) {
 		if (error && maxlength)
-			snprintf(error, maxlength, "Could not create a SourcePawn environment!");
+			ke::SafeStrcpy(error, maxlength, "Could not create a SourcePawn environment!");
 		ShutdownJIT();
 		return false;
 	}


### PR DESCRIPTION
I've been going through looking for changes that I can sweep across the project to keep things consistent. This replaces every instance of `ke::SafeSprintf` which is only used for copying with `ke::SafeStrcpy`.
