### PR TITLE
Mark new methodmap natives as optional

### DIFF
--- a/plugins/include/regex.inc
+++ b/plugins/include/regex.inc
@@ -273,3 +273,19 @@ public Extension __ext_regex =
 	required = 0,
 #endif
 };
+
+#if !defined REQUIRE_EXTENSIONS
+public void __ext_regex_SetNTVOptional()
+{
+	MarkNativeAsOptional("CompileRegex");
+	MarkNativeAsOptional("MatchRegex");
+	MarkNativeAsOptional("GetRegexSubString");
+	MarkNativeAsOptional("Regex.Regex");
+	MarkNativeAsOptional("Regex.Match");
+	MarkNativeAsOptional("Regex.MatchAll");
+	MarkNativeAsOptional("Regex.GetSubString");
+	MarkNativeAsOptional("Regex.MatchCount");
+	MarkNativeAsOptional("Regex.CaptureCount");
+	MarkNativeAsOptional("Regex.MatchOffset");
+}
+#endif

--- a/plugins/include/topmenus.inc
+++ b/plugins/include/topmenus.inc
@@ -430,5 +430,17 @@ public void __ext_topmenus_SetNTVOptional()
 	MarkNativeAsOptional("DisplayTopMenuCategory");
 	MarkNativeAsOptional("FindTopMenuCategory");
 	MarkNativeAsOptional("SetTopMenuTitleCaching");
+	MarkNativeAsOptional("TopMenu.TopMenu");
+	MarkNativeAsOptional("TopMenu.FromHandle");
+	MarkNativeAsOptional("TopMenu.LoadConfig");
+	MarkNativeAsOptional("TopMenu.AddCategory");
+	MarkNativeAsOptional("TopMenu.AddItem");
+	MarkNativeAsOptional("TopMenu.GetInfoString");
+	MarkNativeAsOptional("TopMenu.GetObjName");
+	MarkNativeAsOptional("TopMenu.Remove");
+	MarkNativeAsOptional("TopMenu.Display");
+	MarkNativeAsOptional("TopMenu.DisplayCategory");
+	MarkNativeAsOptional("TopMenu.FindCategory");
+	MarkNativeAsOptional("TopMenu.CacheTitles.set");
 }
 #endif


### PR DESCRIPTION
The `TopMenu` methodmap natives weren't marked as optional if the extension was optional like the other normal natives.

The `Regex` natives weren't marked as optional at all before if the regex extension was included optionally.

This makes the error message cleaner in case topmenus aren't loaded and won't prevent plugins from loading if they're supposed to have an optional dependency.
```
adminmenu.smx (Admin Menu): Required extension "TopMenus" file("topmenus.ext") not running
basebans.smx (Basic Ban Commands): Native "TopMenu.Display" was not found
```