### PR TITLE
Fix build error for the cstrike extention

### DIFF
--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -321,10 +321,10 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	{
 		REGISTER_NATIVE_ADDR("TerminateRound",
 			PassInfo pass[2]; \
-			pass[0].flags = PASSFLAG_BYVAL; \  // delay
+			pass[0].flags = PASSFLAG_BYVAL; \
 			pass[0].type = PassType_Basic; \
 			pass[0].size = sizeof(float); \
-			pass[1].flags = PASSFLAG_BYVAL; \ // reason
+			pass[1].flags = PASSFLAG_BYVAL; \
 			pass[1].type = PassType_Basic; \
 			pass[1].size = sizeof(int); \
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 2))
@@ -350,16 +350,16 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	{
 		REGISTER_NATIVE_ADDR("TerminateRound",
 			PassInfo pass[4]; \
-			pass[0].flags = PASSFLAG_BYVAL; \  // delay
+			pass[0].flags = PASSFLAG_BYVAL; \
 			pass[0].type = PassType_Basic; \
 			pass[0].size = sizeof(float); \
-			pass[1].flags = PASSFLAG_BYVAL; \ // reason
+			pass[1].flags = PASSFLAG_BYVAL; \
 			pass[1].type = PassType_Basic; \
 			pass[1].size = sizeof(int); \
-			pass[2].flags = PASSFLAG_BYVAL; \ // unknown
+			pass[2].flags = PASSFLAG_BYVAL; \
 			pass[2].type = PassType_Basic; \
 			pass[2].size = sizeof(int); \
-			pass[3].flags = PASSFLAG_BYVAL; \ // unknown2
+			pass[3].flags = PASSFLAG_BYVAL; \
 			pass[3].type = PassType_Basic; \
 			pass[3].size = sizeof(int); \
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 4))


### PR DESCRIPTION
Fix for build error C2017: illegal escape sequence, as seen here https://builds.alliedmods.net/sm/builders/windows-1.10/builds/98/steps/build/logs/stdio