### PR TITLE
TFHoliday order update

### DIFF
--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -219,8 +219,8 @@ enum TFHoliday
 public const TFHoliday TFHoliday_Birthday;
 public const TFHoliday TFHoliday_Halloween;
 public const TFHoliday TFHoliday_Christmas;
-public const TFHoliday TFHoliday_EndOfTheLine;
 public const TFHoliday TFHoliday_CommunityUpdate;
+public const TFHoliday TFHoliday_EndOfTheLine;
 public const TFHoliday TFHoliday_ValentinesDay;
 public const TFHoliday TFHoliday_MeetThePyro;
 public const TFHoliday TFHoliday_FullMoon;


### PR DESCRIPTION
As per a snippet posted in the SourceMod Discord server by Deathreus, `TFHoliday_CommunityUpdate` comes before `TFHoliday_EndOfTheLine`. Snippet below:
```
.rodata:0118CC40 _ZL15s_HolidayChecks dd offset _ZL19g_Holiday_NoHoliday
.rodata:0118CC40                                         ; DATA XREF: EconHolidays_IsHolidayActive(int,CRTime const&)+B↑r
.rodata:0118CC40                                         ; EconHolidays_GetHolidayForString(char const*):loc_6A7BB0↑r ...
.rodata:0118CC40                                         ; g_Holiday_NoHoliday
.rodata:0118CC44                 dd offset _ZL21g_Holiday_TF2Birthday ; g_Holiday_TF2Birthday
.rodata:0118CC48                 dd offset _ZL19g_Holiday_Halloween ; g_Holiday_Halloween
.rodata:0118CC4C                 dd offset _ZL19g_Holiday_Christmas ; g_Holiday_Christmas
.rodata:0118CC50                 dd offset _ZL25g_Holiday_CommunityUpdate ; g_Holiday_CommunityUpdate
.rodata:0118CC54                 dd offset _ZL22g_Holiday_EndOfTheLine ; g_Holiday_EndOfTheLine
.rodata:0118CC58                 dd offset _ZL23g_Holiday_ValentinesDay ; g_Holiday_ValentinesDay
.rodata:0118CC5C                 dd offset _ZL21g_Holiday_MeetThePyro ; g_Holiday_MeetThePyro
.rodata:0118CC60                 dd offset _ZL18g_Holiday_FullMoon ; g_Holiday_FullMoon
.rodata:0118CC64                 dd offset _ZL29g_Holiday_HalloweenOrFullMoon ; g_Holiday_HalloweenOrFullMoon
.rodata:0118CC68                 dd offset _ZL41g_Holiday_HalloweenOrFullMoonOrValentines ; g_Holiday_HalloweenOrFullMoonOrValentines
.rodata:0118CC6C                 dd offset _ZL20g_Holiday_AprilFools ; g_Holiday_AprilFools
```