### PR TITLE
Update TF2_IgnitePlayer to support set duration of fire

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -92,7 +92,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 	return 1;
 }
 
-// native TF2_Burn(client, target)
+// native TF2_Burn(client, target, duration)
 cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 {
 	static ICallWrapper *pWrapper = NULL;
@@ -129,7 +129,7 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 										float> //duration
-										vstk(obj, pTarget, nullptr, 10.0f);
+										vstk(obj, pTarget, nullptr, sp_ctof(params[3]));
 
 	pWrapper->Execute(vstk, nullptr);
 	return 1;

--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -126,10 +126,17 @@ cell_t TF2_Burn(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Client index %d is not valid", params[2]);
 	}
 
+	float fDuration = 10.0;
+	// Compatibility fix for the newly-added duration
+	if (params[0] >= 3)
+	{
+		fDuration = sp_ctof(params[3]);
+	}
+
 	void *obj = (void *)((uint8_t *)pEntity + playerSharedOffset->actual_offset);
 	ArgBuffer<void*, CBaseEntity*, CBaseEntity*, 
 										float> //duration
-										vstk(obj, pTarget, nullptr, sp_ctof(params[3]));
+										vstk(obj, pTarget, nullptr, fDuration);
 
 	pWrapper->Execute(vstk, nullptr);
 	return 1;

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -245,13 +245,16 @@ enum TFObjectMode
 };
 
 /**
- * Sets a client on fire for 10 seconds.
+ * Sets a client on fire.
+ *
+ * @note fire duration is capped to 10 seconds.
  *
  * @param client        Player's index.
  * @param attacker      Attacker's index.
+ * @param duration      Duration of fire (in seconds).
  * @error               Invalid client index, client not in game, or no mod support.
  */
-native void TF2_IgnitePlayer(int client, int attacker);
+native void TF2_IgnitePlayer(int client, int attacker, float duration=10.0);
 
 /**
  * Respawns a client

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -247,7 +247,7 @@ enum TFObjectMode
 /**
  * Sets a client on fire.
  *
- * @note fire duration is capped to 10 seconds.
+ * @note Fire duration is capped to 10 seconds.
  *
  * @param client        Player's index.
  * @param attacker      Attacker's index.


### PR DESCRIPTION
See #713 

This PR adds 3rd param `TF2_IgnitePlayer` to allow set duration of fire, while default value kept as 10.0 so older plugins should not break.

However when i tested this, i found out fire duration is capped to 10.0 seconds, even when tempted to set higher than 10. I believe this is valve's shitty fix on infinite fire duration from some weapons, which is really unfortunate. May still be helpful to some plugins when setting fire less than 10 seconds.

Example code when testing this, setting yourself on fire with duration.
```
#include <sourcemod>
#include <tf2>

public void OnPluginStart()
{
	RegConsoleCmd("sm_fire", Command_Fire);
}

public Action Command_Fire(int iClient, int iArgs)
{
	if (GetCmdArgs() == 0)
	{
		TF2_IgnitePlayer(iClient, iClient);
	}
	else
	{
		char sBuffer[4];
		GetCmdArg(1, sBuffer, sizeof(sBuffer));
		float flDuration = StringToFloat(sBuffer);
		TF2_IgnitePlayer(iClient, iClient, flDuration);
	}
	return Plugin_Handled;
}
```