### PR TITLE
Create menu if multiple nom matches found

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -34,8 +34,6 @@
 #include <sourcemod>
 #include <mapchooser>
 
-#define MATCHED_INDEXES_MAX 7
-
 #pragma semicolon 1
 #pragma newdecls required
 

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -234,6 +234,7 @@ public Action Command_Nominate(int client, int args)
 		{
 			// if source is console, attempt instead of displaying menu.
 			AttemptNominate(client, mapname, sizeof(mapname));
+			delete results;
 			return Plugin_Handled;
 		}
 

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -192,10 +192,20 @@ public Action Command_Nominate(int client, int args)
 	{
 		return Plugin_Handled;
 	}
+
+	ReplySource source = GetCmdReplySource();
 	
 	if (args == 0)
-	{
-		OpenNominationMenu(client);
+	{	
+		if (source == SM_REPLY_TO_CHAT)
+		{
+			OpenNominationMenu(client);
+		}
+		else
+		{
+			ReplyToCommand(client, "[SM] Usage: sm_nominate <mapname>");
+		}
+		
 		return Plugin_Handled;
 	}
 	
@@ -211,8 +221,22 @@ public Action Command_Nominate(int client, int args)
 	{
 		ReplyToCommand(client, "%t", "Map was not found", mapname);
 	}
+	// One result
+	else if (matches == 1)
+	{
+		// Get the result and nominate it
+		g_MapList.GetString(results.Get(0), mapResult, sizeof(mapResult));
+		AttemptNominate(client, mapResult, sizeof(mapResult));
+	}
 	else if (matches > 1)
 	{
+		if (source == SM_REPLY_TO_CONSOLE)
+		{
+			// if source is console, attempt instead of displaying menu.
+			AttemptNominate(client, mapname, sizeof(mapname));
+			return Plugin_Handled;
+		}
+
 		// Display results to the client and end
 		Menu menu = new Menu(MenuHandler_MapSelect, MENU_ACTIONS_DEFAULT|MenuAction_DrawItem|MenuAction_DisplayItem);
 		menu.SetTitle("Select map");
@@ -226,13 +250,7 @@ public Action Command_Nominate(int client, int args)
 		menu.Display(client, 30);
 		ReplyToCommand(client, "[SM] %t", "Multiple Matches Found");
 	}
-	// One result
-	else if (matches == 1)
-	{
-		// Get the result and nominate it
-		g_MapList.GetString(results.Get(0), mapResult, sizeof(mapResult));
-		AttemptNominate(client, mapResult, sizeof(mapResult));
-	}
+
 
 	delete results;
 

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -248,9 +248,7 @@ public Action Command_Nominate(int client, int args)
 		}
 
 		menu.Display(client, 30);
-		ReplyToCommand(client, "[SM] %t", "Multiple Matches Found");
 	}
-
 
 	delete results;
 

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -405,7 +405,8 @@ void BuildMapMenu()
 	delete excludeMaps;
 }
 
-public int MenuHandler_MapSelect(Menu menu, MenuAction action, int param1, int param2) {
+public int MenuHandler_MapSelect(Menu menu, MenuAction action, int param1, int param2)
+{
 	switch (action)
 	{
 		case MenuAction_Select:

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -239,7 +239,8 @@ public Action Command_Nominate(int client, int args)
 	return Plugin_Handled;
 }
 
-int FindMatchingMaps(ArrayList mapList, ArrayList results, const char[] input){
+int FindMatchingMaps(ArrayList mapList, ArrayList results, const char[] input)
+{
 	int map_count = mapList.Length;
 
 	if (!map_count)

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -406,7 +406,8 @@ void BuildMapMenu()
 }
 
 public int MenuHandler_MapSelect(Menu menu, MenuAction action, int param1, int param2) {
-	switch (action) {
+	switch (action)
+	{
 		case MenuAction_Select:
 		{
 			char mapname[PLATFORM_MAX_PATH];

--- a/translations/nominations.phrases.txt
+++ b/translations/nominations.phrases.txt
@@ -1,11 +1,5 @@
 "Phrases"
 {
-
-	"Multiple Matches Found"
-	{
-		"en"			"Multiple matches have been found."
-	}
-
 	"Already Nominated"
 	{
 		"en"			"You have already nominated a map."

--- a/translations/nominations.phrases.txt
+++ b/translations/nominations.phrases.txt
@@ -1,16 +1,20 @@
 "Phrases"
 {
+
+	"Multiple Matches Found"
+	{
+		"en"			"Multiple matches have been found."
+	}
+
 	"Already Nominated"
 	{
 		"en"			"You have already nominated a map."
-
 	}
 	
 	"Max Nominations"
 	{
 		"en"			"The maximum allowed nominations has been reached."
 	}
-
 
 	"Map Already In Vote"
 	{


### PR DESCRIPTION
This change checks the nomination against the map arraylist. If the nomination matches multiple results, those results are then added to a menu to allow the client to select available maps. The maps added to the menu go against the same checks as the normal nomination menu and wont allow nomination of disabled maps. ~~There is also a defined MATCHED_INDEXES_MAX of 7, which means there will only be one page of matched maps.~~ Update: Added convar sm_nominate_maxfound.

The main reason for this change is to allow for more flexibility of map nominations. In its current state, the plugin only attempts to nominate the very first match.

Example image of /nominate jump_b
![Nom Menu](https://i.imgur.com/ZdzB0gk.png)

Image demonstrating that disabled maps cannot be selected. 
Command used: /nominate jump_
![Nom Menu2](https://i.imgur.com/KVo4mfX.png)

I would also like feedback on the idea of registering command "sm_nom" with the same callback as "sm_nominate".