### PR TITLE
Fix builds on newer gcc version

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -341,7 +341,7 @@ static cell_t sm_OpenDirectory(IPluginContext *pContext, const cell_t *params)
 		else
 		{
 			valveDir->bHandledFirstPath = false;
-			strncpy(valveDir->szFirstPath, pFirst, sizeof(valveDir->szFirstPath));
+			ke::SafeSprintf(valveDir->szFirstPath, sizeof(valveDir->szFirstPath), "%s", pFirst);
 		}
 		
 		handle = handlesys->CreateHandle(g_ValveDirType, valveDir, pContext->GetIdentity(), g_pCoreIdent, NULL);

--- a/extensions/curl/curl-src/lib/AMBuilder
+++ b/extensions/curl/curl-src/lib/AMBuilder
@@ -28,6 +28,8 @@ for arch in SM.archs:
   if binary.compiler.family == 'clang':
     # https://llvm.org/bugs/show_bug.cgi?id=16428
     binary.compiler.cflags += ['-Wno-attributes']
+  if binary.compiler.family == 'gcc' and binary.compiler.version >= 'gcc-8':
+    binary.compiler.cflags += ['-Wno-stringop-truncation']
 
   binary.sources += [
     'base64.c',

--- a/extensions/geoip/AMBuilder
+++ b/extensions/geoip/AMBuilder
@@ -10,6 +10,8 @@ for arch in SM.archs:
   if builder.target.platform == 'windows':
     binary.compiler.postlink += ['wsock32.lib']
 
+  if binary.compiler.family == 'gcc' and binary.compiler.version >= 'gcc-8':
+    binary.compiler.cflags += ['-Wno-class-memacces', '-Wno-stringop-overflow']
   binary.sources += [
     'extension.cpp',
     'GeoIP.c',


### PR DESCRIPTION
Adds a few `-Wno-` warning supressors in places where hl2sdk code affects us, and then fixed a portion of our code that was throwing the error.

Newer clang versions are fine, needs alliedmodders/metamod-source#63 to merge first