### PR TITLE
fix(include::sourcemod) - corrected frameiterator linenumber type

### DIFF
--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -703,7 +703,7 @@ methodmap FrameIterator < Handle {
 	public native void Reset();
 
 	// Returns the line number of the current function call.
-	property bool LineNumber {
+	property int LineNumber {
 		public native get();
 	}
 


### PR DESCRIPTION
Headline is lazy