### PR TITLE
Fix TF2_MakeBleed using incorrect custom damage type

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -86,7 +86,7 @@ cell_t TF2_MakeBleed(IPluginContext *pContext, const cell_t *params)
 											int, // Damage amount
 											bool, // Permanent
 											int>  // Custom Damage type (bleeding)
-											vstk(obj, pAttacker, NULL, sp_ctof(params[3]), 4, false, 32);
+											vstk(obj, pAttacker, NULL, sp_ctof(params[3]), 4, false, 34);
 
 	pWrapper->Execute(vstk, nullptr);
 	return 1;


### PR DESCRIPTION
PR #965 accidentally changed `TF2_MakeBleed` custom damage type from 34 (`TF_CUSTOM_BLEEDING`) to 32 (`TF_CUSTOM_SHOTGUN_REVENGE_CRIT`).
I don't think using damage custom 32 change anything gameplay wise, but does incorrectly report 32 in `player_death` event, SDKHooks `SDKHook_OnTakeDamage`, and whatever other places damage custom uses.