### PR TITLE
Change `maxlength` to `maxlen` in sample extension

### DIFF
--- a/public/sample_ext/extension.h
+++ b/public/sample_ext/extension.h
@@ -51,11 +51,11 @@ public:
 	 * @brief This is called after the initial loading sequence has been processed.
 	 *
 	 * @param error		Error message buffer.
-	 * @param maxlength	Size of error message buffer.
+	 * @param maxlen	Size of error message buffer.
 	 * @param late		Whether or not the module was loaded after map load.
 	 * @return			True to succeed loading, false to fail.
 	 */
-	//virtual bool SDK_OnLoad(char *error, size_t maxlength, bool late);
+	//virtual bool SDK_OnLoad(char *error, size_t maxlen, bool late);
 	
 	/**
 	 * @brief This is called right before the extension is unloaded.
@@ -77,31 +77,31 @@ public:
 	 * @brief this is called when Core wants to know if your extension is working.
 	 *
 	 * @param error		Error message buffer.
-	 * @param maxlength	Size of error message buffer.
+	 * @param maxlen	Size of error message buffer.
 	 * @return			True if working, false otherwise.
 	 */
-	//virtual bool QueryRunning(char *error, size_t maxlength);
+	//virtual bool QueryRunning(char *error, size_t maxlen);
 public:
 #if defined SMEXT_CONF_METAMOD
 	/**
 	 * @brief Called when Metamod is attached, before the extension version is called.
 	 *
 	 * @param error			Error buffer.
-	 * @param maxlength		Maximum size of error buffer.
+	 * @param maxlen		Maximum size of error buffer.
 	 * @param late			Whether or not Metamod considers this a late load.
 	 * @return				True to succeed, false to fail.
 	 */
-	//virtual bool SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlength, bool late);
+	//virtual bool SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlen, bool late);
 
 	/**
 	 * @brief Called when Metamod is detaching, after the extension version is called.
 	 * NOTE: By default this is blocked unless sent from SourceMod.
 	 *
 	 * @param error			Error buffer.
-	 * @param maxlength		Maximum size of error buffer.
+	 * @param maxlen		Maximum size of error buffer.
 	 * @return				True to succeed, false to fail.
 	 */
-	//virtual bool SDK_OnMetamodUnload(char *error, size_t maxlength);
+	//virtual bool SDK_OnMetamodUnload(char *error, size_t maxlen);
 
 	/**
 	 * @brief Called when Metamod's pause state is changing.
@@ -109,10 +109,10 @@ public:
 	 *
 	 * @param paused		Pause state being set.
 	 * @param error			Error buffer.
-	 * @param maxlength		Maximum size of error buffer.
+	 * @param maxlen		Maximum size of error buffer.
 	 * @return				True to succeed, false to fail.
 	 */
-	//virtual bool SDK_OnMetamodPauseChange(bool paused, char *error, size_t maxlength);
+	//virtual bool SDK_OnMetamodPauseChange(bool paused, char *error, size_t maxlen);
 #endif
 };
 


### PR DESCRIPTION
As stated in the [SourceHook Development wiki page](https://wiki.alliedmods.net/Sourcehook_Development#Getting_an_Interface_Instance):
```
The error and maxlen arguments must be named error and maxlen respectively, or else certain macros will fail
```
So this simply fixes that in the sample extension to avoid any possible confusion when using those macros.