### PR TITLE
Fix DataPack Overwrite Regression

### DIFF
--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -241,6 +241,5 @@ bool CDataPack::RemoveItem(size_t pos)
 	}
 
 	elements.remove(pos);
-	--position;
 	return true;
 }

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -219,10 +219,14 @@ bool CDataPack::RemoveItem(size_t pos)
 	{
 		pos = position;
 	}
-
 	if (pos >= elements.length())
 	{
 		return false;
+	}
+
+	if (pos < position) // we're deleting under us, step back
+	{
+		position--;
 	}
 
 	switch (elements[pos].type)

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -226,7 +226,7 @@ bool CDataPack::RemoveItem(size_t pos)
 
 	if (pos < position) // we're deleting under us, step back
 	{
-		position--;
+		--position;
 	}
 
 	switch (elements[pos].type)


### PR DESCRIPTION
Some tests passed with the implementation prior to this commit, but those were edge cases. Good older behavior is now fully restored