### PR TITLE
Throw configuration error on unsupported compilers

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -217,10 +217,10 @@ class SMConfig(object):
     if cxx.family == 'msvc':
       if cxx.version < 1900:
         raise Exception('Only MSVC 2015 and later are supported.')
-    if cxx..family == 'gcc':
+    if cxx.family == 'gcc':
       if cxx.version < 'gcc-4.9':
         raise Exception('Only GCC versions 4.9 or greater are supported.')
-    if cxx..family == 'clang':
+    if cxx.family == 'clang':
       if cxx.version < 'clang-3.4':
         raise Exception('Only clang versions 3.4 or greater are supported.')
 

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -213,11 +213,16 @@ class SMConfig(object):
     
     if cxx.like('msvc') and len(self.archs) > 1:
       raise Exception('Building multiple archs with MSVC is not currently supported')
-	 
-    if cxx.like('msvc'):
+
+    if cxx.family == 'msvc':
       if cxx.version < 1900:
         raise Exception('Only MSVC 2015 and later are supported.')
-    # TODO: add similar checks here for GCC and Clang minimum supported versions.
+    if cxx..family == 'gcc':
+      if cxx.version < 'gcc-4.9':
+        raise Exception('Only GCC versions 4.9 or greater are supported.')
+    if cxx..family == 'clang':
+      if cxx.version < 'clang-3.4':
+        raise Exception('Only clang versions 3.4 or greater are supported.')
 
     if cxx.like('gcc'):
       self.configure_gcc(cxx)

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -216,13 +216,13 @@ class SMConfig(object):
 
     if cxx.family == 'msvc':
       if cxx.version < 1900:
-        raise Exception('Only MSVC 2015 and later are supported.')
+        raise Exception('Only MSVC 2015 and later are supported, c++14 support is required.')
     if cxx.family == 'gcc':
       if cxx.version < 'gcc-4.9':
-        raise Exception('Only GCC versions 4.9 or greater are supported.')
+        raise Exception('Only GCC versions 4.9 or greater are supported, c++14 support is required.')
     if cxx.family == 'clang':
       if cxx.version < 'clang-3.4':
-        raise Exception('Only clang versions 3.4 or greater are supported.')
+        raise Exception('Only clang versions 3.4 or greater are supported, c++14 support is required.')
 
     if cxx.like('gcc'):
       self.configure_gcc(cxx)

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -213,6 +213,11 @@ class SMConfig(object):
     
     if cxx.like('msvc') and len(self.archs) > 1:
       raise Exception('Building multiple archs with MSVC is not currently supported')
+	 
+    if cxx.like('msvc'):
+      if cxx.version < 1900:
+        raise Exception('Only MSVC 2015 and later are supported.')
+    # TODO: add similar checks here for GCC and Clang minimum supported versions.
 
     if cxx.like('gcc'):
       self.configure_gcc(cxx)
@@ -498,8 +503,7 @@ class SMConfig(object):
 
     if compiler.like('msvc'):
       compiler.defines += ['COMPILER_MSVC', 'COMPILER_MSVC32']
-      if compiler.version >= 1900:
-        compiler.linkflags += ['legacy_stdio_definitions.lib']
+      compiler.linkflags += ['legacy_stdio_definitions.lib']
     else:
       compiler.defines += ['COMPILER_GCC']
 

--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -84,9 +84,7 @@ for sdk_name in SM.sdks:
       elif builder.target.platform == 'windows':
         msvc_ver = compiler.version
         vs_year = ''
-        if msvc_ver == 1800:
-          vs_year = '2013'
-        elif 1900 <= msvc_ver < 2000:
+        if 1900 <= msvc_ver < 2000:
           vs_year = '2015'
         else:
           raise Exception('Cannot find libprotobuf for MSVC version "' + str(compiler.version) + '"')


### PR DESCRIPTION
Throw error at configure stage if using unsupported MSVC version rather than having less obvious errors thrown later by compiler.

With the recent argbuffer addition, we apparently no longer support Visual Studio 2013. I removed a couple of paths for it, and added an early check to make sure a supported version is being used. I think we should do the same for GCC and Clang as well, but I don't know what minimum versions we support.