### PR TITLE
Add new custom flags

### DIFF
--- a/configs/admin_levels.cfg
+++ b/configs/admin_levels.cfg
@@ -37,6 +37,11 @@ Levels
 		"custom4"		"r"
 		"custom5"		"s"
 		"custom6"		"t"
+		"custom7"		"u"
+		"custom8"		"v"
+		"custom9"		"w"
+		"custom10"		"x"
+		"custom11"		"y"
 		
 		/**
 		 * Root is a magic access flag that grants all permissions.

--- a/core/logic/AdminCache.cpp
+++ b/core/logic/AdminCache.cpp
@@ -60,7 +60,7 @@ AdminFlag g_DefaultFlags[26] =
 	Admin_Slay, Admin_Changemap, Admin_Convars, Admin_Config, Admin_Chat,
 	Admin_Vote, Admin_Password, Admin_RCON, Admin_Cheats, Admin_Custom1, 
 	Admin_Custom2, Admin_Custom3, Admin_Custom4, Admin_Custom5, Admin_Custom6,
-	Admin_Generic, Admin_Generic, Admin_Generic, Admin_Generic, Admin_Generic,
+	Admin_Custom7, Admin_Custom8, Admin_Custom9, Admin_Custom10, Admin_Custom11,
 	Admin_Root
 };
 
@@ -73,11 +73,10 @@ public:
 		if (!Parse())
 		{
 			memcpy(g_FlagLetters, g_DefaultFlags, sizeof(AdminFlag) * 26);
-			for (unsigned int i=0; i<20; i++)
+			for (unsigned int i=0; i<26; i++)
 			{
 				g_FlagCharSet[i] = true;
 			}
-			g_FlagCharSet[25] = true;
 		}
 	}
 private:
@@ -271,6 +270,11 @@ void AdminCache::OnSourceModStartup(bool late)
 	NameFlag("custom4", Admin_Custom4);
 	NameFlag("custom5", Admin_Custom5);
 	NameFlag("custom6", Admin_Custom6);
+	NameFlag("custom7", Admin_Custom7);
+	NameFlag("custom8", Admin_Custom8);
+	NameFlag("custom9", Admin_Custom9);
+	NameFlag("custom10", Admin_Custom10);
+	NameFlag("custom11", Admin_Custom11);
 
 	auto sm_dump_admcache = [this] (int client, const ICommandArgs *args) -> bool {
 		char buffer[PLATFORM_MAX_PATH];

--- a/plugins/basecommands.sp
+++ b/plugins/basecommands.sp
@@ -216,14 +216,14 @@ char g_FlagNames[FLAG_STRINGS][20] =
 
 int CustomFlagsToString(char[] buffer, int maxlength, int flags)
 {
-	char joins[6][6];
+	char joins[11][6];
 	int total;
 	
-	for (int i=view_as<int>(Admin_Custom1); i<=view_as<int>(Admin_Custom6); i++)
+	for (int i=view_as<int>(Admin_Custom1); i<=view_as<int>(Admin_Custom11); i++)
 	{
 		if (flags & (1<<i))
 		{
-			IntToString(i - view_as<int>(Admin_Custom1) + 1, joins[total++], 6);
+			IntToString(i - view_as<int>(Admin_Custom1) + 1, joins[total++], sizeof(joins[]));
 		}
 	}
 	

--- a/plugins/include/admin.inc
+++ b/plugins/include/admin.inc
@@ -60,10 +60,16 @@ enum AdminFlag
 	Admin_Custom3,          /**< Third custom flag type */
 	Admin_Custom4,          /**< Fourth custom flag type */
 	Admin_Custom5,          /**< Fifth custom flag type */
-	Admin_Custom6           /**< Sixth custom flag type */
+	Admin_Custom6,          /**< Sixth custom flag type */
+	Admin_Custom7,          /**< Seventh custom flag type */
+	Admin_Custom8,          /**< Eighth custom flag type */
+	Admin_Custom9,          /**< Ninth custom flag type */
+	Admin_Custom10,         /**< Tenth custom flag type */
+	Admin_Custom11,         /**< Eleventh custom flag type */
+	/* --- */
 };
 
-#define AdminFlags_TOTAL   21       /**< Total number of admin flags */
+#define AdminFlags_TOTAL	26       /**< Total number of admin flags */
 
 /**
  * @section Bitwise values definitions for admin flags.
@@ -89,6 +95,11 @@ enum AdminFlag
 #define ADMFLAG_CUSTOM4             (1<<18)     /**< Convenience macro for Admin_Custom4 as a FlagBit */
 #define ADMFLAG_CUSTOM5             (1<<19)     /**< Convenience macro for Admin_Custom5 as a FlagBit */
 #define ADMFLAG_CUSTOM6             (1<<20)     /**< Convenience macro for Admin_Custom6 as a FlagBit */
+#define ADMFLAG_CUSTOM7             (1<<21)     /**< Convenience macro for Admin_Custom7 as a FlagBit */
+#define ADMFLAG_CUSTOM8             (1<<22)     /**< Convenience macro for Admin_Custom8 as a FlagBit */
+#define ADMFLAG_CUSTOM9             (1<<23)     /**< Convenience macro for Admin_Custom9 as a FlagBit */
+#define ADMFLAG_CUSTOM10            (1<<24)     /**< Convenience macro for Admin_Custom10 as a FlagBit */
+#define ADMFLAG_CUSTOM11            (1<<25)     /**< Convenience macro for Admin_Custom11 as a FlagBit */
 
 /**
  * @endsection

--- a/public/IAdminSystem.h
+++ b/public/IAdminSystem.h
@@ -35,7 +35,7 @@
 #include <IShareSys.h>
 
 #define SMINTERFACE_ADMINSYS_NAME		"IAdminSys"
-#define SMINTERFACE_ADMINSYS_VERSION	9
+#define SMINTERFACE_ADMINSYS_VERSION	8
 
 /**
  * @file IAdminSystem.h

--- a/public/IAdminSystem.h
+++ b/public/IAdminSystem.h
@@ -35,7 +35,7 @@
 #include <IShareSys.h>
 
 #define SMINTERFACE_ADMINSYS_NAME		"IAdminSys"
-#define SMINTERFACE_ADMINSYS_VERSION	8
+#define SMINTERFACE_ADMINSYS_VERSION	9
 
 /**
  * @file IAdminSystem.h
@@ -88,6 +88,11 @@ namespace SourceMod
 		Admin_Custom4,			/**< Fourth custom flag type */
 		Admin_Custom5,			/**< Fifth custom flag type */
 		Admin_Custom6,			/**< Sixth custom flag type */
+		Admin_Custom7,			/**< Seventh custom flag type */
+		Admin_Custom8,			/**< Eighth custom flag type */
+		Admin_Custom9,			/**< Ninth custom flag type */
+		Admin_Custom10,			/**< Tenth custom flag type */
+		Admin_Custom11,			/**< Eleventh custom flag type */
 		/* --- */
 		AdminFlags_TOTAL,
 	};
@@ -113,6 +118,11 @@ namespace SourceMod
 	#define ADMFLAG_CUSTOM4				(1<<18)		/**< Convenience macro for Admin_Custom4 as a FlagBit */
 	#define ADMFLAG_CUSTOM5				(1<<19)		/**< Convenience macro for Admin_Custom5 as a FlagBit */
 	#define ADMFLAG_CUSTOM6				(1<<20)		/**< Convenience macro for Admin_Custom6 as a FlagBit */
+	#define ADMFLAG_CUSTOM7				(1<<21)		/**< Convenience macro for Admin_Custom7 as a FlagBit */
+	#define ADMFLAG_CUSTOM8				(1<<22)		/**< Convenience macro for Admin_Custom8 as a FlagBit */
+	#define ADMFLAG_CUSTOM9				(1<<23)		/**< Convenience macro for Admin_Custom9 as a FlagBit */
+	#define ADMFLAG_CUSTOM10			(1<<24)		/**< Convenience macro for Admin_Custom10 as a FlagBit */
+	#define ADMFLAG_CUSTOM11			(1<<25)		/**< Convenience macro for Admin_Custom11 as a FlagBit */
 
 	/**
 	 * @brief Specifies which type of command to override (command or command group).


### PR DESCRIPTION
Sometimes 6 custom flags are not enough to limit access to necessary functions, and using groups to restrict one or two functions is not justified