### PR TITLE
Fix rare crash bug in SDKTools GetGameRulesProxyEnt

### DIFF
--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -53,6 +53,10 @@ static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
 		if (network == NULL)
 			continue;
 
+		IHandleEntity *pHandleEnt = network->GetEntityHandle();
+		if (pHandleEnt == NULL)
+			continue;
+
 		ServerClass *sClass = network->GetServerClass();
 		const char *name = sClass->GetName();
 


### PR DESCRIPTION
https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/ServerNetworkProperty.cpp#L157
```C++
ServerClass* CServerNetworkProperty::GetServerClass()
{
	if ( !m_pServerClass )
		m_pServerClass = m_pOuter->GetServerClass();
	return m_pServerClass;
}
```

m_pOuter can be NULL and then GetServerClass would crash
so check m_pOuter first with GetEntityHandle:
```C++
IHandleEntity *CServerNetworkProperty::GetEntityHandle( )
{
	return m_pOuter;
}
```
https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/game/server/ServerNetworkProperty.cpp#L103

Using GameRules_SetProp would sometimes crash for us, after this fix it hasn't crashed for 2 weeks and it doesn't look wrong to check this either.