### PR TITLE
Allow to escape string even if buffer is not 2*strlen(string)+1.

### DIFF
--- a/extensions/mysql/mysql/MyDatabase.cpp
+++ b/extensions/mysql/mysql/MyDatabase.cpp
@@ -152,24 +152,23 @@ const char *MyDatabase::GetError(int *errCode)
 bool MyDatabase::QuoteString(const char *str, char buffer[], size_t maxlength, size_t *newSize)
 {
 	unsigned long size = static_cast<unsigned long>(strlen(str));
-	unsigned long needed = size * 2 + 1;
-
-	if (maxlength < needed)
-	{
-		if (newSize)
-		{
-			*newSize = (size_t)needed;
-		}
-		return false;
-	}
+	unsigned long needed = 0;
 
 	needed = mysql_real_escape_string(m_mysql, buffer, str, size);
+	
 	if (newSize)
 	{
 		*newSize = (size_t)needed;
 	}
-
-	return true;
+	
+	if (maxlength < needed)
+	{
+		return false;
+	}
+	else
+	{
+		return true;
+	}
 }
 
 bool MyDatabase::DoSimpleQuery(const char *query)


### PR DESCRIPTION
The problem with the actual code that if the buffer is not size x 2 +1 the function returns false even if it was possible to escape string.

I suggest this implementation to allow this case. First call the basic function mysql_real_escape_string() then test if needed is in range of maxlength. The return of mysql_real_escape_string() return -1 if failure and allow the native to return false.