### PR TITLE
Fix LogStackTrace Anomaly

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -940,9 +940,8 @@ static cell_t FrameIterator_GetFilePath(IPluginContext *pContext, const cell_t *
 static cell_t LogStackTrace(IPluginContext *pContext, const cell_t *params)
 {
 	char buffer[512];
-
 	g_pSM->FormatString(buffer, sizeof(buffer), pContext, params, 1);
-		
+
 	IFrameIterator *it = pContext->CreateFrameIterator();
 	ke::Vector<ke::AString> arr = g_DbgReporter.GetStackTrace(it);
 	pContext->DestroyFrameIterator(it);
@@ -951,7 +950,7 @@ static cell_t LogStackTrace(IPluginContext *pContext, const cell_t *params)
 
 	g_Logger.LogError("[SM] Stack trace requested: %s", buffer);
 	g_Logger.LogError("[SM] Called from: %s", pPlugin->GetFilename());
-	for (size_t i = 0; i < arr.length(); i)
+	for (size_t i = 0; i < arr.length(); ++i)
 	{
 		g_Logger.LogError("%s", arr[i].chars());
 	}

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -313,6 +313,16 @@ native void SetFailState(const char[] string, any ...);
 native void ThrowError(const char[] fmt, any ...);
 
 /**
+ * Logs a stack trace from the current function call. Code 
+ * execution continues after the call
+ *
+ * @param fmt		String format.
+ * @param ...		Format arguments.
+ * @error			Always logs a stack trace.
+ */
+native void LogStackTrace(const char[] fmt, any ...);
+
+/**
  * Gets the system time as a unix timestamp.
  *
  * @param bigStamp		Optional array to store the 64bit timestamp in.

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -316,7 +316,7 @@ native void ThrowError(const char[] fmt, any ...);
  * Logs a stack trace from the current function call. Code 
  * execution continues after the call
  *
- * @param fmt		String format.
+ * @param fmt		Format string to send with the stack trace.
  * @param ...		Format arguments.
  * @error			Always logs a stack trace.
  */


### PR DESCRIPTION
These changes should've been included in #685, but it appears my git client didn't stage them for commit. Not sure specifically what happened but this has already been r'd, re-ran tests and all still checkout okay. We should also cherry-pick this to 1.9.