### PR TITLE
SDKHooks: Reset global hookid when unhooking in SH.

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -328,6 +328,7 @@ void SDKHooks::SDK_OnAllLoaded()
 	if (hook != 0) \
 	{ \
 		SH_REMOVE_HOOK_ID(hook); \
+		hook = 0; \
 	}
 
 void SDKHooks::SDK_OnUnload()


### PR DESCRIPTION
This is an ancient bug in SDKHooks (I actually mailed PM about it before I knew better) where we don't reset the global hookids when we unhook functions. This results in double-frees and oddness when the last users of these forwards unload; and the same or new user comes into the fold using the forward again.

This fixes https://github.com/alliedmodders/sourcemod/issues/912
This is also untested.