### PR TITLE
Match old DataPack behavior when overwriting data

### DIFF
--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -230,6 +230,15 @@ bool CDataPack::RemoveItem(size_t pos)
 	{
 		return false;
 	}
+	if (pos == 0)
+	{
+		if (position == elements.length())
+		{
+			return false;
+		}
+		elements.remove(position--);
+		return true;
+	}
 
 	elements.remove(pos-1);
 	--position;

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -235,7 +235,7 @@ bool CDataPack::RemoveItem(size_t pos)
 	{
 		pos = position;
 	}
-	else if (pos >= elements.length())
+	else if (pos > elements.length())
 	{
 		return false;
 	}

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -224,7 +224,15 @@ void *CDataPack::ReadMemory(size_t *size) const
 	return ptr;
 }
 
-void CDataPack::RemoveNextItem()
+void CDataPack::RemoveItem(size_t pos)
 {
-	elements.remove(position--);
+	if (pos < 0)
+	{
+		elements.remove(position--);
+		return;
+	}
+	
+	assert(pos > 0 && pos <= elements.length());
+	elements.remove(pos-1);
+	--position;
 }

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -226,21 +226,21 @@ void *CDataPack::ReadMemory(size_t *size) const
 
 bool CDataPack::RemoveItem(size_t pos)
 {
-	if (pos > elements.length())
+	if (!elements.length())
 	{
 		return false;
 	}
-	if (pos == 0)
+
+	if (pos == static_cast<size_t>(-1))
 	{
-		if (position == elements.length())
-		{
-			return false;
-		}
-		elements.remove(position--);
-		return true;
+		pos = position;
+	}
+	else if (pos >= elements.length())
+	{
+		return false;
 	}
 
-	elements.remove(pos-1);
+	elements.remove(pos);
 	--position;
 	return true;
 }

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -233,14 +233,14 @@ bool CDataPack::RemoveItem(size_t pos)
 
 	if (pos == static_cast<size_t>(-1))
 	{
-		pos = position + 1;
+		pos = position;
 	}
-	if (pos > elements.length())
+	if (pos >= elements.length())
 	{
 		return false;
 	}
 
-	elements.remove(pos-1);
+	elements.remove(pos);
 	--position;
 	return true;
 }

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -223,3 +223,8 @@ void *CDataPack::ReadMemory(size_t *size) const
 
 	return ptr;
 }
+
+void CDataPack::RemoveNextItem()
+{
+	elements.remove(position--);
+}

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -233,14 +233,14 @@ bool CDataPack::RemoveItem(size_t pos)
 
 	if (pos == static_cast<size_t>(-1))
 	{
-		pos = position;
+		pos = position + 1;
 	}
-	else if (pos > elements.length())
+	if (pos > elements.length())
 	{
 		return false;
 	}
 
-	elements.remove(pos);
+	elements.remove(pos-1);
 	--position;
 	return true;
 }

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -224,15 +224,14 @@ void *CDataPack::ReadMemory(size_t *size) const
 	return ptr;
 }
 
-void CDataPack::RemoveItem(size_t pos)
+bool CDataPack::RemoveItem(size_t pos)
 {
-	if (pos < 0)
+	if (pos > elements.length())
 	{
-		elements.remove(position--);
-		return;
+		return false;
 	}
-	
-	assert(pos > 0 && pos <= elements.length());
+
 	elements.remove(pos-1);
 	--position;
+	return true;
 }

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -74,6 +74,7 @@ public: //IDataPack
 	void PackFunction(cell_t function);
 public:
 	void Initialize();
+	void RemoveNextItem();
 	inline size_t GetCapacity() const { return this->elements.length(); };
 	inline CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
 private:

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -76,7 +76,7 @@ public:
 	void Initialize();
 	inline size_t GetCapacity() const { return this->elements.length(); };
 	inline CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
-	bool RemoveItem(size_t pos = 0);
+	bool RemoveItem(size_t pos = -1);
 private:
 
 	typedef union {

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -76,7 +76,7 @@ public:
 	void Initialize();
 	inline size_t GetCapacity() const { return this->elements.length(); };
 	inline CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
-	void RemoveItem(size_t pos);
+	bool RemoveItem(size_t pos);
 private:
 
 	typedef union {

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -76,7 +76,7 @@ public:
 	void Initialize();
 	inline size_t GetCapacity() const { return this->elements.length(); };
 	inline CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
-	bool RemoveItem(size_t pos);
+	bool RemoveItem(size_t pos = 0);
 private:
 
 	typedef union {

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -74,9 +74,9 @@ public: //IDataPack
 	void PackFunction(cell_t function);
 public:
 	void Initialize();
-	void RemoveNextItem();
 	inline size_t GetCapacity() const { return this->elements.length(); };
 	inline CDataPackType GetCurrentType(void) const { return this->elements[this->position].type; };
+	void RemoveItem(size_t pos);
 private:
 
 	typedef union {

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -99,10 +99,15 @@ static cell_t smn_WritePackCell(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
-	bool overwrite = (params[0] >= 3) ? params[3] : true;
-	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	bool insert = (params[0] >= 3) ? params[3] : false;
+	if (!insert)
 	{
-		pDataPack->RemoveItem(-1);
+		size_t pos = pDataPack->GetPosition();
+
+		if (pos != pDataPack->GetCapacity())
+		{
+			pDataPack->RemoveItem(pos+1); // remove next
+		}
 	}
 
 	pDataPack->PackCell(params[2]);
@@ -126,10 +131,15 @@ static cell_t smn_WritePackFloat(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
-	bool overwrite = (params[0] >= 3) ? params[3] : true;
-	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	bool insert = (params[0] >= 3) ? params[3] : false;
+	if (!insert)
 	{
-		pDataPack->RemoveItem(-1);
+		size_t pos = pDataPack->GetPosition();
+
+		if (pos != pDataPack->GetCapacity())
+		{
+			pDataPack->RemoveItem(pos+1); // remove next
+		}
 	}
 
 	pDataPack->PackFloat(sp_ctof(params[2]));
@@ -153,10 +163,15 @@ static cell_t smn_WritePackString(IPluginContext *pContext, const cell_t *params
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
-	bool overwrite = (params[0] >= 3) ? params[3] : true;
-	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	bool insert = (params[0] >= 3) ? params[3] : false;
+	if (!insert)
 	{
-		pDataPack->RemoveItem(-1);
+		size_t pos = pDataPack->GetPosition();
+
+		if (pos != pDataPack->GetCapacity())
+		{
+			pDataPack->RemoveItem(pos+1); // remove next
+		}
 	}
 
 	char *str;
@@ -182,10 +197,15 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
-	bool overwrite = (params[0] >= 3) ? params[3] : true;
-	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	bool insert = (params[0] >= 3) ? params[3] : false;
+	if (!insert)
 	{
-		pDataPack->RemoveItem(-1);
+		size_t pos = pDataPack->GetPosition();
+
+		if (pos != pDataPack->GetCapacity())
+		{
+			pDataPack->RemoveItem(pos+1); // remove next
+		}
 	}
 
 	pDataPack->PackFunction(params[2]);

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -102,11 +102,7 @@ static cell_t smn_WritePackCell(IPluginContext *pContext, const cell_t *params)
 	bool insert = (params[0] >= 3) ? params[3] : false;
 	if (!insert)
 	{
-		size_t pos = pDataPack->GetPosition();
-		if (pos != pDataPack->GetCapacity())
-		{
-			pDataPack->RemoveItem(pos+1); // remove next
-		}
+		pDataPack->RemoveItem();
 	}
 
 	pDataPack->PackCell(params[2]);
@@ -133,11 +129,7 @@ static cell_t smn_WritePackFloat(IPluginContext *pContext, const cell_t *params)
 	bool insert = (params[0] >= 3) ? params[3] : false;
 	if (!insert)
 	{
-		size_t pos = pDataPack->GetPosition();
-		if (pos != pDataPack->GetCapacity())
-		{
-			pDataPack->RemoveItem(pos+1); // remove next
-		}
+		pDataPack->RemoveItem();
 	}
 
 	pDataPack->PackFloat(sp_ctof(params[2]));
@@ -164,11 +156,7 @@ static cell_t smn_WritePackString(IPluginContext *pContext, const cell_t *params
 	bool insert = (params[0] >= 3) ? params[3] : false;
 	if (!insert)
 	{
-		size_t pos = pDataPack->GetPosition();
-		if (pos != pDataPack->GetCapacity())
-		{
-			pDataPack->RemoveItem(pos+1); // remove next
-		}
+		pDataPack->RemoveItem();
 	}
 
 	char *str;
@@ -197,11 +185,7 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 	bool insert = (params[0] >= 3) ? params[3] : false;
 	if (!insert)
 	{
-		size_t pos = pDataPack->GetPosition();
-		if (pos != pDataPack->GetCapacity())
-		{
-			pDataPack->RemoveItem(pos+1); // remove next
-		}
+		pDataPack->RemoveItem();
 	}
 
 	pDataPack->PackFunction(params[2]);

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -102,7 +102,7 @@ static cell_t smn_WritePackCell(IPluginContext *pContext, const cell_t *params)
 	bool overwrite = (params[0] >= 3) ? params[3] : true;
 	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
 	{
-		pDataPack->RemoveNextItem();
+		pDataPack->RemoveItem(-1);
 	}
 
 	pDataPack->PackCell(params[2]);
@@ -129,7 +129,7 @@ static cell_t smn_WritePackFloat(IPluginContext *pContext, const cell_t *params)
 	bool overwrite = (params[0] >= 3) ? params[3] : true;
 	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
 	{
-		pDataPack->RemoveNextItem();
+		pDataPack->RemoveItem(-1);
 	}
 
 	pDataPack->PackFloat(sp_ctof(params[2]));
@@ -156,7 +156,7 @@ static cell_t smn_WritePackString(IPluginContext *pContext, const cell_t *params
 	bool overwrite = (params[0] >= 3) ? params[3] : true;
 	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
 	{
-		pDataPack->RemoveNextItem();
+		pDataPack->RemoveItem(-1);
 	}
 
 	char *str;
@@ -185,7 +185,7 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 	bool overwrite = (params[0] >= 3) ? params[3] : true;
 	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
 	{
-		pDataPack->RemoveNextItem();
+		pDataPack->RemoveItem(-1);
 	}
 
 	pDataPack->PackFunction(params[2]);

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -99,6 +99,12 @@ static cell_t smn_WritePackCell(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
+	bool overwrite = (params[0] >= 3) ? params[3] : true;
+	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	{
+		pDataPack->RemoveNextItem();
+	}
+
 	pDataPack->PackCell(params[2]);
 
 	return 1;
@@ -118,6 +124,12 @@ static cell_t smn_WritePackFloat(IPluginContext *pContext, const cell_t *params)
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
+	}
+
+	bool overwrite = (params[0] >= 3) ? params[3] : true;
+	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	{
+		pDataPack->RemoveNextItem();
 	}
 
 	pDataPack->PackFloat(sp_ctof(params[2]));
@@ -141,6 +153,12 @@ static cell_t smn_WritePackString(IPluginContext *pContext, const cell_t *params
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
 	}
 
+	bool overwrite = (params[0] >= 3) ? params[3] : true;
+	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	{
+		pDataPack->RemoveNextItem();
+	}
+
 	char *str;
 	pContext->LocalToString(params[2], &str);
 	pDataPack->PackString(str);
@@ -162,6 +180,12 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid data pack handle %x (error %d).", hndl, herr);
+	}
+
+	bool overwrite = (params[0] >= 3) ? params[3] : true;
+	if (overwrite && pDataPack->GetPosition() != pDataPack->GetCapacity())
+	{
+		pDataPack->RemoveNextItem();
 	}
 
 	pDataPack->PackFunction(params[2]);

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -103,7 +103,6 @@ static cell_t smn_WritePackCell(IPluginContext *pContext, const cell_t *params)
 	if (!insert)
 	{
 		size_t pos = pDataPack->GetPosition();
-
 		if (pos != pDataPack->GetCapacity())
 		{
 			pDataPack->RemoveItem(pos+1); // remove next
@@ -135,7 +134,6 @@ static cell_t smn_WritePackFloat(IPluginContext *pContext, const cell_t *params)
 	if (!insert)
 	{
 		size_t pos = pDataPack->GetPosition();
-
 		if (pos != pDataPack->GetCapacity())
 		{
 			pDataPack->RemoveItem(pos+1); // remove next
@@ -167,7 +165,6 @@ static cell_t smn_WritePackString(IPluginContext *pContext, const cell_t *params
 	if (!insert)
 	{
 		size_t pos = pDataPack->GetPosition();
-
 		if (pos != pDataPack->GetCapacity())
 		{
 			pDataPack->RemoveItem(pos+1); // remove next
@@ -201,7 +198,6 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 	if (!insert)
 	{
 		size_t pos = pDataPack->GetPosition();
-
 		if (pos != pDataPack->GetCapacity())
 		{
 			pDataPack->RemoveItem(pos+1); // remove next

--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -100,8 +100,8 @@ methodmap DataPack < Handle
 	// Returns whether or not a specified number of bytes from the data pack
 	//  position to the end can be read.
 	//
-	// @param bytes		Number of bytes to simulate reading.
-	public native bool IsReadable(int bytes);
+	// @param unused	Unused variable. Exists for backwards compatability.
+	public native bool IsReadable(int unused = 0);
 	
 	// The read or write position in a data pack.
 	property DataPackPos Position {

--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -49,27 +49,27 @@ methodmap DataPack < Handle
 
 	// Packs a normal cell into a data pack.
 	//
-	// @param cell			Cell to add.
-	// @param overwrite		Whether existing data should be overwritten.
-	public native void WriteCell(any cell, bool overwrite = true);
+	// @param cell		Cell to add.
+	// @param insert	Determines whether mid-pack writes will insert instead of overwrite.
+	public native void WriteCell(any cell, bool insert = false);
 
 	// Packs a float into a data pack.
 	//
-	// @param val			Float to add.
-	// @param overwrite		Whether existing data should be overwritten.
-	public native void WriteFloat(float val, bool overwrite = true);
+	// @param val		Float to add.
+	// @param insert	Determines whether mid-pack writes will insert instead of overwrite.
+	public native void WriteFloat(float val, bool insert = false);
 
 	// Packs a string into a data pack.
 	//
-	// @param str			String to add.
-	// @param overwrite		Whether existing data should be overwritten.
-	public native void WriteString(const char[] str, bool overwrite = true);
+	// @param str		String to add.
+	// @param insert	Determines whether mid-pack writes will insert instead of overwrite.
+	public native void WriteString(const char[] str, bool insert = false);
 
 	// Packs a function pointer into a data pack.
 	//
-	// @param fktptr		Function pointer to add.
-	// @param overwrite		Whether existing data should be overwritten.
-	public native void WriteFunction(Function fktptr, bool overwrite = true);
+	// @param fktptr	Function pointer to add.
+	// @param insert	Determines whether mid-pack writes will insert instead of overwrite.
+	public native void WriteFunction(Function fktptr, bool insert = false);
 
 	// Reads a cell from a data pack.
 	//

--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -49,23 +49,27 @@ methodmap DataPack < Handle
 
 	// Packs a normal cell into a data pack.
 	//
-	// @param cell		Cell to add.
-	public native void WriteCell(any cell);
+	// @param cell			Cell to add.
+	// @param overwrite		Whether existing data should be overwritten.
+	public native void WriteCell(any cell, bool overwrite = true);
 
 	// Packs a float into a data pack.
 	//
-	// @param val		Float to add.
-	public native void WriteFloat(float val);
+	// @param val			Float to add.
+	// @param overwrite		Whether existing data should be overwritten.
+	public native void WriteFloat(float val, bool overwrite = true);
 
 	// Packs a string into a data pack.
 	//
-	// @param str		String to add.
-	public native void WriteString(const char[] str);
+	// @param str			String to add.
+	// @param overwrite		Whether existing data should be overwritten.
+	public native void WriteString(const char[] str, bool overwrite = true);
 
 	// Packs a function pointer into a data pack.
 	//
-	// @param fktptr	Function pointer to add.
-	public native void WriteFunction(Function fktptr);
+	// @param fktptr		Function pointer to add.
+	// @param overwrite		Whether existing data should be overwritten.
+	public native void WriteFunction(Function fktptr, bool overwrite = true);
 
 	// Reads a cell from a data pack.
 	//


### PR DESCRIPTION
```cpp
DataPack dp = new DataPack();
dp.WriteCell(3);
dp.Reset();
dp.WriteCell(4);
delete dp;
```
Instead of the data being overwritten, the current behavior inserts 4 before 3. This is a problem because before #688 DataPacks would overwrite. This adds parameters to every native, default false, which determines whether the data should be inserted or overwritten that way old plugins wont break, and if someone really wants to insert they may.