### PR TITLE
Fix typo in fallback to "default" maplists section

### DIFF
--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -441,7 +441,7 @@ public:
 				 */
 				if (strcmp(name, "default") != 0)
 				{
-					success = GetMapList(&pNewArray, name, &change_serial);
+					success = GetMapList(&pNewArray, "default", &change_serial);
 				}
 				/* If either of the last two conditions failed, try again if we can. */
 				if (!success && strcmp(name, "mapcyclefile") != 0)


### PR DESCRIPTION
When lookup of a more specialized entry in the maplists.cfg failed, it wouldn't fallback to the "default" section, but just try to parse the same section again.

A later fallback would try to parse the "mapcyclefile" again - which is the default redirection/value of the "default" section anyway - so this bug isn't visible unless the admin wanted a different default behavior.