### PR TITLE
Beacon Color (L4D1/L4D2)

### DIFF
--- a/gamedata/funcommands.games.txt
+++ b/gamedata/funcommands.games.txt
@@ -10,11 +10,17 @@
 			"SpriteGlow"		"sprites/blueglow2.vmt"
 			"SpriteHalo"		"sprites/halo01.vmt"
 			
-			"SoundBlip"		"buttons/blip1.wav"
-			"SoundBeep"		"buttons/button17.wav"
-			"SoundFinal"	"weapons/cguard/charging.wav"
-			"SoundBoom"		"weapons/explode3.wav"
-			"SoundFreeze"	"physics/glass/glass_impact_bullet4.wav"
+			"SoundBlip"			"buttons/blip1.wav"
+			"SoundBeep"			"buttons/button17.wav"
+			"SoundFinal"		"weapons/cguard/charging.wav"
+			"SoundBoom"			"weapons/explode3.wav"
+			"SoundFreeze"		"physics/glass/glass_impact_bullet4.wav"
+			
+			"Team1Color"		"green"
+			"Team2Color"		"red"
+			"Team3Color"		"blue
+			"Team4Color"		"orange"
+			"DefaultTeamColor"	"white"
 		}
 	}
 	
@@ -28,8 +34,8 @@
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 			
-			"SoundFinal"	"ui/arm_bomb.wav"
-			"SoundBoom"		"weapons/hegrenade/explode4.wav"
+			"SoundFinal"		"ui/arm_bomb.wav"
+			"SoundBoom"			"weapons/hegrenade/explode4.wav"
 		}
 	}
 	
@@ -56,13 +62,30 @@
 			"SpriteHalo"		"sprites/glow01.vmt"
 		}
 	}
-	
+	"left4dead"
+	{
+		"Keys"
+		{
+			"Team2Color"		"blue"
+			"Team3Color"		"red"
+		}
+	}
+	"left4dead2"
+	{
+		"Keys"
+		{
+			"SpriteBeam"		"sprites/laserbeam.vmt"
+			
+			"Team2Color"		"blue"
+			"Team3Color"		"red"
+		}
+	}
 	"#default"
 	{
 		"#supported"
 		{
-			"game"	"left4dead"
-			"game"	"left4dead2"
+			"game"				"left4dead"
+			"game"				"left4dead2"
 		}
 		
 		"Keys"

--- a/gamedata/funcommands.games.txt
+++ b/gamedata/funcommands.games.txt
@@ -6,14 +6,14 @@
 		{
 			"SpriteBeam"		"sprites/laser.vmt"
 			"SpriteBeam2"		"sprites/bluelight1.vmt"
-			"SpriteExplosion"	"sprites/sprite_fire01.vmt"
+			"SpriteExplosion"		"sprites/sprite_fire01.vmt"
 			"SpriteGlow"		"sprites/blueglow2.vmt"
 			"SpriteHalo"		"sprites/halo01.vmt"
 			
-			"SoundBlip"			"buttons/blip1.wav"
-			"SoundBeep"			"buttons/button17.wav"
+			"SoundBlip"		"buttons/blip1.wav"
+			"SoundBeep"		"buttons/button17.wav"
 			"SoundFinal"		"weapons/cguard/charging.wav"
-			"SoundBoom"			"weapons/explode3.wav"
+			"SoundBoom"		"weapons/explode3.wav"
 			"SoundFreeze"		"physics/glass/glass_impact_bullet4.wav"
 			
 			"Team1Color"		"green"
@@ -30,12 +30,12 @@
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		"sprites/physbeam.vmt"
-			"SpriteExplosion"	""
+			"SpriteExplosion"		""
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 			
 			"SoundFinal"		"ui/arm_bomb.wav"
-			"SoundBoom"			"weapons/hegrenade/explode4.wav"
+			"SoundBoom"		"weapons/hegrenade/explode4.wav"
 		}
 	}
 	
@@ -45,7 +45,7 @@
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		""
-			"SpriteExplosion"	"sprites/sprite_fire01.vmt"
+			"SpriteExplosion"		"sprites/sprite_fire01.vmt"
 			"SpriteGlow"		""
 			"SpriteHalo"		"sprites/glow01.vmt"
 		}
@@ -57,7 +57,7 @@
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		""
-			"SpriteExplosion"	"sprites/flamelet1.vmt"
+			"SpriteExplosion"		"sprites/flamelet1.vmt"
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 		}
@@ -66,15 +66,15 @@
 	{
 		"#supported"
 		{
-			"game"				"left4dead"
-			"game"				"left4dead2"
+			"game"			"left4dead"
+			"game"			"left4dead2"
 		}
 		
 		"Keys"
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		"sprites/physbeam.vmt"
-			"SpriteExplosion"	"sprites/floorfire4_.vmt"
+			"SpriteExplosion"		"sprites/floorfire4_.vmt"
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 			

--- a/gamedata/funcommands.games.txt
+++ b/gamedata/funcommands.games.txt
@@ -6,14 +6,14 @@
 		{
 			"SpriteBeam"		"sprites/laser.vmt"
 			"SpriteBeam2"		"sprites/bluelight1.vmt"
-			"SpriteExplosion"		"sprites/sprite_fire01.vmt"
+			"SpriteExplosion"	"sprites/sprite_fire01.vmt"
 			"SpriteGlow"		"sprites/blueglow2.vmt"
 			"SpriteHalo"		"sprites/halo01.vmt"
 			
-			"SoundBlip"		"buttons/blip1.wav"
-			"SoundBeep"		"buttons/button17.wav"
+			"SoundBlip"			"buttons/blip1.wav"
+			"SoundBeep"			"buttons/button17.wav"
 			"SoundFinal"		"weapons/cguard/charging.wav"
-			"SoundBoom"		"weapons/explode3.wav"
+			"SoundBoom"			"weapons/explode3.wav"
 			"SoundFreeze"		"physics/glass/glass_impact_bullet4.wav"
 			
 			"Team1Color"		"green"
@@ -30,12 +30,12 @@
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		"sprites/physbeam.vmt"
-			"SpriteExplosion"		""
+			"SpriteExplosion"	""
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 			
 			"SoundFinal"		"ui/arm_bomb.wav"
-			"SoundBoom"		"weapons/hegrenade/explode4.wav"
+			"SoundBoom"			"weapons/hegrenade/explode4.wav"
 		}
 	}
 	
@@ -45,7 +45,7 @@
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		""
-			"SpriteExplosion"		"sprites/sprite_fire01.vmt"
+			"SpriteExplosion"	"sprites/sprite_fire01.vmt"
 			"SpriteGlow"		""
 			"SpriteHalo"		"sprites/glow01.vmt"
 		}
@@ -57,7 +57,7 @@
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		""
-			"SpriteExplosion"		"sprites/flamelet1.vmt"
+			"SpriteExplosion"	"sprites/flamelet1.vmt"
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 		}
@@ -66,15 +66,15 @@
 	{
 		"#supported"
 		{
-			"game"			"left4dead"
-			"game"			"left4dead2"
+			"game"				"left4dead"
+			"game"				"left4dead2"
 		}
 		
 		"Keys"
 		{
 			"SpriteBeam"		"sprites/laserbeam.vmt"
 			"SpriteBeam2"		"sprites/physbeam.vmt"
-			"SpriteExplosion"		"sprites/floorfire4_.vmt"
+			"SpriteExplosion"	"sprites/floorfire4_.vmt"
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
 			

--- a/gamedata/funcommands.games.txt
+++ b/gamedata/funcommands.games.txt
@@ -62,24 +62,6 @@
 			"SpriteHalo"		"sprites/glow01.vmt"
 		}
 	}
-	"left4dead"
-	{
-		"Keys"
-		{
-			"Team2Color"		"blue"
-			"Team3Color"		"red"
-		}
-	}
-	"left4dead2"
-	{
-		"Keys"
-		{
-			"SpriteBeam"		"sprites/laserbeam.vmt"
-			
-			"Team2Color"		"blue"
-			"Team3Color"		"red"
-		}
-	}
 	"#default"
 	{
 		"#supported"
@@ -95,6 +77,9 @@
 			"SpriteExplosion"	"sprites/floorfire4_.vmt"
 			"SpriteGlow"		"sprites/blueflare1.vmt"
 			"SpriteHalo"		"sprites/glow01.vmt"
+			
+			"Team2Color"		"blue"
+			"Team3Color"		"red"
 		}
 	}
 }

--- a/plugins/funcommands.sp
+++ b/plugins/funcommands.sp
@@ -68,11 +68,18 @@ int g_ExplosionSprite   = -1;
 
 // Basic color arrays for temp entities
 int redColor[4]		= {255, 75, 75, 255};
-int orangeColor[4]	= {255, 128, 0, 255};
 int greenColor[4]	= {75, 255, 75, 255};
 int blueColor[4]	= {75, 75, 255, 255};
+int orangeColor[4]	= {255, 128, 0, 255};
 int whiteColor[4]	= {255, 255, 255, 255};
 int greyColor[4]	= {128, 128, 128, 255};
+int noColor[4]		= {0, 0, 0, 0};
+
+int g_Team1Color[4];
+int g_Team2Color[4];
+int g_Team3Color[4];
+int g_Team4Color[4];
+int g_DefaultTeamColor[4];
 
 // UserMessageId for Fade.
 UserMsg g_FadeUserMsgId;
@@ -239,6 +246,31 @@ public void OnMapStart()
 		g_HaloSprite = PrecacheModel(buffer);
 	}
 	
+	if (gameConfig.GetKeyValue("Team1Color", buffer, sizeof(buffer)) && buffer[0])
+	{
+		g_Team1Color = GetColor(buffer);
+	}
+	
+	if (gameConfig.GetKeyValue("Team2Color", buffer, sizeof(buffer)) && buffer[0])
+	{
+		g_Team2Color = GetColor(buffer);
+	}
+	
+	if (gameConfig.GetKeyValue("Team3Color", buffer, sizeof(buffer)) && buffer[0])
+	{
+		g_Team3Color = GetColor(buffer);
+	}
+	
+	if (gameConfig.GetKeyValue("Team4Color", buffer, sizeof(buffer)) && buffer[0])
+	{
+		g_Team4Color = GetColor(buffer);
+	}
+	
+	if (gameConfig.GetKeyValue("DefaultTeamColor", buffer, sizeof(buffer)) && buffer[0])
+	{
+		g_DefaultTeamColor = GetColor(buffer);
+	}
+	
 	delete gameConfig;
 }
 
@@ -296,4 +328,21 @@ void AddTranslatedMenuItem(Menu menu, const char[] opt, const char[] phrase, int
 	char buffer[128];
 	Format(buffer, sizeof(buffer), "%T", phrase, client);
 	menu.AddItem(opt, buffer);
+}
+
+int[] GetColor(const char[] color)
+{
+	if (strcmp(color, "red") == 0)
+		return redColor;
+	if (strcmp(color, "green") == 0)
+		return greenColor;
+	if (strcmp(color, "blue") == 0)
+		return blueColor;
+	if (strcmp(color, "orange") == 0)
+		return orangeColor;
+	if (strcmp(color, "white") == 0)
+		return whiteColor;
+	if (strcmp(color, "grey") == 0)
+		return greyColor;
+	return noColor;
 }

--- a/plugins/funcommands.sp
+++ b/plugins/funcommands.sp
@@ -67,13 +67,13 @@ int g_GlowSprite        = -1;
 int g_ExplosionSprite   = -1;
 
 // Basic color arrays for temp entities
-int redColor[4]		= {255, 75, 75, 255};
-int greenColor[4]	= {75, 255, 75, 255};
-int blueColor[4]	= {75, 75, 255, 255};
-int orangeColor[4]	= {255, 128, 0, 255};
-int whiteColor[4]	= {255, 255, 255, 255};
-int greyColor[4]	= {128, 128, 128, 255};
-int noColor[4]		= {0, 0, 0, 0};
+int redColor[4]     = {255, 75, 75, 255};
+int greenColor[4]   = {75, 255, 75, 255};
+int blueColor[4]    = {75, 75, 255, 255};
+int orangeColor[4]  = {255, 128, 0, 255};
+int whiteColor[4]   = {255, 255, 255, 255};
+int greyColor[4]    = {128, 128, 128, 255};
+int noColor[4]      = {0, 0, 0, 0};
 
 int g_Team1Color[4];
 int g_Team2Color[4];
@@ -248,27 +248,27 @@ public void OnMapStart()
 	
 	if (gameConfig.GetKeyValue("Team1Color", buffer, sizeof(buffer)) && buffer[0])
 	{
-		g_Team1Color = GetColor(buffer);
+		g_Team1Color = GetTeamColor(buffer);
 	}
 	
 	if (gameConfig.GetKeyValue("Team2Color", buffer, sizeof(buffer)) && buffer[0])
 	{
-		g_Team2Color = GetColor(buffer);
+		g_Team2Color = GetTeamColor(buffer);
 	}
 	
 	if (gameConfig.GetKeyValue("Team3Color", buffer, sizeof(buffer)) && buffer[0])
 	{
-		g_Team3Color = GetColor(buffer);
+		g_Team3Color = GetTeamColor(buffer);
 	}
 	
 	if (gameConfig.GetKeyValue("Team4Color", buffer, sizeof(buffer)) && buffer[0])
 	{
-		g_Team4Color = GetColor(buffer);
+		g_Team4Color = GetTeamColor(buffer);
 	}
 	
 	if (gameConfig.GetKeyValue("DefaultTeamColor", buffer, sizeof(buffer)) && buffer[0])
 	{
-		g_DefaultTeamColor = GetColor(buffer);
+		g_DefaultTeamColor = GetTeamColor(buffer);
 	}
 	
 	delete gameConfig;
@@ -330,7 +330,7 @@ void AddTranslatedMenuItem(Menu menu, const char[] opt, const char[] phrase, int
 	menu.AddItem(opt, buffer);
 }
 
-int[] GetColor(const char[] color)
+int[] GetTeamColor(const char[] color)
 {
 	if (strcmp(color, "red") == 0)
 		return redColor;

--- a/plugins/funcommands/beacon.sp
+++ b/plugins/funcommands/beacon.sp
@@ -10,7 +10,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -38,7 +38,7 @@ ConVar g_Cvar_BeaconRadius;
 void CreateBeacon(int client)
 {
 	g_BeaconSerial[client] = ++g_Serial_Gen;
-	CreateTimer(1.0, Timer_Beacon, client | (g_Serial_Gen << 7), DEFAULT_TIMER_FLAGS);	
+	CreateTimer(1.0, Timer_Beacon, client | (g_Serial_Gen << 7), DEFAULT_TIMER_FLAGS);
 }
 
 void KillBeacon(int client)
@@ -85,49 +85,62 @@ public Action Timer_Beacon(Handle timer, any value)
 		KillBeacon(client);
 		return Plugin_Stop;
 	}
-	
-	int team = GetClientTeam(client);
 
 	float vec[3];
 	GetClientAbsOrigin(client, vec);
 	vec[2] += 10;
-	
+
 	if (g_BeamSprite > -1 && g_HaloSprite > -1)
 	{
+		int teamColor[4];
+
+		switch (GetClientTeam(client))
+		{
+			case 1:
+			{
+				teamColor = greenColor;
+			}
+			case 2:
+			{
+				if (g_GameEngine == Engine_Left4Dead || g_GameEngine == Engine_Left4Dead2)
+					teamColor = blueColor;
+				else
+					teamColor = redColor;
+			}
+			case 3:
+			{
+				if (g_GameEngine == Engine_Left4Dead || g_GameEngine == Engine_Left4Dead2)
+					teamColor = redColor;
+				else
+					teamColor = blueColor;
+			}
+			case 4:
+			{
+				teamColor = orangeColor;
+			}
+			default:
+			{
+				teamColor = whiteColor;
+			}
+		}
+
 		TE_SetupBeamRingPoint(vec, 10.0, g_Cvar_BeaconRadius.FloatValue, g_BeamSprite, g_HaloSprite, 0, 15, 0.5, 5.0, 0.0, greyColor, 10, 0);
 		TE_SendToAll();
-		
-		if (team == 2)
-		{
-			TE_SetupBeamRingPoint(vec, 10.0, g_Cvar_BeaconRadius.FloatValue, g_BeamSprite, g_HaloSprite, 0, 10, 0.6, 10.0, 0.5, redColor, 10, 0);
-		}
-		else if (team == 3)
-		{
-			TE_SetupBeamRingPoint(vec, 10.0, g_Cvar_BeaconRadius.FloatValue, g_BeamSprite, g_HaloSprite, 0, 10, 0.6, 10.0, 0.5, blueColor, 10, 0);
-		}
-		else
-		{
-			TE_SetupBeamRingPoint(vec, 10.0, g_Cvar_BeaconRadius.FloatValue, g_BeamSprite, g_HaloSprite, 0, 10, 0.6, 10.0, 0.5, greenColor, 10, 0);
-		}
-		
+
+		TE_SetupBeamRingPoint(vec, 10.0, g_Cvar_BeaconRadius.FloatValue, g_BeamSprite, g_HaloSprite, 0, 10, 0.6, 10.0, 0.5, teamColor, 10, 0);
 		TE_SendToAll();
 	}
-	
+
 	if (g_BlipSound[0])
 	{
 		GetClientEyePosition(client, vec);
-		EmitAmbientSound(g_BlipSound, vec, client, SNDLEVEL_RAIDSIREN);	
+		EmitAmbientSound(g_BlipSound, vec, client, SNDLEVEL_RAIDSIREN);
 	}
-		
+
 	return Plugin_Continue;
 }
 
-public void AdminMenu_Beacon(TopMenu topmenu, 
-					  TopMenuAction action,
-					  TopMenuObject object_id,
-					  int param,
-					  char[] buffer,
-					  int maxlength)
+public void AdminMenu_Beacon(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	if (action == TopMenuAction_DisplayOption)
 	{
@@ -142,14 +155,14 @@ public void AdminMenu_Beacon(TopMenu topmenu,
 void DisplayBeaconMenu(int client)
 {
 	Menu menu = new Menu(MenuHandler_Beacon);
-	
+
 	char title[100];
 	Format(title, sizeof(title), "%T:", "Beacon player", client);
 	menu.SetTitle(title);
 	menu.ExitBackButton = true;
-	
+
 	AddTargetsToMenu(menu, client, true, true);
-	
+
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 
@@ -170,7 +183,7 @@ public int MenuHandler_Beacon(Menu menu, MenuAction action, int param1, int para
 	{
 		char info[32];
 		int userid, target;
-		
+
 		menu.GetItem(param2, info, sizeof(info));
 		userid = StringToInt(info);
 
@@ -186,11 +199,11 @@ public int MenuHandler_Beacon(Menu menu, MenuAction action, int param1, int para
 		{
 			char name[MAX_NAME_LENGTH];
 			GetClientName(target, name, sizeof(name));
-			
+
 			PerformBeacon(param1, target);
 			ShowActivity2(param1, "[SM] ", "%t", "Toggled beacon on target", "_s", name);
 		}
-		
+
 		/* Re-draw the menu if they're still valid */
 		if (IsClientInGame(param1) && !IsClientInKickQueue(param1))
 		{
@@ -213,7 +226,7 @@ public Action Command_Beacon(int client, int args)
 	char target_name[MAX_TARGET_LENGTH];
 	int target_list[MAXPLAYERS], target_count;
 	bool tn_is_ml;
-	
+
 	if ((target_count = ProcessTargetString(
 			arg,
 			client,
@@ -227,12 +240,12 @@ public Action Command_Beacon(int client, int args)
 		ReplyToTargetError(client, target_count);
 		return Plugin_Handled;
 	}
-	
+
 	for (int i = 0; i < target_count; i++)
 	{
 		PerformBeacon(client, target_list[i]);
 	}
-	
+
 	if (tn_is_ml)
 	{
 		ShowActivity2(client, "[SM] ", "%t", "Toggled beacon on target", target_name);
@@ -241,6 +254,6 @@ public Action Command_Beacon(int client, int args)
 	{
 		ShowActivity2(client, "[SM] ", "%t", "Toggled beacon on target", "_s", target_name);
 	}
-	
+
 	return Plugin_Handled;
 }

--- a/plugins/funcommands/beacon.sp
+++ b/plugins/funcommands/beacon.sp
@@ -96,32 +96,11 @@ public Action Timer_Beacon(Handle timer, any value)
 
 		switch (GetClientTeam(client))
 		{
-			case 1:
-			{
-				teamColor = greenColor;
-			}
-			case 2:
-			{
-				if (g_GameEngine == Engine_Left4Dead || g_GameEngine == Engine_Left4Dead2)
-					teamColor = blueColor;
-				else
-					teamColor = redColor;
-			}
-			case 3:
-			{
-				if (g_GameEngine == Engine_Left4Dead || g_GameEngine == Engine_Left4Dead2)
-					teamColor = redColor;
-				else
-					teamColor = blueColor;
-			}
-			case 4:
-			{
-				teamColor = orangeColor;
-			}
-			default:
-			{
-				teamColor = whiteColor;
-			}
+			case 1: teamColor = g_Team1Color;
+			case 2: teamColor = g_Team2Color;
+			case 3: teamColor = g_Team3Color;
+			case 4: teamColor = g_Team4Color;
+			default: teamColor = g_DefaultTeamColor;
 		}
 
 		TE_SetupBeamRingPoint(vec, 10.0, g_Cvar_BeaconRadius.FloatValue, g_BeamSprite, g_HaloSprite, 0, 15, 0.5, 5.0, 0.0, greyColor, 10, 0);


### PR DESCRIPTION
New version of the previous pull [#998 ](https://github.com/alliedmodders/sourcemod/pull/998)

-Fixed the beacon color for Survivor/Infected teams on L4D1/L4D2. (since the main teams should be based on the color from team chat, on L4D, "Team 2" and "Team 3" have the opposite color to e.g. Counter-Strike)
-Added orange beacon to the Team 4 (hidden team on L4D2).
-*Unmodified: Spectator beacon maintained in Green color.
-Undefined teams (GetClientTeam < 1 Or GetClientTeam > 4) shows beacon in White color.
-Updated "if else" to "switch case".
-Added game check through g_GameEngine.
-Removed "team" var.
-Added "teamColor" var to set the beacon color based on the client's team, instead of calling TE_SetupBeamRingPoint on each point.
-Moved TE_SetupBeamRingPoint calls more near each other.
-Modified "AdminMenu_Beacon" parameters *ugly* spacing.
-Removed extra spaces.