### PR TITLE
Fix ArrayStack.Pop documentation

### DIFF
--- a/plugins/include/adt_stack.inc
+++ b/plugins/include/adt_stack.inc
@@ -84,7 +84,7 @@ methodmap ArrayStack < Handle
 	// @param block        Optionally specify which block to read from
 	//                     (useful if the blocksize > 0).
 	// @param asChar       Optionally read as a byte instead of a cell.
-	// @return             True on success, false if the stack is empty.
+	// @return             Value popped from the stack.
 	// @error              The stack is empty.
 	public native any Pop(int block=0, bool asChar=false);
 
@@ -92,7 +92,7 @@ methodmap ArrayStack < Handle
 	//
 	// @param buffer       Buffer to store string.
 	// @param maxlength    Maximum size of the buffer.
-	// @oaram written      Number of characters written to buffer, not including
+	// @param written      Number of characters written to buffer, not including
 	//                     the null terminator.
 	// @error              The stack is empty.
 	public native void PopString(char[] buffer, int maxlength, int &written = 0);


### PR DESCRIPTION
`PopStackCell` works differently to `ArrayStack.Pop` with same (incorrect) return documentation.
`PopStackCell` uses 2nd param to store value of the stack popped, returning false/true if stack if empty or not.
`ArrayStack.Pop` returns value of the stack popped, throws an error if stack is empty.

Also fixed `ArrayStack.PopString` with `oaram` while i'm at it. I'm not so great at english, so please do tell me if there a better wording for return documentation, thanks.