### PR TITLE
Change int to any with Address Functions

### DIFF
--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -676,6 +676,7 @@ enum Address
  *
  * @param addr          Address to a memory location.
  * @param size          How many bytes should be read.
+ *                      If loading a floating-point value, use NumberType_Int32.
  * @return              The value that is stored at that address.
  */
 native any LoadFromAddress(Address addr, NumberType size);
@@ -686,6 +687,7 @@ native any LoadFromAddress(Address addr, NumberType size);
  * @param addr          Address to a memory location.
  * @param data          Value to store at the address.
  * @param size          How many bytes should be written.
+ *                      If storing a floating-point value, use NumberType_Int32.
  */
 native void StoreToAddress(Address addr, any data, NumberType size);
 

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -678,7 +678,7 @@ enum Address
  * @param size          How many bytes should be read.
  * @return              The value that is stored at that address.
  */
-native int LoadFromAddress(Address addr, NumberType size);
+native any LoadFromAddress(Address addr, NumberType size);
 
 /**
  * Store up to 4 bytes to a memory address.
@@ -687,7 +687,7 @@ native int LoadFromAddress(Address addr, NumberType size);
  * @param data          Value to store at the address.
  * @param size          How many bytes should be written.
  */
-native void StoreToAddress(Address addr, int data, NumberType size);
+native void StoreToAddress(Address addr, any data, NumberType size);
 
 methodmap FrameIterator < Handle {
 	// Creates a stack frame iterator to build your own stack traces.


### PR DESCRIPTION
Since getting from and storing to addresses gives no regard to the type you throw at it, it makes sense to change these to `any`.

Would help with having to do some obnoxious tagging at the moment:
```cs
// Before
public void OnPluginStart()
{
	Address foo;
	float bar = 12.0;
	StoreToAddress(foo, view_as< int >(bar), NumberType_Int32);
	g_flFooBar = view_as< float >(LoadFromAddress(foo, NumberType_Int32));
}
// After
public void OnPluginStart()
{
	Address foo;
	float bar = 12.0;
	StoreToAddress(foo, bar, NumberType_Int32);
	g_flFooBar = LoadFromAddress(foo, NumberType_Int32);
}
```