### PR TITLE
Add templated helper class to promote type-safety

### DIFF
--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -34,7 +34,7 @@
 #include "forwards.h"
 #include "util_cstrike.h"
 #include <server_class.h>
-#include <sm_memwriter.h>
+#include <sm_argbuffer.h>
 
 #if SOURCE_ENGINE == SE_CSGO
 #include "itemdef-hash.h"
@@ -179,7 +179,7 @@ static cell_t CS_SwitchTeam(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	MemWriter<CBaseEntity*, int> vstk(pEntity, params[2]);
+	ArgBuffer<CBaseEntity*, int> vstk(pEntity, params[2]);
 
 	pWrapper->Execute(vstk.GetBuffer(), NULL);
 #else
@@ -271,7 +271,7 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 		g_pIgnoreCSWeaponDropDetour = true;
 
 	// <psychonic> first one is always false. second is true to toss, false to just drop
-	MemWriter<CBaseEntity*, CBaseEntity*, bool, bool> vstk(pEntity, pWeapon, false, (params[3]) ? true : false);
+	ArgBuffer<CBaseEntity*, CBaseEntity*, bool, bool> vstk(pEntity, pWeapon, false, (params[3]) ? true : false);
 
 	pWrapper->Execute(vstk.GetBuffer(), NULL);
 	return 1;
@@ -320,7 +320,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	if (params[3] == 1 && g_pTerminateRoundDetoured)
 		g_pIgnoreTerminateDetour = true;
 
-	MemWriter<void*, float, int> vstk(gamerules, sp_ctof(params[1]), reason);
+	ArgBuffer<void*, float, int> vstk(gamerules, sp_ctof(params[1]), reason);
 
 	pWrapper->Execute(vstk.GetBuffer(), NULL);
 #elif SOURCE_ENGINE == SE_CSGO && !defined(WIN32)
@@ -348,7 +348,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 	if (params[3] == 1 && g_pTerminateRoundDetoured)
 		g_pIgnoreTerminateDetour = true;
 
-	MemWriter<void*, float, int, int, int> vstk(gamerules, sp_ctof(params[1]), reason, 0, 0);
+	ArgBuffer<void*, float, int, int, int> vstk(gamerules, sp_ctof(params[1]), reason, 0, 0);
 
 	pWrapper->Execute(vstk.GetBuffer(), NULL);
 #else // CSGO Win32
@@ -850,8 +850,7 @@ static cell_t CS_SetClientClanTag(IPluginContext *pContext, const cell_t *params
 	char *szNewTag;
 	pContext->LocalToString(params[2], &szNewTag);
 
-	MemWriter<CBaseEntity*, char*> vstk(pEntity, szNewTag);
-
+	ArgBuffer<CBaseEntity*, char*> vstk(pEntity, szNewTag);
 	pWrapper->Execute(vstk.GetBuffer(), NULL);
 	return 1;
 #endif

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -181,7 +181,7 @@ static cell_t CS_SwitchTeam(IPluginContext *pContext, const cell_t *params)
 
 	ArgBuffer<CBaseEntity*, int> vstk(pEntity, params[2]);
 
-	pWrapper->Execute(vstk.GetBuffer(), NULL);
+	pWrapper->Execute(vstk, NULL);
 #else
 	if (g_pSDKTools == NULL)
 	{
@@ -273,7 +273,7 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	// <psychonic> first one is always false. second is true to toss, false to just drop
 	ArgBuffer<CBaseEntity*, CBaseEntity*, bool, bool> vstk(pEntity, pWeapon, false, (params[3]) ? true : false);
 
-	pWrapper->Execute(vstk.GetBuffer(), NULL);
+	pWrapper->Execute(vstk, NULL);
 	return 1;
 }
 
@@ -322,7 +322,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 
 	ArgBuffer<void*, float, int> vstk(gamerules, sp_ctof(params[1]), reason);
 
-	pWrapper->Execute(vstk.GetBuffer(), NULL);
+	pWrapper->Execute(vstk, NULL);
 #elif SOURCE_ENGINE == SE_CSGO && !defined(WIN32)
 	static ICallWrapper *pWrapper = NULL;
 
@@ -350,7 +350,7 @@ static cell_t CS_TerminateRound(IPluginContext *pContext, const cell_t *params)
 
 	ArgBuffer<void*, float, int, int, int> vstk(gamerules, sp_ctof(params[1]), reason, 0, 0);
 
-	pWrapper->Execute(vstk.GetBuffer(), NULL);
+	pWrapper->Execute(vstk, NULL);
 #else // CSGO Win32
 	static void *addr = NULL;
 
@@ -851,7 +851,7 @@ static cell_t CS_SetClientClanTag(IPluginContext *pContext, const cell_t *params
 	pContext->LocalToString(params[2], &szNewTag);
 
 	ArgBuffer<CBaseEntity*, char*> vstk(pEntity, szNewTag);
-	pWrapper->Execute(vstk.GetBuffer(), NULL);
+	pWrapper->Execute(vstk, NULL);
 	return 1;
 #endif
 }

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -851,6 +851,7 @@ static cell_t CS_SetClientClanTag(IPluginContext *pContext, const cell_t *params
 	pContext->LocalToString(params[2], &szNewTag);
 
 	ArgBuffer<CBaseEntity*, char*> vstk(pEntity, szNewTag);
+
 	pWrapper->Execute(vstk, NULL);
 	return 1;
 #endif

--- a/extensions/cstrike/util_cstrike.cpp
+++ b/extensions/cstrike/util_cstrike.cpp
@@ -35,7 +35,7 @@
 #include <iplayerinfo.h>
 #if SOURCE_ENGINE == SE_CSGO
 #include "itemdef-hash.h"
-#include <sm_memwriter.h>
+#include <sm_argbuffer.h>
 
 ClassnameMap g_mapClassToDefIdx;
 ItemIndexMap g_mapDefIdxToClass;
@@ -136,8 +136,7 @@ CEconItemView *GetEconItemView(CBaseEntity *pEntity, int iSlot)
 		return NULL;
 
 	CEconItemView *ret;
-	
-	MemWriter<void*, int> vstk(reinterpret_cast<void*>(((intptr_t)pEntity + thisPtrOffset)), iSlot);
+	ArgBuffer<void*, int> vstk(reinterpret_cast<void*>(((intptr_t)pEntity + thisPtrOffset)), iSlot);
 
 	pWrapper->Execute(vstk.GetBuffer(), &ret);
 	return ret;
@@ -157,11 +156,10 @@ CCSWeaponData *GetCCSWeaponData(CEconItemView *view)
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, &retpass, NULL, 0))
 	}
 
-	CCSWeaponData *pWpnData = NULL;
-
-	MemWriter<CEconItemView*> vstk(view);
+	CCSWeaponData *pWpnData;
+	ArgBuffer<CEconItemView*> vstk(view);
+	
 	pWrapper->Execute(vstk.GetBuffer(), &pWpnData);
-
 	return pWpnData;
 }
 
@@ -224,11 +222,10 @@ CEconItemDefinition *GetItemDefintionByName(const char *classname)
 		g_RegNatives.Register(pWrapper);
 	}
 
-	CEconItemDefinition *pItemDef = NULL;
-
-	MemWriter<void*, const char *> vstk(pSchema, classname);
+	CEconItemDefinition *pItemDef;
+	ArgBuffer<void*, const char *> vstk(pSchema, classname);
+	
 	pWrapper->Execute(vstk.GetBuffer(), &pItemDef);
-
 	return pItemDef;
 }
 
@@ -391,10 +388,9 @@ void *GetWeaponInfo(int weaponID)
 	}
 
 	void *info = nullptr;
-
-	MemWriter<int> vstk(weaponID);
+	ArgBuffer<int> vstk(weaponID);
+	
 	pWrapper->Execute(vstk.GetBuffer(), &info);
-
 	return info;
 }
 #endif
@@ -434,10 +430,9 @@ const char *GetTranslatedWeaponAlias(const char *weapon)
 	}
 
 	const char *alias = nullptr;
-
-	MemWriter<const char *> vstk(GetWeaponNameFromClassname(weapon));
+	ArgBuffer<const char *> vstk(GetWeaponNameFromClassname(weapon));
+	
 	pWrapper->Execute(vstk.GetBuffer(), &alias);
-
 	return alias;
 #else //this should work for both games maybe replace both?
 	static const char *szAliases[] =
@@ -488,10 +483,9 @@ int AliasToWeaponID(const char *weapon)
 	}
 
 	int weaponID = 0;
-
-	MemWriter<const char *> vstk(GetWeaponNameFromClassname(weapon));
+	ArgBuffer<const char *> vstk(GetWeaponNameFromClassname(weapon));
+	
 	pWrapper->Execute(vstk.GetBuffer(), &weaponID);
-
 	return weaponID;
 #else
 	ItemDefHashValue *pHashValue = GetHashValueFromWeapon(weapon);
@@ -523,10 +517,9 @@ const char *WeaponIDToAlias(int weaponID)
 	}
 
 	const char *alias = nullptr;
-
-	MemWriter<int> vstk(weaponID);
+	ArgBuffer<int> vstk(weaponID);
+	
 	pWrapper->Execute(vstk.GetBuffer(), &alias);
-
 	return alias;
 #else
 	WeaponIDMap::Result res = g_mapWeaponIDToDefIdx.find((SMCSWeapon)weaponID);

--- a/extensions/cstrike/util_cstrike.cpp
+++ b/extensions/cstrike/util_cstrike.cpp
@@ -138,7 +138,7 @@ CEconItemView *GetEconItemView(CBaseEntity *pEntity, int iSlot)
 	CEconItemView *ret;
 	ArgBuffer<void*, int> vstk(reinterpret_cast<void*>(((intptr_t)pEntity + thisPtrOffset)), iSlot);
 
-	pWrapper->Execute(vstk.GetBuffer(), &ret);
+	pWrapper->Execute(vstk, &ret);
 	return ret;
 }
 
@@ -159,7 +159,7 @@ CCSWeaponData *GetCCSWeaponData(CEconItemView *view)
 	CCSWeaponData *pWpnData;
 	ArgBuffer<CEconItemView*> vstk(view);
 	
-	pWrapper->Execute(vstk.GetBuffer(), &pWpnData);
+	pWrapper->Execute(vstk, &pWpnData);
 	return pWpnData;
 }
 
@@ -225,7 +225,7 @@ CEconItemDefinition *GetItemDefintionByName(const char *classname)
 	CEconItemDefinition *pItemDef;
 	ArgBuffer<void*, const char *> vstk(pSchema, classname);
 	
-	pWrapper->Execute(vstk.GetBuffer(), &pItemDef);
+	pWrapper->Execute(vstk, &pItemDef);
 	return pItemDef;
 }
 
@@ -390,7 +390,7 @@ void *GetWeaponInfo(int weaponID)
 	void *info = nullptr;
 	ArgBuffer<int> vstk(weaponID);
 	
-	pWrapper->Execute(vstk.GetBuffer(), &info);
+	pWrapper->Execute(vstk, &info);
 	return info;
 }
 #endif
@@ -432,7 +432,7 @@ const char *GetTranslatedWeaponAlias(const char *weapon)
 	const char *alias = nullptr;
 	ArgBuffer<const char *> vstk(GetWeaponNameFromClassname(weapon));
 	
-	pWrapper->Execute(vstk.GetBuffer(), &alias);
+	pWrapper->Execute(vstk, &alias);
 	return alias;
 #else //this should work for both games maybe replace both?
 	static const char *szAliases[] =
@@ -485,7 +485,7 @@ int AliasToWeaponID(const char *weapon)
 	int weaponID = 0;
 	ArgBuffer<const char *> vstk(GetWeaponNameFromClassname(weapon));
 	
-	pWrapper->Execute(vstk.GetBuffer(), &weaponID);
+	pWrapper->Execute(vstk, &weaponID);
 	return weaponID;
 #else
 	ItemDefHashValue *pHashValue = GetHashValueFromWeapon(weapon);
@@ -519,7 +519,7 @@ const char *WeaponIDToAlias(int weaponID)
 	const char *alias = nullptr;
 	ArgBuffer<int> vstk(weaponID);
 	
-	pWrapper->Execute(vstk.GetBuffer(), &alias);
+	pWrapper->Execute(vstk, &alias);
 	return alias;
 #else
 	WeaponIDMap::Result res = g_mapWeaponIDToDefIdx.find((SMCSWeapon)weaponID);

--- a/extensions/cstrike/util_cstrike.cpp
+++ b/extensions/cstrike/util_cstrike.cpp
@@ -135,10 +135,11 @@ CEconItemView *GetEconItemView(CBaseEntity *pEntity, int iSlot)
 	if (team != 2 && team != 3)
 		return NULL;
 
-	CEconItemView *ret;
 	ArgBuffer<void*, int> vstk(reinterpret_cast<void*>(((intptr_t)pEntity + thisPtrOffset)), iSlot);
 
+	CEconItemView *ret = nullptr;
 	pWrapper->Execute(vstk, &ret);
+
 	return ret;
 }
 
@@ -156,10 +157,11 @@ CCSWeaponData *GetCCSWeaponData(CEconItemView *view)
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_ThisCall, &retpass, NULL, 0))
 	}
 
-	CCSWeaponData *pWpnData;
 	ArgBuffer<CEconItemView*> vstk(view);
-	
+
+	CCSWeaponData *pWpnData = nullptr;
 	pWrapper->Execute(vstk, &pWpnData);
+
 	return pWpnData;
 }
 
@@ -222,10 +224,11 @@ CEconItemDefinition *GetItemDefintionByName(const char *classname)
 		g_RegNatives.Register(pWrapper);
 	}
 
-	CEconItemDefinition *pItemDef;
 	ArgBuffer<void*, const char *> vstk(pSchema, classname);
-	
+
+	CEconItemDefinition *pItemDef = nullptr;
 	pWrapper->Execute(vstk, &pItemDef);
+
 	return pItemDef;
 }
 
@@ -387,10 +390,11 @@ void *GetWeaponInfo(int weaponID)
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_Cdecl, &retpass, pass, 1))
 	}
 
-	void *info = nullptr;
 	ArgBuffer<int> vstk(weaponID);
-	
+
+	void *info = nullptr;
 	pWrapper->Execute(vstk, &info);
+
 	return info;
 }
 #endif
@@ -429,10 +433,11 @@ const char *GetTranslatedWeaponAlias(const char *weapon)
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_Cdecl, &retpass, pass, 1))
 	}
 
-	const char *alias = nullptr;
 	ArgBuffer<const char *> vstk(GetWeaponNameFromClassname(weapon));
-	
+
+	const char *alias = nullptr;
 	pWrapper->Execute(vstk, &alias);
+
 	return alias;
 #else //this should work for both games maybe replace both?
 	static const char *szAliases[] =
@@ -482,10 +487,11 @@ int AliasToWeaponID(const char *weapon)
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_Cdecl, &retpass, pass, 1))
 	}
 
-	int weaponID = 0;
 	ArgBuffer<const char *> vstk(GetWeaponNameFromClassname(weapon));
-	
+
+	int weaponID = 0;
 	pWrapper->Execute(vstk, &weaponID);
+
 	return weaponID;
 #else
 	ItemDefHashValue *pHashValue = GetHashValueFromWeapon(weapon);
@@ -516,10 +522,11 @@ const char *WeaponIDToAlias(int weaponID)
 			pWrapper = g_pBinTools->CreateCall(addr, CallConv_Cdecl, &retpass, pass, 1))
 	}
 
-	const char *alias = nullptr;
 	ArgBuffer<int> vstk(weaponID);
-	
+
+	const char *alias = nullptr;
 	pWrapper->Execute(vstk, &alias);
+
 	return alias;
 #else
 	WeaponIDMap::Result res = g_mapWeaponIDToDefIdx.find((SMCSWeapon)weaponID);

--- a/extensions/sdktools/inputnatives.cpp
+++ b/extensions/sdktools/inputnatives.cpp
@@ -95,9 +95,9 @@ static cell_t AcceptEntityInput(IPluginContext *pContext, const cell_t *params)
 		ENTINDEX_TO_CBASEENTITY(params[4], pCaller);
 	}
 
-	bool ret = false;
-
 	ArgBuffer<void*, const char*, CBaseEntity*, CBaseEntity*, decltype(g_Variant_t), int> vstk(pDest, inputname, pActivator, pCaller, g_Variant_t, params[5]);
+
+	bool ret = false;
 	g_pAcceptInput->Execute(vstk, &ret);
 
 	_init_variant_t();

--- a/extensions/sdktools/inputnatives.cpp
+++ b/extensions/sdktools/inputnatives.cpp
@@ -98,7 +98,7 @@ static cell_t AcceptEntityInput(IPluginContext *pContext, const cell_t *params)
 	bool ret = false;
 
 	ArgBuffer<void*, const char*, CBaseEntity*, CBaseEntity*, decltype(g_Variant_t), int> vstk(pDest, inputname, pActivator, pCaller, g_Variant_t, params[5]);
-	g_pAcceptInput->Execute(vstk.GetBuffer(), &ret);
+	g_pAcceptInput->Execute(vstk, &ret);
 
 	_init_variant_t();
 

--- a/extensions/sdktools/inputnatives.cpp
+++ b/extensions/sdktools/inputnatives.cpp
@@ -32,7 +32,7 @@
 #include "extension.h"
 #include "variant-t.h"
 #include <datamap.h>
-#include <sm_memwriter.h>
+#include <sm_argbuffer.h>
 
 ICallWrapper *g_pAcceptInput = NULL;
 
@@ -97,7 +97,7 @@ static cell_t AcceptEntityInput(IPluginContext *pContext, const cell_t *params)
 
 	bool ret = false;
 
-	MemWriter<void*, const char*, CBaseEntity*, CBaseEntity*, decltype(g_Variant_t), int> vstk(pDest, inputname, pActivator, pCaller, g_Variant_t, params[5]);
+	ArgBuffer<void*, const char*, CBaseEntity*, CBaseEntity*, decltype(g_Variant_t), int> vstk(pDest, inputname, pActivator, pCaller, g_Variant_t, params[5]);
 	g_pAcceptInput->Execute(vstk.GetBuffer(), &ret);
 
 	_init_variant_t();

--- a/extensions/sdktools/inputnatives.cpp
+++ b/extensions/sdktools/inputnatives.cpp
@@ -32,6 +32,7 @@
 #include "extension.h"
 #include "variant-t.h"
 #include <datamap.h>
+#include <sm_memwriter.h>
 
 ICallWrapper *g_pAcceptInput = NULL;
 
@@ -79,9 +80,6 @@ static cell_t AcceptEntityInput(IPluginContext *pContext, const cell_t *params)
 	CBaseEntity *pActivator, *pCaller, *pDest;
 
 	char *inputname;
-	unsigned char vstk[sizeof(void *) + sizeof(const char *) + sizeof(CBaseEntity *)*2 + SIZEOF_VARIANT_T + sizeof(int)];
-	unsigned char *vptr = vstk;
-
 	ENTINDEX_TO_CBASEENTITY(params[1], pDest);
 	pContext->LocalToString(params[2], &inputname);
 	if (params[3] == -1)
@@ -97,20 +95,10 @@ static cell_t AcceptEntityInput(IPluginContext *pContext, const cell_t *params)
 		ENTINDEX_TO_CBASEENTITY(params[4], pCaller);
 	}
 
-	*(void **)vptr = pDest;
-	vptr += sizeof(void *);
-	*(const char **)vptr = inputname;
-	vptr += sizeof(const char *);
-	*(CBaseEntity **)vptr = pActivator;
-	vptr += sizeof(CBaseEntity *);
-	*(CBaseEntity **)vptr = pCaller;
-	vptr += sizeof(CBaseEntity *);
-	memcpy(vptr, g_Variant_t, SIZEOF_VARIANT_T);
-	vptr += SIZEOF_VARIANT_T;
-	*(int *)vptr = params[5];
+	bool ret = false;
 
-	bool ret;
-	g_pAcceptInput->Execute(vstk, &ret);
+	MemWriter<void*, const char*, CBaseEntity*, CBaseEntity*, decltype(g_Variant_t), int> vstk(pDest, inputname, pActivator, pCaller, g_Variant_t, params[5]);
+	g_pAcceptInput->Execute(vstk.GetBuffer(), &ret);
 
 	_init_variant_t();
 

--- a/extensions/sdktools/outputnatives.cpp
+++ b/extensions/sdktools/outputnatives.cpp
@@ -32,7 +32,7 @@
 #include "extension.h"
 #include "variant-t.h"
 #include "output.h"
-#include <sm_memwriter.h>
+#include <sm_argbuffer.h>
 
 ICallWrapper *g_pFireOutput = NULL;
 
@@ -380,7 +380,7 @@ static cell_t FireEntityOutput(IPluginContext *pContext, const cell_t *params)
 			ENTINDEX_TO_CBASEENTITY(params[3], pActivator);
 		}
 
-		MemWriter<void*, decltype(g_Variant_t), CBaseEntity*, CBaseEntity*, float> vstk(pOutput, g_Variant_t, pActivator, pCaller, sp_ctof(params[4]));
+		ArgBuffer<void*, decltype(g_Variant_t), CBaseEntity*, CBaseEntity*, float> vstk(pOutput, g_Variant_t, pActivator, pCaller, sp_ctof(params[4]));
 
 		g_pFireOutput->Execute(vstk.GetBuffer(), nullptr);
 

--- a/extensions/sdktools/outputnatives.cpp
+++ b/extensions/sdktools/outputnatives.cpp
@@ -382,7 +382,7 @@ static cell_t FireEntityOutput(IPluginContext *pContext, const cell_t *params)
 
 		ArgBuffer<void*, decltype(g_Variant_t), CBaseEntity*, CBaseEntity*, float> vstk(pOutput, g_Variant_t, pActivator, pCaller, sp_ctof(params[4]));
 
-		g_pFireOutput->Execute(vstk.GetBuffer(), nullptr);
+		g_pFireOutput->Execute(vstk, nullptr);
 
 		_init_variant_t();
 		return 1;

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -35,7 +35,7 @@
 #include "RegNatives.h"
 
 #include <ISDKTools.h>
-#include <sm_memwriter.h>
+#include <sm_argbuffer.h>
 
 // native TF2_MakeBleed(client, attacker, Float:duration)
 cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
@@ -82,7 +82,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	MemWriter<void*, CBaseEntity*, CBaseEntity*, 
+	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 											float,
 											int, // Damage amount
 											bool, // Permanent
@@ -128,7 +128,7 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	MemWriter<void*, CBaseEntity*, CBaseEntity*, 
+	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 										float> //duration
 										vstk(obj, pTarget, nullptr, 10.0f);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
@@ -180,7 +180,7 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Target client index %d is not valid", params[4]);
 	}
 
-	MemWriter<void*, int, int, CBaseEntity*, bool> vstk(obj, params[2], params[3], pTarget, true);
+	ArgBuffer<void*, int, int, CBaseEntity*, bool> vstk(obj, params[2], params[3], pTarget, true);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
@@ -205,7 +205,7 @@ cell_t TF2_RemoveDisguise(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	MemWriter<void*> vstk(obj);
+	ArgBuffer<void*> vstk(obj);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 	return 1;
 }
@@ -246,7 +246,7 @@ cell_t TF2_AddCondition(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	MemWriter<void*, int, float, CBaseEntity*> vstk(obj, params[2], params[3], pInflictor);
+	ArgBuffer<void*, int, float, CBaseEntity*> vstk(obj, params[2], params[3], pInflictor);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 	return 1;
 }
@@ -277,7 +277,7 @@ cell_t TF2_RemoveCondition(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 	
-	MemWriter<void*, int, bool> vstk(obj, params[2], true);
+	ArgBuffer<void*, int, bool> vstk(obj, params[2], true);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
@@ -322,7 +322,7 @@ cell_t TF2_StunPlayer(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	MemWriter<void*, float, float, int, CBaseEntity*> vstk(obj, sp_ctof(params[2]), sp_ctof(params[3]), params[4], pAttacker);
+	ArgBuffer<void*, float, float, int, CBaseEntity*> vstk(obj, sp_ctof(params[2]), sp_ctof(params[3]), params[4], pAttacker);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
@@ -349,7 +349,7 @@ cell_t TF2_SetPowerplayEnabled(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	MemWriter<void*, bool> vstk(pEntity, params[2] != 0);
+	ArgBuffer<void*, bool> vstk(pEntity, params[2] != 0);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
@@ -386,7 +386,7 @@ cell_t TF2_Respawn(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	MemWriter<void*> vstk(pEntity);
+	ArgBuffer<void*> vstk(pEntity);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
@@ -414,7 +414,7 @@ cell_t TF2_Regenerate(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 	
-	MemWriter<void*, bool> vstk(pEntity, true);
+	ArgBuffer<void*, bool> vstk(pEntity, true);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
@@ -459,7 +459,7 @@ cell_t TF2_IsPlayerInDuel(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	MemWriter<CBaseEntity*> vstk(pPlayer);
+	ArgBuffer<CBaseEntity*> vstk(pPlayer);
 	
 	bool retValue;
 	pWrapper->Execute(vstk.GetBuffer(), &retValue);
@@ -500,7 +500,7 @@ cell_t TF2_IsHolidayActive(IPluginContext *pContext, const cell_t *params)
 		g_RegNatives.Register(pWrapper);
 	}
 
-	MemWriter<void*, int> vstk(pGameRules, params[1]);
+	ArgBuffer<void*, int> vstk(pGameRules, params[1]);
 
 	bool retValue;
 	pWrapper->Execute(vstk.GetBuffer(), &retValue);
@@ -545,7 +545,7 @@ cell_t TF2_RemoveWearable(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Wearable index %d is not valid", params[2]);
 	}
 
-	MemWriter<void*, CBaseEntity*> vstk(pEntity, pWearable);
+	ArgBuffer<void*, CBaseEntity*> vstk(pEntity, pWearable);
 	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -81,13 +81,13 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-
 	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 											float,
 											int, // Damage amount
 											bool, // Permanent
 											int>  // Custom Damage type (bleeding)
 											vstk(obj, pAttacker, NULL, sp_ctof(params[3]), 4, false, 32);
+
 	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
@@ -127,10 +127,10 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-
 	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 										float> //duration
 										vstk(obj, pTarget, nullptr, 10.0f);
+
 	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
@@ -181,8 +181,8 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*, int, int, CBaseEntity*, bool> vstk(obj, params[2], params[3], pTarget, true);
-	pWrapper->Execute(vstk, nullptr);
 
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -204,8 +204,8 @@ cell_t TF2_RemoveDisguise(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-
 	ArgBuffer<void*> vstk(obj);
+
 	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
@@ -245,8 +245,8 @@ cell_t TF2_AddCondition(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-
 	ArgBuffer<void*, int, float, CBaseEntity*> vstk(obj, params[2], params[3], pInflictor);
+
 	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
@@ -276,10 +276,9 @@ cell_t TF2_RemoveCondition(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-	
 	ArgBuffer<void*, int, bool> vstk(obj, params[2], true);
-	pWrapper->Execute(vstk, nullptr);
 
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -321,10 +320,9 @@ cell_t TF2_StunPlayer(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-
 	ArgBuffer<void*, float, float, int, CBaseEntity*> vstk(obj, sp_ctof(params[2]), sp_ctof(params[3]), params[4], pAttacker);
-	pWrapper->Execute(vstk, nullptr);
 
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -350,8 +348,8 @@ cell_t TF2_SetPowerplayEnabled(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*, bool> vstk(pEntity, params[2] != 0);
-	pWrapper->Execute(vstk, nullptr);
 
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -387,8 +385,8 @@ cell_t TF2_Respawn(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*> vstk(pEntity);
-	pWrapper->Execute(vstk, nullptr);
 
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -415,8 +413,8 @@ cell_t TF2_Regenerate(IPluginContext *pContext, const cell_t *params)
 	}
 	
 	ArgBuffer<void*, bool> vstk(pEntity, true);
+	
 	pWrapper->Execute(vstk, nullptr);
-
 	return 1;
 }
 
@@ -463,6 +461,7 @@ cell_t TF2_IsPlayerInDuel(IPluginContext *pContext, const cell_t *params)
 	
 	bool retValue;
 	pWrapper->Execute(vstk, &retValue);
+
 	return (retValue) ? 1 : 0;
 }
 
@@ -546,8 +545,8 @@ cell_t TF2_RemoveWearable(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*, CBaseEntity*> vstk(pEntity, pWearable);
-	pWrapper->Execute(vstk, nullptr);
 
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -88,7 +88,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 											bool, // Permanent
 											int>  // Custom Damage type (bleeding)
 											vstk(obj, pAttacker, NULL, sp_ctof(params[3]), 4, false, 32);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -131,7 +131,7 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 										float> //duration
 										vstk(obj, pTarget, nullptr, 10.0f);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -181,7 +181,7 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*, int, int, CBaseEntity*, bool> vstk(obj, params[2], params[3], pTarget, true);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }
@@ -206,7 +206,7 @@ cell_t TF2_RemoveDisguise(IPluginContext *pContext, const cell_t *params)
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
 	ArgBuffer<void*> vstk(obj);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -247,7 +247,7 @@ cell_t TF2_AddCondition(IPluginContext *pContext, const cell_t *params)
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
 	ArgBuffer<void*, int, float, CBaseEntity*> vstk(obj, params[2], params[3], pInflictor);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 	return 1;
 }
 
@@ -278,7 +278,7 @@ cell_t TF2_RemoveCondition(IPluginContext *pContext, const cell_t *params)
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 	
 	ArgBuffer<void*, int, bool> vstk(obj, params[2], true);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }
@@ -323,7 +323,7 @@ cell_t TF2_StunPlayer(IPluginContext *pContext, const cell_t *params)
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
 	ArgBuffer<void*, float, float, int, CBaseEntity*> vstk(obj, sp_ctof(params[2]), sp_ctof(params[3]), params[4], pAttacker);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }
@@ -350,7 +350,7 @@ cell_t TF2_SetPowerplayEnabled(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*, bool> vstk(pEntity, params[2] != 0);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }
@@ -387,7 +387,7 @@ cell_t TF2_Respawn(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*> vstk(pEntity);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }
@@ -415,7 +415,7 @@ cell_t TF2_Regenerate(IPluginContext *pContext, const cell_t *params)
 	}
 	
 	ArgBuffer<void*, bool> vstk(pEntity, true);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }
@@ -462,7 +462,7 @@ cell_t TF2_IsPlayerInDuel(IPluginContext *pContext, const cell_t *params)
 	ArgBuffer<CBaseEntity*> vstk(pPlayer);
 	
 	bool retValue;
-	pWrapper->Execute(vstk.GetBuffer(), &retValue);
+	pWrapper->Execute(vstk, &retValue);
 	return (retValue) ? 1 : 0;
 }
 
@@ -503,7 +503,7 @@ cell_t TF2_IsHolidayActive(IPluginContext *pContext, const cell_t *params)
 	ArgBuffer<void*, int> vstk(pGameRules, params[1]);
 
 	bool retValue;
-	pWrapper->Execute(vstk.GetBuffer(), &retValue);
+	pWrapper->Execute(vstk, &retValue);
 
 	return (retValue) ? 1 : 0;
 }
@@ -546,7 +546,7 @@ cell_t TF2_RemoveWearable(IPluginContext *pContext, const cell_t *params)
 	}
 
 	ArgBuffer<void*, CBaseEntity*> vstk(pEntity, pWearable);
-	pWrapper->Execute(vstk.GetBuffer(), nullptr);
+	pWrapper->Execute(vstk, nullptr);
 
 	return 1;
 }

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -35,6 +35,7 @@
 #include "RegNatives.h"
 
 #include <ISDKTools.h>
+#include <sm_memwriter.h>
 
 // native TF2_MakeBleed(client, attacker, Float:duration)
 cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
@@ -81,25 +82,13 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float) + sizeof(int) + sizeof(bool) + sizeof(int)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = obj;
-	vptr += sizeof(void *);
-	*(CBaseEntity **)vptr = pAttacker;
-	vptr += sizeof(CBaseEntity *);
-	*(CBaseEntity **)vptr = NULL;
-	vptr += sizeof(CBaseEntity *);
-	*(float *)vptr = sp_ctof(params[3]);
-	vptr += sizeof(float);
-	*(int *)vptr = 4;      // Damage amount
-	vptr += sizeof(int);
-	*(bool *)vptr = false; // Permanent
-	vptr += sizeof(bool);
-	*(int *)vptr = 34;     // Custom Damage type (bleeding)
-
-	pWrapper->Execute(vstk, NULL);
-
+	MemWriter<void*, CBaseEntity*, CBaseEntity*, 
+											float,
+											int, // Damage amount
+											bool, // Permanent
+											int>  // Custom Damage type (bleeding)
+											vstk(obj, pAttacker, NULL, sp_ctof(params[3]), 4, false, 32);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 	return 1;
 }
 
@@ -139,19 +128,10 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(CBaseEntity *) + sizeof(float)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = obj;
-	vptr += sizeof(void *);
-	*(CBaseEntity **)vptr = pTarget;
-	vptr += sizeof(CBaseEntity *);
-	*(CBaseEntity **)vptr = NULL;
-	vptr += sizeof(CBaseEntity *);
-	*(float *)vptr = 10.0f; // duration
-
-	pWrapper->Execute(vstk, NULL);
-
+	MemWriter<void*, CBaseEntity*, CBaseEntity*, 
+										float> //duration
+										vstk(obj, pTarget, nullptr, 10.0f);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 	return 1;
 }
 
@@ -200,21 +180,8 @@ cell_t TF2_Disguise(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Target client index %d is not valid", params[4]);
 	}
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(int) + sizeof(CBaseEntity *) + sizeof(bool)];
-	unsigned char *vptr = vstk;
-
-
-	*(void **)vptr = obj;
-	vptr += sizeof(void *);
-	*(int *)vptr = params[2];
-	vptr += sizeof(int);
-	*(int *)vptr = params[3];
-	vptr += sizeof(int);
-	*(CBaseEntity **)vptr = pTarget;
-	vptr += sizeof(CBaseEntity *);
-	*(bool *)vptr = true;
-	
-	pWrapper->Execute(vstk, NULL);
+	MemWriter<void*, int, int, CBaseEntity*, bool> vstk(obj, params[2], params[3], pTarget, true);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }
@@ -238,14 +205,8 @@ cell_t TF2_RemoveDisguise(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *)];
-	unsigned char *vptr = vstk;
-
-
-	*(void **)vptr = obj;
-
-	pWrapper->Execute(vstk, NULL);
-
+	MemWriter<void*> vstk(obj);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 	return 1;
 }
 
@@ -285,19 +246,8 @@ cell_t TF2_AddCondition(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + sizeof(int) + sizeof(float) + sizeof(CBaseEntity *)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = obj;
-	vptr += sizeof(void *);
-	*(int *)vptr = params[2];
-	vptr += sizeof(int);
-	*(float *)vptr = *(float *)&params[3];
-	vptr += sizeof(float);
-	*(CBaseEntity **)vptr = pInflictor;
-
-	pWrapper->Execute(vstk, NULL);
-
+	MemWriter<void*, int, float, CBaseEntity*> vstk(obj, params[2], params[3], pInflictor);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 	return 1;
 }
 
@@ -326,17 +276,9 @@ cell_t TF2_RemoveCondition(IPluginContext *pContext, const cell_t *params)
 	}
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
-
-	unsigned char vstk[sizeof(void *) + sizeof(int) + sizeof(bool)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = obj;
-	vptr += sizeof(void *);
-	*(int *)vptr = params[2];
-	vptr += sizeof(int);
-	*(bool *)vptr = true;
-
-	pWrapper->Execute(vstk, NULL);
+	
+	MemWriter<void*, int, bool> vstk(obj, params[2], true);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }
@@ -380,20 +322,8 @@ cell_t TF2_StunPlayer(IPluginContext *pContext, const cell_t *params)
 
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 
-	unsigned char vstk[sizeof(void *) + 2*sizeof(float) + sizeof(int) + sizeof(CBaseEntity *)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = obj;
-	vptr += sizeof(void *);
-	*(float *)vptr = sp_ctof(params[2]);
-	vptr += sizeof(float);
-	*(float *)vptr = sp_ctof(params[3]);
-	vptr += sizeof(float);
-	*(int *)vptr = params[4];
-	vptr += sizeof(int);
-	*(CBaseEntity **)vptr = pAttacker;
-
-	pWrapper->Execute(vstk, NULL);
+	MemWriter<void*, float, float, int, CBaseEntity*> vstk(obj, sp_ctof(params[2]), sp_ctof(params[3]), params[4], pAttacker);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }
@@ -419,20 +349,8 @@ cell_t TF2_SetPowerplayEnabled(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	bool bEnablePP = false;
-	if (params[2] != 0)
-	{
-		bEnablePP = true;
-	}
-
-	unsigned char vstk[sizeof(void *) + sizeof(bool)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = (void *)pEntity;
-	vptr += sizeof(void *);
-	*(bool *)vptr = bEnablePP;
-
-	pWrapper->Execute(vstk, NULL);
+	MemWriter<void*, bool> vstk(pEntity, params[2] != 0);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }
@@ -468,13 +386,8 @@ cell_t TF2_Respawn(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	unsigned char vstk[sizeof(void *)];
-	unsigned char *vptr = vstk;
-
-
-	*(void **)vptr = (void *)pEntity;
-
-	pWrapper->Execute(vstk, NULL);
+	MemWriter<void*> vstk(pEntity);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }
@@ -501,14 +414,8 @@ cell_t TF2_Regenerate(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 	
-	unsigned char vstk[sizeof(void *) + sizeof(bool)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = (void *)pEntity;
-	vptr += sizeof(void *);
-	*(bool *)vptr = true;
-
-	pWrapper->Execute(vstk, NULL);
+	MemWriter<void*, bool> vstk(pEntity, true);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }
@@ -552,13 +459,10 @@ cell_t TF2_IsPlayerInDuel(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[1]);
 	}
 
-	unsigned char vstk[sizeof(CBaseEntity *)];
-	unsigned char *vptr = vstk;
-	*(CBaseEntity **)vptr = pPlayer;
-
+	MemWriter<CBaseEntity*> vstk(pPlayer);
+	
 	bool retValue;
-	pWrapper->Execute(vstk, &retValue);
-
+	pWrapper->Execute(vstk.GetBuffer(), &retValue);
 	return (retValue) ? 1 : 0;
 }
 
@@ -596,15 +500,10 @@ cell_t TF2_IsHolidayActive(IPluginContext *pContext, const cell_t *params)
 		g_RegNatives.Register(pWrapper);
 	}
 
-	unsigned char vstk[sizeof(void *) + sizeof(int)];
-	unsigned char *vptr = vstk;
-	*(void **)vptr = pGameRules;
-	vptr += sizeof(void *);
-	*(int *)vptr = params[1];
-	
-	bool retValue;
+	MemWriter<void*, int> vstk(pGameRules, params[1]);
 
-	pWrapper->Execute(vstk, &retValue);
+	bool retValue;
+	pWrapper->Execute(vstk.GetBuffer(), &retValue);
 
 	return (retValue) ? 1 : 0;
 }
@@ -646,14 +545,8 @@ cell_t TF2_RemoveWearable(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Wearable index %d is not valid", params[2]);
 	}
 
-	unsigned char vstk[sizeof(void *) + sizeof(CBaseEntity *)];
-	unsigned char *vptr = vstk;
-
-	*(void **)vptr = (void *)pEntity;
-	vptr += sizeof(void *);
-	*(CBaseEntity **)vptr = pWearable;
-
-	pWrapper->Execute(vstk, NULL);
+	MemWriter<void*, CBaseEntity*> vstk(pEntity, pWearable);
+	pWrapper->Execute(vstk.GetBuffer(), nullptr);
 
 	return 1;
 }

--- a/public/sm_argbuffer.h
+++ b/public/sm_argbuffer.h
@@ -30,7 +30,9 @@
  */
  
 /**
- * A type-safe abstraction for creating a contiguous blob of memory.
+ * A type-safe abstraction for creating a contiguous blob of memory used for 
+ * vtable function calls. This blob contains the parameters to be passed into
+ * the function call.
  */
 template <typename T, typename...Rest>
 class ArgBuffer {
@@ -50,20 +52,20 @@ private:
 	constexpr static int sizetypes() {
 		return sizeof(K) + sizetypes<K2, Kn...>();
 	}
-	
+
 	template <typename K>
-	constexpr void buildbuffer(unsigned char **ptr, K k) {
-		memcpy(*ptr, &k, sizeof(K));
+	void buildbuffer(unsigned char **ptr, K k) {
+		memcpy(*ptr, &k, sizeof(k));
 		*ptr += sizeof(K);
 	}
-	
+
 	template <typename K, typename... Kn>
-	constexpr void buildbuffer(unsigned char **ptr, K k, Kn... kn) {
+	void buildbuffer(unsigned char **ptr, K k, Kn... kn) {
 		buildbuffer(ptr, k);
 		if (sizeof...(kn)!=0)
 			buildbuffer(ptr, kn...);
 	}
-	
+
 private:
 	unsigned char buff[sizetypes<T, Rest...>()];
 };

--- a/public/sm_argbuffer.h
+++ b/public/sm_argbuffer.h
@@ -39,11 +39,8 @@ public:
 		unsigned char *ptr = buff;
 		buildbuffer(&ptr, t, rest...);
 	}
-		
-	void *GetBuffer() {
-		return buff;
-	}
-	
+
+	operator void*() { return buff; }
 private:
 	template <typename K>
 	constexpr static int sizetypes() {

--- a/public/sm_argbuffer.h
+++ b/public/sm_argbuffer.h
@@ -43,6 +43,12 @@ public:
 	}
 
 	operator void*() { return buff; }
+	operator unsigned char*() { return buff; }
+
+	constexpr int size() const {
+		return sizeof(buff);
+	}
+
 private:
 	template <typename K>
 	constexpr static int sizetypes() {

--- a/public/sm_memwriter.h
+++ b/public/sm_memwriter.h
@@ -1,0 +1,80 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2004-2019 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+ 
+/**
+ * A type-safe abstraction for creating a contiguous blob of memory.
+ */
+template <typename T, typename...Rest>
+class MemWriter {
+public:
+	MemWriter(T t, Rest... rest) {
+		size = sizetypes(t, rest...);
+		buff = new unsigned char[size];
+		start = buff;
+		buildbuffer(t, rest...);
+	}
+	
+	~MemWriter() {
+		delete[] start;
+	}
+	
+	void *GetBuffer() const {
+		return start;
+	}
+	
+private:
+	template <typename K>
+	static constexpr int sizetypes(K k) {
+		return sizeof(k);
+	}
+	template <typename K, typename... Kn>
+	static constexpr int sizetypes(K k, Kn... kn) {
+		return sizeof(k) + sizetypes(kn...);
+	}
+	
+	template <typename K>
+	constexpr void buildbuffer(K k) {
+		memcpy(buff, &k, sizeof(K));
+		buff += sizeof(K);
+	}
+	
+	template <typename K, typename... Kn>
+	constexpr void buildbuffer(K k, Kn... kn) {
+		buildbuffer(k);
+		if (sizeof...(kn)!=0)
+			buildbuffer(kn...);
+	}
+	
+private:
+	int size;
+	unsigned char *buff;
+	unsigned char *start;
+};


### PR DESCRIPTION
Along with some type safety checks to ensure everything is kosher, this also technically fixes us relying on UB punning.