### PR TITLE
Adding missing semicolons.

### DIFF
--- a/plugins/include/admin.inc
+++ b/plugins/include/admin.inc
@@ -264,7 +264,7 @@ methodmap AdminId {
 		public native get();
 		public native set(int level);
 	}
-}
+};
 
 methodmap GroupId {
 	// Gets whether or not a flag is enabled on a group's flag set.
@@ -320,7 +320,7 @@ methodmap GroupId {
 		public native get();
 		public native set(int level);
 	}
-}
+};
 
 /**
  * Called when part of the cache needs to be rebuilt.

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -477,7 +477,7 @@ methodmap CommandIterator < Handle {
 	property int Flags {
 		public native get();
 	}
-}
+};
 
 /**
  * Gets a command iterator.  Must be freed with CloseHandle().

--- a/plugins/include/convars.inc
+++ b/plugins/include/convars.inc
@@ -237,7 +237,7 @@ methodmap ConVar < Handle
 	// @param callback  An OnConVarChanged function pointer.
 	// @error           No active hook on convar.
 	public native void RemoveChangeHook(ConVarChanged callback);
-}
+};
 
 /**
  * Creates a hook for when a console variable's value is changed.

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -255,7 +255,7 @@ typeset SQLTxnSuccess
 	// @param results       An array of DBResultSet results, one for each of numQueries. They are closed automatically.
 	// @param queryData     An array of each data value passed to SQL_AddQuery().
 	function void (Database db, any data, int numQueries, DBResultSet[] results, any[] queryData);	
-}
+};
 
 // Callback for a failed transaction.
 //

--- a/plugins/include/events.inc
+++ b/plugins/include/events.inc
@@ -163,7 +163,7 @@ methodmap Event < Handle
 		public native set(bool dontBroadcast);
 		public native get();
 	}
-}
+};
 
 /**
  * Creates a hook for when a game event is fired.

--- a/plugins/include/files.inc
+++ b/plugins/include/files.inc
@@ -237,7 +237,7 @@ methodmap File < Handle
 	property int Position {
 		public native get();
 	}
-}
+};
 
 /**
  * Builds a path relative to the SourceMod folder.  This should be used instead of 

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -380,7 +380,7 @@ typeset NativeCall
 	 * @return 					Value for the native call to return.
 	 */
 	function any (Handle plugin, int numParams);
-}
+};
 
 /**
  * Creates a dynamic native.  This should only be called in AskPluginLoad(), or 

--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -437,7 +437,7 @@ methodmap Menu < Handle
 	property int Selection {
 		public native get();
 	}
-}
+};
 
 /**
  * Creates a new, empty menu using the default style.

--- a/plugins/include/profiler.inc
+++ b/plugins/include/profiler.inc
@@ -63,7 +63,7 @@ methodmap Profiler < Handle
 	property float Time {
 		public native get();
 	}
-}
+};
 
 /**
  * Creates a new profile object.  The Handle must be freed

--- a/plugins/include/regex.inc
+++ b/plugins/include/regex.inc
@@ -179,7 +179,7 @@ methodmap Regex < Handle
 	//
 	// @param match			Match to get the offset of. Match starts at 0, and ends at MatchCount() -1
 	// @return				Offset of the match in the string.
-	public native int MatchOffset(int match = 0)
+	public native int MatchOffset(int match = 0);
 };
 
 /**

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -203,7 +203,7 @@ typeset TraceEntityEnumerator
 	 * @param data			Data value, if used.
 	 * @return				True to continue enumerating, otherwise false.	 */
 	function bool (int entity, any data);
-}
+};
 
 /**
  * Get the contents mask and the entity index at the given position.

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -719,7 +719,7 @@ methodmap FrameIterator < Handle {
 	// @param buffer Buffer to copy to.
 	// @param maxlen Max size of the buffer.
 	public native void GetFilePath(char[] buffer, int maxlen);
-}
+};
 
 #include <helpers>
 #include <entity>


### PR DESCRIPTION
This semicolons not check with currently referenced sourcepawn compiler version, but will throw error with latest sourcepawn compiler, if force semicolon requirement. I already checked all include files. Also tested compiler versions from 1.9 and master for backwards compatibility, it's ok.
_Whether to add it to 1.9 branch?_

P.S. I make search for `#include` directive and build files cross-reference.
Four spaces: included at `#include <sourcemod>` tree.
Two spaces: included at some file
```
    admin -> sourcemod
adminmenu
    adt -> sourcemod
    adt_array -> adt
    adt_stack -> adt
    adt_trie -> adt
    banning -> sourcemod
basecomm
    bitbuffer -> sourcemod
clientprefs
    clients -> sourcemod
    commandfilters -> sourcemod
    commandline -> sourcemod
    console -> sourcemod
    convars -> sourcemod
    core -> sourcemod, geoip, sdktools
cstrike
    datapack -> timers
    dbi -> sourcemod
    entity -> sourcemod
    entity_prop_stocks -> sourcemod
    events -> sourcemod
    files -> sourcemod
    float -> sourcemod
    functions -> sourcemod
geoip
    halflife -> sourcemod
    handles -> sourcemod
    helpers -> sourcemod
    keyvalues -> sourcemod
    lang -> sourcemod
    logging -> sourcemod
mapchooser
    menus -> sourcemod, topmenus
    nextmap -> sourcemod
profiler
    protobuf -> sourcemod
regex
sdkhooks
  sdktools -> tf2_stocks
  sdktools_client -> sdktools
  sdktools_engine -> sdktools
  sdktools_entinput -> sdktools
  sdktools_entoutput -> sdktools
  sdktools_functions -> sdktools
  sdktools_gamerules -> sdktools
  sdktools_hooks -> sdktools
  sdktools_sound -> sdktools
  sdktools_stocks -> sdktools
  sdktools_stringtables -> sdktools
  sdktools_tempents -> sdktools
  sdktools_tempents_stocks -> sdktools
  sdktools_trace -> sdktools
  sdktools_variant_t -> sdktools
  sdktools_voice -> sdktools
    sorting -> sourcemod
    sourcemod
    string -> sourcemod
testing
    textparse -> sourcemod
  tf2 -> tf2_stocks
tf2_stocks
    timers -> sourcemod
  topmenus -> adminmenu
    usermessages -> sourcemod
    vector -> sourcemod
    version -> core
```
Test case was:
```
#include <sourcemod>
#include <adminmenu>
#include <basecomm>
#include <clientprefs>
#include <cstrike>
#include <geoip>
#include <mapchooser>
#include <profiler>
#include <regex>
#include <sdkhooks>
#include <tf2_stocks>
```