### PR TITLE
Add base CommandIterator implementation

### DIFF
--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -342,9 +342,10 @@ bool ConCmdManager::AddAdminCommand(IPluginFunction *pFunction,
 									 const char *group,
 									 int adminflags,
 									 const char *description, 
-									 int flags)
+									 int flags,
+									 IPlugin *pPlugin)
 {
-	ConCmdInfo *pInfo = AddOrFindCommand(name, description, flags);
+	ConCmdInfo *pInfo = AddOrFindCommand(name, description, flags, pPlugin);
 
 	if (!pInfo)
 		return false;
@@ -388,10 +389,11 @@ bool ConCmdManager::AddAdminCommand(IPluginFunction *pFunction,
 bool ConCmdManager::AddServerCommand(IPluginFunction *pFunction, 
 									  const char *name, 
 									  const char *description, 
-									  int flags)
+									  int flags,
+									  IPlugin *pPlugin)
 
 {
-	ConCmdInfo *pInfo = AddOrFindCommand(name, description, flags);
+	ConCmdInfo *pInfo = AddOrFindCommand(name, description, flags, pPlugin);
 
 	if (!pInfo)
 		return false;
@@ -555,7 +557,7 @@ bool ConCmdManager::LookForCommandAdminFlags(const char *cmd, FlagBits *pFlags)
 	return true;
 }
 
-ConCmdInfo *ConCmdManager::AddOrFindCommand(const char *name, const char *description, int flags)
+ConCmdInfo *ConCmdManager::AddOrFindCommand(const char *name, const char *description, int flags, IPlugin *pPlugin)
 {
 	ConCmdInfo *pInfo;
 	if (!m_Cmds.retrieve(name, &pInfo))
@@ -580,6 +582,7 @@ ConCmdInfo *ConCmdManager::AddOrFindCommand(const char *name, const char *descri
 			char *new_name = sm_strdup(name);
 			char *new_help = sm_strdup(description);
 			pCmd = new ConCommand(new_name, CommandCallback, new_help, flags);
+			pInfo->pPlugin = pPlugin;
 			pInfo->sourceMod = true;
 		}
 		else

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -98,8 +98,9 @@ struct ConCmdInfo
 {
 	ConCmdInfo()
 	{
+		pPlugin = nullptr;
 		sourceMod = false;
-		pCmd = NULL;
+		pCmd = nullptr;
 		eflags = 0;
 	}
 	bool sourceMod;					/**< Determines whether or not concmd was created by a SourceMod plugin */
@@ -107,6 +108,7 @@ struct ConCmdInfo
 	CmdHookList hooks;				/**< Hook list */
 	FlagBits eflags;				/**< Effective admin flags */
 	ke::RefPtr<CommandHook> sh_hook;   /**< SourceHook hook, if any. */
+	IPlugin *pPlugin; 				/**< Owning plugin handle. */
 };
 
 typedef List<ConCmdInfo *> ConCmdList;
@@ -131,13 +133,14 @@ public: //IRootConsoleCommand
 public: //IConCommandTracker
 	void OnUnlinkConCommandBase(ConCommandBase *pBase, const char *name) override;
 public:
-	bool AddServerCommand(IPluginFunction *pFunction, const char *name, const char *description, int flags);
+	bool AddServerCommand(IPluginFunction *pFunction, const char *name, const char *description, int flags, IPlugin *pPlugin);
 	bool AddAdminCommand(IPluginFunction *pFunction, 
 						 const char *name, 
 						 const char *group,
 						 int adminflags,
 						 const char *description, 
-						 int flags);
+						 int flags,
+						 IPlugin *pPlugin);
 	ResultType DispatchClientCommand(int client, const char *cmd, int args, ResultType type);
 	void UpdateAdminCmdFlags(const char *cmd, OverrideType type, FlagBits bits, bool remove);
 	bool LookForSourceModCommand(const char *cmd);
@@ -145,7 +148,7 @@ public:
 private:
 	bool InternalDispatch(int client, const ICommandArgs *args);
 	ResultType RunAdminCommand(ConCmdInfo *pInfo, int client, int args);
-	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags);
+	ConCmdInfo *AddOrFindCommand(const char *name, const char *description, int flags, IPlugin *pPlugin);
 	void AddToCmdList(ConCmdInfo *info);
 	void RemoveConCmd(ConCmdInfo *info, const char *cmd, bool untrack);
 	bool CheckAccess(int client, const char *cmd, AdminCmdInfo *pAdmin);

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -1340,18 +1340,13 @@ static cell_t sm_CommandIteratorNext(IPluginContext *pContext, const cell_t *par
 		iter->iter++;
 	}
 
-	while (iter->iter != cmds.end()
-			&& !(*(iter->iter))->sourceMod)
+	// iterate further, skip non-sourcemod cmds
+	while (iter->iter != cmds.end() && !(*(iter->iter))->sourceMod)
 	{
 		iter->iter++;
 	}
-
-	if (iter->iter == cmds.end())
-	{
-		return 0;
-	}
 	
-	return 1;
+	return iter->iter != cmds.end();
 }
 
 static cell_t sm_CommandIteratorFlags(IPluginContext *pContext, const cell_t *params)
@@ -1365,7 +1360,8 @@ static cell_t sm_CommandIteratorFlags(IPluginContext *pContext, const cell_t *pa
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator Handle %x", params[1]);
 	}
-	if (!iter->started)
+	const List<ConCmdInfo *> &cmds = g_ConCmds.GetCommandList();
+	if (!iter->started || iter->iter == cmds.end())
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator position");
 	}
@@ -1385,14 +1381,15 @@ static cell_t sm_CommandIteratorGetDesc(IPluginContext *pContext, const cell_t *
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator Handle %x", params[1]);
 	}
-	if (!iter->started)
+	const List<ConCmdInfo *> &cmds = g_ConCmds.GetCommandList();
+	if (!iter->started || iter->iter == cmds.end())
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator position");
 	}
 
 	ConCmdInfo *pInfo = (*(iter->iter));
-
 	pContext->StringToLocalUTF8(params[2], params[3], pInfo->pCmd->GetHelpText(), NULL);
+
 	return 1;
 }
 
@@ -1407,14 +1404,15 @@ static cell_t sm_CommandIteratorGetName(IPluginContext *pContext, const cell_t *
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator Handle %x", params[1]);
 	}
-	if (!iter->started)
+	const List<ConCmdInfo *> &cmds = g_ConCmds.GetCommandList();
+	if (!iter->started || iter->iter == cmds.end())
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator position");
 	}
 
 	ConCmdInfo *pInfo = (*(iter->iter));
-
 	pContext->StringToLocalUTF8(params[2], params[3], pInfo->pCmd->GetName(), NULL);
+
 	return 1;
 }
 
@@ -1429,13 +1427,13 @@ static cell_t sm_CommandIteratorPlugin(IPluginContext *pContext, const cell_t *p
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator Handle %x", params[1]);
 	}
-	if (!iter->started)
+	const List<ConCmdInfo *> &cmds = g_ConCmds.GetCommandList();
+	if (!iter->started || iter->iter == cmds.end())
 	{
 		return pContext->ThrowNativeError("Invalid CommandIterator position");
 	}
 
 	ConCmdInfo *pInfo = (*(iter->iter));
-
 	return pInfo->pPlugin->GetMyHandle();
 }
 

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -433,6 +433,52 @@ native int GetCmdArg(int argnum, char[] buffer, int maxlength);
  */
 native int GetCmdArgString(char[] buffer, int maxlength);
 
+methodmap CommandIterator < Handle {
+	// Creates a new CommandIterator. Must be freed with delete or
+	// CloseHandle().
+	//
+	// The CommandIterator can be used to iterate commands created by
+	// SourceMod plugins and allows inspection of properties associated
+	// with the command.
+	// 
+	// @return		 New CommandIterator Handle.
+	public native CommandIterator();
+
+	// Determines if there is a next command. If one is found, the
+	// iterator is advanced to it.
+	//
+	// @return		true if found and iterator is advanced.
+	public native bool Next();
+
+	// Retrieves the command's description.
+	//
+	// @param buffer		Buffer to copy to.
+	// @param maxlen		Maximum size of the buffer.
+	// @error				Invalid iterator position.
+	public native void GetDescription(char[] buffer, int maxlen);
+
+	// Retrieves the command's name.
+	//
+	// @param buffer		Buffer to copy to.
+	// @param maxlen		Maximum size of the buffer.
+	// @error				Invalid iterator position.
+	public native void GetName(char[] buffer, int maxlen);
+
+	// Retrieves the plugin handle of the command's creator
+	//
+	// @error				Invalid iterator position.
+	property Handle Plugin {
+		public native get();
+	}
+
+	// Retrieves the command's default flags
+	//
+	// @error				Invalid iterator position.
+	property int Flags {
+		public native get();
+	}
+}
+
 /**
  * Gets a command iterator.  Must be freed with CloseHandle().
  *


### PR DESCRIPTION
Closes #742 

Essentially this adds a methodmap for the existing command iterator, but in the more accepted iteration style that we're using nowadays which allows us to add more info as we see fit, without breaking older plugins. Related to this, I also added an `IPlugin*` to `ConCmdInfo` so we're able to track which plugin made what command, and this plugin handle is exposed through the iterator. 

My test script for this PR is as follows
```
public void OnPluginStart()
{
	CommandIterator it = new CommandIterator();
	
	while (it.Next())
	{
		char name[128];
		it.GetName(name, sizeof(name));
		char desc[128];
		it.GetDescription(desc, sizeof(desc));
		
		int flags = it.Flags;
		char plugin[128];		
		GetPluginFilename(it.Plugin, plugin, sizeof(plugin));
		PrintToServer("%s - %s (created by %s) - flagbits: %08b", name, desc, plugin, flags);
	}
}
```


And the beautiful output given can be seen here

```
sm plugins load test
ff -  (created by basetriggers.smx) - flagbits: 00000000
listmaps -  (created by nextmap.smx) - flagbits: 00000000
motd -  (created by basetriggers.smx) - flagbits: 00000000
nextmap -  (created by basetriggers.smx) - flagbits: 00000000
sm_abortban - sm_abortban (created by basebans.smx) - flagbits: 00000000
sm_addban - sm_addban <time> <steamid> [reason] (created by basebans.smx) - flagbits: 00000000
sm_addweapon - A command to add map weapons (created by hl_weaponspawner.smx) - flagbits: 00100000
sm_addweapons - A command to add map weapons (created by hl_weaponspawner.smx) - flagbits: 00100000
sm_admin - Displays the admin menu (created by adminmenu.smx) - flagbits: 00000010
sm_ban - sm_ban <#userid|name> <minutes|0> [reason] (created by basebans.smx) - flagbits: 00001000
sm_banip - sm_banip <ip|#userid|name> <time> [reason] (created by basebans.smx) - flagbits: 00001000
sm_beacon - sm_beacon <#userid|name> [0/1] (created by funcommands.smx) - flagbits: 00100000
sm_blind - sm_blind <#userid|name> [amount] - Leave amount off to reset. (created by funcommands.smx) - flagbits: 00100000
sm_burn - sm_burn <#userid|name> [time] (created by funcommands.smx) - flagbits: 00100000
sm_cancelvote - sm_cancelvote (created by basecommands.smx) - flagbits: 00000000
sm_chat - sm_chat <message> - sends message to admins (created by basechat.smx) - flagbits: 00000000
sm_cookies - sm_cookies <name> [value] (created by clientprefs.smx) - flagbits: 00000000
sm_csay - sm_csay <message> - sends centered message to all players (created by basechat.smx) - flagbits: 00000000
sm_cvar - sm_cvar <cvar> [value] (created by basecommands.smx) - flagbits: 10000000
sm_drug - sm_drug <#userid|name> [0/1] (created by funcommands.smx) - flagbits: 00100000
sm_execcfg - sm_execcfg <filename> (created by basecommands.smx) - flagbits: 00000000
sm_firebomb - sm_firebomb <#userid|name> [0/1] (created by funcommands.smx) - flagbits: 00100000
sm_freeze - sm_freeze <#userid|name> [time] (created by funcommands.smx) - flagbits: 00100000
sm_freezebomb - sm_freezebomb <#userid|name> [0/1] (created by funcommands.smx) - flagbits: 00100000
sm_gag - sm_gag <player> - Removes a player's ability to use chat. (created by basecomm.smx) - flagbits: 00000000
sm_gravity - sm_gravity <#userid|name> [amount] - Leave amount off to reset. Amount is 0.0 through 5.0 (created by funcommands.smx) - flagbits: 00100000
sm_help - Displays SourceMod commands and descriptions (created by adminhelp.smx) - flagbits: 00000000
sm_hsay - sm_hsay <message> - sends hint message to all players (created by basechat.smx) - flagbits: 00000000
sm_kick - sm_kick <#userid|name> [reason] (created by basecommands.smx) - flagbits: 00000100
sm_map - sm_map <map> (created by basecommands.smx) - flagbits: 01000000
sm_maphistory - Shows the most recent maps played (created by nextmap.smx) - flagbits: 01000000
sm_msay - sm_msay <message> - sends message as a menu panel (created by basechat.smx) - flagbits: 00000000
sm_mute - sm_mute <player> - Removes a player's ability to use voice. (created by basecomm.smx) - flagbits: 00000000
sm_noclip - sm_noclip <#userid|name> (created by funcommands.smx) - flagbits: 00100000
sm_play - sm_play <#userid|name> <filename> (created by sounds.smx) - flagbits: 00000010
sm_psay - sm_psay <name or #userid> <message> - sends private message (created by basechat.smx) - flagbits: 00000000
sm_rcon - sm_rcon <args> (created by basecommands.smx) - flagbits: 00000000
sm_reloadadmins - sm_reloadadmins (created by basecommands.smx) - flagbits: 00001000
sm_rename - sm_rename <#userid|name> (created by playercommands.smx) - flagbits: 00100000
sm_resetcvar - sm_resetcvar <cvar> (created by basecommands.smx) - flagbits: 10000000
sm_revote -  (created by basecommands.smx) - flagbits: 00000000
sm_say - sm_say <message> - sends message to all players (created by basechat.smx) - flagbits: 00000000
sm_searchcmd - Searches SourceMod commands (created by adminhelp.smx) - flagbits: 00000000
sm_settings -  (created by clientprefs.smx) - flagbits: 00000000
sm_silence - sm_silence <player> - Removes a player's ability to use voice or chat. (created by basecomm.smx) - flagbits: 00000000
sm_slap - sm_slap <#userid|name> [damage] (created by playercommands.smx) - flagbits: 00100000
sm_slay - sm_slay <#userid|name> (created by playercommands.smx) - flagbits: 00100000
sm_timebomb - sm_timebomb <#userid|name> [0/1] (created by funcommands.smx) - flagbits: 00100000
sm_tsay - sm_tsay [color] <message> - sends top-left message to all players (created by basechat.smx) - flagbits: 00000000
sm_unban - sm_unban <steamid|ip> (created by basebans.smx) - flagbits: 00010000
sm_ungag - sm_ungag <player> - Restores a player's ability to use chat. (created by basecomm.smx) - flagbits: 00000000
sm_unmute - sm_unmute <player> - Restores a player's ability to use voice. (created by basecomm.smx) - flagbits: 00000000
sm_unsilence - sm_unsilence <player> - Restores a player's ability to use voice and chat. (created by basecomm.smx) - flagbits: 00000000
sm_vote - sm_vote <question> [Answer1] [Answer2] ... [Answer5] (created by basevotes.smx) - flagbits: 00000000
sm_votealltalk - sm_votealltalk (created by funvotes.smx) - flagbits: 00000000
sm_voteban - sm_voteban <player> [reason] (created by basevotes.smx) - flagbits: 00001000
sm_voteburn - sm_voteburn <player> (created by funvotes.smx) - flagbits: 00100000
sm_voteff - sm_voteff (created by funvotes.smx) - flagbits: 00000000
sm_votegravity - sm_votegravity <amount> [amount2] ... [amount5] (created by funvotes.smx) - flagbits: 00000000
sm_votekick - sm_votekick <player> [reason] (created by basevotes.smx) - flagbits: 00000100
sm_votemap - sm_votemap <mapname> [mapname2] ... [mapname5]  (created by basevotes.smx) - flagbits: 01000000
sm_voteslay - sm_voteslay <player> (created by funvotes.smx) - flagbits: 00100000
sm_who - sm_who [#userid|name] (created by basecommands.smx) - flagbits: 00000010
[SM] Loaded plugin test.smx successfully.
```