### PR TITLE
Add an option to build against no SDKs

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -143,6 +143,7 @@ class SMConfig(object):
 
   def detectSDKs(self):
     sdk_list = builder.options.sdks.split(',')
+    use_none = sdk_list[0] == 'none'
     use_all = sdk_list[0] == 'all'
     use_present = sdk_list[0] == 'present'
 
@@ -161,7 +162,7 @@ class SMConfig(object):
           sdk.path = Normalize(sdk_path)
           self.sdks[sdk_name] = sdk
 
-    if len(self.sdks) < 1 and len(sdk_list):
+    if len(self.sdks) < 1 and len(sdk_list) and not use_none:
       raise Exception('No SDKs were found that build on {0}-{1}, nothing to do.'.format(
         builder.target.platform, builder.target.arch))
 

--- a/configure.py
+++ b/configure.py
@@ -33,8 +33,8 @@ parser.options.add_option('--enable-optimize', action='store_const', const='1', 
 parser.options.add_option('--no-mysql', action='store_false', default=True, dest='hasMySql',
                        help='Disable building MySQL extension')
 parser.options.add_option('-s', '--sdks', default='all', dest='sdks',
-                       help='Build against specified SDKs; valid args are "all", "present", or '
-                            'comma-delimited list of engine names (default: %default)')
+                       help='Build against specified SDKs; valid args are "none", "all", "present",'
+                            ' or comma-delimited list of engine names (default: %default)')
 parser.options.add_option('--breakpad-dump', action='store_true', dest='breakpad_dump',
 											 default=False, help='Dump and upload breakpad symbols')
 parser.options.add_option('--disable-auto-versioning', action='store_true', dest='disable_auto_versioning',


### PR DESCRIPTION
Quite often I find myself only needing to build the SDK-independent code, which we have more and more of these days.