### PR TITLE
Raised limits for csgo HintText and SayText protobuffs

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -513,7 +513,11 @@ bool CHalfLife2::TextMsg(int client, int dest, const char *msg)
 		/* Use SayText user message instead */
 		if (chat_saytext != NULL && strcmp(chat_saytext, "yes") == 0)
 		{
+#if SOURCE_ENGINE == SE_CSGO
+			char buffer[2022];
+#else
 			char buffer[253];
+#endif
 			ke::SafeSprintf(buffer, sizeof(buffer), "%s\1\n", msg);
 
 #if SOURCE_ENGINE == SE_CSGO

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -329,7 +329,11 @@ static cell_t PrintToChat(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
+#if SOURCE_ENGINE == SE_CSGO
+	char buffer[2023];
+#else
 	char buffer[254];
+#endif
 
 	{
 		DetectExceptions eh(pContext);
@@ -397,7 +401,12 @@ static cell_t PrintHintText(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
+#if SOURCE_ENGINE == SE_CSGO
+	char buffer[0xFFFF];
+#else
 	char buffer[254];
+#endif
+
 	{
 		DetectExceptions eh(pContext);
 		g_SourceMod.FormatString(buffer, sizeof(buffer), pContext, params, 2);

--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -200,6 +200,7 @@
 		"Keys"
 		{
 			"HudRadioMenuMsg"		"ShowMenu"
+			"ChatSayText"			"yes"
 		}
 	}
 	


### PR DESCRIPTION
Raised limits for SayText and HintText protobuffs and also enabled SayText as a chat message in csgo. Was compiled and tested on win, that pr will allow a lot more characters in chat messages and hints and that will allow use of much more colored messages (in chat) and more html tags (in hints).

Not sure how known that thing is, but big thanks to [@Rostu13](https://github.com/Rostu13), as he told me about that.