### PR TITLE
Avoid losing console messages.

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -902,11 +902,17 @@ void PlayerManager::OnPrintfFrameAction(int client)
 {
 	CPlayer &player = m_Players[client];
 	if (!player.IsConnected())
+	{
+		player.m_PrintfBuffer.clear();
 		return;
+	}
 
 	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(client));
 	if (pNetChan == NULL)
+	{
+		player.m_PrintfBuffer.clear();
 		return;
+	}
 
 	while (!player.m_PrintfBuffer.empty())
 	{

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -903,7 +903,7 @@ void PlayerManager::OnClientPrintf(edict_t *pEdict, const char *szMsg)
 void PlayerManager::OnPrintfFrameAction(int client)
 {
 	CPlayer &player = m_Players[client];
-	if (!player->IsConnected())
+	if (!player.IsConnected())
 		return;
 
 	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(client));

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -869,7 +869,7 @@ void PlayerManager::OnClientPrintf(edict_t *pEdict, const char *szMsg)
 
 	size_t nMsgLen = strlen(szMsg);
 #if SOURCE_ENGINE == SE_EPISODEONE
-	int nNumBitsWritten = 0;
+	static const int nNumBitsWritten = 0;
 #else
 	int nNumBitsWritten = pNetChan->GetNumBitsWritten(false); // SVC_Print uses unreliable netchan
 #endif
@@ -914,7 +914,7 @@ void PlayerManager::OnPrintfFrameAction(unsigned int serial)
 	while (!player.m_PrintfBuffer.empty())
 	{
 #if SOURCE_ENGINE == SE_EPISODEONE
-		int nNumBitsWritten = 0;
+		static const int nNumBitsWritten = 0;
 #else
 		int nNumBitsWritten = pNetChan->GetNumBitsWritten(false); // SVC_Print uses unreliable netchan
 #endif

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -900,14 +900,14 @@ void PlayerManager::OnPrintfFrameAction(unsigned int serial)
 	CPlayer &player = m_Players[client];
 	if (!player.IsConnected())
 	{
-		player.m_PrintfBuffer.clear();
+		player.ClearNetchannelQueue();
 		return;
 	}
 
 	INetChannel *pNetChan = static_cast<INetChannel *>(engine->GetPlayerNetInfo(client));
 	if (pNetChan == NULL)
 	{
-		player.m_PrintfBuffer.clear();
+		player.ClearNetchannelQueue();
 		return;
 	}
 
@@ -2236,7 +2236,13 @@ void CPlayer::Disconnect()
 #if SOURCE_ENGINE == SE_CSGO
 	m_LanguageCookie = InvalidQueryCvarCookie;
 #endif
-	m_PrintfBuffer.clear();
+	ClearNetchannelQueue();
+}
+
+void CPlayer::ClearNetchannelQueue(void)
+{
+	while (!m_PrintfBuffer.empty())
+		m_PrintfBuffer.popFront();
 }
 
 void CPlayer::SetName(const char *name)

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -97,8 +97,7 @@ SH_DECL_HOOK2_void(IVEngineServer, ClientPrintf, SH_NOATTRIB, 0, edict_t *, cons
 
 static void PrintfBuffer_FrameAction(void *data)
 {
-	int client = (int)(intptr_t)data;
-	g_Players.OnPrintfFrameAction(client);
+	g_Players.OnPrintfFrameAction(reintrepret_cast<unsigned int>(data));
 }
 
 ConCommand *maxplayersCmd = NULL;

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -97,7 +97,7 @@ SH_DECL_HOOK2_void(IVEngineServer, ClientPrintf, SH_NOATTRIB, 0, edict_t *, cons
 
 static void PrintfBuffer_FrameAction(void *data)
 {
-	g_Players.OnPrintfFrameAction(reintrepret_cast<unsigned int>(data));
+	g_Players.OnPrintfFrameAction(reinterpret_cast<unsigned int>(data));
 }
 
 ConCommand *maxplayersCmd = NULL;

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -919,8 +919,7 @@ void PlayerManager::OnPrintfFrameAction(unsigned int serial)
 		int nNumBitsWritten = pNetChan->GetNumBitsWritten(false); // SVC_Print uses unreliable netchan
 #endif
 
-		ke::LinkedList<ke::AString>::iterator iter = player.m_PrintfBuffer.begin();
-		ke::AString &string = (*iter);
+		ke::AString &string = player.m_PrintfBuffer.front();
 
 		// stop if we'd overflow the SVC_Print buffer  (+7 as ceil)
 		if ((nNumBitsWritten + NETMSG_TYPE_BITS + 7) / 8 + string.length() >= SVC_Print_BufferSize)
@@ -928,13 +927,13 @@ void PlayerManager::OnPrintfFrameAction(unsigned int serial)
 
 		SH_CALL(engine, &IVEngineServer::ClientPrintf)(player.m_pEdict, string.chars());
 
-		player.m_PrintfBuffer.erase(iter);
+		player.m_PrintfBuffer.popFront();
 	}
 
 	if (!player.m_PrintfBuffer.empty())
 	{
 		// continue processing it on the next gameframe as buffer is not empty
-		g_SourceMod.AddFrameAction(PrintfBuffer_FrameAction, (void *)(intptr_t)client);
+		g_SourceMod.AddFrameAction(PrintfBuffer_FrameAction, (void *)(uintptr_t)player.GetSerial());
 	}
 }
 

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -874,9 +874,6 @@ void PlayerManager::OnClientPrintf(edict_t *pEdict, const char *szMsg)
 	int nNumBitsWritten = pNetChan->GetNumBitsWritten(false); // SVC_Print uses unreliable netchan
 #endif
 
-	const int NETMSG_TYPE_BITS = 5; // SVC_Print overhead for netmsg type
-	const int SVC_Print_BufferSize = 2048 - 1; // -1 for terminating \0
-
 	// if the msg is bigger than allowed then just let it fail
 	if (nMsgLen + 1 >= SVC_Print_BufferSize) // +1 for NETMSG_TYPE_BITS
 		RETURN_META(MRES_IGNORED);
@@ -921,9 +918,6 @@ void PlayerManager::OnPrintfFrameAction(unsigned int serial)
 #else
 		int nNumBitsWritten = pNetChan->GetNumBitsWritten(false); // SVC_Print uses unreliable netchan
 #endif
-
-		const int NETMSG_TYPE_BITS = 5; // SVC_Print overhead for netmsg type
-		const int SVC_Print_BufferSize = 2048 - 1; // -1 for terminating \0
 
 		ke::LinkedList<ke::AString>::iterator iter = player.m_PrintfBuffer.begin();
 		ke::AString &string = (*iter);

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -124,6 +124,7 @@ private:
 	bool IsAuthStringValidated();
 	bool SetEngineString();
 	bool SetCSteamID();
+	void ClearNetchannelQueue(void);
 private:
 	bool m_IsConnected = false;
 	bool m_IsInGame = false;

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -153,7 +153,7 @@ private:
 #if SOURCE_ENGINE == SE_CSGO
 	QueryCvarCookie_t m_LanguageCookie = InvalidQueryCvarCookie;
 #endif
-	ke::LinkedList<ke::AString> m_PrintfBuffer;
+	ke::Deque<ke::AString> m_PrintfBuffer;
 };
 
 class PlayerManager : 

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -154,7 +154,6 @@ private:
 	QueryCvarCookie_t m_LanguageCookie = InvalidQueryCvarCookie;
 #endif
 	ke::LinkedList<ke::AString> m_PrintfBuffer;
-	bool m_PrintfStop = false;
 };
 
 class PlayerManager : 

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -271,6 +271,9 @@ private:
 	int m_SourceTVUserId;
 	int m_ReplayUserId;
 	bool m_bInCCKVHook;
+private:
+	static const int NETMSG_TYPE_BITS = 5; // SVC_Print overhead for netmsg type
+	static const int SVC_Print_BufferSize = 2048 - 1; // -1 for terminating \0
 };
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -43,6 +43,7 @@
 #include <sh_list.h>
 #include <sh_vector.h>
 #include <am-string.h>
+#include <am-linkedlist.h>
 #include "ConVarManager.h"
 
 #include <steam/steamclientpublic.h>
@@ -65,32 +66,6 @@ union serial_t
 		uint32_t index  :  8;
 		uint32_t serial : 24;
 	} bits;
-};
-
-class CPrintfBuffer
-{
-public:
-	struct CChunk
-	{
-		void *m_pMem;
-		char *m_pMessage;
-		size_t m_Length;
-		struct CChunk *m_pNext;
-	};
-
-	bool m_StopSend;
-
-private:
-	CChunk *m_pFirstChunk;
-	CChunk *m_pLastChunk;
-	size_t m_MaxLength;
-	size_t m_Length;
-
-public:
-	CPrintfBuffer(size_t MaxLength=16384);
-	bool Append(const char *pString, size_t Length);
-	const CChunk *Get();
-	void Consumed(size_t Length);
 };
 
 class CPlayer : public IGamePlayer
@@ -178,7 +153,8 @@ private:
 #if SOURCE_ENGINE == SE_CSGO
 	QueryCvarCookie_t m_LanguageCookie = InvalidQueryCvarCookie;
 #endif
-	CPrintfBuffer m_PrintfBuffer;
+	ke::LinkedList<ke::AString> m_PrintfBuffer;
+	bool m_PrintfStop = false;
 };
 
 class PlayerManager : 
@@ -218,7 +194,7 @@ public:
 	//void OnClientSettingsChanged_Pre(edict_t *pEntity);
 	void OnServerHibernationUpdate(bool bHibernating);
 	void OnClientPrintf(edict_t *pEdict, const char *szMsg);
-	void OnGameFrame();
+	void OnPrintfFrameAction(int client);
 public: //IPlayerManager
 	void AddClientListener(IClientListener *listener);
 	void RemoveClientListener(IClientListener *listener);

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -43,7 +43,7 @@
 #include <sh_list.h>
 #include <sh_vector.h>
 #include <am-string.h>
-#include <am-linkedlist.h>
+#include <am-deque.h>
 #include "ConVarManager.h"
 
 #include <steam/steamclientpublic.h>

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -193,7 +193,7 @@ public:
 	//void OnClientSettingsChanged_Pre(edict_t *pEntity);
 	void OnServerHibernationUpdate(bool bHibernating);
 	void OnClientPrintf(edict_t *pEdict, const char *szMsg);
-	void OnPrintfFrameAction(int client);
+	void OnPrintfFrameAction(unsigned int serial);
 public: //IPlayerManager
 	void AddClientListener(IClientListener *listener);
 	void RemoveClientListener(IClientListener *listener);

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -67,6 +67,32 @@ union serial_t
 	} bits;
 };
 
+class CPrintfBuffer
+{
+public:
+	struct CChunk
+	{
+		void *m_pMem;
+		char *m_pMessage;
+		size_t m_Length;
+		struct CChunk *m_pNext;
+	};
+
+	bool m_StopSend;
+
+private:
+	CChunk *m_pFirstChunk;
+	CChunk *m_pLastChunk;
+	size_t m_MaxLength;
+	size_t m_Length;
+
+public:
+	CPrintfBuffer(size_t MaxLength=16384);
+	bool Append(const char *pString, size_t Length);
+	const CChunk *Get();
+	void Consumed(size_t Length);
+};
+
 class CPlayer : public IGamePlayer
 {
 	friend class PlayerManager;
@@ -152,6 +178,7 @@ private:
 #if SOURCE_ENGINE == SE_CSGO
 	QueryCvarCookie_t m_LanguageCookie = InvalidQueryCvarCookie;
 #endif
+	CPrintfBuffer m_PrintfBuffer;
 };
 
 class PlayerManager : 
@@ -190,6 +217,8 @@ public:
 	void OnClientSettingsChanged(edict_t *pEntity);
 	//void OnClientSettingsChanged_Pre(edict_t *pEntity);
 	void OnServerHibernationUpdate(bool bHibernating);
+	void OnClientPrintf(edict_t *pEdict, const char *szMsg);
+	void OnGameFrame();
 public: //IPlayerManager
 	void AddClientListener(IClientListener *listener);
 	void RemoveClientListener(IClientListener *listener);


### PR DESCRIPTION
Buffers up to 16k bytes of SVC_Print if buffer would overflow, then sends chunks every frame.
Sends up to 2048 bytes per frame and does not split messages.

Only tested on cstrike, works without any changes on plugins.
On client the order is still messed up sometimes because the client itself fucks up the order (also on console commands like find)