### PR TITLE
Fixed memory leak

### DIFF
--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -65,12 +65,13 @@ CDataPack::Free(CDataPack *pack)
 
 void CDataPack::Initialize()
 {
+	position = 0;
+	
 	do
 	{
 	} while (this->RemoveItem());
 
 	elements.clear();
-	position = 0;
 }
 
 void CDataPack::ResetSize()
@@ -214,6 +215,7 @@ bool CDataPack::RemoveItem(size_t pos)
 	{
 		pos = position;
 	}
+	
 	if (pos >= elements.length())
 	{
 		return false;

--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -230,7 +230,7 @@ bool CDataPack::RemoveItem(size_t pos)
 	{
 		case CDataPackType::Raw:
 		{
-			delete elements[pos].pData.vval;
+			delete [] elements[pos].pData.vval;
 			break;
 		}
 


### PR DESCRIPTION
When a pack was cleared or destroyed the String and Raw types could cause memory leaks. This happens when "position" is sitting at the end of the vector and can never get past the "if (pos >= elements.length())" statement. This means there is a memory leak in any plugin that clears/destroys a pack with strings and doesn't set the position to length-1 or less beforehand.