### PR TITLE
Always use hl2sdk-proxy-repo in checkout-deps

### DIFF
--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -56,13 +56,13 @@ Function Checkout-Repo
         Set-Location $Name
         If ($Origin)
         {
-            & git remote set-url origin ..\$Repo
+            & git remote set-url origin ..\$Repo 2>&1 | Write-Host
         }
         & git checkout $Branch 2>&1 | Write-Host
         & git pull origin $Branch 2>&1 | Write-Host
         If ($Origin)
         {
-            & git remote set-url origin $Origin
+            & git remote set-url origin $Origin 2>&1 | Write-Host
         }
         Set-Location ..
     }

--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -81,7 +81,7 @@ else
 }
 
 $SDKS | % {
-    Checkout-Repo -Name "hl2sdk-$_" -Branch $_ "hl2sdk-proxy-repo" -Repo "https://github.com/alliedmodders/hl2sdk.git"
+    Checkout-Repo -Name "hl2sdk-$_" -Branch $_ -Repo "hl2sdk-proxy-repo"
 }
 
 Checkout-Repo -Name "ambuild" -Branch "master" -Repo "https://github.com/alliedmodders/ambuild.git"

--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -47,16 +47,23 @@ Function Checkout-Repo
         If ($Origin)
         {
             Set-Location $Name
-            & git  remote rm origin 2>&1 | Write-Host
-            & git remote add origin $Origin 2>&1 | Write-Host
+            & git remote set-url origin $Origin 2>&1 | Write-Host
             Set-Location ..
         }
     }
     Else
     {
         Set-Location $Name
+        If ($Origin)
+        {
+            & git remote set-url origin ..\$Repo
+        }
         & git checkout $Branch 2>&1 | Write-Host
         & git pull origin $Branch 2>&1 | Write-Host
+        If ($Origin)
+        {
+            & git remote set-url origin $Origin
+        }
         Set-Location ..
     }
 }
@@ -81,7 +88,7 @@ else
 }
 
 $SDKS | % {
-    Checkout-Repo -Name "hl2sdk-$_" -Branch $_ -Repo "hl2sdk-proxy-repo"
+    Checkout-Repo -Name "hl2sdk-$_" -Branch $_ -Repo "hl2sdk-proxy-repo" "https://github.com/alliedmodders/hl2sdk.git"
 }
 
 Checkout-Repo -Name "ambuild" -Branch "master" -Repo "https://github.com/alliedmodders/ambuild.git"

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -116,7 +116,7 @@ fi
 for sdk in "${sdks[@]}"
 do
   repo=hl2sdk-proxy-repo
-  origin="https://github.com/alliedmodders/hl2sdk"
+  origin=
   name=hl2sdk-$sdk
   branch=$sdk
   checkout

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -74,14 +74,19 @@ checkout ()
     git clone $repo -b $branch $name
     if [ -n "$origin" ]; then
       cd $name
-      git remote rm origin
-      git remote add origin $origin
+      git remote set-url origin $origin
       cd ..
     fi
   else
     cd $name
+    if [ -n "$origin" ]; then
+      git remote set-url origin ../$repo
+    fi
     git checkout $branch
     git pull origin $branch
+    if [ -n "$origin" ]; then
+      git remote set-url origin $origin
+    fi
     cd ..
   fi
 }
@@ -116,7 +121,7 @@ fi
 for sdk in "${sdks[@]}"
 do
   repo=hl2sdk-proxy-repo
-  origin=
+  origin="https://github.com/alliedmodders/hl2sdk"
   name=hl2sdk-$sdk
   branch=$sdk
   checkout


### PR DESCRIPTION
There were two separate issues with the checkout-deps scripts on windows and linux.

Windows didn't use the hl2sdk repository mirror "hl2sdk-proxy-repo" when cloning the different engine branches into their own folders like `hl2sdk-csgo`, `hl2sdk-css`, ... but cloned from github.com every time. When rerunning the checkout-deps.ps1 script later it would fail to find the "hl2sdk-proxy-repo" folder and fail to update the sdks.

Linux did use the local mirror repository for the initial clone of the different game sdk branches, but used github.com for later updates of the game sdks instead of using the local mirror.

Fix both scripts to always use the local mirror.

Looks like the AppVeyor config has to be updated too if it doesn't use the checkout-deps.ps1 script. #969 