### PR TITLE
NPOTB: Fix GCC 9 Builds 

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -295,7 +295,8 @@ class SMConfig(object):
       cxx.cxxflags += ['-Wno-delete-non-virtual-dtor']
     if cxx.version >= 'gcc-4.8':
       cxx.cflags += ['-Wno-unused-result']
-
+    if cxx.version >= 'gcc-9.0':
+      cxx.cxxflags += ['-Wno-class-memaccess', '-Wno-packed-not-aligned']
     if have_clang:
       cxx.cxxflags += ['-Wno-implicit-exception-spec-mismatch']
       if cxx.version >= 'apple-clang-5.1' or cxx.version >= 'clang-3.4':


### PR DESCRIPTION
GCC 9 was released earlier this month and I happened to have accidentially installed it on my new fedora machine. Turns out the addition of some new warnings prevented builds to pass.

This obviously doesn't fix the actual warnings the compiler is referring to. I'm more concerned about the `memset`ing that we're doing and I'll submit a patch in the future(TM) to address that directly to correct what it's warning about, but the other warning (`packed-not-aligned`) is found in the hl2sdk so there's not much we can do about it.