### PR TITLE
More TR natives

### DIFF
--- a/extensions/sdktools/extension.cpp
+++ b/extensions/sdktools/extension.cpp
@@ -61,6 +61,7 @@ SH_DECL_HOOK1_void_vafmt(IVEngineServer, ClientCommand, SH_NOATTRIB, 0, edict_t 
 SDKTools g_SdkTools;		/**< Global singleton for extension's main interface */
 IServerGameEnts *gameents = NULL;
 IEngineTrace *enginetrace = NULL;
+ISpatialPartition *partition = NULL;
 IEngineSound *engsound = NULL;
 INetworkStringTableContainer *netstringtables = NULL;
 IServerPluginHelpers *pluginhelpers = NULL;
@@ -269,6 +270,7 @@ bool SDKTools::SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlen, bool
 	GET_V_IFACE_ANY(GetServerFactory, gameents, IServerGameEnts, INTERFACEVERSION_SERVERGAMEENTS);
 	GET_V_IFACE_ANY(GetEngineFactory, engsound, IEngineSound, IENGINESOUND_SERVER_INTERFACE_VERSION);
 	GET_V_IFACE_ANY(GetEngineFactory, enginetrace, IEngineTrace, INTERFACEVERSION_ENGINETRACE_SERVER);
+	GET_V_IFACE_ANY(GetEngineFactory, partition, ISpatialPartition, INTERFACEVERSION_SPATIALPARTITION);
 	GET_V_IFACE_ANY(GetEngineFactory, netstringtables, INetworkStringTableContainer, INTERFACENAME_NETWORKSTRINGTABLESERVER);
 	GET_V_IFACE_ANY(GetEngineFactory, pluginhelpers, IServerPluginHelpers, INTERFACEVERSION_ISERVERPLUGINHELPERS);
 	GET_V_IFACE_ANY(GetServerFactory, serverClients, IServerGameClients, INTERFACEVERSION_SERVERGAMECLIENTS);

--- a/extensions/sdktools/extension.h
+++ b/extensions/sdktools/extension.h
@@ -42,6 +42,7 @@
 #include <IPlayerHelpers.h>
 #include <IGameHelpers.h>
 #include <IEngineTrace.h>
+#include <ispatialpartition.h>
 #include <IEngineSound.h>
 #include <ivoiceserver.h>
 #include <iplayerinfo.h>
@@ -131,6 +132,7 @@ extern SDKTools g_SdkTools;
 /* Interfaces from engine or gamedll */
 extern IServerGameEnts *gameents;
 extern IEngineTrace *enginetrace;
+extern ISpatialPartition *partition;
 extern IEngineSound *engsound;
 extern INetworkStringTableContainer *netstringtables;
 extern IServerPluginHelpers *pluginhelpers;

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -884,7 +884,7 @@ static cell_t smn_TRGetSurfaceName(IPluginContext *pContext, const cell_t *param
 		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[1], err);
 	}
 
-	pContext->StringToLocal(params[2], params[3], tr->surface.name);
+	pContext->StringToLocal(params[1], params[2], tr->surface.name);
 
 	return 1;
 }

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -117,16 +117,13 @@ enum
 // For backwards compatibility, old EnumerateEntities functions accepted bool instead of flags
 int TranslatePartitionFlags(int input)
 {
-	if (input == 0)
+	switch (input)
 	{
+	case 0:
 		return PARTITION_ENGINE_SOLID_EDICTS;
-	}
-	else if (input == 1)
-	{
+	case 1:
 		return PARTITION_ENGINE_TRIGGER_EDICTS;
-	}
-	else
-	{
+	default:
 		return input >> 1;
 	}
 }

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -877,7 +877,7 @@ static cell_t smn_TRGetSurfaceName(IPluginContext *pContext, const cell_t *param
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), myself->GetIdentity());
 
-	if (params[1] == BAD_HANDLE)
+	if (params[3] == BAD_HANDLE)
 	{
 		tr = &g_Trace;
 	} else if ((err = handlesys->ReadHandle(params[1], g_TraceHandle, &sec, (void **)&tr)) != HandleError_None) {

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -874,14 +874,14 @@ static cell_t smn_TRGetSurfaceName(IPluginContext *pContext, const cell_t *param
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), myself->GetIdentity());
 
-	if (params[3] == BAD_HANDLE)
+	if (params[1] == BAD_HANDLE)
 	{
 		tr = &g_Trace;
 	} else if ((err = handlesys->ReadHandle(params[1], g_TraceHandle, &sec, (void **)&tr)) != HandleError_None) {
-		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[3], err);
+		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[1], err);
 	}
 
-	pContext->StringToLocal(params[1], params[2], tr->surface.name);
+	pContext->StringToLocal(params[2], params[3], tr->surface.name);
 
 	return 1;
 }

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -115,7 +115,7 @@ enum
 };
 
 // For backwards compatibility, old EnumerateEntities functions accepted bool instead of flags
-int TranslatePartitionFlags(int input)
+static int TranslatePartitionFlags(int input)
 {
 	switch (input)
 	{

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -855,7 +855,7 @@ static cell_t smn_TRGetEndPosition(IPluginContext *pContext, const cell_t *param
 	return 1;
 }
 
-static cell_t smn_TRGetDispFlags(IPluginContext *pContext, const cell_t *params)
+static cell_t smn_TRGetDisplacementFlags(IPluginContext *pContext, const cell_t *params)
 {
 	sm_trace_t *tr;
 	HandleError err;
@@ -1096,7 +1096,7 @@ sp_nativeinfo_t g_TRNatives[] =
 	{"TR_GetStartPosition",			smn_TRGetStartPosition},
 	{"TR_GetEndPosition",			smn_TRGetEndPosition},
 	{"TR_GetEntityIndex",			smn_TRGetEntityIndex},
-	{"TR_GetDispFlags",				smn_TRGetDispFlags},
+	{"TR_GetDisplacementFlags",		smn_TRGetDisplacementFlags },
 	{"TR_GetSurfaceName",			smn_TRGetSurfaceName},
 	{"TR_GetSurfaceProps",			smn_TRGetSurfaceProps},
 	{"TR_GetSurfaceFlags",			smn_TRGetSurfaceFlags},

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -812,15 +812,15 @@ static cell_t smn_TRGetStartPosition(IPluginContext *pContext, const cell_t *par
 	HandleError err;
 	HandleSecurity sec(pContext->GetIdentity(), myself->GetIdentity());
 
-	if (params[2] == BAD_HANDLE)
+	if (params[1] == BAD_HANDLE)
 	{
 		tr = &g_Trace;
-	} else if ((err = handlesys->ReadHandle(params[2], g_TraceHandle, &sec, (void **)&tr)) != HandleError_None) {
-		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[2], err);
+	} else if ((err = handlesys->ReadHandle(params[1], g_TraceHandle, &sec, (void **)&tr)) != HandleError_None) {
+		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[1], err);
 	}
 
 	cell_t *addr;
-	pContext->LocalToPhysAddr(params[1], &addr);
+	pContext->LocalToPhysAddr(params[2], &addr);
 
 	addr[0] = sp_ftoc(tr->startpos.x);
 	addr[1] = sp_ftoc(tr->startpos.y);

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -881,7 +881,7 @@ static cell_t smn_TRGetSurfaceName(IPluginContext *pContext, const cell_t *param
 	{
 		tr = &g_Trace;
 	} else if ((err = handlesys->ReadHandle(params[1], g_TraceHandle, &sec, (void **)&tr)) != HandleError_None) {
-		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[1], err);
+		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[3], err);
 	}
 
 	pContext->StringToLocal(params[1], params[2], tr->surface.name);

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -282,7 +282,7 @@ native void TR_EnumerateEntities(const float pos[3],
  * @param vec			Ending position of the ray.
  * @param mins			Hull minimum size.
  * @param maxs			Hull maximum size.
- * @param mask			Mask to use for the trace. See PARTITION_ENGINE_* flags.
+ * @param mask			Mask to use for the trace. See PARTITION_* flags.
  * @param enumerator	Function to use as enumerator. For each entity found
  *						along the ray, this function is called.
  * @param data			Arbitrary data value to pass through to the enumerator.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -108,24 +108,24 @@
  * @section Surface flags.
  */
  
-#define SURF_LIGHT       0x0001      // value will hold the light strength
-#define SURF_SKY2D       0x0002      // don't draw, indicates we should skylight + draw 2d sky but not draw the 3D skybox
-#define SURF_SKY         0x0004      // don't draw, but add to skybox
-#define SURF_WARP        0x0008      // turbulent water warp
+#define SURF_LIGHT       0x0001      /**< value will hold the light strength */
+#define SURF_SKY2D       0x0002      /**< don't draw, indicates we should skylight + draw 2d sky but not draw the 3D skybox */
+#define SURF_SKY         0x0004      /**< don't draw, but add to skybox */
+#define SURF_WARP        0x0008      /**< turbulent water warp */
 #define SURF_TRANS       0x0010
-#define SURF_NOPORTAL    0x0020      // the surface can not have a portal placed on it
-#define SURF_TRIGGER     0x0040      // This is an xbox hack to work around elimination of trigger surfaces, which breaks occluders
-#define SURF_NODRAW      0x0080      // don't bother referencing the texture
+#define SURF_NOPORTAL    0x0020      /**< the surface can not have a portal placed on it */
+#define SURF_TRIGGER     0x0040      /**< This is an xbox hack to work around elimination of trigger surfaces, which breaks occluders */
+#define SURF_NODRAW      0x0080      /**< don't bother referencing the texture */
 
-#define SURF_HINT        0x0100      // make a primary bsp splitter
+#define SURF_HINT        0x0100      /**< make a primary bsp splitter */
 
-#define SURF_SKIP        0x0200      // completely ignore, allowing non-closed brushes
-#define SURF_NOLIGHT     0x0400      // Don't calculate light
-#define SURF_BUMPLIGHT   0x0800      // calculate three lightmaps for the surface for bumpmapping
-#define SURF_NOSHADOWS   0x1000      // Don't receive shadows
-#define SURF_NODECALS    0x2000      // Don't receive decals
-#define SURF_NOCHOP      0x4000      // Don't subdivide patches on this surface 
-#define SURF_HITBOX      0x8000      // surface is part of a hitbox
+#define SURF_SKIP        0x0200      /**< completely ignore, allowing non-closed brushes */
+#define SURF_NOLIGHT     0x0400      /**< Don't calculate light */
+#define SURF_BUMPLIGHT   0x0800      /**< calculate three lightmaps for the surface for bumpmapping */
+#define SURF_NOSHADOWS   0x1000      /**< Don't receive shadows */
+#define SURF_NODECALS    0x2000      /**< Don't receive decals */
+#define SURF_NOCHOP      0x4000      /**< Don't subdivide patches on this surface */
+#define SURF_HITBOX      0x8000      /**< surface is part of a hitbox */
 
 /**
  * @endsection
@@ -135,9 +135,9 @@
  * @section Partition masks.
  */
  
-#define PARTITION_SOLID_EDICTS        (1 << 1) // every edict_t that isn't SOLID_TRIGGER or SOLID_NOT (and static props)
-#define PARTITION_TRIGGER_EDICTS      (1 << 2) // every edict_t that IS SOLID_TRIGGER
-#define PARTITION_NON_STATIC_EDICTS   (1 << 5) // everything in solid & trigger except the static props, includes SOLID_NOTs
+#define PARTITION_SOLID_EDICTS        (1 << 1) /**< every edict_t that isn't SOLID_TRIGGER or SOLID_NOT (and static props) */
+#define PARTITION_TRIGGER_EDICTS      (1 << 2) /**< every edict_t that IS SOLID_TRIGGER */
+#define PARTITION_NON_STATIC_EDICTS   (1 << 5) /**< everything in solid & trigger except the static props, includes SOLID_NOTs */
 #define PARTITION_STATIC_PROPS        (1 << 7)
 
 /**

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -597,10 +597,10 @@ native int TR_GetSurfaceFlags(Handle hndl=INVALID_HANDLE);
 native int TR_GetPhysicsBone(Handle hndl=INVALID_HANDLE);
 
 /**
- * If true, plane is not valid.
+ * Returns whether the entire trace was in a solid area.
  *
  * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
- * @return				Physics bone index.
+ * @return				True if entire trace was in a solid area, otherwise false.
  * @error				Invalid Handle.
  */
 native bool TR_AllSolid(Handle hndl=INVALID_HANDLE);

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -527,11 +527,11 @@ native float TR_GetFractionLeftSolid(Handle hndl=INVALID_HANDLE);
 /**
  * Returns the starting position of a trace.
  *
- * @param pos			Vector buffer to store data in.
  * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @param pos			Vector buffer to store data in.
  * @error				Invalid Handle.
  */
-native void TR_GetStartPosition(float pos[3], Handle hndl=INVALID_HANDLE);
+native void TR_GetStartPosition(Handle hndl, float pos[3]);
 
 /**
  * Returns the collision position of a trace result.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -563,11 +563,13 @@ native int TR_GetDisplacementFlags(Handle hndl=INVALID_HANDLE);
 /**
  * Returns the name of the surface that was hit.
  *
+ * @param buffer			Buffer to store surface name in
+ * @param maxlen			Maximum length of output buffer
  * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
  * @noreturn
  * @error				Invalid Handle.
  */
-native void TR_GetSurfaceName(Handle hndl=INVALID_HANDLE, char[] buffer, int maxlen);
+native void TR_GetSurfaceName(char[] buffer, int maxlen, Handle hndl=INVALID_HANDLE);
 
 /**
  * Returns the surface properties index of the surface that was hit.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -35,70 +35,70 @@
 #endif
 #define _sdktools_trace_included
 
-#define	CONTENTS_EMPTY			0		/**< No contents. */
-#define	CONTENTS_SOLID			0x1		/**< an eye is never valid in a solid . */
-#define	CONTENTS_WINDOW			0x2		/**< translucent, but not watery (glass). */
-#define	CONTENTS_AUX			0x4
-#define	CONTENTS_GRATE			0x8		/**< alpha-tested "grate" textures.  Bullets/sight pass through, but solids don't. */
-#define	CONTENTS_SLIME			0x10
-#define	CONTENTS_WATER			0x20
-#define	CONTENTS_MIST			0x40
-#define CONTENTS_OPAQUE			0x80		/**< things that cannot be seen through (may be non-solid though). */
-#define	LAST_VISIBLE_CONTENTS	0x80
-#define ALL_VISIBLE_CONTENTS 	(LAST_VISIBLE_CONTENTS | (LAST_VISIBLE_CONTENTS-1))
-#define CONTENTS_TESTFOGVOLUME	0x100
-#define CONTENTS_UNUSED5		0x200
-#define CONTENTS_UNUSED6		0x4000
-#define CONTENTS_TEAM1			0x800		/**< per team contents used to differentiate collisions. */
-#define CONTENTS_TEAM2			0x1000		/**< between players and objects on different teams. */
-#define CONTENTS_IGNORE_NODRAW_OPAQUE	0x2000		/**< ignore CONTENTS_OPAQUE on surfaces that have SURF_NODRAW. */
-#define CONTENTS_MOVEABLE		0x4000		/**< hits entities which are MOVETYPE_PUSH (doors, plats, etc) */
-#define	CONTENTS_AREAPORTAL		0x8000		/**< remaining contents are non-visible, and don't eat brushes. */
-#define	CONTENTS_PLAYERCLIP		0x10000
-#define	CONTENTS_MONSTERCLIP	0x20000
+#define CONTENTS_EMPTY                   0           /**< No contents. */
+#define CONTENTS_SOLID                   0x1         /**< an eye is never valid in a solid . */
+#define CONTENTS_WINDOW                  0x2         /**< translucent, but not watery (glass). */
+#define CONTENTS_AUX                     0x4
+#define CONTENTS_GRATE                   0x8         /**< alpha-tested "grate" textures.  Bullets/sight pass through, but solids don't. */
+#define CONTENTS_SLIME                   0x10
+#define CONTENTS_WATER                   0x20
+#define CONTENTS_MIST                    0x40
+#define CONTENTS_OPAQUE                  0x80        /**< things that cannot be seen through (may be non-solid though). */
+#define LAST_VISIBLE_CONTENTS            0x80
+#define ALL_VISIBLE_CONTENTS             (LAST_VISIBLE_CONTENTS | (LAST_VISIBLE_CONTENTS-1))
+#define CONTENTS_TESTFOGVOLUME           0x100
+#define CONTENTS_UNUSED5                 0x200
+#define CONTENTS_UNUSED6                 0x4000
+#define CONTENTS_TEAM1                   0x800       /**< per team contents used to differentiate collisions. */
+#define CONTENTS_TEAM2                   0x1000      /**< between players and objects on different teams. */
+#define CONTENTS_IGNORE_NODRAW_OPAQUE    0x2000      /**< ignore CONTENTS_OPAQUE on surfaces that have SURF_NODRAW. */
+#define CONTENTS_MOVEABLE                0x4000      /**< hits entities which are MOVETYPE_PUSH (doors, plats, etc) */
+#define CONTENTS_AREAPORTAL              0x8000      /**< remaining contents are non-visible, and don't eat brushes. */
+#define CONTENTS_PLAYERCLIP              0x10000
+#define CONTENTS_MONSTERCLIP             0x20000
 
 /**
  * @section currents can be added to any other contents, and may be mixed
  */
-#define	CONTENTS_CURRENT_0		0x40000
-#define	CONTENTS_CURRENT_90		0x80000
-#define	CONTENTS_CURRENT_180	0x100000
-#define	CONTENTS_CURRENT_270	0x200000
-#define	CONTENTS_CURRENT_UP		0x400000
-#define	CONTENTS_CURRENT_DOWN	0x800000
+#define CONTENTS_CURRENT_0      0x40000
+#define CONTENTS_CURRENT_90     0x80000
+#define CONTENTS_CURRENT_180    0x100000
+#define CONTENTS_CURRENT_270    0x200000
+#define CONTENTS_CURRENT_UP     0x400000
+#define CONTENTS_CURRENT_DOWN   0x800000
 
 /**
  * @endsection
  */
 
-#define	CONTENTS_ORIGIN			0x1000000	/**< removed before bsp-ing an entity. */
-#define	CONTENTS_MONSTER		0x2000000	/**< should never be on a brush, only in game. */
-#define	CONTENTS_DEBRIS			0x4000000
-#define	CONTENTS_DETAIL			0x8000000	/**< brushes to be added after vis leafs. */
-#define	CONTENTS_TRANSLUCENT	0x10000000	/**< auto set if any surface has trans. */
-#define	CONTENTS_LADDER			0x20000000
-#define CONTENTS_HITBOX			0x40000000	/**< use accurate hitboxes on trace. */
+#define CONTENTS_ORIGIN         0x1000000   /**< removed before bsp-ing an entity. */
+#define CONTENTS_MONSTER        0x2000000   /**< should never be on a brush, only in game. */
+#define CONTENTS_DEBRIS         0x4000000
+#define CONTENTS_DETAIL         0x8000000   /**< brushes to be added after vis leafs. */
+#define CONTENTS_TRANSLUCENT    0x10000000  /**< auto set if any surface has trans. */
+#define CONTENTS_LADDER         0x20000000
+#define CONTENTS_HITBOX         0x40000000  /**< use accurate hitboxes on trace. */
 
 /**
  * @section Trace masks.
  */
-#define	MASK_ALL				(0xFFFFFFFF)
-#define	MASK_SOLID				(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_MONSTER|CONTENTS_GRATE) 			/**< everything that is normally solid */
-#define	MASK_PLAYERSOLID		(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_PLAYERCLIP|CONTENTS_WINDOW|CONTENTS_MONSTER|CONTENTS_GRATE) 	/**< everything that blocks player movement */
-#define	MASK_NPCSOLID			(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTERCLIP|CONTENTS_WINDOW|CONTENTS_MONSTER|CONTENTS_GRATE) /**< blocks npc movement */
-#define	MASK_WATER				(CONTENTS_WATER|CONTENTS_MOVEABLE|CONTENTS_SLIME) 							/**< water physics in these contents */
-#define	MASK_OPAQUE				(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_OPAQUE) 							/**< everything that blocks line of sight for AI, lighting, etc */
-#define MASK_OPAQUE_AND_NPCS	(MASK_OPAQUE|CONTENTS_MONSTER)										/**< everything that blocks line of sight for AI, lighting, etc, but with monsters added. */
-#define	MASK_VISIBLE			(MASK_OPAQUE|CONTENTS_IGNORE_NODRAW_OPAQUE) 								/**< everything that blocks line of sight for players */
-#define MASK_VISIBLE_AND_NPCS	(MASK_OPAQUE_AND_NPCS|CONTENTS_IGNORE_NODRAW_OPAQUE) 							/**< everything that blocks line of sight for players, but with monsters added. */
-#define	MASK_SHOT				(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_DEBRIS|CONTENTS_HITBOX) 	/**< bullets see these as solid */
-#define MASK_SHOT_HULL			(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_DEBRIS|CONTENTS_GRATE) 	/**< non-raycasted weapons see this as solid (includes grates) */
-#define MASK_SHOT_PORTAL		(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW) 							/**< hits solids (not grates) and passes through everything else */
-#define MASK_SOLID_BRUSHONLY	(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_GRATE) 					/**< everything normally solid, except monsters (world+brush only) */
-#define MASK_PLAYERSOLID_BRUSHONLY	(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_PLAYERCLIP|CONTENTS_GRATE) 			/**< everything normally solid for player movement, except monsters (world+brush only) */
-#define MASK_NPCSOLID_BRUSHONLY	(CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_MONSTERCLIP|CONTENTS_GRATE) 			/**< everything normally solid for npc movement, except monsters (world+brush only) */
-#define MASK_NPCWORLDSTATIC		(CONTENTS_SOLID|CONTENTS_WINDOW|CONTENTS_MONSTERCLIP|CONTENTS_GRATE) 					/**< just the world, used for route rebuilding */
-#define MASK_SPLITAREAPORTAL	(CONTENTS_WATER|CONTENTS_SLIME) 									/**< These are things that can split areaportals */
+#define MASK_ALL                    (0xFFFFFFFF)
+#define MASK_SOLID                  (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_MONSTER|CONTENTS_GRATE)                      /**< everything that is normally solid */
+#define MASK_PLAYERSOLID            (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_PLAYERCLIP|CONTENTS_WINDOW|CONTENTS_MONSTER|CONTENTS_GRATE)  /**< everything that blocks player movement */
+#define MASK_NPCSOLID               (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTERCLIP|CONTENTS_WINDOW|CONTENTS_MONSTER|CONTENTS_GRATE) /**< blocks npc movement */
+#define MASK_WATER                  (CONTENTS_WATER|CONTENTS_MOVEABLE|CONTENTS_SLIME)                                                       /**< water physics in these contents */
+#define MASK_OPAQUE                 (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_OPAQUE)                                                      /**< everything that blocks line of sight for AI, lighting, etc */
+#define MASK_OPAQUE_AND_NPCS        (MASK_OPAQUE|CONTENTS_MONSTER)                                                                          /**< everything that blocks line of sight for AI, lighting, etc, but with monsters added. */
+#define MASK_VISIBLE                (MASK_OPAQUE|CONTENTS_IGNORE_NODRAW_OPAQUE)                                                             /**< everything that blocks line of sight for players */
+#define MASK_VISIBLE_AND_NPCS       (MASK_OPAQUE_AND_NPCS|CONTENTS_IGNORE_NODRAW_OPAQUE)                                                    /**< everything that blocks line of sight for players, but with monsters added. */
+#define MASK_SHOT                   (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_DEBRIS|CONTENTS_HITBOX)     /**< bullets see these as solid */
+#define MASK_SHOT_HULL              (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_DEBRIS|CONTENTS_GRATE)      /**< non-raycasted weapons see this as solid (includes grates) */
+#define MASK_SHOT_PORTAL            (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW)                                                      /**< hits solids (not grates) and passes through everything else */
+#define MASK_SOLID_BRUSHONLY        (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_GRATE)                                       /**< everything normally solid, except monsters (world+brush only) */
+#define MASK_PLAYERSOLID_BRUSHONLY  (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_PLAYERCLIP|CONTENTS_GRATE)                   /**< everything normally solid for player movement, except monsters (world+brush only) */
+#define MASK_NPCSOLID_BRUSHONLY     (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_WINDOW|CONTENTS_MONSTERCLIP|CONTENTS_GRATE)                  /**< everything normally solid for npc movement, except monsters (world+brush only) */
+#define MASK_NPCWORLDSTATIC         (CONTENTS_SOLID|CONTENTS_WINDOW|CONTENTS_MONSTERCLIP|CONTENTS_GRATE)                                    /**< just the world, used for route rebuilding */
+#define MASK_SPLITAREAPORTAL        (CONTENTS_WATER|CONTENTS_SLIME)                                                                         /**< These are things that can split areaportals */
 
 /**
  * @endsection
@@ -108,24 +108,24 @@
  * @section Surface flags.
  */
  
-#define	SURF_LIGHT		0x0001		// value will hold the light strength
-#define	SURF_SKY2D		0x0002		// don't draw, indicates we should skylight + draw 2d sky but not draw the 3D skybox
-#define	SURF_SKY		0x0004		// don't draw, but add to skybox
-#define	SURF_WARP		0x0008		// turbulent water warp
-#define	SURF_TRANS		0x0010
-#define SURF_NOPORTAL	0x0020	// the surface can not have a portal placed on it
-#define	SURF_TRIGGER	0x0040	// FIXME: This is an xbox hack to work around elimination of trigger surfaces, which breaks occluders
-#define	SURF_NODRAW		0x0080	// don't bother referencing the texture
+#define SURF_LIGHT       0x0001      // value will hold the light strength
+#define SURF_SKY2D       0x0002      // don't draw, indicates we should skylight + draw 2d sky but not draw the 3D skybox
+#define SURF_SKY         0x0004      // don't draw, but add to skybox
+#define SURF_WARP        0x0008      // turbulent water warp
+#define SURF_TRANS       0x0010
+#define SURF_NOPORTAL    0x0020      // the surface can not have a portal placed on it
+#define SURF_TRIGGER     0x0040      // This is an xbox hack to work around elimination of trigger surfaces, which breaks occluders
+#define SURF_NODRAW      0x0080      // don't bother referencing the texture
 
-#define	SURF_HINT		0x0100	// make a primary bsp splitter
+#define SURF_HINT        0x0100      // make a primary bsp splitter
 
-#define	SURF_SKIP		0x0200	// completely ignore, allowing non-closed brushes
-#define SURF_NOLIGHT	0x0400	// Don't calculate light
-#define SURF_BUMPLIGHT	0x0800	// calculate three lightmaps for the surface for bumpmapping
-#define SURF_NOSHADOWS	0x1000	// Don't receive shadows
-#define SURF_NODECALS	0x2000	// Don't receive decals
-#define SURF_NOCHOP		0x4000	// Don't subdivide patches on this surface 
-#define SURF_HITBOX		0x8000	// surface is part of a hitbox
+#define SURF_SKIP        0x0200      // completely ignore, allowing non-closed brushes
+#define SURF_NOLIGHT     0x0400      // Don't calculate light
+#define SURF_BUMPLIGHT   0x0800      // calculate three lightmaps for the surface for bumpmapping
+#define SURF_NOSHADOWS   0x1000      // Don't receive shadows
+#define SURF_NODECALS    0x2000      // Don't receive decals
+#define SURF_NOCHOP      0x4000      // Don't subdivide patches on this surface 
+#define SURF_HITBOX      0x8000      // surface is part of a hitbox
 
 /**
  * @endsection
@@ -135,10 +135,10 @@
  * @section Partition masks.
  */
  
-#define PARTITION_SOLID_EDICTS      (1 << 1) // every edict_t that isn't SOLID_TRIGGER or SOLID_NOT (and static props)
-#define PARTITION_TRIGGER_EDICTS    (1 << 2) // every edict_t that IS SOLID_TRIGGER
-#define PARTITION_NON_STATIC_EDICTS (1 << 5) // everything in solid & trigger except the static props, includes SOLID_NOTs
-#define PARTITION_STATIC_PROPS      (1 << 7)
+#define PARTITION_SOLID_EDICTS        (1 << 1) // every edict_t that isn't SOLID_TRIGGER or SOLID_NOT (and static props)
+#define PARTITION_TRIGGER_EDICTS      (1 << 2) // every edict_t that IS SOLID_TRIGGER
+#define PARTITION_NON_STATIC_EDICTS   (1 << 5) // everything in solid & trigger except the static props, includes SOLID_NOTs
+#define PARTITION_STATIC_PROPS        (1 << 7)
 
 /**
  * @endsection
@@ -148,11 +148,11 @@
  * @section Displacement flags.
  */
  
-#define DISPSURF_FLAG_SURFACE		(1<<0)
-#define DISPSURF_FLAG_WALKABLE		(1<<1)
-#define DISPSURF_FLAG_BUILDABLE		(1<<2)
-#define DISPSURF_FLAG_SURFPROP1		(1<<3)
-#define DISPSURF_FLAG_SURFPROP2		(1<<4)
+#define DISPSURF_FLAG_SURFACE         (1<<0)
+#define DISPSURF_FLAG_WALKABLE        (1<<1)
+#define DISPSURF_FLAG_BUILDABLE       (1<<2)
+#define DISPSURF_FLAG_SURFPROP1       (1<<3)
+#define DISPSURF_FLAG_SURFPROP2       (1<<4)
 
 /**
  * @endsection
@@ -160,8 +160,8 @@
  
 enum RayType
 {
-	RayType_EndPoint,	/**< The trace ray will go from the start position to the end position. */
-	RayType_Infinite	/**< The trace ray will go from the start position to infinity using a direction vector. */
+	RayType_EndPoint,   /**< The trace ray will go from the start position to the end position. */
+	RayType_Infinite    /**< The trace ray will go from the start position to infinity using a direction vector. */
 };
 
 typeset TraceEntityFilter

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -522,7 +522,7 @@ native float TR_GetFraction(Handle hndl=INVALID_HANDLE);
  * @return				Time fraction left solid value of the trace.
  * @error				Invalid Handle.
  */
-native float TR_GetFraction(Handle hndl=INVALID_HANDLE);
+native float TR_GetFractionLeftSolid(Handle hndl=INVALID_HANDLE);
 
 /**
  * Returns the starting position of a trace.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -563,13 +563,13 @@ native int TR_GetDisplacementFlags(Handle hndl=INVALID_HANDLE);
 /**
  * Returns the name of the surface that was hit.
  *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
  * @param buffer			Buffer to store surface name in
  * @param maxlen			Maximum length of output buffer
- * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
  * @noreturn
  * @error				Invalid Handle.
  */
-native void TR_GetSurfaceName(char[] buffer, int maxlen, Handle hndl=INVALID_HANDLE);
+native void TR_GetSurfaceName(Handle hndl, char[] buffer, int maxlen);
 
 /**
  * Returns the surface properties index of the surface that was hit.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -103,7 +103,61 @@
 /**
  * @endsection
  */
+ 
+/**
+ * @section Surface flags.
+ */
+ 
+#define	SURF_LIGHT		0x0001		// value will hold the light strength
+#define	SURF_SKY2D		0x0002		// don't draw, indicates we should skylight + draw 2d sky but not draw the 3D skybox
+#define	SURF_SKY		0x0004		// don't draw, but add to skybox
+#define	SURF_WARP		0x0008		// turbulent water warp
+#define	SURF_TRANS		0x0010
+#define SURF_NOPORTAL	0x0020	// the surface can not have a portal placed on it
+#define	SURF_TRIGGER	0x0040	// FIXME: This is an xbox hack to work around elimination of trigger surfaces, which breaks occluders
+#define	SURF_NODRAW		0x0080	// don't bother referencing the texture
 
+#define	SURF_HINT		0x0100	// make a primary bsp splitter
+
+#define	SURF_SKIP		0x0200	// completely ignore, allowing non-closed brushes
+#define SURF_NOLIGHT	0x0400	// Don't calculate light
+#define SURF_BUMPLIGHT	0x0800	// calculate three lightmaps for the surface for bumpmapping
+#define SURF_NOSHADOWS	0x1000	// Don't receive shadows
+#define SURF_NODECALS	0x2000	// Don't receive decals
+#define SURF_NOCHOP		0x4000	// Don't subdivide patches on this surface 
+#define SURF_HITBOX		0x8000	// surface is part of a hitbox
+
+/**
+ * @endsection
+ */
+ 
+/**
+ * @section Partition masks.
+ */
+ 
+#define PARTITION_SOLID_EDICTS      (1 << 1) // every edict_t that isn't SOLID_TRIGGER or SOLID_NOT (and static props)
+#define PARTITION_TRIGGER_EDICTS    (1 << 2) // every edict_t that IS SOLID_TRIGGER
+#define PARTITION_NON_STATIC_EDICTS (1 << 5) // everything in solid & trigger except the static props, includes SOLID_NOTs
+#define PARTITION_STATIC_PROPS      (1 << 7)
+
+/**
+ * @endsection
+ */
+ 
+/**
+ * @section Disp flags.
+ */
+ 
+#define DISPSURF_FLAG_SURFACE		(1<<0)
+#define DISPSURF_FLAG_WALKABLE		(1<<1)
+#define DISPSURF_FLAG_BUILDABLE		(1<<2)
+#define DISPSURF_FLAG_SURFPROP1		(1<<3)
+#define DISPSURF_FLAG_SURFPROP2		(1<<4)
+
+/**
+ * @endsection
+ */
+ 
 enum RayType
 {
 	RayType_EndPoint,	/**< The trace ray will go from the start position to the end position. */
@@ -206,8 +260,7 @@ native void TR_TraceHull(const float pos[3],
  * @param pos			Starting position of the ray.
  * @param vec			Depending on RayType, it will be used as the ending
  *						point, or the direction angle.
- * @param triggers		If true, enumerate only triggers. Otherwise, enumerate
- *						only non-triggers.
+ * @param mask			Mask to use for the trace. See PARTITION_* flags.
  * @param rtype			Method to calculate the ray direction.
  * @param enumerator	Function to use as enumerator. For each entity found
  *						along the ray, this function is called.
@@ -215,7 +268,7 @@ native void TR_TraceHull(const float pos[3],
  */
 native void TR_EnumerateEntities(const float pos[3],
 								const float vec[3],
-								bool triggers,
+								int mask,
 								RayType rtype,
 								TraceEntityEnumerator enumerator,
 								any data=0);
@@ -229,8 +282,7 @@ native void TR_EnumerateEntities(const float pos[3],
  * @param vec			Ending position of the ray.
  * @param mins			Hull minimum size.
  * @param maxs			Hull maximum size.
- * @param triggers		If true, enumerate only triggers. Otherwise, enumerate
- *						only non-triggers.
+ * @param mask			Mask to use for the trace. See PARTITION_ENGINE_* flags.
  * @param enumerator	Function to use as enumerator. For each entity found
  *						along the ray, this function is called.
  * @param data			Arbitrary data value to pass through to the enumerator.
@@ -239,7 +291,7 @@ native void TR_EnumerateEntitiesHull(const float pos[3],
 								    const float vec[3],
 								    const float mins[3],
 								    const float maxs[3],
-								    bool triggers,
+								    int mask,
 									TraceEntityEnumerator enumerator,
 									any data=0);
 
@@ -463,6 +515,25 @@ native Handle TR_ClipCurrentRayToEntityEx(int flags, int entity);
 native float TR_GetFraction(Handle hndl=INVALID_HANDLE);
 
 /**
+ * Returns the time fraction from a trace result when it left a solid.
+ * Only valid if trace started in solid
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				Time fraction left solid value of the trace.
+ * @error				Invalid Handle.
+ */
+native float TR_GetFraction(Handle hndl=INVALID_HANDLE);
+
+/**
+ * Returns the starting position of a trace.
+ *
+ * @param pos			Vector buffer to store data in.
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @error				Invalid Handle.
+ */
+native void TR_GetStartPosition(float pos[3], Handle hndl=INVALID_HANDLE);
+
+/**
  * Returns the collision position of a trace result.
  *
  * @param pos			Vector buffer to store data in.
@@ -479,6 +550,69 @@ native void TR_GetEndPosition(float pos[3], Handle hndl=INVALID_HANDLE);
  * @error				Invalid Handle.
  */
 native int TR_GetEntityIndex(Handle hndl=INVALID_HANDLE);
+
+/**
+ * Returns the displacement flags for the surface that was hit. See DISPSURF_FLAG_*.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				Displacement flags.
+ * @error				Invalid Handle.
+ */
+native int TR_GetDispFlags(Handle hndl=INVALID_HANDLE);
+
+/**
+ * Returns the name of the surface that was hit.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @noreturn
+ * @error				Invalid Handle.
+ */
+native void TR_GetSurfaceName(Handle hndl=INVALID_HANDLE, char[] buffer, int maxlen);
+
+/**
+ * Returns the surface properties index of the surface that was hit.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				Surface props.
+ * @error				Invalid Handle.
+ */
+native int TR_GetSurfaceProps(Handle hndl=INVALID_HANDLE);
+
+/**
+ * Returns the surface flags. See SURF_*.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				Surface flags.
+ * @error				Invalid Handle.
+ */
+native int TR_GetSurfaceFlags(Handle hndl=INVALID_HANDLE);
+
+/**
+ * Returns the index of the physics bone that was hit.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				Physics bone index.
+ * @error				Invalid Handle.
+ */
+native int TR_GetPhysicsBone(Handle hndl=INVALID_HANDLE);
+
+/**
+ * If true, plane is not valid.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				Physics bone index.
+ * @error				Invalid Handle.
+ */
+native bool TR_AllSolid(Handle hndl=INVALID_HANDLE);
+
+/**
+ * Returns whether the initial point was in a solid area.
+ *
+ * @param hndl			A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return				True if initial point was in a solid area, otherwise false.
+ * @error				Invalid Handle.
+ */
+native bool TR_StartSolid(Handle hndl=INVALID_HANDLE);
 
 /**
  * Returns if there was any kind of collision along the trace ray.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -145,7 +145,7 @@
  */
  
 /**
- * @section Disp flags.
+ * @section Displacement flags.
  */
  
 #define DISPSURF_FLAG_SURFACE		(1<<0)
@@ -558,7 +558,7 @@ native int TR_GetEntityIndex(Handle hndl=INVALID_HANDLE);
  * @return				Displacement flags.
  * @error				Invalid Handle.
  */
-native int TR_GetDispFlags(Handle hndl=INVALID_HANDLE);
+native int TR_GetDisplacementFlags(Handle hndl=INVALID_HANDLE);
 
 /**
  * Returns the name of the surface that was hit.


### PR DESCRIPTION
Adds some more TR natives that expose more properties of the trace results. Here's a short summary of the new natives:
```
TR_GetStartPosition - Self explanatory, added this in just for completion since GetEndPosition exists.
TR_GetFractionLeftSolid - Similar to GetFraction, but returns the fraction of when the trace left a solid (assuming it started in a solid)
TR_GetDispFlags - Returns the displacement flags of a surface. See DISPSURF_FLAG_* for possible values.
TR_GetSurfaceName - Returns the name of the surface that was hit.
TR_GetSurfaceProps - Returns the surface properties index of the surface that was hit. Not sure if this is very useful alone since it might require other non-TR related functions to be exposed to get any real info from the index.
TR_GetSurfaceFlags - Returns the surface flags of the surface that was hit. See SURF_* for possible values.
TR_GetPhysicsBone - Returns the physics bone index, if one was hit.
TR_AllSolid - Returns whether or not the entire trace was in a solid area.
TR_StartSolid - Returns whether or not the start of the trace was in a solid area.
```

In addition to the new natives, I also changed the existing `TR_EnumerateEntities` native to accept partition flags instead of the `triggers` bool value. This means that the traces made with `TR_EnumerateEntities` are no longer restricted to just "solids or triggers". Instead you can specify any combination of partition flags to use.

The biggest bonus of doing this is that you can now hit non-solid entities with traces. To showcase this (as well as a few of the new natives), here's the output of a little test I made that traces against a non-solid brush, something that was impossible to do previously.
```
Entity: 77 (func_brush)
    Start Pos: 843.38 -185.22 320.03
    Did Hit: true
    All Solid: false
    Start Solid: false
    Fraction Left Solid: 0.000000
    Displacement Flags: 00000000
    Surface Name: DEV/DEV_MEASUREGENERIC01B
    Surface Props: 41
    Surface Flags: 0000000000000000
    Physics Bone: 0
```

For reference, or if anyone else wants to play around with this, here's the plugin I used to do this: https://pastebin.com/xYXvrfa4

Another thing to note is that the partition flag values used in the inc file are a bit different to the original SDK flags. This was done to maintain backwards compatibility so that old plugins that use `true`/`false` still keep their expected behaviour.