### PR TITLE
Handlesys: Introduce concept of exclusive identity handles

### DIFF
--- a/core/logic/HandleSys.cpp
+++ b/core/logic/HandleSys.cpp
@@ -1169,3 +1169,16 @@ void HandleSystem::Dump(const HandleReporter &fn)
 	rep(fn, "-- Approximately %d bytes of memory are in use by Handles.\n", total_size);
 }
 
+HandleError HandleSystem::GetHandleAccess(Handle_t handle, HandleAccess &*pAccess)
+{
+	unsigned int index;
+	QHandle *pHandle;
+	HandleError err;
+	IdentityToken_t *ident = NULL;
+
+	if ((err=GetHandle(handle, ident, &pHandle, &index)) != HandleError_None)
+		return err;
+
+	pAccess = &(pHandle->sec);
+	return err;
+}

--- a/core/logic/HandleSys.cpp
+++ b/core/logic/HandleSys.cpp
@@ -532,6 +532,9 @@ bool HandleSystem::CheckAccess(QHandle *pHandle, HandleAccessRight right, const 
 	/* Check if the owner is allowed */
 	if (access & HANDLE_RESTRICT_OWNER)
 	{
+		if ((access & HANDLE_RESTRICT_IDENTEXCLUSIVE) == HANDLE_RESTRICT_IDENTEXCLUSIVE)
+			return false;
+
 		IdentityToken_t *owner = pHandle->owner;
 		if (owner
 			&& (!pSecurity || pSecurity->pOwner != owner))

--- a/core/logic/HandleSys.h
+++ b/core/logic/HandleSys.h
@@ -262,4 +262,43 @@ private:
 	Handle_t hndl;
 };
 
+struct AutoHandleIdentLocker
+{
+public:
+	AutoHandleIdentLocker() : pSecurity(nullptr)
+	{
+	}
+
+	AutoHandleIdentLocker(Handle_t hndl) : pSecurity(nullptr)
+	{
+		if (hndl != BAD_HANDLE)
+		{
+			if (g_HandleSys.GetHandleAccess(hndl, this->pSecurity) == HandleError_None)
+			{
+				if ((this->pSecurity[HandleAccess_Delete] & HANDLE_RESTRICT_IDENTEXCLUSIVE) == HANDLE_RESTRICT_IDENTEXCLUSIVE)
+					this->pSecurity = nullptr;
+				else
+					pSecurity->access[HandleAccess_Delete] |= HANDLE_RESTRICT_IDENTEXCLUSIVE;
+			}
+		}
+	}
+
+	~AutoHandleIdentLocker()
+	{
+		if (this->pSecurity)
+			this->pSecurity->access[HandleAccess_Delete] &= ~HANDLE_RESTRICT_IDENTEXCLUSIVE;
+
+		this->pSecurity = nullptr;
+	}
+
+public:
+	AutoHandleIdentLocker &operator =(const AutoHandleIdentLocker &other)
+	{
+		~AutoHandleIdentLocker();
+		this->pSecurity = other.pSecurity;
+	}
+private:
+	HandleAccess *pSecurity;
+}
+
 #endif //_INCLUDE_SOURCEMOD_HANDLESYSTEM_H_

--- a/core/logic/HandleSys.h
+++ b/core/logic/HandleSys.h
@@ -173,6 +173,8 @@ public: //IHandleSystem
 
 	/* Bypasses security checks. */
 	Handle_t FastCloneHandle(Handle_t hndl);
+
+	HandleError GetHandleAccess(Handle_t handle, HandleAccess &*pSecurity);
 protected:
 	/**
 	 * Decodes a handle with sanity and security checking.

--- a/public/AutoHandleRooter.h
+++ b/public/AutoHandleRooter.h
@@ -87,5 +87,44 @@ public:
 	}
 };
 
+class AutoHandleIdentLocker
+{
+public:
+	AutoHandleIdentLocker() : pSecurity(nullptr)
+	{
+	}
+
+	AutoHandleIdentLocker(Handle_t hndl) : pSecurity(nullptr)
+	{
+		if (hndl != BAD_HANDLE)
+		{
+			if (handlesys->GetHandleAccess(hndl, this->pSecurity) == HandleError_None)
+			{
+				if ((this->pSecurity[HandleAccess_Delete] & HANDLE_RESTRICT_IDENTEXCLUSIVE) == HANDLE_RESTRICT_IDENTEXCLUSIVE)
+					this->pSecurity = nullptr;
+				else
+					pSecurity->access[HandleAccess_Delete] |= HANDLE_RESTRICT_IDENTEXCLUSIVE;
+			}
+		}
+	}
+
+	~AutoHandleIdentLocker()
+	{
+		if (this->pSecurity)
+			this->pSecurity->access[HandleAccess_Delete] &= ~HANDLE_RESTRICT_IDENTEXCLUSIVE;
+
+		this->pSecurity = nullptr;
+	}
+
+public:
+	AutoHandleIdentLocker &operator =(const AutoHandleIdentLocker &other)
+	{
+		~AutoHandleIdentLocker();
+		this->pSecurity = other.pSecurity;
+	}
+private:
+	HandleAccess *pSecurity;
+};
+
 #endif /* _INCLUDE_SOURCEMOD_AUTO_HANDLE_ROOTER_H_ */
 

--- a/public/IHandleSys.h
+++ b/public/IHandleSys.h
@@ -375,6 +375,15 @@ namespace SourceMod
 		 * @return			True if "given" is a subtype of "actual", false otherwise.
 		 */
 		virtual bool TypeCheck(HandleType_t given, HandleType_t actual) = 0;
+
+		/**
+		 * @brief Obtain the HandleAccess address from the passed in handle.
+		 *
+		 * @param handle	Handle_t identifier to destroy.
+		 * @param pAccess	Access information struct.
+		 * @return			HandleError error code.
+		 */
+		virtual HandleError GetHandleAccess(Handle_t handle, HandleAccess &*pAccess) = 0;
 	};
 }
 

--- a/public/IHandleSys.h
+++ b/public/IHandleSys.h
@@ -135,6 +135,8 @@ namespace SourceMod
 	#define HANDLE_RESTRICT_IDENTITY	(1<<0)	
 	/** Access is restricted to the owner */
 	#define HANDLE_RESTRICT_OWNER		(1<<1)
+	/** Access is identity exclusive */
+	#define HANDLE_RESTRICT_IDENTEXCLUSIVE	(1<<2)
 
 	/**
 	 * @brief This is used to define per-type access rights.


### PR DESCRIPTION
This one is likely a doozy (and not even compile tested). This is to fix the freeing during callback problems that plague us to throw an error immediately mid-callback. menusys, functions, timers, anything with a delayed callback can cause us problems. I think this is the best option after sitting on it for a couple days and reviewing this morning least invasive approach we can take.

https://github.com/alliedmodders/sourcemod/issues/1041