### PR TITLE
Add missing semicolon

### DIFF
--- a/plugins/include/regex.inc
+++ b/plugins/include/regex.inc
@@ -179,7 +179,7 @@ methodmap Regex < Handle
 	//
 	// @param match			Match to get the offset of. Match starts at 0, and ends at MatchCount() -1
 	// @return				Offset of the match in the string.
-	public native int MatchOffset(int match = 0)
+	public native int MatchOffset(int match = 0);
 };
 
 /**


### PR DESCRIPTION
Otherwise you'll get this error:
regex.inc(182) : error 001: expected token: ";", but found "<newline>"

[Example with latest sourcemod (1.10.6383) version](https://travis-ci.org/Bara/TroubleinTerroristTown/jobs/495529570#L640)