### PR TITLE
Added DMG_HEADSHOT and DMG_LASTGENERICFLAG

### DIFF
--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -69,8 +69,10 @@
 #define DMG_AIRBOAT                 (1 << 25)   /**< Hit by the airboat's gun */
 #define DMG_DISSOLVE                (1 << 26)   /**< Dissolving! */
 #define DMG_BLAST_SURFACE           (1 << 27)   /**< A blast on the surface of water that cannot harm things underwater */
-#define DMG_DIRECT                  (1 << 28)
+#define DMG_DIRECT                  (1 << 28)	/**< Damage from being on fire.(DMG_BURN relates to external sources hurting you) */
 #define DMG_BUCKSHOT                (1 << 29)   /**< not quite a bullet. Little, rounder, different. */
+#define DMG_LASTGENERICFLAG         (1 << 30)
+#define DMG_HEADSHOT                (2147483648)   /**< Damage from a headshot. */
 #endif
 
 #if !defined DMG_CRIT


### PR DESCRIPTION
Added in new damage types DMG_HEADSHOT and DMG_LASTGENERIC Flag, and gave a reason for DMG_DIRECT

As for why DMG_HEADSHOT isn't "1<<31" I wasn't too sure how bitwise operations work but when testing in C++ "1<<31" returned a negative value. So ye :) 