### PR TITLE
Fix CSS Builds

### DIFF
--- a/extensions/cstrike/util_cstrike.cpp
+++ b/extensions/cstrike/util_cstrike.cpp
@@ -33,9 +33,10 @@
 #include "util_cstrike.h"
 #include "RegNatives.h"
 #include <iplayerinfo.h>
+#include <sm_argbuffer.h>
+
 #if SOURCE_ENGINE == SE_CSGO
 #include "itemdef-hash.h"
-#include <sm_argbuffer.h>
 
 ClassnameMap g_mapClassToDefIdx;
 ItemIndexMap g_mapDefIdxToClass;


### PR DESCRIPTION
This is a regression from #965 and fixes builds for CS:S.

The include was accidentally slipped under `#if SOURCE_ENGINE == SE_CSGO`