### PR TITLE
Fix Miscellaneous Regressions and UBs

### DIFF
--- a/core/logic/CellArray.h
+++ b/core/logic/CellArray.h
@@ -227,11 +227,17 @@ private:
 		/* finally, allocate the new block */
 		if (m_Data)
 		{
-			m_Data = (cell_t *)realloc(m_Data, sizeof(cell_t) * m_BlockSize * m_AllocSize);
+            cell_t *data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * m_AllocSize));
+			if (!data)  // allocation failure
+            {
+                return false;
+            }
+
+            m_Data = data;
 		} else {
-			m_Data = (cell_t *)malloc(sizeof(cell_t) * m_BlockSize * m_AllocSize);
+			m_Data = static_cast<cell_t*>(malloc(sizeof(cell_t) * m_BlockSize * m_AllocSize));
 		}
-		return (m_Data != NULL);
+		return (m_Data != nullptr);
 	}
 private:
 	cell_t *m_Data;

--- a/core/logic/CellArray.h
+++ b/core/logic/CellArray.h
@@ -227,13 +227,13 @@ private:
 		/* finally, allocate the new block */
 		if (m_Data)
 		{
-            cell_t *data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * m_AllocSize));
+			cell_t *data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * m_AllocSize));
 			if (!data)  // allocation failure
-            {
-                return false;
-            }
+			{
+				return false;
+			}
 
-            m_Data = data;
+			m_Data = data;
 		} else {
 			m_Data = static_cast<cell_t*>(malloc(sizeof(cell_t) * m_BlockSize * m_AllocSize));
 		}

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -416,57 +416,20 @@ void CExtension::AddChildDependent(CExtension *pOther, SMInterface *iface)
 	m_ChildDeps.push_back(info);
 }
 
+// note: dependency iteration deprecated since 1.10
 ITERATOR *CExtension::FindFirstDependency(IExtension **pOwner, SMInterface **pInterface)
 {
-	List<IfaceInfo>::iterator iter = m_Deps.begin();
-
-	if (iter == m_Deps.end())
-	{
-		return NULL;
-	}
-
-	if (pOwner)
-	{
-		*pOwner = (*iter).owner;
-	}
-	if (pInterface)
-	{
-		*pInterface = (*iter).iface;
-	}
-
-	List<IfaceInfo>::iterator *pIter = new List<IfaceInfo>::iterator(iter);
-
-	return (ITERATOR *)pIter;
+	return nullptr;
 }
 
 bool CExtension::FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface)
 {
-	auto &it = *reinterpret_cast<List<IfaceInfo>::iterator*>(iter);
-
-	if (it == m_Deps.end())
-	{
-		return false;
-	}
-
-	it++;
-
-	if (pOwner)
-	{
-		*pOwner = (*it).owner;
-	}
-	if (pInterface)
-	{
-		*pInterface = (*it).iface;
-	}
-
-	return it != m_Deps.end();
+	return false;
 }
 
 void CExtension::FreeDependencyIterator(ITERATOR *iter)
 {
-	List<IfaceInfo>::iterator *pIter = (List<IfaceInfo>::iterator *)iter;
 
-	delete pIter;
 }
 
 void CExtension::AddInterface(SMInterface *pInterface)

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -441,33 +441,25 @@ ITERATOR *CExtension::FindFirstDependency(IExtension **pOwner, SMInterface **pIn
 
 bool CExtension::FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface)
 {
-	List<IfaceInfo>::iterator *pIter = (List<IfaceInfo>::iterator *)iter;
-	List<IfaceInfo>::iterator _iter;
+	auto *it = static_cast<List<IfaceInfo>::iterator*>(iter);
 
-	if (_iter == m_Deps.end())
+	if (it == m_Deps.end())
 	{
 		return false;
 	}
 
-	_iter++;
+	it++;
 
 	if (pOwner)
 	{
-		*pOwner = (*_iter).owner;
+		*pOwner = (*it).owner;
 	}
 	if (pInterface)
 	{
-		*pInterface = (*_iter).iface;
+		*pInterface = (*it).iface;
 	}
 
-	*pIter = _iter;
-
-	if (_iter == m_Deps.end())
-	{
-		return false;
-	}
-
-	return true;
+	return it != m_Deps.end();
 }
 
 void CExtension::FreeDependencyIterator(ITERATOR *iter)

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -441,7 +441,7 @@ ITERATOR *CExtension::FindFirstDependency(IExtension **pOwner, SMInterface **pIn
 
 bool CExtension::FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface)
 {
-	auto *it = static_cast<List<IfaceInfo>::iterator*>(iter);
+	auto &it = *reinterpret_cast<List<IfaceInfo>::iterator*>(iter);
 
 	if (it == m_Deps.end())
 	{

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -162,18 +162,16 @@ bool ShareSystem::RequestInterface(const char *iface_name,
 								   SMInterface **pIface)
 {
 	/* See if the interface exists */
-	List<IfaceInfo>::iterator iter;
 	SMInterface *iface;
-	IExtension *iface_owner;
+	IExtension *iface_owner = nullptr;
 	bool found = false;
-	for (iter=m_Interfaces.begin(); iter!=m_Interfaces.end(); iter++)
+	for (auto iter = m_Interfaces.begin(); iter!=m_Interfaces.end(); iter++)
 	{
-		IfaceInfo &info = (*iter);
+		IfaceInfo &info = *iter;
 		iface = info.iface;
 		if (strcmp(iface->GetInterfaceName(), iface_name) == 0)
 		{
-			if (iface->GetInterfaceVersion() == iface_vers
-				|| iface->IsVersionCompatible(iface_vers))
+			if (iface->GetInterfaceVersion() == iface_vers || iface->IsVersionCompatible(iface_vers))
 			{
 				iface_owner = info.owner;
 				found = true;

--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -381,7 +381,11 @@ public:
     {
         if (len > max_size)
         {
-            buffer = (char *)realloc(buffer, len);
+            auto *newbuffer = static_cast<char *>(realloc(buffer, len));
+            if (!newbuffer)
+                return nullptr;
+
+            buffer = newbuffer;
             max_size = len;
         }
         return buffer;
@@ -420,7 +424,11 @@ cell_t InternalFormat(IPluginContext *pCtx, const cell_t *params, int start)
 	{
 		if (maxlen > sizeof(g_formatbuf))
 		{
-			__copy_buf = g_extrabuf.GetWithSize(maxlen);
+		    char *tmpbuff = g_extrabuf.GetWithSize(maxlen);
+            if (!tmpbuff)
+                pCtx->ThrowNativeError("Unable to allocate buffer with a size of \"%u\"", maxlen);
+
+            __copy_buf = tmpbuff;
 		}
 		else
 		{

--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -424,11 +424,11 @@ cell_t InternalFormat(IPluginContext *pCtx, const cell_t *params, int start)
 	{
 		if (maxlen > sizeof(g_formatbuf))
 		{
-		    char *tmpbuff = g_extrabuf.GetWithSize(maxlen);
-            if (!tmpbuff)
-                pCtx->ThrowNativeError("Unable to allocate buffer with a size of \"%u\"", maxlen);
+			char *tmpbuff = g_extrabuf.GetWithSize(maxlen);
+			if (!tmpbuff)
+				pCtx->ThrowNativeError("Unable to allocate buffer with a size of \"%u\"", maxlen);
 
-            __copy_buf = tmpbuff;
+			__copy_buf = tmpbuff;
 		}
 		else
 		{

--- a/core/logic/stringutil.cpp
+++ b/core/logic/stringutil.cpp
@@ -426,7 +426,7 @@ cell_t InternalFormat(IPluginContext *pCtx, const cell_t *params, int start)
 		{
 			char *tmpbuff = g_extrabuf.GetWithSize(maxlen);
 			if (!tmpbuff)
-				pCtx->ThrowNativeError("Unable to allocate buffer with a size of \"%u\"", maxlen);
+				return pCtx->ThrowNativeError("Unable to allocate buffer with a size of \"%u\"", maxlen);
 
 			__copy_buf = tmpbuff;
 		}

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -2595,7 +2595,7 @@ static cell_t GetEntityFlags(IPluginContext *pContext, const cell_t *params)
 
 	for (int32_t i = 0; i < 32; i++)
 	{
-		int32_t flag = (1<<i);
+		int32_t flag = (1U<<i);
 		if ((actual_flags & flag) == flag)
 		{
 			sm_flags |= SDKEntFlagToSMEntFlag(flag);
@@ -2641,7 +2641,7 @@ static cell_t SetEntityFlags(IPluginContext *pContext, const cell_t *params)
 
 	for (int32_t i = 0; i < 32; i++)
 	{
-		int32_t flag = (1<<i);
+		int32_t flag = (1U<<i);
 		if ((sm_flags & flag) == flag)
 		{
 			actual_flags |= SMEntFlagToSDKEntFlag(flag);

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -84,28 +84,28 @@ namespace SourceMod
 		virtual IdentityToken_t *GetIdentity() =0;
 
 		/**
-		 * @brief Retrieves the extension dependency list for this extension.
+		 * @brief Deprecated, do not use.
 		 *
-		 * @param pOwner		Optional pointer to store the first interface's owner.
-		 * @param pInterface	Optional pointer to store the first interface.
-		 * @return				An ITERATOR pointer for the results, or NULL if no results at all.
+		 * @param pOwner        Unused
+		 * @param pInterface    Unused
+		 * @return              nullptr
 		 */
 		virtual ITERATOR *FindFirstDependency(IExtension **pOwner, SMInterface **pInterface) =0;
 
 		/**
-		 * @brief Finds the next dependency in the dependency list.
+		 * @brief Deprecated, do not use.
 		 *
-		 * @param iter			Pointer to iterator from FindFirstDependency.
-		 * @param pOwner		Optional pointer to store the interface's owner.
-		 * @param pInterface	Optional pointer to store the interface.
-		 * @return				True if there are more results after this, false otherwise.
+		 * @param iter          Unused
+		 * @param pOwner        Unused
+		 * @param pInterface    Unused
+		 * @return              false
 		 */
 		virtual bool FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface) =0;
 
 		/**
-		 * @brief Frees an ITERATOR handle from FindFirstDependency.
+		 * @brief Deprecated, do not use.
 		 *
-		 * @param iter			Pointer to iterator to free.
+		 * @param iter          Unused
 		 */
 		virtual void FreeDependencyIterator(ITERATOR *iter) =0;
 


### PR DESCRIPTION
Ran the cppcheck static analyzer against /core/ to check if we were doing any ugliness that I didn't know about. Turns out there's a few situations where we were regressed.

First, and likely the most significant, was `CExtension::FindNextDependency`. This method must not have worked correctly for many many years. All operations were mistakenly done on a default-constructed iterator. 

Secondly, `realloc` can fail. By doing assignment directly on the result of `realloc` we miss the opportunity to check if the retval is null or not. If it *is* null, then our memory allocated previously is still valid and we've just successfully leaked it. For the case involving `InternalFormat`, an exception was added for realloc failures.

Finally, `1<<31` is undefined behavior as `1` is an int32. 

Also switched some casts to static_cast because this is c++, after all...