### PR TITLE
New parameter to FindValueInArray to compare with number of cells

### DIFF
--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -580,15 +580,15 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	}
 	
 	size_t cells = cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber;
-
+	
 	for (size_t i = 0; i < array->size(); i++)
 	{
-		cell_t *blk = array->at(i);		
+		cell_t *blk = array->at(i);
 		
 		if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * cells) == 0)
 		{
 			return (cell_t) i;
-		}		
+		}
 	}
 
 	return -1;

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -578,25 +578,17 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	{
 		return pContext->ThrowNativeError("Comparing %d cells (blocksize: %d)", blocknumber + cellsToCompare, array->blocksize());
 	}
+	
+	size_t cells = cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber;
 
 	for (size_t i = 0; i < array->size(); i++)
 	{
-		cell_t *blk = array->at(i);
+		cell_t *blk = array->at(i);		
 		
-		if (cellsToCompare > 0)
+		if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * cells) == 0)
 		{
-			if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * cellsToCompare) == 0)
-			{
-				return (cell_t) i;
-			}
-		}
-		else
-		{
-			if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * (array->blocksize() - blocknumber)) == 0)
-			{
-				return (cell_t) i;
-			}			
-		}
+			return (cell_t) i;
+		}		
 	}
 
 	return -1;

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -579,7 +579,7 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Comparing %d cells (blocksize: %d)", blocknumber + cellsToCompare, array->blocksize());
 	}
 
-	for (unsigned int i = 0; i < array->size(); i++)
+	for (size_t i = 0; i < array->size(); i++)
 	{
 		cell_t *blk = array->at(i);
 		

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -582,7 +582,7 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	for (unsigned int i = 0; i < array->size(); i++)
 	{
 		cell_t *blk = array->at(i);
-		if (memcmp(params[2], blk[blocknumber], sizeof(cell_t) * (cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber)) == 0)
+		if (memcmp(params + 2, blk + blocknumber, sizeof(cell_t) * (cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber)) == 0)
 		{
 			return (cell_t) i;
 		}

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -560,7 +560,7 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	size_t blocknumber = 0;
 	if (params[0] >= 3)
 	{
-		blocknumber = (size_t) params[3];		
+		blocknumber = (size_t) params[3];
 	}
 
 	if (blocknumber >= array->blocksize())
@@ -582,9 +582,20 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	for (unsigned int i = 0; i < array->size(); i++)
 	{
 		cell_t *blk = array->at(i);
-		if (memcmp(params + 2, blk + blocknumber, sizeof(cell_t) * (cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber)) == 0)
+		
+		if (cellsToCompare > 0)
 		{
-			return (cell_t) i;
+			if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * cellsToCompare) == 0)
+			{
+				return (cell_t) i;
+			}
+		}
+		else
+		{
+			if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * (array->blocksize() - blocknumber)) == 0)
+			{
+				return (cell_t) i;
+			}			
 		}
 	}
 

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -560,18 +560,30 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	size_t blocknumber = 0;
 	if (params[0] >= 3)
 	{
-		blocknumber = (size_t) params[3];
+		blocknumber = (size_t) params[3];		
 	}
 
 	if (blocknumber >= array->blocksize())
 	{
 		return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", blocknumber, array->blocksize());
 	}
+	
+	size_t cellsToCompare = 0;
+	
+	if (params[0] >= 4)
+	{
+		cellsToCompare = (size_t) params[4];
+	}
+	
+	if (blocknumber + cellsToCompare > array->blocksize())
+	{
+		return pContext->ThrowNativeError("Comparing %d cells (blocksize: %d)", blocknumber + cellsToCompare, array->blocksize());
+	}
 
 	for (unsigned int i = 0; i < array->size(); i++)
 	{
 		cell_t *blk = array->at(i);
-		if (params[2] == blk[blocknumber])
+		if (memcmp(params[2], blk[blocknumber], cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber) == 0)
 		{
 			return (cell_t) i;
 		}

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -579,13 +579,16 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Comparing %d cells (blocksize: %d)", blocknumber + cellsToCompare, array->blocksize());
 	}
 	
+	cell_t *addr;
+	pContext->LocalToPhysAddr(params[2], &addr);
+	
 	size_t cells = cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber;
 	
 	for (size_t i = 0; i < array->size(); i++)
 	{
 		cell_t *blk = array->at(i);
 		
-		if (memcmp(&params[2], &blk[blocknumber], sizeof(cell_t) * cells) == 0)
+		if (memcmp(addr, &blk[blocknumber], sizeof(cell_t) * cells) == 0)
 		{
 			return (cell_t) i;
 		}

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -568,8 +568,7 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", blocknumber, array->blocksize());
 	}
 	
-	size_t cellsToCompare = 0;
-	
+	size_t cellsToCompare = 0;	
 	if (params[0] >= 4)
 	{
 		cellsToCompare = (size_t) params[4];
@@ -583,7 +582,7 @@ static cell_t FindValueInArray(IPluginContext *pContext, const cell_t *params)
 	for (unsigned int i = 0; i < array->size(); i++)
 	{
 		cell_t *blk = array->at(i);
-		if (memcmp(params[2], blk[blocknumber], cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber) == 0)
+		if (memcmp(params[2], blk[blocknumber], sizeof(cell_t) * (cellsToCompare > 0 ? cellsToCompare : array->blocksize() - blocknumber)) == 0)
 		{
 			return (cell_t) i;
 		}

--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -203,10 +203,11 @@ methodmap ArrayList < Handle {
 	// value cannot be located, -1 will be returned.
 	//
 	// @param item          Value to search for
-    // @param block         Optionally which block to search in
+    	// @param block         Optionally which block to search in
+    	// @param cellsToCompare Optionally the number of cells to compare, 0 stands for the rest of the cells
 	// @return              Array index, or -1 on failure
 	// @error               Invalid block index
-	public native int FindValue(any item, int block=0);
+	public native int FindValue(any item, int block=0, int cellsToCompare=1);
 
 	// Retrieve the size of the array.
 	property int Length {
@@ -440,10 +441,11 @@ native int FindStringInArray(Handle array, const char[] item);
  * @param array			Array Handle.
  * @param item			Value to search for
  * @param block			Optionally which block to search in
+ * @param cellsToCompare 	Optionally the number of cells to compare, 0 stands for the rest of the cells
  * @return				Array index, or -1 on failure
  * @error				Invalid Handle or invalid block
  */
-native int FindValueInArray(Handle array, any item, int block=0);
+native int FindValueInArray(Handle array, any item, int block=0, int cellsToCompare=1);
 
 /**
  * Returns the blocksize the array was created with.

--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -204,7 +204,7 @@ methodmap ArrayList < Handle {
 	//
 	// @param item          Value to search for
     	// @param block         Optionally which block to search in
-    	// @param cellsToCompare Optionally the number of cells to compare, 0 stands for the rest of the cells
+    	// @param cellsToCompare Optionally the number of cells to compare, anything below 1 stands for the rest of the cells
 	// @return              Array index, or -1 on failure
 	// @error               Invalid block index
 	public native int FindValue(any item, int block=0, int cellsToCompare=1);
@@ -441,7 +441,7 @@ native int FindStringInArray(Handle array, const char[] item);
  * @param array			Array Handle.
  * @param item			Value to search for
  * @param block			Optionally which block to search in
- * @param cellsToCompare 	Optionally the number of cells to compare, 0 stands for the rest of the cells
+ * @param cellsToCompare 	Optionally the number of cells to compare, anything below 1 stands for the rest of the cells
  * @return				Array index, or -1 on failure
  * @error				Invalid Handle or invalid block
  */


### PR DESCRIPTION
```
/**
 * Returns the index for the first occurrence of the provided value. If the value
 * cannot be located, -1 will be returned.
 *
 * @param array				Array Handle.
 * @param item				Value to search for
 * @param block				Optionally which block to search in
 * @param cellsToCompare	Optionally the number of cells to compare, 0 stands for the rest of the cells (Example: if you have a blocksize of 4 cells, and you want to compare the last 3 cells then: block = 1 and cellsToCompare should be 3)
 * @return					Array index, or -1 on failure
 * @error					Invalid Handle or invalid block
 */
native int FindValueInArray(Handle array, any item, int block=0, int cellsToCompare=0);
```

The new parameter 'cellsToCompare' will allow us to compare a certain number of cells, starting from 'block', since FindValue only compares a single cell right now,

It is very useful when working with structures that have array as members. Here's an example with an array of 2:
`#include <sourcemod>

#pragma newdecls required

enum struct SomeStructure
{
	int firstMember;
	int otherMembers[3];
}

ArrayList g_Array;

public void OnClientSayCommand_Post(int client, const char[] command, const char[] sArgs)
{
	int pos = -1;
	
	if( strcmp(sArgs, "array_create", false) == 0 )
	{
		g_Array = new ArrayList(sizeof(SomeStructure));
	
		if( g_Array )
		{
			PrintToChat(client, "Created array g_Array[x][%d] with success!", sizeof(SomeStructure));
		}
		
	}
	else if( strcmp(sArgs, "array_push", false) == 0 )
	{
		SomeStructure data;
		data.firstMember = 6;
		data.otherMembers[0] = 1;
		data.otherMembers[1] = 0;
		
		if( g_Array.PushArray(data) != -1 )
		{	
			pos = g_Array.Length - 1;
	
			PrintToChat(client, "Pushed some structure into the entry %d", pos);			
			PrintToChat(client, "Expected values: firstMember = %d, otherMembers[2] = {%d, %d}", data.firstMember, data.otherMembers[0], data.otherMembers[1]);	
		}
	}
	// Adding  this just because I want more than 1 entry....
	else if( strcmp(sArgs, "array_push_dummy", false) == 0 )
	{
		SomeStructure data;
		data.firstMember = GetRandomInt(-1337, 1337);
		data.otherMembers[0] = GetRandomInt(-1337, 1337);
		data.otherMembers[1] = GetRandomInt(-1337, 1337);
		
		if( g_Array.PushArray(data) != -1 )
		{
			pos = g_Array.Length - 1;
			
			PrintToChat(client, "Pushed some structure into the entry %d", pos);			
			PrintToChat(client, "Expected values: firstMember = %d, otherMembers[2] = {%d, %d}", data.firstMember, data.otherMembers[0], data.otherMembers[1]);			
		}
	}
	else if( strcmp(sArgs, "array_find", false) == 0 )
	{
		// Search starting from 1th cell
		if( (pos = g_Array.FindValue(6)) != -1 )
		{
			PrintToChat(client, "Found 6 at the entry %d", pos);
		}
		
		// Search starting from 2nd cell
		if( (pos = g_Array.FindValue(1, 1)) != -1 )
		{
			PrintToChat(client, "Found 1 at the entry %d", pos);
		}
		
		// Search starting from 3rd cell
		if( (pos = g_Array.FindValue(0, 2)) != -1 )
		{
			PrintToChat(client, "Found 0 at the entry %d", pos);
		}		
		
		// Works alright, but what if we want to compare a bigger number of cells? say 32 > 2?

		// comparing Array[X].otherMembers[1] and Array[X].otherMembers[2] parts of the blocksize
		if( (pos = g_Array.FindValue(1, 1)) != -1 && (pos = g_Array.FindValue(0, 2)) != -1 )
		{
			PrintToChat(client, "Found otherMembers[2] = {0, 1} at the entry %d", pos);
		}
		
		// comparing Array[X].firstMember and Array[X].otherMembers[0] parts of the blocksize
		if( (pos = g_Array.FindValue(6)) != -1 && (pos = g_Array.FindValue(1, 1)) != -1 )
		{
			PrintToChat(client, "Found firstMember = 6, otherMembers[0] = 1 at the entry %d", pos);
		}
	}
}`

Output from chat:
DS‎ : array_create
	Created array g_Array[x][4] with success!
	
	DS‎ : array_push_dummy
	Pushed some structure into the entry 0
	Expected values: firstMember = -365, otherMembers[2] = {337, -269}
	
	DS‎ : array_push_dummy
	Pushed some structure into the entry 1
	Expected values: firstMember = 131, otherMembers[2] = {738, 954}
	
	DS‎ : array_push_dummy
	Pushed some structure into the entry 2
	Expected values: firstMember = -1279, otherMembers[2] = {-610, 440}
	
	DS‎ : array_push_dummy
	Pushed some structure into the entry 3
	Expected values: firstMember = 762, otherMembers[2] = {426, -323}
	
	DS‎ : array_push
	Pushed some structure into the entry 4
	Expected values: firstMember = 6, otherMembers[2] = {1, 0}
	
	DS‎ : array_find
	Found 6 at the entry 4
	Found 1 at the entry 4
	Found 0 at the entry 4
	Found otherMembers[2] = {0, 1} at the entry 4
	Found firstMember = 6, otherMembers[0] = 1 at the entry 4

It works fine, yes. but, imagine having an array with size bigger than 2?