### PR TITLE
Fix memory leak regression from #848.

### DIFF
--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -225,7 +225,7 @@ bool CDataPack::RemoveItem(size_t pos)
 		return false;
 	}
 
-	switch (elements[index].type)
+	switch (elements[pos].type)
 	{
 		case CDataPackType::Raw:
 		{

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -65,25 +65,9 @@ CDataPack::Free(IDataPack *pack)
 
 void CDataPack::Initialize()
 {
-	for (size_t index = 0; index < elements.length(); ++index)
+	do
 	{
-		switch (elements[index].type)
-		{
-			case CDataPackType::Raw:
-			{
-				delete elements[index].pData.vval;
-				elements.remove(index--);
-				break;
-			}
-
-			case CDataPackType::String:
-			{
-				delete elements[index].pData.sval;
-				elements.remove(index--);
-				break;
-			}
-		}
-	}
+	} while (!this->RemoveItem());
 
 	elements.clear();
 	position = 0;
@@ -235,9 +219,25 @@ bool CDataPack::RemoveItem(size_t pos)
 	{
 		pos = position;
 	}
+
 	if (pos >= elements.length())
 	{
 		return false;
+	}
+
+	switch (elements[index].type)
+	{
+		case CDataPackType::Raw:
+		{
+			delete elements[pos].pData.vval;
+			break;
+		}
+
+		case CDataPackType::String:
+		{
+			delete elements[pos].pData.sval;
+			break;
+		}
 	}
 
 	elements.remove(pos);

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -67,7 +67,7 @@ void CDataPack::Initialize()
 {
 	do
 	{
-	} while (!this->RemoveItem());
+	} while (this->RemoveItem());
 
 	elements.clear();
 	position = 0;


### PR DESCRIPTION
Agh. We focused a little too heavily on the regression from https://github.com/alliedmodders/sourcemod/pull/688 and missed a memory leak from not properly freeing dynamic objects when they're overwritten in https://github.com/alliedmodders/sourcemod/pull/848. All good, shower thoughts drove this out.