### PR TITLE
Speculative fix for MySQL crashes

### DIFF
--- a/extensions/mysql/extension.cpp
+++ b/extensions/mysql/extension.cpp
@@ -46,9 +46,12 @@ SMEXT_LINK(&g_MySqlDBI);
 
 bool DBI_MySQL::SDK_OnLoad(char *error, size_t maxlength, bool late)
 {
+	if (mysql_library_init(0, NULL, NULL) != 0) {
+		smutils->Format(error, maxlength, "Could not initialize MySQL client library");
+		return false;	
+	}
+	
 	dbi->AddDriver(&g_MyDriver);
-
-	my_init();
 
 	return true;
 }
@@ -56,8 +59,8 @@ bool DBI_MySQL::SDK_OnLoad(char *error, size_t maxlength, bool late)
 void DBI_MySQL::SDK_OnUnload()
 {
 	dbi->RemoveDriver(&g_MyDriver);
-	//:TODO: is this needed?
-	//mysql_library_end();
+
+	mysql_library_end();
 }
 
 const char *DBI_MySQL::GetExtensionVerString()
@@ -69,4 +72,3 @@ const char *DBI_MySQL::GetExtensionDateString()
 {
 	return SOURCEMOD_BUILD_TIME;
 }
-


### PR DESCRIPTION
https://crash.limetech.org/stats/dbi.mysql.ext.%25/my_real_read
https://crash.limetech.org/stats/dbi.mysql.ext.%25/net_real_write

Both of these are caused by the VIO ptr ending up as null in the middle of reading/writing to a connection - I can't find any indication of a fix for this made to MySQL, so don't think it is a bug fix we're missing, but there are some musings around the internet that it could be caused by improper thread-safety initialisation.

`my_init` (what we had here) is called internally by `mysql_library_init` but I think would have still led to an automatic `mysql_library_init` call the first time `mysql_init` was called (which we can do on a thread in case of threaded connections), which is exactly the thread-safety issue called out by the MySQL docs, so hopefully doing things properly here will help.