### PR TITLE
Allow any returns in native callbacks

### DIFF
--- a/plugins/adminmenu.sp
+++ b/plugins/adminmenu.sp
@@ -162,9 +162,9 @@ public void DefaultCategoryHandler(TopMenu topmenu,
 	}
 }
 
-public int __GetAdminTopMenu(Handle plugin, int numParams)
+public any __GetAdminTopMenu(Handle plugin, int numParams)
 {
-	return view_as<int>(hAdminMenu);
+	return hAdminMenu;
 }
 
 public int __AddTargetsToMenu(Handle plugin, int numParams)

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -357,16 +357,30 @@ native int Call_Finish(any &result=0);
  */
 native void Call_Cancel();
 
-/**
- * Defines a native function.
- *
- * It is not necessary to validate the parameter count 
- *
- * @param plugin			Handle of the calling plugin.
- * @param numParams			Number of parameters passed to the native.
- * @return 					Value for the native call to return.
- */
-typedef NativeCall = function int (Handle plugin, int numParams);
+typeset NativeCall
+{
+	/**
+	 * Defines a native function.
+	 *
+	 * It is not necessary to validate the parameter count 
+	 *
+	 * @param plugin			Handle of the calling plugin.
+	 * @param numParams			Number of parameters passed to the native.
+	 * @return 					Value for the native call to return.
+	 */
+	function int (Handle plugin, int numParams);
+
+	/**
+	 * Defines a native function.
+	 *
+	 * It is not necessary to validate the parameter count 
+	 *
+	 * @param plugin			Handle of the calling plugin.
+	 * @param numParams			Number of parameters passed to the native.
+	 * @return 					Value for the native call to return.
+	 */
+	function any (Handle plugin, int numParams);
+}
 
 /**
  * Creates a dynamic native.  This should only be called in AskPluginLoad(), or 


### PR DESCRIPTION
Native callbacks currently require plugin authors to retag their returns to an `int`, but by adding `any` as another acceptable prototype we allow them to return without needing to retag.

```cpp
public any Native_Something(Handle plugin, int numParams)
{
    float val =5.0;
    return val; // no tag mismatch
}
```

Thanks asherkin for bringing this change to light