### PR TITLE
Check short name for remote extensions

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -1364,7 +1364,7 @@ bool CLocalExtension::IsSameFile(const char *file)
 
 bool CRemoteExtension::IsSameFile(const char *file)
 {
-	/* :TODO: this could be better, but no one uses this API anyway. */
-	return strcmp(file, m_Path.c_str()) == 0;
+	/* Check full path and name passed in from LoadExternal */
+	return strcmp(file, m_Path.c_str()) == 0 || strcmp(file, m_File.c_str()) == 0;
 }
 


### PR DESCRIPTION
Checks the filename passed in via `LoadExternal` for remote extensions for same-file tests.

This fixes `FindExtensionByFile` not finding an existing remote extension in the case where the filepath is not equal to the filename (and subsequently loading it twice) and allows plugins to successfully load when specifying that name as a dependency.