### PR TITLE
Allow custom sort natives and callback use any types and optional data

### DIFF
--- a/core/logic/smn_sorting.cpp
+++ b/core/logic/smn_sorting.cpp
@@ -280,7 +280,7 @@ static cell_t sm_SortStrings(IPluginContext *pContext, const cell_t *params)
 struct sort_info
 {
 	IPluginFunction *pFunc;
-	Handle_t hndl;
+	cell_t data;
 	cell_t array_addr;
 	cell_t *array_base;
 	cell_t *array_remap;
@@ -302,7 +302,7 @@ int sort1d_amx_custom(const void *elem1, const void *elem2)
 	pf->PushCell(c1);
 	pf->PushCell(c2);
 	pf->PushCell(g_SortInfo.array_addr);
-	pf->PushCell(g_SortInfo.hndl);
+	pf->PushCell(g_SortInfo.data);
 	pf->Invoke(&result);
 
 	return result;
@@ -324,7 +324,7 @@ static cell_t sm_SortCustom1D(IPluginContext *pContext, const cell_t *params)
 	sort_info oldinfo = g_SortInfo;
 
 	DetectExceptions eh(pContext);
-	g_SortInfo.hndl = params[4];
+	g_SortInfo.data = params[4];
 	g_SortInfo.array_addr = params[1];
 	g_SortInfo.array_remap = NULL;
 	g_SortInfo.array_base = NULL;
@@ -357,7 +357,7 @@ int sort2d_amx_custom(const void *elem1, const void *elem2)
 	g_SortInfo.pFunc->PushCell(c1_addr);
 	g_SortInfo.pFunc->PushCell(c2_addr);
 	g_SortInfo.pFunc->PushCell(g_SortInfo.array_addr);
-	g_SortInfo.pFunc->PushCell(g_SortInfo.hndl);
+	g_SortInfo.pFunc->PushCell(g_SortInfo.data);
 	g_SortInfo.pFunc->Invoke(&result);
 
 	return result;
@@ -389,7 +389,7 @@ static cell_t sm_SortCustom2D(IPluginContext *pContext, const cell_t *params)
 
 	DetectExceptions eh(pContext);
 	g_SortInfo.pFunc = pFunction;
-	g_SortInfo.hndl = params[4];
+	g_SortInfo.data = params[4];
 	g_SortInfo.array_addr = params[1];
 	g_SortInfo.eh = &eh;
 	
@@ -521,7 +521,7 @@ struct sort_infoADT
 	cell_t *array_base;
 	cell_t array_bsize;
 	Handle_t array_hndl;
-	Handle_t hndl;
+	cell_t data;
 	ExceptionHandler *eh;
 };
 
@@ -537,7 +537,7 @@ int sort_adtarray_custom(const void *elem1, const void *elem2)
 	pf->PushCell(((cell_t) ((cell_t *) elem1 - g_SortInfoADT.array_base)) / g_SortInfoADT.array_bsize);
 	pf->PushCell(((cell_t) ((cell_t *) elem2 - g_SortInfoADT.array_base)) / g_SortInfoADT.array_bsize);
 	pf->PushCell(g_SortInfoADT.array_hndl);
-	pf->PushCell(g_SortInfoADT.hndl);
+	pf->PushCell(g_SortInfoADT.data);
 	pf->Invoke(&result);
 
 	return result;
@@ -572,7 +572,7 @@ static cell_t sm_SortADTArrayCustom(IPluginContext *pContext, const cell_t *para
 	g_SortInfoADT.array_base = array;
 	g_SortInfoADT.array_bsize = (cell_t) blocksize;
 	g_SortInfoADT.array_hndl = params[1];
-	g_SortInfoADT.hndl = params[3];
+	g_SortInfoADT.data = params[3];
 	g_SortInfoADT.eh = &eh;
 	
 	qsort(array, arraysize, blocksize * sizeof(cell_t), sort_adtarray_custom);

--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -219,8 +219,8 @@ methodmap ArrayList < Handle {
 	// Custom sorts an ADT Array. You must pass in a comparison function.
 	//
 	// @param sortfunc      Sort comparison function to use
-	// @param hndl          Optional Handle to pass through the comparison calls.
-	public native void SortCustom(SortFuncADTArray sortfunc, Handle hndl=INVALID_HANDLE); 
+	// @param data          Optional data to pass through the comparison calls.
+	public native void SortCustom(SortFuncADTArray sortfunc, any data=0); 
 
 	// Retrieve the size of the array.
 	property int Length {

--- a/plugins/include/sorting.inc
+++ b/plugins/include/sorting.inc
@@ -90,12 +90,16 @@ native void SortStrings(char[][] array, int array_size, SortOrder order = Sort_A
  * @param elem1         First element to compare.
  * @param elem2         Second element to compare.
  * @param array         Array that is being sorted (order is undefined).
- * @param hndl          Handle optionally passed in while sorting.
+ * @param data          Data optionally passed in while sorting.
  * @return              -1 if first should go before second
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
-typedef SortFunc1D = function int (int elem1, int elem2, const int[] array, Handle hndl);
+typeset SortFunc1D
+{
+	function int (any elem1, any elem2, const any[] array);
+	function int (any elem1, any elem2, const any[] array, any data);
+}
 
 /**
  * Sorts a custom 1D array.  You must pass in a comparison function.
@@ -103,9 +107,9 @@ typedef SortFunc1D = function int (int elem1, int elem2, const int[] array, Hand
  * @param array         Array to sort.
  * @param array_size    Size of the array to sort.
  * @param sortfunc      Sort function.
- * @param hndl          Optional Handle to pass through the comparison calls.
+ * @param data          Optional data to pass through the comparison calls.
  */
-native void SortCustom1D(int[] array, int array_size, SortFunc1D sortfunc, Handle hndl=INVALID_HANDLE);
+native void SortCustom1D(any[] array, int array_size, SortFunc1D sortfunc, any data=0);
 
 /**
  * Sort comparison function for 2D array elements (sub-arrays).
@@ -114,15 +118,15 @@ native void SortCustom1D(int[] array, int array_size, SortFunc1D sortfunc, Handl
  * @param elem1         First array to compare.
  * @param elem2         Second array to compare.
  * @param array         Array that is being sorted (order is undefined).
- * @param hndl          Handle optionally passed in while sorting.
+ * @param data          Data optionally passed in while sorting.
  * @return              -1 if first should go before second
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
 typeset SortFunc2D
 {
-	function int (int[] elem1, int[] elem2, const int[][] array, Handle hndl);
-	function int (char[] elem1, char[] elem2, const char[][] array, Handle hndl);
+	function int (any[] elem1, any[] elem2, const any[][] array);
+	function int (any[] elem1, any[] elem2, const any[][] array, any data);
 };
 
 /**
@@ -131,9 +135,9 @@ typeset SortFunc2D
  * @param array         Array to sort.
  * @param array_size    Size of the major array to sort (first index, outermost).
  * @param sortfunc      Sort comparison function to use.
- * @param hndl          Optional Handle to pass through the comparison calls.
+ * @param data          Optional data to pass through the comparison calls.
  */
-native void SortCustom2D(any[][] array, int array_size, SortFunc2D sortfunc, Handle hndl=INVALID_HANDLE);
+native void SortCustom2D(any[][] array, int array_size, SortFunc2D sortfunc, any data=0);
 
 /**
  * Sort an ADT Array. Specify the type as Integer, Float, or String.
@@ -152,12 +156,16 @@ native void SortADTArray(Handle array, SortOrder order, SortType type);
  * @param index1        First index to compare.
  * @param index2        Second index to compare.
  * @param array         Array that is being sorted (order is undefined).
- * @param hndl          Handle optionally passed in while sorting.
+ * @param data          Data optionally passed in while sorting.
  * @return              -1 if first should go before second
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
-typedef SortFuncADTArray = function int (int index1, int index2, Handle array, Handle hndl);
+typeset SortFuncADTArray
+{
+	function int (int index1, int index2, ArrayList array);
+	function int (int index1, int index2, ArrayList array, any data);
+}
 
 /**
  * Custom sorts an ADT Array. You must pass in a comparison function.


### PR DESCRIPTION
3 main things done with `SortCustom1D`, `SortCustom2D`, and `ArrayList.SortCustom` natives:

- Allow `any` variable to custom sort rather than limited to `int`. Meaning floats, enums, methodmap etc can be used to pass and custom sort.
- Replace optional `Handle hndl` pass to `any data`. I don't see anywhere on why it should be limited to handles, so allow `any` without needing to create new handles. Also updated core to use `cell_t` data, doesn't make any difference but may well then do it.
- Use `ArrayList` instead of `Handle` in `SortFuncADTArray` callback. `Handle` variable can still be used from old plugins.

Only thing missing is `any` for regular 1D sorting. I'm not sure if it a good idea to allow `any` in `SortIntegers` native to sort enums, but i left it untouched.
`SortADTArrayCustom` also left untouched because we have `ArrayList.SortCustom` traditional syntax instead.

Hopefully i didn't miss anything that would break old plugins, but please do let me know if i did break one.
Compiled with this, no warnings and tested.

```
public void OnPluginStart()
{
	// New sortings
	
	int Data = 322;
	Action Array1D[3] = {Plugin_Handled, Plugin_Continue, Plugin_Stop};
	SortCustom1D(Array1D, sizeof(Array1D), Sort1D, Data);
	
	float Array2D[3][2] = {{3.7, 1.1}, {7.4, -4.7}, {1.0, 2.3}};
	SortCustom2D(Array2D, sizeof(Array2D), Sort2D);
	
	ArrayList ArrayADT = new ArrayList();
	ArrayADT.Push(2);
	ArrayADT.Push(7);
	ArrayADT.Push(3);
	ArrayADT.SortCustom(SortADT);
	delete ArrayADT;
	
	
	// Old sortings
	
	int OldArray1D[3] = {5, 1, 3};
	SortCustom1D(OldArray1D, sizeof(OldArray1D), OldSort1D);
	
	Handle Trie = CreateTrie();
	int OldArray2D[3][2] = {{2, 4}, {7, 1}, {2, 6}};
	SortCustom2D(OldArray2D, sizeof(OldArray2D), OldSort2D, Trie);
	CloseHandle(Trie);
	
	Handle OldArrayADT = CreateArray();
	PushArrayCell(OldArrayADT, 1);
	PushArrayCell(OldArrayADT, 8);
	PushArrayCell(OldArrayADT, 2);
	SortADTArrayCustom(OldArrayADT, OldSortADT);
	CloseHandle(OldArrayADT);
}

public int Sort1D(Action elem1, Action elem2, const Action[] array, any data)
{
	PrintToServer("Sort1D - %d %d - data %d", elem1, elem2, data);
	return 0;
}

public int Sort2D(float[] elem1, float[] elem2, const float[][] array)
{
	PrintToServer("Sort2D - %.2f %.2f", elem1[0], elem2[0]);
	return 0;
}

public int SortADT(int index1, int index2, ArrayList array)
{
	PrintToServer("SortADT - %d %d", array.Get(index1), array.Get(index2));
	return 0;
}

public int OldSort1D(int elem1, int elem2, const int[] array, Handle hndl)
{
	PrintToServer("OldSort1D - %d %d", elem1, elem2);
	return 0;
}

public int OldSort2D(int[] elem1, int[] elem2, const int[][] array, Handle hndl)
{
	PrintToServer("OldSort2D - %d %d - hndl %x", elem1[0], elem2[0], hndl);
	return 0;
}

public int OldSortADT(int index1, int index2, Handle array, Handle hndl)
{
	PrintToServer("OldSortADT - %d %d", GetArrayCell(array, index1), GetArrayCell(array, index2));
	return 0;
}
```