### PR TITLE
NPOTB: Clarify cstrike preprocessor logic

### DIFF
--- a/extensions/cstrike/forwards.cpp
+++ b/extensions/cstrike/forwards.cpp
@@ -126,7 +126,7 @@ DETOUR_DECL_MEMBER0(DetourWeaponPrice, int)
 }
 #endif
 
-#if SOURCE_ENGINE != SE_CSGO
+#if SOURCE_ENGINE == SE_CSS
 DETOUR_DECL_MEMBER2(DetourTerminateRound, void, float, delay, int, reason)
 {
 	if (g_pIgnoreTerminateDetour)
@@ -135,7 +135,7 @@ DETOUR_DECL_MEMBER2(DetourTerminateRound, void, float, delay, int, reason)
 		DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason);
 		return;
 	}
-#elif !defined(WIN32)
+#elif SOURCE_ENGINE == SE_CSGO && !defined(WIN32)
 DETOUR_DECL_MEMBER4(DetourTerminateRound, void, float, delay, int, reason, int, unknown, int, unknown2)
 {
 	if (g_pIgnoreTerminateDetour)
@@ -189,12 +189,12 @@ DETOUR_DECL_MEMBER3(DetourTerminateRound, void, int, reason, int, unknown, int, 
 	reason++;
 #endif
 	
-#if SOURCE_ENGINE != SE_CSGO
+#if SOURCE_ENGINE == SE_CSS
 	if (result == Pl_Changed)
 		return DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason);
 
 	return DETOUR_MEMBER_CALL(DetourTerminateRound)(orgdelay, orgreason);
-#elif !defined(WIN32)
+#elif SOURCE_ENGINE == SE_CSGO && !defined(WIN32)
 	if (result == Pl_Changed)
 		return DETOUR_MEMBER_CALL(DetourTerminateRound)(delay, reason, unknown, unknown2);
 

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -314,7 +314,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	reason++;
 #endif
 	
-#if SOURCE_ENGINE != SE_CSGO
+#if SOURCE_ENGINE == SE_CSS
 	static ICallWrapper *pWrapper = NULL;
 
 	if (!pWrapper)
@@ -343,7 +343,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	*(int*)vptr = reason;
 
 	pWrapper->Execute(vstk, NULL);
-#elif !defined(WIN32)
+#elif SOURCE_ENGINE == SE_CSGO && !defined(WIN32)
 	static ICallWrapper *pWrapper = NULL;
 
 	if (!pWrapper)
@@ -382,7 +382,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	*(int*)vptr = 0;
 
 	pWrapper->Execute(vstk, NULL);
-#else
+#else // CSGO Win32
 	static void *addr = NULL;
 
 	if(!addr)


### PR DESCRIPTION
Drifter left me some comments about clarifying this logic for the future, and he is right that this makes it much easier to understand. This doesn't actually change sourcemod behavior, just a simple clarification. 