### PR TITLE
Block loading of incompatible IBinTools interface

### DIFF
--- a/public/extensions/IBinTools.h
+++ b/public/extensions/IBinTools.h
@@ -37,6 +37,8 @@
 
 #define SMINTERFACE_BINTOOLS_NAME		"IBinTools"
 #define SMINTERFACE_BINTOOLS_VERSION	4
+// Backwards incompatible change for x64 support.
+#define SMINTERFACE_BINTOOLS_MIN_VERSION 4
 
 /**
  * @brief Function calling encoding utilities
@@ -183,6 +185,15 @@ namespace SourceMod
 		virtual unsigned int GetInterfaceVersion()
 		{
 			return SMINTERFACE_BINTOOLS_VERSION;
+		}
+		virtual bool IsVersionCompatible(unsigned int version)
+		{
+			if (version < SMINTERFACE_BINTOOLS_MIN_VERSION || version > SMINTERFACE_BINTOOLS_VERSION)
+			{
+				return false;
+			}
+
+			return true;
 		}
 	public:
 		/**


### PR DESCRIPTION
In #705 SourceMod received support for x64 binaries. The `IBinTools` interface was updated to call functions in 64bit binaries. The `PassInfo` struct's size was increased and the `Create[V]Call()` functions signatures changed, thus making the interface incompatible for consumers which were compiled against an earlier version.

`IBinTools::IsVersionCompatible` wasn't adjusted to that fact, so extensions compiled against pre SM 1.10 could request an `IBinTools` interface pointer, but crash when they try to use it.

This change makes requests to older interface versions invalid, thus letting `RequestInterface` return `NULL` for older extensions. It doesn't fix the backwards incompatibility, but at least makes the problem more blatant, so extensions can handle it themselves.