### PR TITLE
Add OnEntitySpawned to SDKHooks.

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -888,7 +888,6 @@ void SDKHooks::OnEntityCreated(CBaseEntity *pEntity)
 void SDKHooks::OnEntitySpawned(CBaseEntity *pEntity)
 {
 	// Call OnEntitySpawned forward
-	int ref = gamehelpers->EntityToReference(pEntity);
 	int index = gamehelpers->ReferenceToIndex(ref);
 
 	// This can be -1 for player ents before any players have connected
@@ -903,6 +902,7 @@ void SDKHooks::OnEntitySpawned(CBaseEntity *pEntity)
 		return;
 	}
 
+	int ref = gamehelpers->EntityToReference(pEntity);
 	HandleEntitySpawned(pEntity, index, ref);
 }
 

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -247,6 +247,7 @@ bool SDKHooks::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	sharesys->AddInterface(myself, &g_Interface);
 	sharesys->AddCapabilityProvider(myself, this, "SDKHook_DmgCustomInOTD");
 	sharesys->AddCapabilityProvider(myself, this, "SDKHook_LogicalEntSupport");
+	sharesys->AddCapabilityProvider(myself, this, "SDKHook_OnEntitySpawned");
 
 	playerhelpers->AddClientListener(&g_Interface);
 	
@@ -359,6 +360,7 @@ void SDKHooks::SDK_OnUnload()
 
 	sharesys->DropCapabilityProvider(myself, this, "SDKHook_DmgCustomInOTD");
 	sharesys->DropCapabilityProvider(myself, this, "SDKHook_LogicalEntSupport");
+	sharesys->DropCapabilityProvider(myself, this, "SDKHook_OnEntitySpawned");
 
 	CUtlVector<IEntityListener *> *entListeners = EntListeners();
 	entListeners->FindAndRemove(this);

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -888,6 +888,7 @@ void SDKHooks::OnEntityCreated(CBaseEntity *pEntity)
 void SDKHooks::OnEntitySpawned(CBaseEntity *pEntity)
 {
 	// Call OnEntitySpawned forward
+	int ref = gamehelpers->EntityToReference(pEntity);
 	int index = gamehelpers->ReferenceToIndex(ref);
 
 	// This can be -1 for player ents before any players have connected
@@ -902,7 +903,6 @@ void SDKHooks::OnEntitySpawned(CBaseEntity *pEntity)
 		return;
 	}
 
-	int ref = gamehelpers->EntityToReference(pEntity);
 	HandleEntitySpawned(pEntity, index, ref);
 }
 

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -1820,23 +1820,23 @@ void SDKHooks::HandleEntitySpawned(CBaseEntity *pEntity, int index, cell_t ref)
 {
 	if (g_pOnEntitySpawned->GetFunctionCount() || m_EntListeners.size())
 	{
-		const char *pName = gamehelpers->GetEntityClassname(pEntity);
 		cell_t bcompatRef = gamehelpers->EntityToBCompatRef(pEntity);
+		const char *pName = gamehelpers->GetEntityClassname(pEntity);
+		if (!pName)
+			pName = "";
 
 		// Send OnEntitySpawned to SM listeners
-		SourceHook::List<ISMEntityListener *>::iterator iter;
-		ISMEntityListener *pListener = NULL;
-		for (iter = m_EntListeners.begin(); iter != m_EntListeners.end(); iter++)
+		for (SourceHook::List<ISMEntityListener *>::iterator iter = m_EntListeners.begin(); iter != m_EntListeners.end(); iter++)
 		{
-			pListener = (*iter);
-			pListener->OnEntitySpawned(pEntity, pName ? pName : "");
+			ISMEntityListener *pListener = (*iter);
+			pListener->OnEntitySpawned(pEntity, pName);
 		}
 
 		// Call OnEntitySpawned forward
 		if (g_pOnEntitySpawned->GetFunctionCount())
 		{
 			g_pOnEntitySpawned->PushCell(bcompatRef);
-			g_pOnEntitySpawned->PushString(pName ? pName : "");
+			g_pOnEntitySpawned->PushString(pName);
 			g_pOnEntitySpawned->Execute(NULL);
 		}
 	}

--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -238,6 +238,7 @@ public:  // IFeatureProvider
 
 public:  // IEntityListener
 	virtual void OnEntityCreated(CBaseEntity *pEntity);
+	virtual void OnEntitySpawned(CBaseEntity *pEntity);
 	virtual void OnEntityDeleted(CBaseEntity *pEntity);
 
 public:  // IClientListener
@@ -330,6 +331,7 @@ public:
 	
 private:
 	void HandleEntityCreated(CBaseEntity *pEntity, int index, cell_t ref);
+	void HandleEntitySpawned(CBaseEntity *pEntity, int index, cell_t ref);
 	void HandleEntityDeleted(CBaseEntity *pEntity);
 	void Unhook(CBaseEntity *pEntity);
 	void Unhook(IPluginContext *pContext);

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -352,6 +352,8 @@ forward void OnEntityCreated(int entity, const char[] classname);
  *
  * @param entity        Entity index
  * @param classname     Class name
+ *
+ * @note Check for support at runtime using GetFeatureStatus on SDKHook_OnEntitySpawned capability.
  */
 forward void OnEntitySpawned(int entity, const char[] classname);
 

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -348,6 +348,14 @@ typeset SDKHookCB
 forward void OnEntityCreated(int entity, const char[] classname);
 
 /**
+ * When an entity is spawned
+ *
+ * @param entity        Entity index
+ * @param classname     Class name
+ */
+forward void OnEntitySpawned(int entity, const char[] classname);
+
+/**
  * When an entity is destroyed
  *
  * @param entity        Entity index

--- a/public/extensions/ISDKHooks.h
+++ b/public/extensions/ISDKHooks.h
@@ -36,7 +36,7 @@
 #include <IShareSys.h>
 
 #define SMINTERFACE_SDKHOOKS_NAME		"ISDKHooks"
-#define SMINTERFACE_SDKHOOKS_VERSION	1
+#define SMINTERFACE_SDKHOOKS_VERSION	2
 
 class CBaseEntity;
 
@@ -69,6 +69,16 @@ namespace SourceMod
 		 * @param	pEntity		CBaseEntity entity.
 		 */
 		virtual void OnEntityDestroyed(CBaseEntity *pEntity)
+		{
+		}
+
+		/**
+		 * @brief	When an entity is spawned
+		 *
+		 * @param	pEntity		CBaseEntity entity.
+		 * @param	classname	Entity classname.
+		 */
+		virtual void OnEntitySpawned(CBaseEntity *pEntity, const char *classname)
 		{
 		}
 	};


### PR DESCRIPTION
As a much much much faster alternative to:
```C++
public void OnEntityCreated(int entity, const char[] classname)
{
	SDKHook(entity, SDKHook_SpawnPost, OnEntitySpawned);
}
```

now simply use:
```C++
public void OnEntitySpawned(int entity, const char[] classname)
```

The first one causes substantial lag/delay on round change due to all entities being recreated (unhook & hook).
Some plugins need to hook certain entities right after they spawn and filter those by user supplied config files which use props like targetname, hammerid, etc.
The entity props are only available after Spawn() and can not be accessed in OnEntityCreated().

I'm finding it weird that this wasn't exported as a forward right away as it's very useful and straightforward to do.