### PR TITLE
Fix crash when ArrayList runs out of memory #1233

### DIFF
--- a/core/logic/CellArray.h
+++ b/core/logic/CellArray.h
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ICellArray.h>
+#include <amtl/am-bits.h>
 
 extern HandleType_t htCellArray;
 
@@ -220,19 +221,21 @@ private:
 		{
 			newAllocSize = 8;
 		}
+		if (!ke::IsUintPtrAddSafe(m_Size, count))
+		{
+			return false;
+		}
 		/* If it's not enough, keep doubling */
 		while (m_Size + count > newAllocSize)
 		{
+			if (!ke::IsUintPtrMultiplySafe(newAllocSize, 2))
+			{
+				return false;
+			}
 			newAllocSize *= 2;
 		}
 		/* finally, allocate the new block */
-		cell_t *data = nullptr;
-		if (m_Data)
-		{
-			data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * newAllocSize));
-		} else {
-			data = static_cast<cell_t*>(malloc(sizeof(cell_t) * m_BlockSize * newAllocSize));
-		}
+		cell_t *data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * newAllocSize));
 		/* Update state if allocation was successful */
 		if (data)
 		{

--- a/core/logic/CellArray.h
+++ b/core/logic/CellArray.h
@@ -214,30 +214,32 @@ private:
 		{
 			return true;
 		}
+		size_t newAllocSize = m_AllocSize;
 		/* Set a base allocation size of 8 items */
-		if (!m_AllocSize)
+		if (!newAllocSize)
 		{
-			m_AllocSize = 8;
+			newAllocSize = 8;
 		}
 		/* If it's not enough, keep doubling */
-		while (m_Size + count > m_AllocSize)
+		while (m_Size + count > newAllocSize)
 		{
-			m_AllocSize *= 2;
+			newAllocSize *= 2;
 		}
 		/* finally, allocate the new block */
+		cell_t *data = nullptr;
 		if (m_Data)
 		{
-			cell_t *data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * m_AllocSize));
-			if (!data)  // allocation failure
-			{
-				return false;
-			}
-
-			m_Data = data;
+			data = static_cast<cell_t*>(realloc(m_Data, sizeof(cell_t) * m_BlockSize * newAllocSize));
 		} else {
-			m_Data = static_cast<cell_t*>(malloc(sizeof(cell_t) * m_BlockSize * m_AllocSize));
+			data = static_cast<cell_t*>(malloc(sizeof(cell_t) * m_BlockSize * newAllocSize));
 		}
-		return (m_Data != nullptr);
+		/* Update state if allocation was successful */
+		if (data)
+		{
+			m_AllocSize = newAllocSize;
+			m_Data = data;
+		}
+		return (data != nullptr);
 	}
 private:
 	cell_t *m_Data;


### PR DESCRIPTION
The allocation size was still updated to the bigger size even if memory allocation failed. Trying to write to the supposedly available new space would overflow the heap and crash.