### PR TITLE
Travis CI: Swap gcc-7 for gcc-9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ addons:
       - g++-4.9
       - g++-5-multilib
       - g++-5
-      - g++-7-multilib
-      - g++-7
+      - g++-9-multilib
+      - g++-9
     cache:
       directories:
         - ../mysql-5.0
@@ -41,7 +41,7 @@ env:
  - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
  - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
  - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
- - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+ - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
 
 matrix:
   fast_finish: true
@@ -105,7 +105,7 @@ matrix:
     - env: MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
     - env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - env: MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-    - env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - env: MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
 
 
 before_script:

--- a/extensions/curl/curl-src/lib/AMBuilder
+++ b/extensions/curl/curl-src/lib/AMBuilder
@@ -28,7 +28,8 @@ for arch in SM.archs:
   if binary.compiler.family == 'clang':
     # https://llvm.org/bugs/show_bug.cgi?id=16428
     binary.compiler.cflags += ['-Wno-attributes']
-
+  if binary.compiler.version >= 'gcc-9':
+        binary.compiler.cflags += ['-Wno-stringop-truncation']
   binary.sources += [
     'base64.c',
     'connect.c',


### PR DESCRIPTION
GCC 7.0 always failed with macro redefinition errors (beyond our control, anyway), so might as well swap for GCC 9.x

