### PR TITLE
mapchooser: Fix previous map exclusion bug

### DIFF
--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -260,7 +260,7 @@ public void OnMapEnd()
 	RemoveStringFromArray(g_OldMapList, map);
 	g_OldMapList.PushString(map);
 				
-	if (g_OldMapList.Length > g_Cvar_ExcludeMaps.IntValue)
+	while (g_OldMapList.Length > g_Cvar_ExcludeMaps.IntValue)
 	{
 		g_OldMapList.Erase(0);
 	}	


### PR DESCRIPTION
This commit fixes a bug where if the value of `sm_mapvote_exclude` is reduced, the change may not take effect for an extended period of time. The size of the old map list is not updated when this happens.