### PR TITLE
FormatTime() and time correcting #875

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -202,7 +202,8 @@ static cell_t FormatTime(IPluginContext *pContext, const cell_t *params)
 #endif
 
 	time_t t = (params[4] == -1) ? g_pSM->GetAdjustedTime() : (time_t)params[4];
-	size_t written = strftime(buffer, params[2], format, localtime(&t));
+	struct tm *tm_t = (params[0] > 4 && params[5] == 0) ? gmtime(&t) : localtime(&t);
+	size_t written = strftime(buffer, params[2], format, tm_t);
 
 #if defined SUBPLATFORM_SECURECRT
 	_set_invalid_parameter_handler(handler);

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -375,9 +375,10 @@ native int GetTime(int bigStamp[2]={0,0});
  * @param maxlength		Maximum length of output string buffer.
  * @param format		Formatting rules (passing NULL_STRING will use the rules defined in sm_datetime_format).
  * @param stamp			Optional time stamp.
+ * @param localtime		Requires use OS timezone settings.
  * @error			Buffer too small or invalid time format.
  */
-native void FormatTime(char[] buffer, int maxlength, const char[] format, int stamp=-1);
+native void FormatTime(char[] buffer, int maxlength, const char[] format, int stamp=-1, bool localtime = true);
 
 /**
  * Loads a game config file.


### PR DESCRIPTION
Implementing time formatting without taking into account time zone changes
compatibility old plugins not be broken