### PR TITLE
Make ConVar cache case insensitive, fixes #1166

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -41,7 +41,7 @@ ConVarManager g_ConVarManager;
 
 const ParamType CONVARCHANGE_PARAMS[] = {Param_Cell, Param_String, Param_String};
 typedef List<const ConVar *> ConVarList;
-NameHashSet<ConVarInfo *> convar_cache;
+NameHashSet<ConVarInfo *, ConVarInfo::ConVarPolicy> convar_cache;
 
 class ConVarReentrancyGuard
 {

--- a/core/ConVarManager.h
+++ b/core/ConVarManager.h
@@ -66,7 +66,7 @@ struct ConVarInfo
 
 	struct ConVarPolicy
 	{
-		static inline bool matches(const char* name, ConVarInfo* info)
+		static inline bool matches(const char *name, ConVarInfo *info)
 		{
 			const char* conVarChars = info->pVar->GetName();
 
@@ -76,7 +76,7 @@ struct ConVarInfo
 			return convarName == input;
 		}
 
-		static inline uint32_t hash(const detail::CharsAndLength& key)
+		static inline uint32_t hash(const detail::CharsAndLength &key)
 		{
 			ke::AString original(key.chars());
 			ke::AString lower = original.lowercase();

--- a/core/ConVarManager.h
+++ b/core/ConVarManager.h
@@ -64,14 +64,26 @@ struct ConVarInfo
 	ConVar *pVar;						/**< The actual convar */
 	List<IConVarChangeListener *> changeListeners;
 
-	static inline bool matches(const char *name, const ConVarInfo *info)
+	struct ConVarPolicy
 	{
-		return strcmp(name, info->pVar->GetName()) == 0;
-	}
-	static inline uint32_t hash(const detail::CharsAndLength &key)
-	{
-		return key.hash();
-	}
+		static inline bool matches(const char* name, ConVarInfo* info)
+		{
+			const char* conVarChars = info->pVar->GetName();
+
+			ke::AString convarName = ke::AString(conVarChars).lowercase();
+			ke::AString input = ke::AString(name).lowercase();
+
+			return convarName == input;
+		}
+
+		static inline uint32_t hash(const detail::CharsAndLength& key)
+		{
+			ke::AString original(key.chars());
+			ke::AString lower = original.lowercase();
+
+			return detail::CharsAndLength(lower.chars()).hash();
+		}
+	};
 };
 
 /**

--- a/core/ConVarManager.h
+++ b/core/ConVarManager.h
@@ -68,7 +68,7 @@ struct ConVarInfo
 	{
 		static inline bool matches(const char *name, ConVarInfo *info)
 		{
-			const char* conVarChars = info->pVar->GetName();
+			const char *conVarChars = info->pVar->GetName();
 
 			ke::AString convarName = ke::AString(conVarChars).lowercase();
 			ke::AString input = ke::AString(name).lowercase();


### PR DESCRIPTION
Test code:

```cpp
public void OnPluginStart() {
	ConVar SV_CHEATS = FindConVar("SV_CHEATS");
	ConVar sv_cheats = FindConVar("sv_cheats");
	ConVar sV_cHeAtS = FindConVar("sV_cHeAtS");
	
	LogMessage("'SV_CHEATS' = %i, 'sv_cheats' = %i, 'sV_cHeAtS' = %i", SV_CHEATS, sv_cheats, sV_cHeAtS);
}
```

Output: 
```
L 02/10/2020 - 09:04:54: [ConVarLeakTest.smx] 'SV_CHEATS' = 4718664, 'sv_cheats' = 4718664, 'sV_cHeAtS' = 4718664
```