### PR TITLE
Fix typo in plugin description

### DIFF
--- a/plugins/clientprefs.sp
+++ b/plugins/clientprefs.sp
@@ -43,7 +43,7 @@ public Plugin myinfo =
 {
 	name = "Client Preferences",
 	author = "AlliedModders LLC",
-	description = "Client peferences and settings menu",
+	description = "Client preferences and settings menu",
 	version = SOURCEMOD_VERSION,
 	url = "http://www.sourcemod.net/"
 };


### PR DESCRIPTION
This was found by LuqS: https://discordapp.com/channels/335290997317697536/335290997317697536/655499997298688040