### PR TITLE
Update Function Offsets For PVKII

### DIFF
--- a/gamedata/sdkhooks.games/game.pvkii.txt
+++ b/gamedata/sdkhooks.games/game.pvkii.txt
@@ -32,8 +32,8 @@
 			"GroundEntChanged"
 			{
 				"windows"	"180"
-				"linux"		"181"
-				"mac"		"181"
+				"linux"		"182"
+				"mac"		"182"
 			}
 			"OnTakeDamage"
 			{
@@ -58,6 +58,12 @@
 				"windows"	"339"
 				"linux"		"340"
 				"mac"		"340"
+			}
+			"Reload"
+			{
+				"windows"	"275"
+				"linux"		"276"
+				"mac"		"276"
 			}
 			"SetTransmit"
 			{

--- a/gamedata/sdkhooks.games/game.pvkii.txt
+++ b/gamedata/sdkhooks.games/game.pvkii.txt
@@ -7,147 +7,141 @@
 		{
 			"Blocked"
 			{
+				"windows"	"105"
+				"linux"		"106"
+				"mac"		"106"
+			}
+			"EndTouch"
+			{
 				"windows"	"103"
 				"linux"		"104"
 				"mac"		"104"
 			}
-			"EndTouch"
-			{
-				"windows"	"101"
-				"linux"		"102"
-				"mac"		"102"
-			}
 			"FireBullets"
 			{
-				"windows"	"113"
-				"linux"		"114"
-				"mac"		"114"
+				"windows"	"115"
+				"linux"		"116"
+				"mac"		"116"
 			}
 			"GetMaxHealth"
 			{
-				"windows"	"118"
-				"linux"		"119"
-				"mac"		"119"
+				"windows"	"120"
+				"linux"		"121"
+				"mac"		"121"
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"178"
-				"linux"		"180"
-				"mac"		"180"
+				"windows"	"180"
+				"linux"		"181"
+				"mac"		"181"
 			}
 			"OnTakeDamage"
 			{
-				"windows"	"63"
-				"linux"		"64"
-				"mac"		"64"
+				"windows"	"65"
+				"linux"		"66"
+				"mac"		"66"
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"275"
-				"linux"		"276"
-				"mac"		"276"
+				"windows"	"277"
+				"linux"		"278"
+				"mac"		"278"
 			}
 			"PreThink"
 			{
-				"windows"	"336"
-				"linux"		"337"
-				"mac"		"337"
+				"windows"	"338"
+				"linux"		"339"
+				"mac"		"339"
 			}
 			"PostThink"
 			{
-				"windows"	"337"
-				"linux"		"338"
-				"mac"		"338"
-			}
-			"Reload"
-			{
-				"windows"	"273"
-				"linux"		"274"
-				"mac"		"274"
+				"windows"	"339"
+				"linux"		"340"
+				"mac"		"340"
 			}
 			"SetTransmit"
-			{
-				"windows"	"21"
-				"linux"		"22"
-				"mac"		"22"
-			}
-			"ShouldCollide"
-			{
-				"windows"	"16"
-				"linux"		"17"
-				"mac"		"17"
-			}
-			"Spawn"
 			{
 				"windows"	"23"
 				"linux"		"24"
 				"mac"		"24"
 			}
+			"ShouldCollide"
+			{
+				"windows"	"18"
+				"linux"		"19"
+				"mac"		"19"
+			}
+			"Spawn"
+			{
+				"windows"	"25"
+				"linux"		"26"
+				"mac"		"26"
+			}
 			"StartTouch"
 			{
-				"windows"	"99"
-				"linux"		"100"
-				"mac"		"100"
+				"windows"	"101"
+				"linux"		"102"
+				"mac"		"102"
 			}
 			"Think"
 			{
-				"windows"	"48"
-				"linux"		"49"
-				"mac"		"49"
+				"windows"	"50"
+				"linux"		"51"
+				"mac"		"51"
 			}
 			"Touch"
+			{
+				"windows"	"102"
+				"linux"		"103"
+				"mac"		"103"
+			}
+			"TraceAttack"
+			{
+				"windows"	"63"
+				"linux"		"64"
+				"mac"		"64"
+			}
+			"Use"
 			{
 				"windows"	"100"
 				"linux"		"101"
 				"mac"		"101"
 			}
-			"TraceAttack"
-			{
-				"windows"	"61"
-				"linux"		"62"
-				"mac"		"62"
-			}
-			"Use"
-			{
-				"windows"	"98"
-				"linux"		"99"
-				"mac"		"99"
-			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"158"
-				"linux"		"159"
-				"mac"		"159"
+				"windows"	"160"
+				"linux"		"161"
+				"mac"		"161"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"269"
-				"linux"		"270"
-				"mac"		"270"
+				"windows"	"271"
+				"linux"		"272"
+				"mac"		"272"
 			}
 			"Weapon_CanUse"
 			{
-				"windows"	"263"
-				"linux"		"264"
-				"mac"		"264"
+				"windows"	"265"
+				"linux"		"266"
+				"mac"		"266"
 			}
 			"Weapon_Drop"
+			{
+				"windows"	"268"
+				"linux"		"269"
+				"mac"		"269"
+			}
+			"Weapon_Equip"
 			{
 				"windows"	"266"
 				"linux"		"267"
 				"mac"		"267"
 			}
-			"Weapon_Equip"
-			{
-				"windows"	"264"
-				"linux"		"265"
-				"mac"		"265"
-			}
 			"Weapon_Switch"
 			{
-				"windows"	"267"
-				"linux"		"268"
-				"mac"		"268"
+				"windows"	"269"
+				"linux"		"270"
+				"mac"		"270"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.pvkii.txt
+++ b/gamedata/sdktools.games/game.pvkii.txt
@@ -37,93 +37,93 @@
 			/* CBasePlayer */
 			"GiveNamedItem"
 			{
-				"windows"	"404"
-				"linux"		"405"
-				"mac"		"405"
+				"windows"	"406"
+				"linux"		"407"
+				"mac"		"407"
 			}
 			"RemovePlayerItem"
+			{
+				"windows"	"275"
+				"linux"		"276"
+				"mac"		"276"
+			}
+			"Weapon_GetSlot"
 			{
 				"windows"	"273"
 				"linux"		"274"
 				"mac"		"274"
 			}
-			"Weapon_GetSlot"
-			{
-				"windows"	"271"
-				"linux"		"272"
-				"mac"		"272"
-			}
 			"Ignite"
 			{
-				"windows"	"212"
-				"linux"		"213"
-				"mac"		"213"
+				"windows"	"214"
+				"linux"		"215"
+				"mac"		"215"
 			}
 			"Extinguish"
 			{
-				"windows"	"216"
-				"linux"		"217"
-				"mac"		"217"
+				"windows"	"218"
+				"linux"		"219"
+				"mac"		"219"
 			}
 			"Teleport"
 			{
-				"windows"	"109"
-				"linux"		"110"
-				"mac"		"110"
+				"windows"	"111"
+				"linux"		"112"
+				"mac"		"112"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"443"
-				"linux"		"443"
-				"mac"		"443"
+				"windows"	"444"
+				"linux"		"445"
+				"mac"		"445"
 			}
 			"GetVelocity"
 			{
-				"windows"	"141"
-				"linux"		"142"
-				"mac"		"142"
+				"windows"	"143"
+				"linux"		"144"
+				"mac"		"144"
 			}
 			"EyeAngles"
 			{
-				"windows"	"132"
-				"linux"		"133"
-				"mac"		"133"
+				"windows"	"134"
+				"linux"		"135"
+				"mac"		"135"
 			}
 			"AcceptInput"
 			{
-				"windows"	"37"
-				"linux"		"38"
-				"mac"		"38"
+				"windows"	"39"
+				"linux"		"40"
+				"mac"		"40"
 			}
 			"SetEntityModel"
 			{
-				"windows"	"25"
-				"linux"		"26"
-				"mac"		"26"
+				"windows"	"27"
+				"linux"		"28"
+				"mac"		"28"
 			}
 			"WeaponEquip"
 			{
-				"windows"	"264"
-				"linux"		"265"
-				"mac"		"265"
+				"windows"	"266"
+				"linux"		"267"
+				"mac"		"267"
 			}
 			"Activate"
 			{
-				"windows"	"34"
-				"linux"		"35"
-				"mac"		"35"
+				"windows"	"36"
+				"linux"		"37"
+				"mac"		"37"
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"422"
-				"linux"		"423"
-				"mac"		"423"
+				"windows"	"424"
+				"linux"		"425"
+				"mac"		"425"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"255"
-				"linux"		"256"
-				"mac"		"256"
+				"windows"	"257"
+				"linux"		"258"
+				"mac"		"258"
 			}
 		}
 		


### PR DESCRIPTION
-Updates offsets
-Removes "Reload" as no corresponding function actually exists

Extra Notes:

- There does not seem to be any "Reload" function, and the offsets in this gamedata update seem to have gone up by 2, and the corresponding (Windows) offset 273+2 is CBasePlayer::RemovePlayerItem() which is probably not "Reload"

- GroundEntChanged points to a network state change. Windows and Linux were previously pointing to two different versions of this function, one that takes a void* and one that does not. They are now both the same HOWEVER I am not sure if this is desired behavior

I have attached a copy of the offset dump which should correspond to Linux offsets. (The dump was done with the Mac server.dylib binary)

[server_dump_linux.txt](https://github.com/alliedmodders/sourcemod/files/1962813/server_dump_linux.txt)
