### PR TITLE
Add helper stocks for getting numerical command arguments

### DIFF
--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -424,6 +424,37 @@ native int GetCmdArgs();
 native int GetCmdArg(int argnum, char[] buffer, int maxlength);
 
 /**
+ * Retrieves a numeric command argument given its index, from the current
+ * console or server command. Will return 0 if the argument can not be
+ * parsed as a number. Use GetCmdArgIntEx to handle that explicitly.
+ *
+ * @param argnum Argument number to retrieve.
+ * @return       Value of the command argument.
+ */
+stock int GetCmdArgInt(int argnum) {
+    char str[12];
+    GetCmdArg(argnum, str, sizeof(str));
+
+    return StringToInt(str);
+}
+
+/**
+ * Retrieves a numeric command argument given its index, from the current
+ * console or server command. Returns false if the argument can not be
+ * completely parsed as an integer.
+ *
+ * @param argnum Argument number to retrieve.
+ * @param value  Populated with the value of the command argument.
+ * @return       Whether the argument was entirely a numeric value.
+ */
+stock bool GetCmdArgIntEx(int argnum, int &value) {
+    char str[12];
+    int len = GetCmdArg(argnum, str, sizeof(str));
+
+    return StringToIntEx(str, value) == len && len > 0;
+}
+
+/**
  * Retrieves the entire command argument string in one lump from the current 
  * console or server command.
  *


### PR DESCRIPTION
This is quite a common operation, it is all over our base plugins and examples on the wiki. I wrote a plugin for the first time in a very long time the other day that needed some commands and it was really weird not having this available by default.

Tested with the following test plugin:
```sourcepawn
public void OnPluginStart()
{
	RegConsoleCmd("sm_test", Cmd_Test);
}

Action Cmd_Test(int client, int args)
{
	for (int i = 1; i <= args; ++i) {
		char strVal[32];
		GetCmdArg(i, strVal, sizeof(strVal));
		
		int intVal = GetCmdArgInt(i);
		
		int checkedIntVal;
		bool checked = GetCmdArgIntEx(i, checkedIntVal);
		
		ReplyToCommand(client, "'%s' %d %d (%s)",
			strVal, intVal, checkedIntVal,
			checked ? "valid" : "invalid");
	}
	
	return Plugin_Handled;
}
```

Input:
```
sm_test hello 9 99 999 9999 99999 999999 9999999 99999999 999999999 9999999999 99999999999 -9 -99 -999 -9999 -99999 -999999 -9999999 -99999999 -999999999 -9999999999 -99999999999 42hello hello42 0 0hello "" 9999999999nope 99999999999nope
```

Output:
```
'hello' 0 0 (invalid)
'9' 9 9 (valid)
'99' 99 99 (valid)
'999' 999 999 (valid)
'9999' 9999 9999 (valid)
'99999' 99999 99999 (valid)
'999999' 999999 999999 (valid)
'9999999' 9999999 9999999 (valid)
'99999999' 99999999 99999999 (valid)
'999999999' 999999999 999999999 (valid)
'9999999999' -1 -1 (valid)
'99999999999' -1 -1 (valid)
'-9' -9 -9 (valid)
'-99' -99 -99 (valid)
'-999' -999 -999 (valid)
'-9999' -9999 -9999 (valid)
'-99999' -99999 -99999 (valid)
'-999999' -999999 -999999 (valid)
'-9999999' -9999999 -9999999 (valid)
'-99999999' -99999999 -99999999 (valid)
'-999999999' -999999999 -999999999 (valid)
'-9999999999' -1 -1 (valid)
'-99999999999' -1 -1 (valid)
'42hello' 42 42 (invalid)
'hello42' 0 0 (invalid)
'0' 0 0 (valid)
'0hello' 0 0 (invalid)
'' 0 0 (invalid)
'9999999999nope' -1 -1 (invalid)
'99999999999nope' -1 -1 (valid)
```

There are some edge-cases where the Ex variant doesn't detect invalid input, but they're inherited from StringToIntEx sadly and it seems to do a fairly respectable job. I think it is worth adding both variants as 99% of current code doesn't check for failure (and it complicates code a bit), but it is good to give people the option.