### PR TITLE
NPOTB: Enable cstrike builds w/ Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,5 +114,5 @@ script:
   - mkdir build && cd build
   - PATH="~/.local/bin:$PATH"
   - eval "${MATRIX_EVAL}"
-  - python ../configure.py --enable-optimize --sdks=episode1,tf2,l4d2,csgo,dota
+  - python ../configure.py --enable-optimize --sdks=episode1,css,tf2,l4d2,csgo,dota
   - ambuild


### PR DESCRIPTION
Travis-CI seems to have finally improved their environment so we should be okay to test this unique code-path now with CI.

https://github.com/alliedmodders/sourcemod/pull/992