### PR TITLE
Make GetStringTableData native binary-safe

### DIFF
--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -202,8 +202,8 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	char *addr;
 	pContext->LocalToString(params[3], &addr);
 
-	size_t maxBytes = params[4];
-	size_t numBytes = MIN(datalen, maxBytes);
+	int maxBytes = params[4];
+	size_t numBytes = MIN(maxBytes, datalen);
 
 	if (userdata)
 	{

--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -212,7 +212,6 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	else if (datalen > 0)
 	{
 		addr[0] = '\0';
-		datalen = 1;
 	}
 
 	return datalen;

--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -199,18 +199,20 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	}
 
 	userdata = (const char *)pTable->GetStringUserData(stringidx, &datalen);
-	if (!userdata)
-	{
-		userdata = "";
-		numBytes = 1;
-	}
-
-	size_t maxBytes = params[4];
 
 	char *addr;
 	pContext->LocalToString(params[3], &addr);
 
-	memcpy(addr, userdata, MIN(numBytes, maxBytes));
+	size_t maxBytes = params[4];
+
+	if (userdata)
+	{
+		memcpy(addr, userdata, MIN(numBytes, maxBytes));
+	}
+	else if (maxBytes > 0)
+	{
+		addr[0] = '\0';
+	}
 
 	return numBytes;
 }

--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -185,7 +185,7 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	int stringidx;
 	const char *userdata;
 	int datalen;
-	size_t numBytes;
+	size_t datalen = 0;
 
 	if (!pTable)
 	{
@@ -203,18 +203,19 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	char *addr;
 	pContext->LocalToString(params[3], &addr);
 
-	size_t maxBytes = params[4];
+	size_t datalen = params[4];
 
 	if (userdata)
 	{
-		memcpy(addr, userdata, MIN(numBytes, maxBytes));
+		memcpy(addr, userdata, datalen);
 	}
-	else if (maxBytes > 0)
+	else if (datalen > 0)
 	{
 		addr[0] = '\0';
+		datalen = 1;
 	}
 
-	return numBytes;
+	return datalen;
 }
 
 static cell_t SetStringTableData(IPluginContext *pContext, const cell_t *params)

--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -202,9 +202,15 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	if (!userdata)
 	{
 		userdata = "";
+		numBytes = 1;
 	}
 
-	pContext->StringToLocalUTF8(params[3], params[4], userdata, &numBytes);
+	size_t maxBytes = params[4];
+
+	char *addr;
+	pContext->LocalToString(params[3], &addr);
+
+	memcpy(addr, userdata, MIN(numBytes, maxBytes));
 
 	return numBytes;
 }

--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -203,7 +203,7 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	char *addr;
 	pContext->LocalToString(params[3], &addr);
 
-	size_t datalen = params[4];
+	datalen = params[4];
 
 	if (userdata)
 	{

--- a/extensions/sdktools/vstringtable.cpp
+++ b/extensions/sdktools/vstringtable.cpp
@@ -184,8 +184,7 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	INetworkStringTable *pTable = netstringtables->GetTable(idx);
 	int stringidx;
 	const char *userdata;
-	int datalen;
-	size_t datalen = 0;
+	int datalen = 0;
 
 	if (!pTable)
 	{
@@ -203,18 +202,20 @@ static cell_t GetStringTableData(IPluginContext *pContext, const cell_t *params)
 	char *addr;
 	pContext->LocalToString(params[3], &addr);
 
-	datalen = params[4];
+	size_t maxBytes = params[4];
+	size_t numBytes = MIN(datalen, maxBytes);
 
 	if (userdata)
 	{
-		memcpy(addr, userdata, datalen);
+		memcpy(addr, userdata, numBytes);
 	}
-	else if (datalen > 0)
+	else if (maxBytes > 0)
 	{
 		addr[0] = '\0';
+		numBytes = 0;
 	}
 
-	return datalen;
+	return numBytes;
 }
 
 static cell_t SetStringTableData(IPluginContext *pContext, const cell_t *params)

--- a/plugins/include/sdktools_stringtables.inc
+++ b/plugins/include/sdktools_stringtables.inc
@@ -133,10 +133,9 @@ native int GetStringTableData(int tableidx, int stringidx, char[] userdata, int 
  * @param stringidx     A string index.
  * @param userdata      User data string that will be set.
  * @param length        Length of user data string. This should include the null terminator.
- * @return              Returns 1 on success.
  * @error               Invalid string table index or string index.
  */
-native int SetStringTableData(int tableidx, int stringidx, const char[] userdata, int length);
+native void SetStringTableData(int tableidx, int stringidx, const char[] userdata, int length);
 
 /**
  * Adds a string to a given string table.

--- a/plugins/include/sdktools_stringtables.inc
+++ b/plugins/include/sdktools_stringtables.inc
@@ -119,7 +119,7 @@ native int GetStringTableDataLength(int tableidx, int stringidx);
  *
  * @param tableidx      A string table index.
  * @param stringidx     A string index.
- * @param userdata      Buffer to store the user data. userdata[0] will be set to null terminator if there is no user data.
+ * @param userdata      Buffer to store the user data. This will be set to "" if there is no user data
  * @param maxlength     Maximum length of string buffer.
  * @return              Number of bytes written to the buffer (binary safe, includes the null terminator).
  * @error               Invalid string table index or string index.

--- a/plugins/include/sdktools_stringtables.inc
+++ b/plugins/include/sdktools_stringtables.inc
@@ -119,9 +119,9 @@ native int GetStringTableDataLength(int tableidx, int stringidx);
  *
  * @param tableidx      A string table index.
  * @param stringidx     A string index.
- * @param userdata      Buffer to store the user data. This will be set to "" if there is no user data.
+ * @param userdata      Buffer to store the user data. userdata[0] will be set to null terminator if there is no user data.
  * @param maxlength     Maximum length of string buffer.
- * @return              Number of bytes written to the buffer (UTF-8 safe).
+ * @return              Number of bytes written to the buffer (binary safe, includes the null terminator).
  * @error               Invalid string table index or string index.
  */
 native int GetStringTableData(int tableidx, int stringidx, char[] userdata, int maxlength);
@@ -133,7 +133,7 @@ native int GetStringTableData(int tableidx, int stringidx, char[] userdata, int 
  * @param stringidx     A string index.
  * @param userdata      User data string that will be set.
  * @param length        Length of user data string. This should include the null terminator.
- * @return              Number of bytes written to the buffer (UTF-8 safe).
+ * @return              Returns 1 on success.
  * @error               Invalid string table index or string index.
  */
 native int SetStringTableData(int tableidx, int stringidx, const char[] userdata, int length);


### PR DESCRIPTION
Replaced StringToLocalUTF8 with LocalToString and memcpy to make this binary-safe. Discussed this with @asherkin on Discord.

This probably won't hurt as it looks like the function was originally intended to be binary safe.

resolves #1230 