### PR TITLE
Fix matching Regex against an empty string

### DIFF
--- a/extensions/regex/extension.cpp
+++ b/extensions/regex/extension.cpp
@@ -134,12 +134,6 @@ static cell_t MatchRegex(IPluginContext *pCtx, const cell_t *params)
 	char *str;
 	pCtx->LocalToString(params[2], &str);
 
-	size_t len = strlen(str);
-	if (offset >= len)
-	{
-		return pCtx->ThrowNativeError("Offset greater or equal than string length\n");
-	}
-
 	int e = x->Match(str, offset);
 	if (e == -1)
 	{


### PR DESCRIPTION
Matching a Regex against an empty string throws an exception:
```sourcepawn
Regex regex = new Regex(".*");

int matches = regex.Match("");
```
Which is caused by this check:
```cpp
	size_t len = strlen(str);
	if (offset >= len)
	{
		return pCtx->ThrowNativeError("Offset greater or equal than string length\n");
	}
```
Because `offset` and `len` are both 0.

However, this check is redundant, because `pcre_exec()` already returns `PCRE_ERROR_BADOFFSET` if the offset is negative or greater than the passed length, and [RegexError](https://sourcemod.dev/#/regex/enumeration.RegexError) already supports this.