### PR TITLE
Prevent FrameIterator OOB Errors

### DIFF
--- a/core/logic/FrameIterator.cpp
+++ b/core/logic/FrameIterator.cpp
@@ -52,13 +52,7 @@ bool SafeFrameIterator::Done() const
 bool SafeFrameIterator::Next()
 {
 	current++;
-
-	if (!this->Done())
-	{
-		return true;
-	}
-	
-	return false;
+	return !this->Done();
 }
 
 void SafeFrameIterator::Reset()

--- a/core/logic/FrameIterator.cpp
+++ b/core/logic/FrameIterator.cpp
@@ -46,14 +46,15 @@ SafeFrameIterator::SafeFrameIterator(IFrameIterator *it)
 
 bool SafeFrameIterator::Done() const
 {
-	return current == frames.length();
+	return current >= frames.length();
 }
 
 bool SafeFrameIterator::Next()
 {
+	current++;
+
 	if (!this->Done())
 	{
-		current++;
 		return true;
 	}
 	


### PR DESCRIPTION
Before this patch, we'd check OOB before incrementing which makes no sense. We'll increment always this time, and change our OOB check to account for that.

Prior versions of the FrameIterator never worked, so we should probably cherry-pick this to 1.9