### PR TITLE
Remove duplicates from previous map vote history

### DIFF
--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -257,6 +257,7 @@ public void OnMapEnd()
 	
 	char map[PLATFORM_MAX_PATH];
 	GetCurrentMap(map, sizeof(map));
+	RemoveStringFromArray(g_OldMapList, map);
 	g_OldMapList.PushString(map);
 				
 	if (g_OldMapList.Length > g_Cvar_ExcludeMaps.IntValue)


### PR DESCRIPTION
This commit ranks previous maps from least to most recently played. The mapchooser would then exclude x number of most recently played maps instead of x number of previous maps.