### PR TITLE
Fix admin map chooser not using display names for menu

### DIFF
--- a/plugins/basecommands/map.sp
+++ b/plugins/basecommands/map.sp
@@ -159,8 +159,10 @@ int LoadMapList(Menu menu)
 	
 	for (int i = 0; i < map_count; i++)
 	{
+		char displayName[PLATFORM_MAX_PATH];
 		GetArrayString(g_map_array, i, map_name, sizeof(map_name));
-		menu.AddItem(map_name, map_name);
+		GetMapDisplayName(map_name, displayName, sizeof(displayName));
+		menu.AddItem(map_name, displayName);
 	}
 	
 	return map_count;


### PR DESCRIPTION
From the SM Discord:

> 4:52 PM] HiGPS: Is there any plugin that helps with the workshop map names not working properly in TF2, they show ID's and not the map names in the admin menu , but works in the nominations menu

This copies the display name-related lines from the `LoadMapList` function in `basevotes/votemap.sp` to `basecommands/map.sp`.  It's otherwise left as-is &mdash; I'd have no issues changing the styling / hoisting the variable declaration to make it more consistent if desired.