### PR TITLE
Fix issue #1170

### DIFF
--- a/extensions/sdktools/vsound.cpp
+++ b/extensions/sdktools/vsound.cpp
@@ -677,11 +677,7 @@ bool InternalPrecacheScriptSound(const char *soundname)
 	for (int wave = 0; wave < waveCount; wave++)
 	{
 		const char* waveName = soundemitterbase->GetWaveName(internal->GetSoundNames()[wave].symbol);
-		// return true even if we precache no new wavs
-		if (!engsound->IsSoundPrecached(waveName))
-		{
-			engsound->PrecacheSound(waveName);
-		}
+		engsound->PrecacheSound(waveName);
 	}
 
 	return true;
@@ -1589,11 +1585,7 @@ static cell_t smn_GetGameSoundParams(IPluginContext *pContext, const cell_t *par
 
 	pContext->StringToLocal(params[6], params[7], soundParams.soundname);
 
-	// Precache the sound we're returning
-	if (!engsound->IsSoundPrecached(soundParams.soundname))
-	{
-		InternalPrecacheScriptSound(soundname);
-	}
+	InternalPrecacheScriptSound(soundname);
 
 	return true;
 }

--- a/extensions/sdktools/vsound.cpp
+++ b/extensions/sdktools/vsound.cpp
@@ -1585,6 +1585,7 @@ static cell_t smn_GetGameSoundParams(IPluginContext *pContext, const cell_t *par
 
 	pContext->StringToLocal(params[6], params[7], soundParams.soundname);
 
+	// Precache the sound we're returning
 	InternalPrecacheScriptSound(soundname);
 
 	return true;

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -322,9 +322,9 @@ native bool PrecacheSound(const char[] sound, bool preload=false);
  *
  * @param sound         Name of the sound to check.
  * @return              True if precached, false otherwise.
- * @deprecated          Doesn't work correct, always returns true.
+ * @deprecated          Doesn't work correctly, always returns true.
  */
-#pragma deprecated Doesn't work correct, always returns true.
+#pragma deprecated Doesn't work correctly, always returns true.
 native bool IsSoundPrecached(const char[] sound);
 
 /**

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -322,7 +322,9 @@ native bool PrecacheSound(const char[] sound, bool preload=false);
  *
  * @param sound         Name of the sound to check.
  * @return              True if precached, false otherwise.
+ * @deprecated          Doesn't work correct, always returns true.
  */
+#pragma deprecated Doesn't work correct, always returns true.
 native bool IsSoundPrecached(const char[] sound);
 
 /**


### PR DESCRIPTION
After doing some testing with a debugger, I noticed that `engsound->IsSoundPrecached(waveName)` returns `true`, even though the sound is not precached. Because I don't have the patience to compile Sourcemod, I replaced the jnz instruction with nops and now sounds are successfully precached.
For this reason, I removed `IsSoundPrecached` from `PrecacheSoundScript` and `GetGameSoundParameters`

I think it'll be a good idea to add a note to [IsSoundPrecached](https://sm.alliedmods.net/new-api/halflife/IsSoundPrecached) warning that this function may not work correctly(always returning `true`)

Fixes issue #1170 