### PR TITLE
Fix heap corruption in CUtlVector destructor

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1241,9 +1241,11 @@ public:
 
 void CHalfLife2::FreeUtlVectorUtlString(CUtlVector<CUtlString, CUtlMemoryGlobalMalloc<CUtlString>> &vec)
 {
+	CUtlMemoryGlobalMalloc<unsigned char> *pMemory;
 	FOR_EACH_VEC(vec, i)
 	{
-		g_pMemAlloc->Free(vec[i].m_Storage.m_Memory.Detach());
+		pMemory = (CUtlMemoryGlobalMalloc<unsigned char> *) &vec[i].m_Storage.m_Memory;
+		pMemory->Purge();
 		vec[i].m_Storage.SetLength(0);
 	}
 }

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -179,6 +179,12 @@ enum class SMFindMapResult : cell_t {
 	PossiblyAvailable
 };
 
+#if SOURCE_ENGINE >= SE_LEFT4DEAD && defined PLATFORM_WINDOWS
+template< class T, class I = int >
+class CUtlMemoryGlobalMalloc;
+class CUtlString;
+#endif
+
 class CHalfLife2 : 
 	public SMGlobalClass,
 	public IGameHelpers
@@ -229,6 +235,9 @@ public: //IGameHelpers
 	bool IsMapValid(const char *map);
 	SMFindMapResult FindMap(char *pMapName, size_t nMapNameMax);
 	SMFindMapResult FindMap(const char *pMapName, char *pFoundMap = NULL, size_t nMapNameMax = 0);
+#if SOURCE_ENGINE >= SE_LEFT4DEAD && defined PLATFORM_WINDOWS
+	void FreeUtlVectorUtlString(CUtlVector<CUtlString, CUtlMemoryGlobalMalloc<CUtlString>> &vec);
+#endif
 	bool GetMapDisplayName(const char *pMapName, char *pDisplayname, size_t nMapNameMax);
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 	string_t AllocPooledString(const char *pszValue);


### PR DESCRIPTION
`CHalfLife2::FindMap` works around the missing `IVEngineServer::FindMap` function by using the command autocompletion feature of the `changelevel` command.

The function populates a `CUtlVector<CUtlString>` object with the auto completion results. The game allocates memory for the vector and strings and we try to free it. This crashes when the C Run-time library version differs, which can happen when compiling using a newer toolchain.

Fixes #910 like @psychonic suggested.

I've only tested this on CS:GO Windows. This allowed me to run my server with a self-compiled build of SourceMod.