### PR TITLE
NPOTB: Correct GitHub's Linguist inaccuracies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# GitHub views all .h files as C, let's assume it's C++
+*.h linguist-language=c++
+
+# Internal tools overriding
+tools/* linguist-vendored
+editor/* linguist-vendored
+
+# Third-party overriding 
+extensions/curl/curl-src/* linguist-vendored
+extensions/geoip/GeoIP.c linguist-vendored
+extensions/geoip/GeoIP.h linguist-vendored
+extensions/sqlite/sqlite-source/* linguist-vendored


### PR DESCRIPTION
Just a little nit-pick I've always had, but never did anything about.

We just mark in-tree third-party code as vendored code, and assume `.h` file extensions are C++, this should cover 90% of the cases in this repo.