### PR TITLE
Don't double-format in ReplyToCommand.

### DIFF
--- a/core/logic/smn_console.cpp
+++ b/core/logic/smn_console.cpp
@@ -267,8 +267,7 @@ static cell_t ReplyToCommand(IPluginContext *pContext, const cell_t *params)
 	size_t len;
 	{
 		DetectExceptions eh(pContext);
-		g_pSM->FormatString(buffer, sizeof(buffer), pContext, params, 2);
-		len = g_pSM->FormatString(buffer, sizeof(buffer) - 2, pContext, params, 2);
+		len = g_pSM->FormatString(buffer, sizeof(buffer) - 1, pContext, params, 2);
 		if (eh.HasException())
 			return 0;
 	}


### PR DESCRIPTION
Note: this was caught by triggering an assertion in the 1.9 exception handling code. We're not supposed to throw an error if the VM is already in an error state, and nothing cleared errors in between the two format operations.