### PR TITLE
Add bounds check for userid reset on disconnect

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1474,7 +1474,10 @@ void PlayerManager::InvalidatePlayer(CPlayer *pPlayer)
 		}
 	}
 	
-	m_UserIdLookUp[engine->GetPlayerUserId(pPlayer->m_pEdict)] = 0;
+	auto userid = engine->GetPlayerUserId(pPlayer->m_pEdict);
+	if (userid != -1)
+		m_UserIdLookUp[userid] = 0;
+
 	pPlayer->Disconnect();
 }
 


### PR DESCRIPTION
Fixes #1107 

Left out the check for player connection since it may be impossible for IVEngineServer::GetPlayerUserId to return -1 at the point in time we ask for it.