### PR TITLE
Add CS_DMG_THROW to cstrike.inc

### DIFF
--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -47,6 +47,7 @@
 #define CS_SLOT_C4			4	/**< C4 slot. */
 
 #define CS_DMG_HEADSHOT		(1 << 30)	/**< Headshot */
+#define CS_DMG_THROW		(2 << 6)	/**< Throw damage */
 
 enum CSRoundEndReason
 {


### PR DESCRIPTION
I added this in cstrike.inc, because I don't know which other games has throwable weapons/items which make damage.

I already use this in one of [my plugins](https://github.com/Bara/LR-Melee/blob/master/scripting/lastrequest_melee.sp#L230) and it works pretty good.