### PR TITLE
Patch-up InternalFilterCommandTarget during connection phase.

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1499,10 +1499,23 @@ int PlayerManager::InternalFilterCommandTarget(CPlayer *pAdmin, CPlayer *pTarget
 
 	if (pAdmin != NULL)
 	{
-		if ((flags & COMMAND_FILTER_NO_IMMUNITY) != COMMAND_FILTER_NO_IMMUNITY
-			&& !adminsys->CanAdminTarget(pAdmin->GetAdminId(), pTarget->GetAdminId()))
+		if ((flags & COMMAND_FILTER_NO_IMMUNITY) != COMMAND_FILTER_NO_IMMUNITY)
 		{
-			return COMMAND_TARGET_IMMUNE;
+			AdminId tid = pTarget->GetAdminId();
+			/* If the target is pre-auth they're targetable; bypassing immunity rules... */
+			if (tid == INVALID_ADMIN_ID && !pTarget->IsAuthStringValidated())
+			{
+				tid = adminsys->FindAdminByIdentity("steam", pTarget->GetAuthString(false));
+				if (tid == INVALID_ADMIN_ID)
+				{
+					tid = adminsys->FindAdminByIdentity("ip", pTarget->GetIPAddress());
+				}
+			}
+
+			if (!adminsys->CanAdminTarget(pAdmin->GetAdminId(), tid))
+			{
+				return COMMAND_TARGET_IMMUNE;
+			}
 		}
 	}
 


### PR DESCRIPTION
As a christmas gift to a peer I've finally looked at this problem. During the connection phase immunity rules are ignored and as a result a "lower level admin" can kick a "higher level admin" or queue a bunch of timers on them while they're still downloading the level. By adding these additional checks to InternalFilterCommandTarget I think we can fix this everywhere while not introducing any additional issues.

This is untested against master as my production gear is running an older version of core.