### PR TITLE
Add classic knife to CSWeaponID

### DIFF
--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -156,6 +156,7 @@ enum CSWeaponID
 	CSWeapon_BUMPMINE = 85,
 	CSWeapon_MAX_WEAPONS_NO_KNIFES, // Max without the knife item defs, useful when treating all knives as a regular knife.
 	CSWeapon_BAYONET = 500,
+	CSWeapon_KNIFE_CLASSIC = 503,
 	CSWeapon_KNIFE_FLIP = 505,
 	CSWeapon_KNIFE_GUT = 506,
 	CSWeapon_KNIFE_KARAMBIT = 507,


### PR DESCRIPTION
Instead of KNIFE_CSS i would call it WEAPON_CLASSIC, like it [Valve](http://media.steampowered.com/apps/csgo/blog/images/cs20/knife13.png) does.

#1105