### PR TITLE
Fix edge case basecommands plugin error

### DIFF
--- a/plugins/basecommands.sp
+++ b/plugins/basecommands.sp
@@ -395,10 +395,15 @@ public Action Command_Rcon(int client, int args)
 	if (client == 0) // They will already see the response in the console.
 	{
 		ServerCommand("%s", argstring);
-	} else {
+	}
+	else
+	{
 		char responseBuffer[4096];
 		ServerCommandEx(responseBuffer, sizeof(responseBuffer), "%s", argstring);
-		ReplyToCommand(client, responseBuffer);
+		if (IsClientConnected(client))
+		{
+			ReplyToCommand(client, responseBuffer);
+		}
 	}
 
 	return Plugin_Handled;


### PR DESCRIPTION
While testing a plugin I was creating, I needed to use `sm_rcon` to kick myself from the server console to ensure my console check was working as intended.

I found that when using `sm_rcon kick me`, I got this error:
```
L 12/10/2019 - 22:53:23: [SM] Exception reported: Client 1 is not connected
L 12/10/2019 - 22:53:23: [SM] Blaming: basecommands.smx
L 12/10/2019 - 22:53:23: [SM] Call stack trace:
L 12/10/2019 - 22:53:23: [SM]   [0] ReplyToCommand
L 12/10/2019 - 22:53:23: [SM]   [1] Line 401, D:\builds\build-sourcemod-msvc12\windows-1.10\build\plugins\basecommands.sp::Command_Rcon
```

So as the title states, this is an extreme edge case and does not apply when using `sm_rcon sm_kick`, but I figure a proper IsClientConnected check was in order to not throw an error in an odd case like this.

I also took the liberty of formatting the couple lines leading up to the fix to match the coding style of the rest of the plugin, hope that's okay.