### PR TITLE
Fixed buffer size for workshop map.

### DIFF
--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -266,7 +266,7 @@ public int Handler_VoteCallback(Menu menu, MenuAction action, int param1, int pa
 	}	
 	else if (action == MenuAction_VoteEnd)
 	{
-		char item[64], display[64];
+		char item[PLATFORM_MAX_PATH], display[64];
 		float percent, limit;
 		int votes, totalVotes;
 
@@ -420,7 +420,7 @@ bool TestVoteDelay(int client)
 
 public Action Timer_ChangeMap(Handle timer, DataPack dp)
 {
-	char mapname[65];
+	char mapname[PLATFORM_MAX_PATH];
 	
 	dp.Reset();
 	dp.ReadString(mapname, sizeof(mapname));

--- a/plugins/basevotes/votemap.sp
+++ b/plugins/basevotes/votemap.sp
@@ -141,7 +141,7 @@ public int MenuHandler_Map(Menu menu, MenuAction action, int param1, int param2)
 	}
 	else if (action == MenuAction_DrawItem)
 	{
-		char info[32], name[32];
+		char info[PLATFORM_MAX_PATH], name[32];
 		
 		menu.GetItem(param2, info, sizeof(info), _, name, sizeof(name));
 		
@@ -156,7 +156,7 @@ public int MenuHandler_Map(Menu menu, MenuAction action, int param1, int param2)
 	}
 	else if (action == MenuAction_Select)
 	{
-		char info[32], name[32];
+		char info[PLATFORM_MAX_PATH], name[32];
 		
 		menu.GetItem(param2, info, sizeof(info), _, name, sizeof(name));
 		


### PR DESCRIPTION
I noticed on my CS:GO server that voting to change the map does not change it.
After reviewing the logs carefully, I realized that not full the mapname is taken.
Sorry for "my russian english".
Below is a log before and after this changes.

```
----------------Before:
L 02/03/2019 - 14:34:22: -------- Mapchange to workshop/524648589/mg_sonic_islands_v3_w --------
L 02/03/2019 - 14:34:53: [basevotes.smx] "Ҝℴţأķ<2><STEAM_1:1:58422681><>" initiated a map vote.
L 02/03/2019 - 14:34:54: [basevotes.smx] Changing map to workshop/141714364/mg_saw_rfix_ due to vote.
L 02/03/2019 - 14:34:59: [SM] Changed map to "workshop/141714364/mg_saw_rfix_"
-----------------------------------------------------↑ Not full mapname.
L 02/03/2019 - 14:35:18: SourceMod log file session started (file "/home/csgo/serverfiles/csgo/addons/sourcemod-test/logs/L20190203.log") (Version "1.10.0.6377")
L 02/03/2019 - 14:35:18: -------- Mapchange to workshop/524648589/mg_sonic_islands_v3_w --------
----------------After:
L 02/03/2019 - 14:44:20: -------- Mapchange to workshop/524648589/mg_sonic_islands_v3_w --------
L 02/03/2019 - 14:44:33: [basecommands.smx] "Ҝℴţأķ<2><STEAM_1:1:58422681><>" changed map to "workshop/524648589/mg_sonic_islands_v3_w"
L 02/03/2019 - 14:44:36: [SM] Changed map to "workshop/524648589/mg_sonic_islands_v3_w"
L 02/03/2019 - 14:44:37: -------- Mapchange to workshop/524648589/mg_sonic_islands_v3_w --------
L 02/03/2019 - 14:44:55: [basevotes.smx] "Ҝℴţأķ<2><STEAM_1:1:58422681><>" initiated a map vote.
L 02/03/2019 - 14:44:56: [basevotes.smx] Changing map to workshop/141714364/mg_saw_rfix_64v_csgo due to vote.
L 02/03/2019 - 14:45:01: [SM] Changed map to "workshop/141714364/mg_saw_rfix_64v_csgo"
-----------------------------------------------------↑ Full mapname.
L 02/03/2019 - 14:45:02: -------- Mapchange to workshop/141714364/mg_saw_rfix_64v_csgo --------
L 02/03/2019 - 14:47:10: Log file closed.
```