### PR TITLE
Remove `MAPLIST_FLAG_NO_DEFAULT` misuses

### DIFF
--- a/plugins/basecommands/map.sp
+++ b/plugins/basecommands/map.sp
@@ -133,7 +133,7 @@ int LoadMapList(Menu menu)
 	if ((map_array = ReadMapList(g_map_array,
 			g_map_serial,
 			"sm_map menu",
-			MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_NO_DEFAULT|MAPLIST_FLAG_MAPSFOLDER))
+			MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_MAPSFOLDER))
 		!= null)
 	{
 		g_map_array = map_array;

--- a/plugins/basevotes/votemap.sp
+++ b/plugins/basevotes/votemap.sp
@@ -274,7 +274,7 @@ int LoadMapList(Menu menu)
 	if ((map_array = ReadMapList(g_map_array,
 			g_map_serial,
 			"sm_votemap menu",
-			MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_NO_DEFAULT|MAPLIST_FLAG_MAPSFOLDER))
+			MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_MAPSFOLDER))
 		!= null)
 	{
 		g_map_array = map_array;


### PR DESCRIPTION
These two base plugins are using the `MAPLIST_FLAG_NO_DEFAULT` when they shouldn't, which causes much user (and SM developer) confusion as it is completely counter to the documentation.

Raised by @DoctorOcsid on Discord.