### PR TITLE
Fix matchmaking_ds bin not being found for gamedata (#1006).

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -50,8 +50,8 @@
 
 typedef ICommandLine *(*FakeGetCommandLine)();
 
-#define TIER0_NAME			SOURCE_BIN_PREFIX "tier0" SOURCE_BIN_SUFFIX SOURCE_BIN_EXT
-#define VSTDLIB_NAME		SOURCE_BIN_PREFIX "vstdlib" SOURCE_BIN_SUFFIX SOURCE_BIN_EXT
+#define TIER0_NAME			FORMAT_SOURCE_BIN_NAME("tier0")
+#define VSTDLIB_NAME		FORMAT_SOURCE_BIN_NAME("vstdlib")
 
 CHalfLife2 g_HL2;
 ConVar *sv_lan = NULL;

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -84,6 +84,9 @@ using namespace SourceMod;
 #define SOURCE_BIN_EXT ".so"
 #endif
 
+#define FORMAT_SOURCE_BIN_NAME(basename) \
+	(SOURCE_BIN_PREFIX basename SOURCE_BIN_SUFFIX SOURCE_BIN_EXT)
+
 struct DataTableInfo
 {
 	struct SendPropPolicy

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -627,13 +627,7 @@ void CoreProviderImpl::InitializeBridge()
 	this->serverFactory = (void *)g_SMAPI->GetServerFactory(false);
 	this->listeners = SMGlobalClass::head;
 
-	char path[PLATFORM_MAX_PATH];
-
-	ke::path::Format(path, sizeof(path),
-	                 "%s/bin/" PLATFORM_FOLDER "matchmaking_ds" SOURCE_BIN_SUFFIX SOURCE_BIN_EXT,
-                     g_SMAPI->GetBaseDir());
-
-	if (ke::RefPtr<ke::SharedLib> mmlib = ke::SharedLib::Open(path, NULL, 0)) {
+	if (ke::RefPtr<ke::SharedLib> mmlib = ke::SharedLib::Open(FORMAT_SOURCE_BIN_NAME("matchmaking_ds"), NULL, 0)) {
 		this->matchmakingDSFactory =
 		  mmlib->get<decltype(sCoreProviderImpl.matchmakingDSFactory)>("CreateInterface");
 	}


### PR DESCRIPTION
As reported in #1006, the matchmaking_ds binary is not found since our path to it is incorrect.

This changes our lookup to just use the binary name instead of including the path - similar to how we find tier0 and/or vstdlib to find symbols in those. Only tested on Windows, but that confirms that the binary is loaded by the time our lookup runs, so it should also be fine for dlopen.