### PR TITLE
Adding a forward that lets you know when another plugin is unloaded

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -379,7 +379,7 @@ void CPlugin::Call_OnPluginEnd()
 			pFunction = plugin->GetBaseContext()->GetFunctionByName("OnPluginEndEx");
 			if (pFunction)
 			{
-				pFunction->PushCell(plugin->GetMyHandle());
+				pFunction->PushCell(m_handle);
 				pFunction->Execute(&result);
 			}
 		}

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -164,6 +164,13 @@ forward APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_ma
 forward void OnPluginEnd();
 
 /**
+ * Called when other plugins are unloaded.
+ *
+ * @param plugin		Нandle of the plugin that is unloaded.
+ */
+forward void OnPluginEndEx(Handle plugin);
+
+/**
  * Called when the plugin's pause status is changing.
  *
  * @param pause			True if the plugin is being paused, false otherwise.


### PR DESCRIPTION
This may allow the kernel plugin to delete the data of the module that is being unloaded to avoid problems the next time the module is loaded.