### PR TITLE
Prevent clients from spamming global chat using sm_nominate

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -351,7 +351,7 @@ void AttemptNominate(int client, const char[] map, int size)
 	char name[MAX_NAME_LENGTH];
 	GetClientName(client, name, sizeof(name));
 
-	PrintToChatAll("[SM] %t", "Map Nominated", name, displayName);
+	ReplyToCommand(client, "[SM] %t", "Map Nominated", name, displayName);
 	
 	return;
 }

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -351,7 +351,11 @@ void AttemptNominate(int client, const char[] map, int size)
 	char name[MAX_NAME_LENGTH];
 	GetClientName(client, name, sizeof(name));
 
-	ReplyToCommand(client, "[SM] %t", "Map Nominated", name, displayName);
+	if (result == Nominate_Added) {
+		PrintToChatAll("[SM] %t", "Map Nominated", name, displayName);
+	} else {
+		ReplyToCommand(client, "[SM] %t", "Map Nominated", name, displayName);
+	}
 	
 	return;
 }


### PR DESCRIPTION
Using the nominate command it is possible to spam global chat by alternating between two maps e.g.
`bind mwheeldown "sm_nominate de_dust2;sm_nominate de_mirage;"`
By replying to successful nominations instead of putting in global this issue is prevented as clients can only spam themselves.