### PR TITLE
Change MultiTargetFilter to a typeset that allows ArrayList

### DIFF
--- a/plugins/include/commandfilters.inc
+++ b/plugins/include/commandfilters.inc
@@ -139,7 +139,10 @@ stock void ReplyToTargetError(int client, int reason)
  * @param clients       Array to fill with unique, valid client indexes.
  * @return              True if pattern was recognized, false otherwise.
  */
-typedef MultiTargetFilter = function bool (const char[] pattern, Handle clients);
+typeset MultiTargetFilter {
+	function bool (const char[] pattern, Handle clients);
+	function bool (const char[] pattern, ArrayList clients);
+}
 
 /**
  * Adds a multi-target filter function for ProcessTargetString().


### PR DESCRIPTION
This is to fix the "error 100: function prototypes do not match" compiler error that occurs if you try to define a MultiTarget that takes an ArrayList instead of a generic Handle (which is an ArrayList).