### PR TITLE
Backport #764

### DIFF
--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -77,10 +77,8 @@ for sdk_name in SM.sdks:
       vs_year = ''
       if msvc_ver == 1800:
         vs_year = '2013'
-      elif msvc_ver == 1900:
+      elif 1900 <= msvc_ver < 2000:
         vs_year = '2015'
-      elif msvc_ver == 1910:
-        vs_year = '2017'
       else:
         raise Exception('Cannot find libprotobuf for MSVC version "' + str(compiler.version) + '"')
 


### PR DESCRIPTION
Backport #764 to 1.9-dev, to fix build on updated versions of VS 2017. Reported via Discord.