### PR TITLE
Revert "csgo: enable SayText + raise msg limits (#1118)"

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -513,11 +513,7 @@ bool CHalfLife2::TextMsg(int client, int dest, const char *msg)
 		/* Use SayText user message instead */
 		if (chat_saytext != NULL && strcmp(chat_saytext, "yes") == 0)
 		{
-#if SOURCE_ENGINE == SE_CSGO
-			char buffer[2022];
-#else
 			char buffer[253];
-#endif
 			ke::SafeSprintf(buffer, sizeof(buffer), "%s\1\n", msg);
 
 #if SOURCE_ENGINE == SE_CSGO

--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -329,11 +329,7 @@ static cell_t PrintToChat(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
-#if SOURCE_ENGINE == SE_CSGO
-	char buffer[2023];
-#else
 	char buffer[254];
-#endif
 
 	{
 		DetectExceptions eh(pContext);
@@ -401,12 +397,7 @@ static cell_t PrintHintText(IPluginContext *pContext, const cell_t *params)
 
 	g_SourceMod.SetGlobalTarget(client);
 
-#if SOURCE_ENGINE == SE_CSGO
-	char buffer[0xFFFF];
-#else
 	char buffer[254];
-#endif
-
 	{
 		DetectExceptions eh(pContext);
 		g_SourceMod.FormatString(buffer, sizeof(buffer), pContext, params, 2);

--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -200,7 +200,6 @@
 		"Keys"
 		{
 			"HudRadioMenuMsg"		"ShowMenu"
-			"ChatSayText"			"yes"
 		}
 	}
 	


### PR DESCRIPTION
Reverts alliedmodders/sourcemod#1118

CS:GO makes a beeping sound when `SayText` is used.