### PR TITLE
Handle NULLs in SDKCall string return (Fixes #874)

### DIFF
--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -449,6 +449,11 @@ static cell_t SDKCall(IPluginContext *pContext, const cell_t *params)
 			cell_t *addr;
 			size_t written;
 			pContext->LocalToPhysAddr(params[retparam+1], &addr);
+			if (!(*(char **)vc->retbuf))
+			{
+				pContext->StringToLocalUTF8(params[retparam], *addr, "", &written);
+				return -1;
+			}
 			pContext->StringToLocalUTF8(params[retparam], *addr, *(char **)vc->retbuf, &written);
 			return (cell_t)written;
 		} else if (vc->retinfo->vtype == Valve_Vector


### PR DESCRIPTION
`SDKCall` has existing semantics that a `-1` retval indicates null, so use that and write an empty string to the buffer.

Consumers can tell the difference between `""` and `NULL` by checking if the return value is `0` or `-1`.