### PR TITLE
Fix MySQL extension build using vs2015

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -182,7 +182,7 @@ class SMConfig(object):
       if builder.options.mysql_path:
         self.mysql_root['x86'] = builder.options.mysql_path
       else:
-        for i in range(7):
+        for i in range(10):
           self.mysql_root['x86'] = ResolveEnvPath('MYSQL55', 'mysql-5.' + str(i))
           if self.mysql_root['x86']:
             break
@@ -192,10 +192,10 @@ class SMConfig(object):
 
       # For now, ignore 64-bit MySQL on Windows
       if 'x64' in self.archs and builder.target.platform != 'windows':
-        if builder.options.mysql_path:
+        if builder.options.mysql64_path:
           self.mysql_root['x64'] = builder.options.mysql64_path
         else:
-          for i in range(7):
+          for i in range(10):
             self.mysql_root['x64'] = ResolveEnvPath('MYSQL55_64', 'mysql-5.' + str(i) + '-x86_64')
             if self.mysql_root['x64']:
               break

--- a/extensions/mysql/AMBuilder
+++ b/extensions/mysql/AMBuilder
@@ -42,6 +42,7 @@ if SM.mysql_root:
     if binary.compiler.family == 'msvc' and binary.compiler.version >= 1900:
       binary.sources += [ 'msvc15hack.c' ]
       binary.compiler.linkflags += ['legacy_stdio_definitions.lib', 'legacy_stdio_wide_specifiers.lib']
+      binary.compiler.defines += ['HAVE_STRUCT_TIMESPEC']
 
     SM.extensions += [builder.Add(binary)]
 

--- a/extensions/mysql/mysql/MyDriver.h
+++ b/extensions/mysql/mysql/MyDriver.h
@@ -39,9 +39,9 @@
 #include <WinSock2.h>
 #endif
 
-#include <mysql.h>
 #include <my_global.h>
 #include <my_sys.h>
+#include <mysql.h>
 
 #include <sh_string.h>
 #include <sh_list.h>


### PR DESCRIPTION
MySQL defines its own timespec_t. Official mysql builds are built using VS2013, so you still need to compile the client library yourself to be able to link it, but this change makes the dbi extension compatible with future versions already.