### PR TITLE
Update SourcePawn to 093edef

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -416,7 +416,7 @@ class SMConfig(object):
     if '-lgcc_eh' in binary.compiler.linkflags:
       binary.compiler.linkflags.remove('-lgcc_eh')
     if binary.compiler.like('gcc'):
-      binary.compiler.linkflags += ['-lstdc++']
+      binary.compiler.linkflags += ['-lstdc++', '-lpthread']
     if binary.compiler.like('msvc'):
       binary.compiler.linkflags += ['/SUBSYSTEM:CONSOLE']
     return binary


### PR DESCRIPTION
Includes the following SourcePawn changes:
- PR#339 Fix various compilation problems
- PR#340 Restyle spcomp
- PR#344 Fix uninitialized variable guarding profiling scopes
- PR#346 Fix Travis Emscripten build
- PR#345 Simplify inline exit frames