### PR TITLE
Add option for persistent previous map storage

### DIFF
--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -219,7 +219,7 @@ public void OnConfigsExecuted()
 		}
 	}
 	
-	// Recall previous maps from a text file, if persistency is enabled
+	/* First-load previous maps from a text file when persistency is enabled. */
 	static bool g_FirstConfigExec = true;
 	if (g_FirstConfigExec)
 	{
@@ -1243,7 +1243,6 @@ public int Native_GetNominatedMapList(Handle plugin, int numParams)
 }
 
 /* Add functions for persistent previous map storage */
-
 void ReadPreviousMapsFromText()
 {      
 	File file = OpenFile(GetTextFilePath(), "r");	
@@ -1287,7 +1286,8 @@ void WritePreviousMapsToText()
 
 char GetTextFilePath()
 {
-	char path[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "data/mapchooser_history.txt");
+	static char path[PLATFORM_MAX_PATH];
+	if (path[0] == '\0')
+		BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "data/mapchooser_history.txt");
 	return path;
 }

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -106,8 +106,6 @@ int g_winCount[MAXTEAMS];
 #define VOTE_EXTEND "##extend##"
 #define VOTE_DONTCHANGE "##dontchange##"
 
-#define MAPCHOOSER_TXT "data/mapchooser_history.txt"
-
 public void OnPluginStart()
 {
 	LoadTranslations("mapchooser.phrases");
@@ -1290,6 +1288,6 @@ void WritePreviousMapsToText()
 char GetTextFilePath()
 {
 	char path[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, path, PLATFORM_MAX_PATH, MAPCHOOSER_TXT);
+	BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "data/mapchooser_history.txt");
 	return path;
 }

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -1274,7 +1274,6 @@ void WritePreviousMapsToText()
 	}
     
 	char lastMap[PLATFORM_MAX_PATH];
-    
 	for (int idx=0; idx<g_OldMapList.Length; idx++)
 	{
 		g_OldMapList.GetString(idx, lastMap, sizeof(lastMap));		

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -221,6 +221,18 @@ public void OnConfigsExecuted()
 		}
 	}
 	
+	// Recall previous maps from a text file, if persistency is enabled
+	static bool g_FirstConfigExec = true;
+	if (g_FirstConfigExec)
+	{
+		if (g_Cvar_PersistentMaps.BoolValue)
+		{
+			ReadPreviousMapsFromText();
+		}
+		
+		g_FirstConfigExec = false;
+	}
+	
 	CreateNextVote();
 	SetupTimeleftTimer();
 	
@@ -246,18 +258,6 @@ public void OnConfigsExecuted()
 		{
 			LogError("Warning - Bonus Round Time shorter than Vote Time. Votes during bonus round may not have time to complete");
 		}
-	}
-	
-	// Recall previous maps from a text file, if persistency is enabled
-	static bool g_FirstConfigExec = true;
-	if (g_FirstConfigExec)
-	{
-		if (g_Cvar_PersistentMaps.BoolValue)
-		{
-			ReadPreviousMapsFromText();
-		}
-		
-		g_FirstConfigExec = false;
 	}
 }
 

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -186,7 +186,7 @@ public void OnPluginStart()
 	}
 	
 	g_NominationsResetForward = new GlobalForward("OnNominationRemoved", ET_Ignore, Param_String, Param_Cell);
-	g_MapVoteStartedForward = new GlobalForward("OnMapVoteStarted", ET_Ignore);	
+	g_MapVoteStartedForward = new GlobalForward("OnMapVoteStarted", ET_Ignore);
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)


### PR DESCRIPTION
Adds option to persistently store the previous map vote history in a text file. The previous map ArrayList is repopulated after the configuration files are executed for the first time.