### PR TITLE
Add File.Flush methodmap

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -1195,6 +1195,7 @@ REGISTER_NATIVES(filesystem)
 	{"File.WriteLine",			sm_WriteFileLine},
 	{"File.EndOfFile",			sm_IsEndOfFile},
 	{"File.Seek",				sm_FileSeek},
+	{"File.Flush",				sm_FlushFile},
 	{"File.Position.get",		sm_FilePosition},
 	{"File.ReadInt8",			File_ReadTyped<int8_t>},
 	{"File.ReadUint8",			File_ReadTyped<uint8_t>},

--- a/plugins/include/files.inc
+++ b/plugins/include/files.inc
@@ -233,6 +233,13 @@ methodmap File < Handle
 	// @return                True on success, false otherwise.
 	public native bool Seek(int position, int where);
 
+	// Flushes a file's buffered output; any buffered output
+	// is immediately written to the file.
+	// 
+	// @return              True on success or use_valve_fs specified with OpenFile,
+	//                      otherwise false on failure.
+	public native bool Flush();
+	
 	// Get the current position in the file; returns -1 on failure.
 	property int Position {
 		public native get();


### PR DESCRIPTION
Here is a snippet from the current TF2 event I'm working on:
```
g_FlatFile.WriteLine("wave,%d,%d,%d,%d", Steam3, TimeStamp, MissionIndex, WaveNumber);
FlushFile(g_FlatFile);
```
I would like to be able to flush the file like this so that I can consistently use methodmaps on the file handle instead of flip flopping between legacy and new API:
```
g_FlatFile.WriteLine("wave,%d,%d,%d,%d", Steam3, TimeStamp, MissionIndex, WaveNumber);
g_FlatFile.Flush();
```
Here is a patch (one for smn_filesystem.cpp and one for files.inc) that adds the Flush method to the file methodmap. Please review and let me know if I accidentally broke something or violated any coding conventions. I don't have a C++ compiler so I wasn't able to test if this will break the buildbots or CI.

Thanks.