### PR TITLE
Add stock AssertStrEq to testing include

### DIFF
--- a/plugins/include/testing.inc
+++ b/plugins/include/testing.inc
@@ -79,3 +79,17 @@ stock void AssertTrue(const char[] text, bool value)
 		ThrowError("test %d (%s in %s) failed", TestNumber, text, TestContext);
 	}
 }
+
+stock void AssertStrEq(const char[] text, const char[] value, const char[] expected)
+{
+	TestNumber++;
+	if (StrEqual(value, expected))
+	{
+		PrintToServer("[%d] %s: '%s' == '%s' OK", TestNumber, TestContext, text, value, expected);
+	}
+	else
+	{
+		PrintToServer("[%d] %s FAIL: %s should be '%s', got '%s'", TestNumber, TestContext, text, expected, value);
+		ThrowError("test %d (%s in %s) failed", TestNumber, text, TestContext);
+	}
+}

--- a/plugins/include/testing.inc
+++ b/plugins/include/testing.inc
@@ -85,7 +85,7 @@ stock void AssertStrEq(const char[] text, const char[] value, const char[] expec
 	TestNumber++;
 	if (StrEqual(value, expected))
 	{
-		PrintToServer("[%d] %s: '%s' == '%s' OK", TestNumber, TestContext, text, value, expected);
+		PrintToServer("[%d] %s: '%s' == '%s' OK", TestNumber, TestContext, text, expected);
 	}
 	else
 	{


### PR DESCRIPTION
Adds a new stock function `AssertStrEq` to assert equality between two strings.

It's a minor convenience over `AssertTrue` since it prints the expected string without having to include it in the `text` argument.