### PR TITLE
Allow RequestFrameCallback not require data param

### DIFF
--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -615,7 +615,10 @@ native int FormatNativeString(int out_param,
  *
  * @param data          Data passed to the RequestFrame native.
  */
-typedef RequestFrameCallback = function void (any data);
+typeset RequestFrameCallback {
+	function void ();
+	function void (any data);
+}
 
 /**
  * Creates a single use Next Frame hook.


### PR DESCRIPTION
When i want to call `RequestFrame` without any data param, `RequestFrameCallback` still requires me to add pointless data param.
```
public void OnPluginStart()
{
	RequestFrame(OnFrame);
}

public void OnFrame(int pointless)	//pointless param
{
	//do something
}
```

I want to allow plugin to be compiled without needing data param, making it look bit more nicer when not passing any data.
```
public void OnPluginStart()
{
	RequestFrame(OnFrame);
}

public void OnFrame()	//param not needed as RequestFrame not passing any data
{
	//do something
}
```