### PR TITLE
Restore the frame pointer on Linux

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -322,6 +322,9 @@ class SMConfig(object):
     if builder.options.opt == '1':
       cxx.cflags += ['-O3']
 
+    # Don't omit the frame pointer.
+    cxx.cflags += ['-fno-omit-frame-pointer']
+
   def configure_msvc(self, cxx):
     if builder.options.debug == '1':
       cxx.cflags += ['/MTd']


### PR DESCRIPTION
Looks like the default here changed when we upgraded the Linux build server.

This is causing issues when debugging crash dumps.