### PR TITLE
Add TR_GetHitBoxIndex() native

### DIFF
--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -998,6 +998,22 @@ static cell_t smn_TRGetHitGroup(IPluginContext *pContext, const cell_t *params)
 	return tr->hitgroup;
 }
 
+static cell_t smn_TRGetHitBox(IPluginContext *pContext, const cell_t *params)
+{
+	sm_trace_t *tr;
+	HandleError err;
+	HandleSecurity sec(pContext->GetIdentity(), myself->GetIdentity());
+
+	if (params[1] == BAD_HANDLE)
+	{
+		tr = &g_Trace;
+	} else if ((err = handlesys->ReadHandle(params[1], g_TraceHandle, &sec, (void **)&tr)) != HandleError_None) {
+		return pContext->ThrowNativeError("Invalid Handle %x (error %d)", params[1], err);
+	}
+
+	return tr->hitbox;
+}
+
 static cell_t smn_TRGetEntityIndex(IPluginContext *pContext, const cell_t *params)
 {
 	sm_trace_t *tr;
@@ -1102,6 +1118,7 @@ sp_nativeinfo_t g_TRNatives[] =
 	{"TR_StartSolid",				smn_TRStartSolid},
 	{"TR_DidHit",					smn_TRDidHit},
 	{"TR_GetHitGroup",				smn_TRGetHitGroup},
+	{"TR_GetHitBox",				smn_TRGetHitBox},
 	{"TR_ClipRayToEntity",			smn_TRClipRayToEntity},
 	{"TR_ClipRayToEntityEx",		smn_TRClipRayToEntityEx},
 	{"TR_ClipRayHullToEntity",		smn_TRClipRayHullToEntity},

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -998,7 +998,7 @@ static cell_t smn_TRGetHitGroup(IPluginContext *pContext, const cell_t *params)
 	return tr->hitgroup;
 }
 
-static cell_t smn_TRGetHitBox(IPluginContext *pContext, const cell_t *params)
+static cell_t smn_TRGetHitBoxIndex(IPluginContext *pContext, const cell_t *params)
 {
 	sm_trace_t *tr;
 	HandleError err;
@@ -1118,7 +1118,7 @@ sp_nativeinfo_t g_TRNatives[] =
 	{"TR_StartSolid",				smn_TRStartSolid},
 	{"TR_DidHit",					smn_TRDidHit},
 	{"TR_GetHitGroup",				smn_TRGetHitGroup},
-	{"TR_GetHitBox",				smn_TRGetHitBox},
+	{"TR_GetHitBoxIndex",	    	smn_TRGetHitBoxIndex},
 	{"TR_ClipRayToEntity",			smn_TRClipRayToEntity},
 	{"TR_ClipRayToEntityEx",		smn_TRClipRayToEntityEx},
 	{"TR_ClipRayHullToEntity",		smn_TRClipRayHullToEntity},

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -1118,7 +1118,7 @@ sp_nativeinfo_t g_TRNatives[] =
 	{"TR_StartSolid",				smn_TRStartSolid},
 	{"TR_DidHit",					smn_TRDidHit},
 	{"TR_GetHitGroup",				smn_TRGetHitGroup},
-	{"TR_GetHitBoxIndex",	    	smn_TRGetHitBoxIndex},
+	{"TR_GetHitBoxIndex",			smn_TRGetHitBoxIndex},
 	{"TR_ClipRayToEntity",			smn_TRClipRayToEntity},
 	{"TR_ClipRayToEntityEx",		smn_TRClipRayToEntityEx},
 	{"TR_ClipRayHullToEntity",		smn_TRClipRayHullToEntity},

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -634,6 +634,18 @@ native bool TR_DidHit(Handle hndl=INVALID_HANDLE);
 native int TR_GetHitGroup(Handle hndl=INVALID_HANDLE);
 
 /**
+ * Returns in which hitbox the trace collided if any. 
+ *
+ * Note: if the entity that collided with the trace is the world entity, 
+ * then this function doesn't return an hitbox index but a static prop index.
+ *
+ * @param hndl          A trace Handle, or INVALID_HANDLE to use a global trace result.
+ * @return              Hitbox index (Or static prop index).
+ * @error               Invalid Handle.
+ */
+native int TR_GetHitBox(Handle hndl=INVALID_HANDLE);
+
+/**
  * Find the normal vector to the collision plane of a trace.
  *
  * @param hndl          A trace Handle, or INVALID_HANDLE to use a global trace result.

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -643,7 +643,7 @@ native int TR_GetHitGroup(Handle hndl=INVALID_HANDLE);
  * @return              Hitbox index (Or static prop index).
  * @error               Invalid Handle.
  */
-native int TR_GetHitBox(Handle hndl=INVALID_HANDLE);
+native int TR_GetHitBoxIndex(Handle hndl=INVALID_HANDLE);
 
 /**
  * Find the normal vector to the collision plane of a trace.


### PR DESCRIPTION
Related to the issue #1080.

Add **TR_GetHitBoxIndex()** native to retrieve the member "hitbox" from the class "CGameTrace".

https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/public/gametrace.h#L73