### PR TITLE
Fix CS_TerminateRound calls & detour

### DIFF
--- a/extensions/cstrike/forwards.cpp
+++ b/extensions/cstrike/forwards.cpp
@@ -126,7 +126,7 @@ DETOUR_DECL_MEMBER0(DetourWeaponPrice, int)
 }
 #endif
 
-#if SOURCE_ENGINE != SE_CSGO || !defined(WIN32)
+#if SOURCE_ENGINE != SE_CSGO
 DETOUR_DECL_MEMBER2(DetourTerminateRound, void, float, delay, int, reason)
 {
 	if (g_pIgnoreTerminateDetour)
@@ -135,20 +135,31 @@ DETOUR_DECL_MEMBER2(DetourTerminateRound, void, float, delay, int, reason)
 		DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason);
 		return;
 	}
+#elif !defined(WIN32)
+DETOUR_DECL_MEMBER4(DetourTerminateRound, void, float, delay, int, reason, int, unknown, int, unknown2)
+{
+	if (g_pIgnoreTerminateDetour)
+	{
+		g_pIgnoreTerminateDetour = false;
+		DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason, unknown, unknown2);
+		return;
+	}
 #else
 //Windows CSGO
 //char __userpurge TerminateRound(int a1@<ecx>, float a2@<xmm1>, int *a3)
 // a1 - this
 // a2 - delay
 // a3 - reason
-DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
+// a4 - unknown
+// a5 - unknown
+DETOUR_DECL_MEMBER3(DetourTerminateRound, void, int, reason, int, unknown, int, unknown2)
 {
 	float delay;
 
 	if (g_pIgnoreTerminateDetour)
 	{
 		g_pIgnoreTerminateDetour = false;
-		return DETOUR_MEMBER_CALL(DetourTerminateRound)(reason);
+		return DETOUR_MEMBER_CALL(DetourTerminateRound)(reason, unknown, unknown2);
 	}
 
 	//Save the delay
@@ -178,11 +189,16 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 	reason++;
 #endif
 	
-#if SOURCE_ENGINE != SE_CSGO || !defined(WIN32)
+#if SOURCE_ENGINE != SE_CSGO
 	if (result == Pl_Changed)
 		return DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason);
 
 	return DETOUR_MEMBER_CALL(DetourTerminateRound)(orgdelay, orgreason);
+#elif !defined(WIN32)
+	if (result == Pl_Changed)
+		return DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason, unknown, unknown2);
+
+	return DETOUR_MEMBER_CALL(DetourTerminateRound)(orgdelay, orgreason, unknown, unknown2);
 #else
 	if (result == Pl_Changed)
 	{
@@ -190,13 +206,13 @@ DETOUR_DECL_MEMBER1(DetourTerminateRound, void, int, reason)
 		{
 			movss xmm1, delay
 		}
-		return DETOUR_MEMBER_CALL(DetourTerminateRound)(reason);
+		return DETOUR_MEMBER_CALL(DetourTerminateRound)(reason, unknown, unknown2);
 	}
 	__asm
 	{
 		movss xmm1, orgdelay
 	}
-	return DETOUR_MEMBER_CALL(DetourTerminateRound)(orgreason);
+	return DETOUR_MEMBER_CALL(DetourTerminateRound)(orgreason, unknown, unknown2);
 #endif
 }
 

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -314,17 +314,17 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	reason++;
 #endif
 	
-#if SOURCE_ENGINE != SE_CSGO || !defined(WIN32)
+#if SOURCE_ENGINE != SE_CSGO
 	static ICallWrapper *pWrapper = NULL;
 
 	if (!pWrapper)
 	{
 		REGISTER_NATIVE_ADDR("TerminateRound",
 			PassInfo pass[2]; \
-			pass[0].flags = PASSFLAG_BYVAL; \
+			pass[0].flags = PASSFLAG_BYVAL; \  // delay
 			pass[0].type = PassType_Basic; \
 			pass[0].size = sizeof(float); \
-			pass[1].flags = PASSFLAG_BYVAL; \
+			pass[1].flags = PASSFLAG_BYVAL; \ // reason
 			pass[1].type = PassType_Basic; \
 			pass[1].size = sizeof(int); \
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 2))
@@ -343,6 +343,45 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	*(int*)vptr = reason;
 
 	pWrapper->Execute(vstk, NULL);
+#elif !defined(WIN32)
+	static ICallWrapper *pWrapper = NULL;
+
+	if (!pWrapper)
+	{
+		REGISTER_NATIVE_ADDR("TerminateRound",
+			PassInfo pass[4]; \
+			pass[0].flags = PASSFLAG_BYVAL; \  // delay
+			pass[0].type = PassType_Basic; \
+			pass[0].size = sizeof(float); \
+			pass[1].flags = PASSFLAG_BYVAL; \ // reason
+			pass[1].type = PassType_Basic; \
+			pass[1].size = sizeof(int); \
+			pass[2].flags = PASSFLAG_BYVAL; \ // unknown
+			pass[2].type = PassType_Basic; \
+			pass[2].size = sizeof(int); \
+			pass[3].flags = PASSFLAG_BYVAL; \ // unknown2
+			pass[3].type = PassType_Basic; \
+			pass[3].size = sizeof(int); \
+			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 4))
+	}
+
+	if (params[3] == 1 && g_pTerminateRoundDetoured)
+		g_pIgnoreTerminateDetour = true;
+
+	unsigned char vstk[sizeof(void *) + sizeof(float)+ sizeof(int)];
+	unsigned char *vptr = vstk;
+
+	*(void **)vptr = gamerules;
+	vptr += sizeof(void *);
+	*(float *)vptr = sp_ctof(params[1]);
+	vptr += sizeof(float);
+	*(int*)vptr = reason;
+	vptr += sizeof(int);
+	*(int*)vptr = 0;
+	vptr += sizeof(int);
+	*(int*)vptr = 0;
+
+	pWrapper->Execute(vstk, NULL);
 #else
 	static void *addr = NULL;
 
@@ -358,6 +397,8 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	
 	__asm
 	{
+		push 0
+		push 0
 		push reason
 		movss xmm1, delay
 		mov ecx, gamerules


### PR DESCRIPTION
CS:GO added two parameters onto the end of TerminateRound, after inspecting their use I was unable to conclude exactly what they did, but passing zero seems to work as expected. 

One seems to be used as a loop condition, and the other possibly something to do with bot difficulty. I'm still unsure, but I don't think that's very important.