### PR TITLE
Change unnecessary int[]'s to any[]

### DIFF
--- a/plugins/include/entity.inc
+++ b/plugins/include/entity.inc
@@ -715,7 +715,7 @@ native int GetEntPropArraySize(int entity, PropType type, const char[] prop);
  * @param dataSize      Size of each value in bytes (1, 2, or 4).
  * @error               Invalid entity or offset out of reasonable bounds.
  */
-stock void GetEntDataArray(int entity, int offset, int[] array, int arraySize, int dataSize=4)
+stock void GetEntDataArray(int entity, int offset, any[] array, int arraySize, int dataSize=4)
 {
 	for (int i = 0; i < arraySize; i++)
 	{
@@ -734,7 +734,7 @@ stock void GetEntDataArray(int entity, int offset, int[] array, int arraySize, i
  * @param changeState   True to set the network state as changed; false otherwise.
  * @error               Invalid entity or offset out of reasonable bounds.
  */
-stock void SetEntDataArray(int entity, int offset, const int[] array, int arraySize, int dataSize=4, bool changeState=false)
+stock void SetEntDataArray(int entity, int offset, const any[] array, int arraySize, int dataSize=4, bool changeState=false)
 {
 	for (int i = 0; i < arraySize; i++)
 	{

--- a/plugins/include/files.inc
+++ b/plugins/include/files.inc
@@ -126,7 +126,7 @@ methodmap File < Handle
 	// @param size            Size of each element, in bytes, to be read.
 	//                        Valid sizes are 1, 2, or 4.
 	// @return                Number of elements read, or -1 on error.
-	public native int Read(int[] items, int num_items, int size);
+	public native int Read(any[] items, int num_items, int size);
 
 	// Reads a UTF8 or ANSI string from a file.
 	//
@@ -152,7 +152,7 @@ methodmap File < Handle
 	// @param size            Size of each item in the array in bytes.
 	//                        Valid sizes are 1, 2, or 4.
 	// @return                True on success, false on error.
-	public native bool Write(const int[] items, int num_items, int size);
+	public native bool Write(const any[] items, int num_items, int size);
 
 	// Writes a binary string to a file.
 	//
@@ -361,7 +361,7 @@ native bool ReadFileLine(Handle hndl, char[] buffer, int maxlength);
  *                      Valid sizes are 1, 2, or 4.
  * @return              Number of elements read, or -1 on error.
  */
-native int ReadFile(Handle hndl, int[] items, int num_items, int size);
+native int ReadFile(Handle hndl, any[] items, int num_items, int size);
 
 /**
  * Reads a UTF8 or ANSI string from a file.
@@ -394,7 +394,7 @@ native int ReadFileString(Handle hndl, char[] buffer, int max_size, int read_cou
  * @return              True on success, false on error.
  * @error               Invalid Handle.
  */
-native bool WriteFile(Handle hndl, const int[] items, int num_items, int size);
+native bool WriteFile(Handle hndl, const any[] items, int num_items, int size);
 
 /**
  * Writes a binary string to a file.


### PR DESCRIPTION
Nothing should stop you from using eg. a float array on these natives.

It gets kinda annoying to use `view_as<int>()`
