### PR TITLE
CStrike Ext: Add native to retrieve loadout slot of weapon

### DIFF
--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -947,6 +947,21 @@ static cell_t CS_WeaponIDToItemDefIndex(IPluginContext *pContext, const cell_t *
 #endif
 }
 
+static cell_t CS_WeaponIDToLoadoutSlot(IPluginContext *pContext, const cell_t *params)
+{
+#if SOURCE_ENGINE == SE_CSGO
+	WeaponIDMap::Result res = g_mapWeaponIDToDefIdx.find((SMCSWeapon)params[1]);
+
+	if (!res.found())
+		return  pContext->ThrowNativeError("Invalid weapon id passed.");
+
+	return res->value.m_iLoadoutSlot;
+#else
+	return pContext->ThrowNativeError("CS_WeaponIDToLoadoutSlot is not supported on this game");
+#endif
+}
+
+
 sp_nativeinfo_t g_CSNatives[] = 
 {
 	{"CS_RespawnPlayer",			CS_RespawnPlayer}, 
@@ -971,6 +986,7 @@ sp_nativeinfo_t g_CSNatives[] =
 	{"CS_IsValidWeaponID",			CS_IsValidWeaponID},
 	{"CS_ItemDefIndexToID",			CS_ItemDefIndexToID},
 	{"CS_WeaponIDToItemDefIndex",	CS_WeaponIDToItemDefIndex},
+	{"CS_WeaponIDToLoadoutSlot",	CS_WeaponIDToLoadoutSlot},
 	{NULL,							NULL}
 };
 

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -443,6 +443,16 @@ native CSWeaponID CS_ItemDefIndexToID(int iDefIndex);
 native int CS_WeaponIDToItemDefIndex(CSWeaponID id);
 
 /**
+ * Returns the loadout slot based on the CSWeaponID.
+ *
+ * @param id            CSWeaponID to get the loadout slot for.
+ * @return              Returns loadout slot value for the weapon id.
+ * @error               Invalid weapon id.
+ * 
+ */
+native int CS_WeaponIDToLoadoutSlot(CSWeaponID id);
+
+/**
  * Do not edit below this line!
  */
 public Extension __ext_cstrike = 
@@ -482,5 +492,6 @@ public void __ext_cstrike_SetNTVOptional()
 	MarkNativeAsOptional("CS_UpdateClientModel");
 	MarkNativeAsOptional("CS_ItemDefIndexToID");
 	MarkNativeAsOptional("CS_WeaponIDToItemDefIndex");
+	MarkNativeAsOptional("CS_WeaponIDToLoadoutSlot");
 }
 #endif

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -438,17 +438,16 @@ native CSWeaponID CS_ItemDefIndexToID(int iDefIndex);
  * @return              Returns item definition index value for the weapon id.
  * @error               Invalid weapon id.
  *
- * @note In most cases the item deinition index will be the id. Works for CS:GO ONLY.
+ * @note In most cases the item definition index will be the id. Works for CS:GO ONLY.
  */
 native int CS_WeaponIDToItemDefIndex(CSWeaponID id);
 
 /**
- * Returns the loadout slot based on the CSWeaponID.
+ * Returns the loadout slot based on the CSWeaponID. (CS:GO only)
  *
  * @param id            CSWeaponID to get the loadout slot for.
  * @return              Returns loadout slot value for the weapon id.
  * @error               Invalid weapon id.
- * 
  */
 native int CS_WeaponIDToLoadoutSlot(CSWeaponID id);
 


### PR DESCRIPTION
Some events, mainly the "dm_bonus_weapon_start" event, pass the loadout slot of the weapon that is now the bonus weapon, rather than an item index or a weapon id.

We are already creating a map of this in the cstrike extension, this native simply returns another member from that mapped value.

Let me know if I have missed anything, do I also need to update the .inc file in the tests folder?