### PR TITLE
Add windows supported SDKs to powershell checkout-deps

### DIFF
--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -8,6 +8,15 @@
 [CmdletBinding()]
 param(
     [string[]]$SDKs = @(
+        'orangebox',
+        'blade',
+        'episode1',
+        'bms',
+        'darkm',
+        'swarm',
+        'bgt',
+        'eye',
+        'contagion',
         'csgo',
         'hl2dm',
         'nucleardawn',

--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -8,15 +8,6 @@
 [CmdletBinding()]
 param(
     [string[]]$SDKs = @(
-        'orangebox',
-        'blade',
-        'episode1',
-        'bms',
-        'darkm',
-        'swarm',
-        'bgt',
-        'eye',
-        'contagion',
         'csgo',
         'hl2dm',
         'nucleardawn',
@@ -27,7 +18,16 @@ param(
         'tf2',
         'insurgency',
         'sdk2013',
-        'dota'
+        'dota',
+        'orangebox',
+        'blade',
+        'episode1',
+        'bms',
+        'darkm',
+        'swarm',
+        'bgt',
+        'eye',
+        'contagion'
         )
 )
 

--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -27,7 +27,8 @@ param(
         'swarm',
         'bgt',
         'eye',
-        'contagion'
+        'contagion',
+        'doi'
         )
 )
 


### PR DESCRIPTION
.sh version has this bit:

```
if [ $ismac -eq 0 ]; then
  # Add these SDKs for Windows or Linux
  sdks+=( orangebox blade episode1 bms )

  # Add more SDKs for Windows only
  if [ $iswin -eq 1 ]; then
    sdks+=( darkm swarm bgt eye contagion )
  fi
fi
```
Added these to the ps1 SDK list. If there is a better approach, please let me know.