### PR TITLE
Send ShowActivity messages to TV clients

### DIFF
--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -1123,7 +1123,6 @@ static cell_t _ShowActivity(IPluginContext *pContext,
 	{
 		IGamePlayer *pPlayer = playerhelpers->GetGamePlayer(i);
 		if (!pPlayer->IsInGame()
-			|| (pPlayer->IsFakeClient() && !pPlayer->IsSourceTV())
 			|| (display_in_chat && i == client))
 		{
 			continue;
@@ -1250,7 +1249,6 @@ static cell_t _ShowActivity2(IPluginContext *pContext,
 	{
 		IGamePlayer *pPlayer = playerhelpers->GetGamePlayer(i);
 		if (!pPlayer->IsInGame()
-			|| (pPlayer->IsFakeClient() && !pPlayer->IsSourceTV())
 			|| i == client)
 		{
 			continue;

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -1123,7 +1123,7 @@ static cell_t _ShowActivity(IPluginContext *pContext,
 	{
 		IGamePlayer *pPlayer = playerhelpers->GetGamePlayer(i);
 		if (!pPlayer->IsInGame()
-			|| pPlayer->IsFakeClient()
+			|| (pPlayer->IsFakeClient() && !pPlayer->IsSourceTV())
 			|| (display_in_chat && i == client))
 		{
 			continue;
@@ -1250,7 +1250,7 @@ static cell_t _ShowActivity2(IPluginContext *pContext,
 	{
 		IGamePlayer *pPlayer = playerhelpers->GetGamePlayer(i);
 		if (!pPlayer->IsInGame()
-			|| pPlayer->IsFakeClient()
+			|| (pPlayer->IsFakeClient() && !pPlayer->IsSourceTV())
 			|| i == client)
 		{
 			continue;


### PR DESCRIPTION
`ShowActivity` and related functions are used to inform all clients about the usage of admin commands (such as bans or mutes). These messages are not sent to any fake clients, however they _should_ be sent to SourceTV/GOTV fake clients because messages they receive are actually visible to broadcast viewers and in demos recorded with `tv_record`. 

Player chat messages as well as SM functions like `PrintToChat`/`PrintToChatAll` broadcast to TV clients, but `ShowActivity` does not.

This fix could also be implemented by sending these messages to all fake clients, like `PrintToChat` does.