### PR TITLE
Remove arch loops from build scripts.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -639,32 +639,40 @@ for arch in SM.archs:
      SP.libsourcepawn[arch]
   ]
 
-BuildScripts = [
-  'loader/AMBuilder',
-  'core/AMBuilder',
+NonSDKBuilds = [
   'core/logic/AMBuilder',
   'extensions/bintools/AMBuilder',
   'extensions/clientprefs/AMBuilder',
   'extensions/curl/AMBuilder',
-  'extensions/cstrike/AMBuilder',
   'extensions/geoip/AMBuilder',
-  'extensions/mysql/AMBuilder',
   'extensions/regex/AMBuilder',
-  'extensions/sdkhooks/AMBuilder',
-  'extensions/sdktools/AMBuilder',
   'extensions/sqlite/AMBuilder',
-  'extensions/tf2/AMBuilder',
   'extensions/topmenus/AMBuilder',
   'extensions/updater/AMBuilder',
+  'loader/AMBuilder',
 ]
+if SM.mysql_root:
+  NonSDKBuilds += [
+    'extensions/mysql/AMBuilder',
+  ]
+for arch in SM.archs:
+  builder.Build(NonSDKBuilds, { 'SM': SM, 'arch': arch })
+
+SDKBuilds = [
+  'core/AMBuilder',
+  'extensions/cstrike/AMBuilder',
+  'extensions/sdkhooks/AMBuilder',
+  'extensions/sdktools/AMBuilder',
+  'extensions/tf2/AMBuilder',
+]
+builder.Build(SDKBuilds, { 'SM': SM })
 
 if builder.backend == 'amb2':
-  BuildScripts += [
+  OtherScripts = [
     'plugins/AMBuilder',
     'tools/buildbot/PackageScript',
   ]
-
-builder.Build(BuildScripts, { 'SM': SM })
+  builder.Build(OtherScripts, { 'SM': SM })
 
 if builder.options.breakpad_dump:
   builder.Build('tools/buildbot/BreakpadSymbols', { 'SM': SM })

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -1,98 +1,97 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.Library(builder, 'sourcemod.logic', arch)
-  binary.compiler.cxxincludes += [
-    builder.sourcePath,
-    os.path.join(builder.sourcePath, 'core', 'logic'),
-    os.path.join(builder.sourcePath, 'public'),
-    os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
-    os.path.join(builder.sourcePath, 'public', 'amtl', 'amtl'),
-    os.path.join(builder.sourcePath, 'public', 'amtl'),
-    os.path.join(SM.mms_root, 'core', 'sourcehook')
-  ]
-  binary.compiler.defines += [
-    'SM_DEFAULT_THREADER',
-    'SM_LOGIC'
-  ]
-  
-  if builder.target.platform == 'linux':
-    binary.compiler.postlink += ['-lpthread', '-lrt']
-  elif builder.target.platform == 'mac':
-    binary.compiler.cflags += ['-Wno-deprecated-declarations']
-    binary.compiler.postlink += ['-framework', 'CoreServices']
+binary = SM.Library(builder, 'sourcemod.logic', arch)
+binary.compiler.cxxincludes += [
+  builder.sourcePath,
+  os.path.join(builder.sourcePath, 'core', 'logic'),
+  os.path.join(builder.sourcePath, 'public'),
+  os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
+  os.path.join(builder.sourcePath, 'public', 'amtl', 'amtl'),
+  os.path.join(builder.sourcePath, 'public', 'amtl'),
+  os.path.join(SM.mms_root, 'core', 'sourcehook')
+]
+binary.compiler.defines += [
+  'SM_DEFAULT_THREADER',
+  'SM_LOGIC'
+]
 
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+if builder.target.platform == 'linux':
+  binary.compiler.postlink += ['-lpthread', '-lrt']
+elif builder.target.platform == 'mac':
+  binary.compiler.cflags += ['-Wno-deprecated-declarations']
+  binary.compiler.postlink += ['-framework', 'CoreServices']
 
-  binary.sources += [
-    'common_logic.cpp',
-    'smn_adt_array.cpp',
-    'smn_sorting.cpp',
-    'smn_maplists.cpp',
-    'ADTFactory.cpp',
-    'smn_adt_stack.cpp',
-    'thread/ThreadWorker.cpp',
-    'thread/BaseWorker.cpp',
-    'ThreadSupport.cpp',
-    'smn_float.cpp',
-    'TextParsers.cpp',
-    'smn_textparse.cpp',
-    'smn_adt_trie.cpp',
-    'smn_functions.cpp',
-    'smn_timers.cpp',
-    'smn_players.cpp',
-    'MemoryUtils.cpp',
-    'smn_admin.cpp',
-    'smn_banning.cpp',
-    'smn_filesystem.cpp',
-    'stringutil.cpp',
-    'Translator.cpp',
-    'PhraseCollection.cpp',
-    'smn_lang.cpp',
-    'smn_string.cpp',
-    'smn_handles.cpp',
-    'smn_datapacks.cpp',
-    'smn_gameconfigs.cpp',
-    'smn_fakenatives.cpp',
-    'GameConfigs.cpp',
-    'sm_crc32.cpp',
-    'smn_profiler.cpp',
-    'ShareSys.cpp',
-    'PluginSys.cpp',
-    'HandleSys.cpp',
-    'NativeOwner.cpp',
-    'ExtensionSys.cpp',
-    'DebugReporter.cpp',
-    'Database.cpp',
-    'smn_database.cpp',
-    'ForwardSys.cpp',
-    'AdminCache.cpp',
-    'sm_trie.cpp',
-    'smn_console.cpp',
-    'ProfileTools.cpp',
-    'Logger.cpp',
-    'smn_core.cpp',
-    'smn_menus.cpp',
-    'sprintf.cpp',
-    'LibrarySys.cpp',
-    'RootConsoleMenu.cpp',
-    'CDataPack.cpp',
-    'frame_tasks.cpp',
-    'smn_halflife.cpp',
-    'FrameIterator.cpp',
-    'DatabaseConfBuilder.cpp',
-  ]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  if arch == 'x64':
-    binary.sources += ['PseudoAddrManager.cpp']
+binary.sources += [
+  'common_logic.cpp',
+  'smn_adt_array.cpp',
+  'smn_sorting.cpp',
+  'smn_maplists.cpp',
+  'ADTFactory.cpp',
+  'smn_adt_stack.cpp',
+  'thread/ThreadWorker.cpp',
+  'thread/BaseWorker.cpp',
+  'ThreadSupport.cpp',
+  'smn_float.cpp',
+  'TextParsers.cpp',
+  'smn_textparse.cpp',
+  'smn_adt_trie.cpp',
+  'smn_functions.cpp',
+  'smn_timers.cpp',
+  'smn_players.cpp',
+  'MemoryUtils.cpp',
+  'smn_admin.cpp',
+  'smn_banning.cpp',
+  'smn_filesystem.cpp',
+  'stringutil.cpp',
+  'Translator.cpp',
+  'PhraseCollection.cpp',
+  'smn_lang.cpp',
+  'smn_string.cpp',
+  'smn_handles.cpp',
+  'smn_datapacks.cpp',
+  'smn_gameconfigs.cpp',
+  'smn_fakenatives.cpp',
+  'GameConfigs.cpp',
+  'sm_crc32.cpp',
+  'smn_profiler.cpp',
+  'ShareSys.cpp',
+  'PluginSys.cpp',
+  'HandleSys.cpp',
+  'NativeOwner.cpp',
+  'ExtensionSys.cpp',
+  'DebugReporter.cpp',
+  'Database.cpp',
+  'smn_database.cpp',
+  'ForwardSys.cpp',
+  'AdminCache.cpp',
+  'sm_trie.cpp',
+  'smn_console.cpp',
+  'ProfileTools.cpp',
+  'Logger.cpp',
+  'smn_core.cpp',
+  'smn_menus.cpp',
+  'sprintf.cpp',
+  'LibrarySys.cpp',
+  'RootConsoleMenu.cpp',
+  'CDataPack.cpp',
+  'frame_tasks.cpp',
+  'smn_halflife.cpp',
+  'FrameIterator.cpp',
+  'DatabaseConfBuilder.cpp',
+]
 
-  if builder.target.platform == 'windows':
-    binary.sources += ['thread/WinThreads.cpp']
-  else:
-    binary.sources += ['thread/PosixThreads.cpp']
+if arch == 'x64':
+  binary.sources += ['PseudoAddrManager.cpp']
 
-  SM.binaries += [builder.Add(binary)]
+if builder.target.platform == 'windows':
+  binary.sources += ['thread/WinThreads.cpp']
+else:
+  binary.sources += ['thread/PosixThreads.cpp']
+
+SM.binaries += [builder.Add(binary)]

--- a/extensions/bintools/AMBuilder
+++ b/extensions/bintools/AMBuilder
@@ -1,30 +1,28 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'bintools.ext', arch)
-  binary.compiler.defines += ['HOOKING_ENABLED']
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core', 'sourcehook'),
-    os.path.join(builder.sourcePath, 'public', 'jit'),
-    os.path.join(builder.sourcePath, 'public', 'jit', 'x86'),
-  ]
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'bintools.ext', arch)
+binary.compiler.defines += ['HOOKING_ENABLED']
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core', 'sourcehook'),
+  os.path.join(builder.sourcePath, 'public', 'jit'),
+  os.path.join(builder.sourcePath, 'public', 'jit', 'x86'),
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  binary.sources += [
-    'extension.cpp',
-    'CallMaker.cpp',
-    'CallWrapper.cpp',
-    '../../public/smsdk_ext.cpp'
-  ]
-  
-  if arch == 'x64':
-    binary.sources += ['jit_call_x64.cpp']
-  else:
-    binary.sources += ['jit_call.cpp']
+binary.sources += [
+  'extension.cpp',
+  'CallMaker.cpp',
+  'CallWrapper.cpp',
+  '../../public/smsdk_ext.cpp'
+]
 
-  SM.extensions += [builder.Add(binary)]
+if arch == 'x64':
+  binary.sources += ['jit_call_x64.cpp']
+else:
+  binary.sources += ['jit_call.cpp']
 
+SM.extensions += [builder.Add(binary)]

--- a/extensions/clientprefs/AMBuilder
+++ b/extensions/clientprefs/AMBuilder
@@ -1,24 +1,22 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'clientprefs.ext', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core', 'sourcehook'),
-  ]
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'clientprefs.ext', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core', 'sourcehook'),
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  binary.sources += [
-    'extension.cpp',
-    'cookie.cpp',
-    'menus.cpp',
-    'natives.cpp',
-    'query.cpp',
-    '../../public/smsdk_ext.cpp'
-  ]
+binary.sources += [
+  'extension.cpp',
+  'cookie.cpp',
+  'menus.cpp',
+  'natives.cpp',
+  'query.cpp',
+  '../../public/smsdk_ext.cpp'
+]
 
-  SM.extensions += [builder.Add(binary)]
-
+SM.extensions += [builder.Add(binary)]

--- a/extensions/curl/AMBuilder
+++ b/extensions/curl/AMBuilder
@@ -2,27 +2,26 @@
 import os
 
 libcurl = builder.Build('curl-src/lib/AMBuilder')
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'webternet.ext', arch)
-  binary.compiler.includes += [
-    os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'include')
-  ]
-  binary.compiler.defines += ['CURL_STATICLIB']
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
-  binary.compiler.postlink += [libcurl[arch].binary]
-  if builder.target.platform == 'linux':
-    binary.compiler.postlink += ['-lrt']
-  elif builder.target.platform == 'windows':
-    binary.compiler.postlink += ['ws2_32.lib']
 
-  binary.sources += [
-    'extension.cpp',
-    'curlapi.cpp',
-    '../../public/smsdk_ext.cpp'
-  ]
+binary = SM.ExtLibrary(builder, 'webternet.ext', arch)
+binary.compiler.includes += [
+  os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'include')
+]
+binary.compiler.defines += ['CURL_STATICLIB']
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
+binary.compiler.postlink += [libcurl[arch].binary]
+if builder.target.platform == 'linux':
+  binary.compiler.postlink += ['-lrt']
+elif builder.target.platform == 'windows':
+  binary.compiler.postlink += ['ws2_32.lib']
 
-  SM.extensions += [builder.Add(binary)]
+binary.sources += [
+  'extension.cpp',
+  'curlapi.cpp',
+  '../../public/smsdk_ext.cpp'
+]
 
+SM.extensions += [builder.Add(binary)]

--- a/extensions/geoip/AMBuilder
+++ b/extensions/geoip/AMBuilder
@@ -1,20 +1,18 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'geoip.ext', arch)
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
-  if builder.target.platform == 'windows':
-    binary.compiler.postlink += ['wsock32.lib']
+binary = SM.ExtLibrary(builder, 'geoip.ext', arch)
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
+if builder.target.platform == 'windows':
+  binary.compiler.postlink += ['wsock32.lib']
 
-  binary.sources += [
-    'extension.cpp',
-    'GeoIP.c',
-    '../../public/smsdk_ext.cpp'
-  ]
+binary.sources += [
+  'extension.cpp',
+  'GeoIP.c',
+  '../../public/smsdk_ext.cpp'
+]
 
-  SM.extensions += [builder.Add(binary)]
-
+SM.extensions += [builder.Add(binary)]

--- a/extensions/mysql/AMBuilder
+++ b/extensions/mysql/AMBuilder
@@ -1,48 +1,45 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-if SM.mysql_root:
-  for arch in SM.archs:
-    binary = SM.ExtLibrary(builder, 'dbi.mysql.ext', arch)
-    binary.compiler.cxxincludes += [
-      os.path.join(SM.mysql_root[arch], 'include'),
-      os.path.join(SM.mms_root, 'core', 'sourcehook')
-    ]
-    if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-      binary.compiler.cxxflags += ['-fno-rtti']
-    elif binary.compiler.family == 'msvc':
-      binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'dbi.mysql.ext', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mysql_root[arch], 'include'),
+  os.path.join(SM.mms_root, 'core', 'sourcehook')
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-    if builder.target.platform == 'linux' or builder.target.platform == 'mac':
-      binary.compiler.postlink += [
-        os.path.join(SM.mysql_root[arch], 'lib', 'libmysqlclient_r.a'),
-        '-lz',
-        '-lpthread',
-        '-lm',
-      ]
-    if builder.target.platform == 'linux':
-      binary.compiler.postlink += ['-lrt']
-    elif builder.target.platform == 'windows':
-      binary.compiler.defines += ['WIN32_LEAN_AND_MEAN']
-      binary.compiler.postlink += [
-        os.path.join(SM.mysql_root[arch], 'lib', 'mysqlclient.lib'),
-        'wsock32.lib'
-      ]
+if builder.target.platform == 'linux' or builder.target.platform == 'mac':
+  binary.compiler.postlink += [
+    os.path.join(SM.mysql_root[arch], 'lib', 'libmysqlclient_r.a'),
+    '-lz',
+    '-lpthread',
+    '-lm',
+  ]
+if builder.target.platform == 'linux':
+  binary.compiler.postlink += ['-lrt']
+elif builder.target.platform == 'windows':
+  binary.compiler.defines += ['WIN32_LEAN_AND_MEAN']
+  binary.compiler.postlink += [
+    os.path.join(SM.mysql_root[arch], 'lib', 'mysqlclient.lib'),
+    'wsock32.lib'
+  ]
 
-    binary.sources += [
-      '../../public/smsdk_ext.cpp',
-      'mysql/MyBasicResults.cpp',
-      'mysql/MyBoundResults.cpp',
-      'mysql/MyDatabase.cpp',
-      'mysql/MyDriver.cpp',
-      'mysql/MyStatement.cpp',
-      'extension.cpp'
-    ]
-  
-    if binary.compiler.family == 'msvc' and binary.compiler.version >= 1900:
-      binary.sources += [ 'msvc15hack.c' ]
-      binary.compiler.linkflags += ['legacy_stdio_definitions.lib', 'legacy_stdio_wide_specifiers.lib']
-      binary.compiler.defines += ['HAVE_STRUCT_TIMESPEC']
+binary.sources += [
+  '../../public/smsdk_ext.cpp',
+  'mysql/MyBasicResults.cpp',
+  'mysql/MyBoundResults.cpp',
+  'mysql/MyDatabase.cpp',
+  'mysql/MyDriver.cpp',
+  'mysql/MyStatement.cpp',
+  'extension.cpp'
+]
 
-    SM.extensions += [builder.Add(binary)]
+if binary.compiler.family == 'msvc' and binary.compiler.version >= 1900:
+  binary.sources += [ 'msvc15hack.c' ]
+  binary.compiler.linkflags += ['legacy_stdio_definitions.lib', 'legacy_stdio_wide_specifiers.lib']
+  binary.compiler.defines += ['HAVE_STRUCT_TIMESPEC']
 
+SM.extensions += [builder.Add(binary)]

--- a/extensions/regex/AMBuilder
+++ b/extensions/regex/AMBuilder
@@ -1,35 +1,33 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'regex.ext', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core', 'sourcehook'),
-  ]
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'regex.ext', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core', 'sourcehook'),
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  if builder.target.platform == 'linux':
-    if arch == 'x86':
-      path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux', 'libpcre.a')
-    elif arch == 'x64':
-      path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux64', 'libpcre.a')
-  elif builder.target.platform == 'windows':
-    path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_win', 'pcre.lib')
-  elif builder.target.platform == 'mac':
-    if arch == 'x86':
-      path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin', 'libpcre.a')
-    elif arch == 'x64':
-      path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin64', 'libpcre.a')
-  binary.compiler.postlink += [binary.Dep(path)]
+if builder.target.platform == 'linux':
+  if arch == 'x86':
+    path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux', 'libpcre.a')
+  elif arch == 'x64':
+    path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux64', 'libpcre.a')
+elif builder.target.platform == 'windows':
+  path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_win', 'pcre.lib')
+elif builder.target.platform == 'mac':
+  if arch == 'x86':
+    path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin', 'libpcre.a')
+  elif arch == 'x64':
+    path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin64', 'libpcre.a')
+binary.compiler.postlink += [binary.Dep(path)]
 
-  binary.sources += [
-    'extension.cpp',
-    'CRegEx.cpp',
-    '../../public/smsdk_ext.cpp'
-  ]
+binary.sources += [
+  'extension.cpp',
+  'CRegEx.cpp',
+  '../../public/smsdk_ext.cpp'
+]
 
-  SM.extensions += [builder.Add(binary)]
-
+SM.extensions += [builder.Add(binary)]

--- a/extensions/sqlite/AMBuilder
+++ b/extensions/sqlite/AMBuilder
@@ -1,34 +1,32 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'dbi.sqlite.ext', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core', 'sourcehook'),
-  ]
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'dbi.sqlite.ext', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core', 'sourcehook'),
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  binary.compiler.defines += [
-    'SQLITE_OMIT_LOAD_EXTENSION',
-    'SQLITE_THREADSAFE',
-    'SQLITE_USE_URI',
-    'SQLITE_ALLOW_URI_AUTHORITY',
-  ]
-  if builder.target.platform == 'linux':
-    binary.compiler.postlink += ['-ldl', '-lpthread']
+binary.compiler.defines += [
+  'SQLITE_OMIT_LOAD_EXTENSION',
+  'SQLITE_THREADSAFE',
+  'SQLITE_USE_URI',
+  'SQLITE_ALLOW_URI_AUTHORITY',
+]
+if builder.target.platform == 'linux':
+  binary.compiler.postlink += ['-ldl', '-lpthread']
 
-  binary.sources += [
-    '../../public/smsdk_ext.cpp',
-    'extension.cpp',
-    'driver/SqDatabase.cpp',
-    'driver/SqDriver.cpp',
-    'driver/SqQuery.cpp',
-    'driver/SqResults.cpp',
-    'sqlite-source/sqlite3.c'
-  ]
+binary.sources += [
+  '../../public/smsdk_ext.cpp',
+  'extension.cpp',
+  'driver/SqDatabase.cpp',
+  'driver/SqDriver.cpp',
+  'driver/SqQuery.cpp',
+  'driver/SqResults.cpp',
+  'sqlite-source/sqlite3.c'
+]
 
-  SM.extensions += [builder.Add(binary)]
-
+SM.extensions += [builder.Add(binary)]

--- a/extensions/topmenus/AMBuilder
+++ b/extensions/topmenus/AMBuilder
@@ -1,22 +1,21 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'topmenus.ext', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core', 'sourcehook'),
-  ]
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'topmenus.ext', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core', 'sourcehook'),
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  binary.sources += [
-    'extension.cpp',
-    'smn_topmenus.cpp',
-    'TopMenu.cpp',
-    'TopMenuManager.cpp',
-    '../../public/smsdk_ext.cpp',
-  ]
+binary.sources += [
+  'extension.cpp',
+  'smn_topmenus.cpp',
+  'TopMenu.cpp',
+  'TopMenuManager.cpp',
+  '../../public/smsdk_ext.cpp',
+]
 
-  SM.extensions += [builder.Add(binary)]
+SM.extensions += [builder.Add(binary)]

--- a/extensions/updater/AMBuilder
+++ b/extensions/updater/AMBuilder
@@ -1,23 +1,21 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'updater.ext', arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core', 'sourcehook'),
-  ]
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
+binary = SM.ExtLibrary(builder, 'updater.ext', arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core', 'sourcehook'),
+]
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
 
-  binary.sources += [
-    'extension.cpp',
-    'MemoryDownloader.cpp',
-    'Updater.cpp',
-    'md5.cpp',
-    '../../public/smsdk_ext.cpp'
-  ]
+binary.sources += [
+  'extension.cpp',
+  'MemoryDownloader.cpp',
+  'Updater.cpp',
+  'md5.cpp',
+  '../../public/smsdk_ext.cpp'
+]
 
-  SM.extensions += [builder.Add(binary)]
-
+SM.extensions += [builder.Add(binary)]

--- a/loader/AMBuilder
+++ b/loader/AMBuilder
@@ -1,31 +1,30 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os.path
 
-for arch in SM.archs:
-  if builder.target.platform in ['windows', 'mac']:
-    name = 'sourcemod_mm'
-    extra_ldflags = []
-  elif builder.target.platform == 'linux':
-    name = 'sourcemod_mm_i486'
-    extra_ldflags = ['-ldl']
+if builder.target.platform in ['windows', 'mac']:
+  name = 'sourcemod_mm'
+  extra_ldflags = []
+elif builder.target.platform == 'linux':
+  name = 'sourcemod_mm_i486'
+  extra_ldflags = ['-ldl']
 
-  if arch == 'x64':
-    name = 'sourcemod_mm.x64'
+if arch == 'x64':
+  name = 'sourcemod_mm.x64'
 
-  binary = SM.Library(builder, name, arch)
-  binary.compiler.cxxincludes += [
-    os.path.join(SM.mms_root, 'core'),
-    os.path.join(SM.mms_root, 'sourcehook')
-  ]
-  binary.compiler.defines += ['META_NO_HL2SDK']
-  if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
-  elif binary.compiler.family == 'msvc':
-    binary.compiler.cxxflags += ['/GR-']
-  binary.compiler.linkflags += extra_ldflags
-  binary.sources = [
-    'loader.cpp'
-  ]
+binary = SM.Library(builder, name, arch)
+binary.compiler.cxxincludes += [
+  os.path.join(SM.mms_root, 'core'),
+  os.path.join(SM.mms_root, 'sourcehook')
+]
+binary.compiler.defines += ['META_NO_HL2SDK']
+if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
+  binary.compiler.cxxflags += ['-fno-rtti']
+elif binary.compiler.family == 'msvc':
+  binary.compiler.cxxflags += ['/GR-']
+binary.compiler.linkflags += extra_ldflags
+binary.sources = [
+  'loader.cpp'
+]
 
-  nodes = builder.Add(binary)
-  SM.binaries += [nodes]
+nodes = builder.Add(binary)
+SM.binaries += [nodes]


### PR DESCRIPTION
This simplifies non-sdk build scripts by removing their loops over SM.archs. Instead the top-level
build script will re-evaluate them for each architecture.

Aside from the top-level AMBuildScript, this is all unindenting.