### PR TITLE
Added support of XMM&GP registers for Windows x86 custom callconv

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -51,6 +51,10 @@ jit_uint8_t g_ThisPtrReg;
 const jit_uint8_t STACK_PARAM = 16;
 const jit_uint8_t INVALID_REG = 255;
 
+/********************
+ * Assembly Helpers *
+ ********************/
+
 inline jit_uint8_t NextScratchReg()
 {
 	switch (g_RegDecoder++ % 3)

--- a/extensions/bintools/jit_compile.h
+++ b/extensions/bintools/jit_compile.h
@@ -44,33 +44,6 @@ void *JIT_HookCompile(HookWrapper *pWrapper);
 void JIT_FreeHook(void *addr);
 #endif
 
-/********************
- * Assembly Helpers *
- ********************/
-
-inline jit_uint8_t _DecodeRegister3(jit_uint32_t val)
-{
-	switch (val % 3)
-	{
-	case 0:
-		{
-			return kREG_EAX;
-		}
-	case 1:
-		{
-			return kREG_EDX;
-		}
-	case 2:
-		{
-			return kREG_ECX;
-		}
-	}
-
-	/* Should never happen */
-	assert(false);
-	return 0xFF;
-}
-
 extern jit_uint32_t g_RegDecoder;
 
 #endif //_INCLUDE_SOURCEMOD_JIT_COMPILE_H_

--- a/extensions/bintools/x64_macros.h
+++ b/extensions/bintools/x64_macros.h
@@ -48,14 +48,6 @@ const jit_uint8_t kREG_R13      = 13;
 const jit_uint8_t kREG_R14      = 14;
 const jit_uint8_t kREG_R15      = 15;
 
-const jit_uint8_t kREG_XMM0		= 0;
-const jit_uint8_t kREG_XMM1		= 1;
-const jit_uint8_t kREG_XMM2		= 2;
-const jit_uint8_t kREG_XMM3		= 3;
-const jit_uint8_t kREG_XMM4		= 4;
-const jit_uint8_t kREG_XMM5		= 5;
-const jit_uint8_t kREG_XMM6		= 6;
-const jit_uint8_t kREG_XMM7		= 7;
 const jit_uint8_t kREG_XMM8		= 8;
 const jit_uint8_t kREG_XMM9		= 9;
 const jit_uint8_t kREG_XMM10	= 10;

--- a/extensions/sdktools/vcallbuilder.cpp
+++ b/extensions/sdktools/vcallbuilder.cpp
@@ -102,7 +102,7 @@ ValveCall *CreateValveCall(void *addr,
 	if (retInfo)
 	{
 		retBuf.fields = retFieldBuf;
-		if ((size = ValveParamToBinParam(retInfo->vtype, retInfo->type, retInfo->flags, &retBuf, retbuf_needs_extra)) == 0)
+		if ((size = ValveParamToBinParam(retInfo->vtype, retInfo->type, retInfo->reg, retInfo->flags, &retBuf, retbuf_needs_extra)) == 0)
 		{
 			delete vc;
 			return NULL;
@@ -122,6 +122,7 @@ ValveCall *CreateValveCall(void *addr,
 		paramBuf[i].fields = fieldBuf[i];
 		if ((size = ValveParamToBinParam(params[i].vtype, 
 			params[i].type,
+			params[i].reg,
 			params[i].flags,
 			&paramBuf[i],
 			needs_extra)) == 0)
@@ -259,7 +260,7 @@ ValveCall *CreateValveVCall(unsigned int vtableIdx,
 	bool retbuf_needs_extra;
 	if (retInfo)
 	{
-		if ((size = ValveParamToBinParam(retInfo->vtype, retInfo->type, retInfo->flags, &retBuf, retbuf_needs_extra)) == 0)
+		if ((size = ValveParamToBinParam(retInfo->vtype, retInfo->type, retInfo->reg, retInfo->flags, &retBuf, retbuf_needs_extra)) == 0)
 		{
 			delete vc;
 			return NULL;
@@ -277,6 +278,7 @@ ValveCall *CreateValveVCall(unsigned int vtableIdx,
 		bool needs_extra;
 		if ((size = ValveParamToBinParam(params[i].vtype, 
 										params[i].type,
+										params[i].reg,
 										params[i].flags,
 										&paramBuf[i],
 										needs_extra)) == 0)

--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -243,7 +243,16 @@ static cell_t PrepSDKCall_AddParameter(IPluginContext *pContext, const cell_t *p
 	DecodePassMethod(info->vtype, method, info->type, info->flags);
 	info->decflags = params[3] | VDECODE_FLAG_BYREF;
 	info->encflags = params[4];
-
+#ifdef PLATFORM_WINDOWS
+	// Validate that the parameter exist, otherwise reset to default
+	if(params[0] == 5)
+		info->reg = (RegisterType)params[5];
+	else
+		info->reg = RegisterType_None;
+#else
+	info->reg = RegisterType_None;
+#endif
+	
 	/* Since SDKPass_ByRef acts like SDKPass_Pointer we can't allow NULL, just in case */
 	if (method == SDKPass_ByRef)
 	{

--- a/extensions/sdktools/vdecoder.cpp
+++ b/extensions/sdktools/vdecoder.cpp
@@ -49,11 +49,13 @@ using namespace SourcePawn;
 
 size_t ValveParamToBinParam(ValveType type, 
 						  PassType pass,
+						  RegisterType reg,
 						  unsigned int flags,
 						  PassInfo *info,
 						  bool &needs_extra)
 {
 	needs_extra = false;
+	info->reg = reg;
 	switch (type)
 	{
 	case Valve_Vector:

--- a/extensions/sdktools/vdecoder.h
+++ b/extensions/sdktools/vdecoder.h
@@ -92,6 +92,7 @@ struct ValvePassInfo
 	unsigned int decflags;	/**< IN: VDECODE_FLAG_* */
 	unsigned int encflags;	/**< IN: VENCODE_FLAG_* */
 	PassType type;			/**< IN: Pass information */
+	RegisterType reg;		/**< IN: Register type */
 	unsigned int flags;		/**< IN: Pass flags */
 	size_t offset;			/**< OUT: stack offset */
 	size_t obj_offset;		/**< OUT: object offset at end of the stack */
@@ -104,6 +105,7 @@ struct ValveCall;
  *
  * @param type			Valve type.
  * @param pass			Either basic or object.
+ * @param reg			Register type.
  * @param flags			Either BYVAL or BYREF.
  * @param info			Buffer to store param info in.
  * @return				Number of bytes this will use in the virtual stack,
@@ -111,6 +113,7 @@ struct ValveCall;
  */
 size_t ValveParamToBinParam(ValveType type, 
 					  PassType pass,
+					  RegisterType reg,
 					  unsigned int flags,
 					  PassInfo *info,
 					  bool &needs_extra);

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -45,12 +45,13 @@
 SourceHook::List<ValveCall *> g_RegCalls;
 SourceHook::List<ICallWrapper *> g_CallWraps;
 
-inline void InitPass(ValvePassInfo &info, ValveType vtype, PassType type, unsigned int flags, unsigned int decflags=0)
+inline void InitPass(ValvePassInfo &info, ValveType vtype, PassType type, unsigned int flags, unsigned int decflags=0, RegisterType reg=RegisterType_None)
 {
 	info.decflags = decflags;
 	info.encflags = 0;
 	info.flags = flags;
 	info.type = type;
+	info.reg = reg;
 	info.vtype = vtype;
 }
 

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -97,6 +97,28 @@ enum SDKPassMethod
 	SDKPass_ByRef,			/**< Pass an object by reference */
 };
 
+enum SDKRegister
+{
+	// Don't change the register and use the stack
+	SDKRegister_None = 0,
+
+	// 32-bit general purpose registers
+	SDKRegister_EAX,
+	SDKRegister_ECX,
+	SDKRegister_EDX,
+	SDKRegister_EBX,
+	
+	// 128-bit XMM registers
+	SDKRegister_XMM0,
+	SDKRegister_XMM1,
+	SDKRegister_XMM2,
+	SDKRegister_XMM3,
+	SDKRegister_XMM4,
+	SDKRegister_XMM5,
+	SDKRegister_XMM6,
+	SDKRegister_XMM7
+};
+
 #define VDECODE_FLAG_ALLOWNULL		(1<<0)		/**< Allow NULL for pointers */
 #define VDECODE_FLAG_ALLOWNOTINGAME	(1<<1)		/**< Allow players not in game */
 #define VDECODE_FLAG_ALLOWWORLD		(1<<2)		/**< Allow World entity */
@@ -168,8 +190,9 @@ native void PrepSDKCall_SetReturnInfo(SDKType type, SDKPassMethod pass, int decf
  * @param pass			How the data is passed in C++.
  * @param decflags		Flags on decoding from the plugin to C++.
  * @param encflags		Flags on encoding from C++ to the plugin.
+ * @param reg			Which register the data is used in C++. (Used only on Windows OS)
  */
-native void PrepSDKCall_AddParameter(SDKType type, SDKPassMethod pass, int decflags=0, int encflags=0);
+native void PrepSDKCall_AddParameter(SDKType type, SDKPassMethod pass, int decflags=0, int encflags=0, SDKRegister reg=SDKRegister_None);
 
 /**
  * Finalizes an SDK call preparation and returns the resultant Handle.

--- a/public/extensions/IBinTools.h
+++ b/public/extensions/IBinTools.h
@@ -36,9 +36,9 @@
 
 
 #define SMINTERFACE_BINTOOLS_NAME		"IBinTools"
-#define SMINTERFACE_BINTOOLS_VERSION	4
+#define SMINTERFACE_BINTOOLS_VERSION	5
 // Backwards incompatible change for x64 support.
-#define SMINTERFACE_BINTOOLS_MIN_VERSION 4
+#define SMINTERFACE_BINTOOLS_MIN_VERSION 5
 
 /**
  * @brief Function calling encoding utilities
@@ -53,7 +53,7 @@ namespace SourceMod
 	enum CallConvention
 	{
 		CallConv_ThisCall,		/**< This call (object pointer required) */
-		CallConv_Cdecl,			/**< Standard C call */
+		CallConv_Cdecl			/**< Standard C call */
 	};
 
 	/**
@@ -64,6 +64,31 @@ namespace SourceMod
 		PassType_Basic,			/**< Plain old register data (pointers, integers) */
 		PassType_Float,			/**< Floating point data */
 		PassType_Object,		/**< Object or structure */
+	};
+	
+	/**
+	 * @brief Supported registers for custom call conventions
+	 */
+	enum RegisterType
+	{
+		// Don't change the register and use the stack
+		RegisterType_None=0,
+
+		// 32-bit general purpose registers
+		RegisterType_EAX,
+		RegisterType_ECX,
+		RegisterType_EDX,
+		RegisterType_EBX,
+		
+		// 128-bit XMM registers
+		RegisterType_XMM0,
+		RegisterType_XMM1,
+		RegisterType_XMM2,
+		RegisterType_XMM3,
+		RegisterType_XMM4,
+		RegisterType_XMM5,
+		RegisterType_XMM6,
+		RegisterType_XMM7
 	};
 
 	#define PASSFLAG_BYVAL		(1<<0)		/**< Passing by value */
@@ -93,14 +118,19 @@ namespace SourceMod
 	 */
 	struct PassInfo
 	{
-		PassInfo() : fields(nullptr), numFields(0)
+		PassInfo() : reg(RegisterType_None), fields(nullptr), numFields(0)
 		{ }
 		
 		PassInfo(PassType type, unsigned int flags, size_t size, ObjectField *fields, unsigned int numFields)
-			: type(type), flags(flags), size(size), fields(fields), numFields(numFields)
+			: type(type), reg(RegisterType_None), flags(flags), size(size), fields(fields), numFields(numFields)
+		{ }
+		
+		PassInfo(PassType type, RegisterType reg, unsigned int flags, size_t size, ObjectField *fields, unsigned int numFields)
+			: type(type), reg(reg), flags(flags), size(size), fields(fields), numFields(numFields)
 		{ }
 		
 		PassType type;			/**< PassType value */
+		RegisterType reg;		/**< RegisterType value */
 		unsigned int flags;		/**< Pass/return flags */
 		size_t size;			/**< Size of the data being passed */
 		ObjectField *fields;	/**< List of fields for PassType_Object.


### PR DESCRIPTION
In addition added support of some GP registers for making calls with custom call conventions on Windows x86 operating systems. In addition, this code require addional changes in sourcehook.h in the metamod core.