### PR TITLE
fix incorrect command reply in nominations

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -338,7 +338,7 @@ void AttemptNominate(int client, const char[] map, int size)
 		}
 		else
 		{
-			ReplyToCommand(client, "[SM] %t", "Map Already Nominated");
+			ReplyToCommand(client, "[SM] %t", "Max Nominations");
 		}
 		
 		return;	


### PR DESCRIPTION
When a map is nominated and the max nominations have been reached, the wrong text is returned if the map hasn't been nominated yet. Instead of printing the "Max Nominations" text, it prints out the "Map Already Nominated" text instead.