### PR TITLE
MySQL: Support multiple result sets in prepared queries

### DIFF
--- a/extensions/mysql/mysql/MyBoundResults.cpp
+++ b/extensions/mysql/mysql/MyBoundResults.cpp
@@ -69,18 +69,13 @@ enum_field_types GetTheirType(DBType type)
 	return MYSQL_TYPE_STRING;
 }
 
-MyBoundResults::MyBoundResults(MYSQL_STMT *stmt, MYSQL_RES *res)
-: m_stmt(stmt), m_pRes(res), m_Initialized(false), m_RowCount(0), m_CurRow(0)
+MyBoundResults::MyBoundResults(MYSQL_STMT *stmt, MYSQL_RES *res, unsigned int num_fields)
+: m_stmt(stmt), m_pRes(res), m_ColCount(num_fields), m_Initialized(false), m_RowCount(0), m_CurRow(0)
 {
 	/**
-	 * Important things to note here: 
-	 * 1) We're guaranteed at least one field.
-	 * 2) The field information should never change, and thus we
-	 *    never rebuild it.  If someone ALTERs the table during
-	 *    a prepared query's lifetime, it's their own death.
+	 * Important thing to note here: 
+	 * We're guaranteed at least one field.
 	 */
-
-	m_ColCount = (unsigned int)mysql_num_fields(m_pRes);
 
 	/* Allocate buffers */
 	m_bind = (MYSQL_BIND *)malloc(sizeof(MYSQL_BIND) * m_ColCount);

--- a/extensions/mysql/mysql/MyBoundResults.h
+++ b/extensions/mysql/mysql/MyBoundResults.h
@@ -55,7 +55,7 @@ class MyBoundResults :
 {
 	friend class MyStatement;
 public:
-	MyBoundResults(MYSQL_STMT *stmt, MYSQL_RES *res);
+	MyBoundResults(MYSQL_STMT *stmt, MYSQL_RES *res, unsigned int num_fields);
 	~MyBoundResults();
 public: //IResultSet
 	unsigned int GetRowCount();

--- a/extensions/mysql/mysql/MyStatement.h
+++ b/extensions/mysql/mysql/MyStatement.h
@@ -67,6 +67,7 @@ public: //IPreparedQuery
 	unsigned int GetInsertID();
 private:
 	void *CopyBlob(unsigned int param, const void *blobptr, size_t length);
+	void ClearResults();
 private:
 	MYSQL *m_mysql;
 	ke::RefPtr<MyDatabase> m_pParent;


### PR DESCRIPTION
Prepared statements can return multiple result sets in MySQL 5.5. That can happen when calling stored procedures using `CALL x();`.

This change removes the previous caching of result bindings, since the number of fields in a result can differ from result set to result set. This could potentially have a negative impact on performance of prepared statements always only returning one result set, since the result binding buffers are recreated everytime the statement is executed instead of once. That difference should be negligible though.

Fixes #823.

Usage is just like with normal queries:
```sourcepawn
// From https://dev.mysql.com/doc/refman/5.5/en/c-api-prepared-call-statements.html
public void OnPluginStart()
{
	char error[255];
	Database db = SQL_DefConnect(error, sizeof(error));
	if (db == null){
		PrintToServer("Could not connect: %s", error);
		return;
	}

	/*
	CREATE PROCEDURE p1(
	  IN p_in INT,
	  OUT p_out INT,
	  INOUT p_inout INT)
	BEGIN
	  SELECT p_in, p_out, p_inout;
	  SET p_in = 100, p_out = 200, p_inout = 300;
	  SELECT p_in, p_out, p_inout;
	END
	*/

	DBStatement hStmt = SQL_PrepareQuery(db, "CALL p1(?, ?, ?)", error, sizeof(error));
	if (!hStmt){
		PrintToServer(error);
		delete db;
		return;
	}
	
	/* assign values to parameters and execute statement */
	hStmt.BindInt(0, 10); /* p_in */
	hStmt.BindInt(1, 20); /* p_out */
	hStmt.BindInt(2, 30); /* p_inout */

	if (!SQL_Execute(hStmt)){
		SQL_GetError(hStmt, error, sizeof(error));
		PrintToServer(error);
		delete hStmt;
		delete db;
		return;
	}
	
	do 
	{
		int rows = SQL_GetRowCount(hStmt); 
		PrintToServer("Num rows: %d", rows);

		int num_fields = SQL_GetFieldCount(hStmt);
		while (SQL_FetchRow(hStmt))
		{
			for (int i = 0; i < num_fields; i++)
			{
				if (SQL_IsFieldNull(hStmt, i))
					PrintToServer("val[%d] = NULL", i);
				else
					PrintToServer("val[%d] = %d", i, SQL_FetchInt(hStmt, i));
			}
		}
	}
	while (SQL_FetchMoreResults(hStmt));

	delete hStmt;
	delete db;
}
```

Output:
```
Num rows: 1
val[0] = 10
val[1] = NULL
val[2] = 30
Num rows: 1
val[0] = 100
val[1] = 200
val[2] = 300
Num rows: 1
val[0] = 200
val[1] = 300
```