### PR TITLE
Fix unnecessary ConCommand cache misses

### DIFF
--- a/core/concmd_cleaner.cpp
+++ b/core/concmd_cleaner.cpp
@@ -108,20 +108,20 @@ public:
 			listener = listener->next;
 		}
 
-        while (iter != tracked_bases.end())
-        {
-            if ((*iter)->pBase == pBase)
-            {
-                pInfo = (*iter);
-                iter = tracked_bases.erase(iter);
-                pInfo->cls->OnUnlinkConCommandBase(pBase, pBase->GetName());
-                delete pInfo;
-            }
-            else
-            {
-                iter++;
-            }
-        }
+		while (iter != tracked_bases.end())
+		{
+		    if ((*iter)->pBase == pBase)
+		    {
+			pInfo = (*iter);
+			iter = tracked_bases.erase(iter);
+			pInfo->cls->OnUnlinkConCommandBase(pBase, pBase->GetName());
+			delete pInfo;
+		    }
+		    else
+		    {
+			iter++;
+		    }
+		}
 	}
 
 	void AddTarget(ConCommandBase *pBase, IConCommandTracker *cls)

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -182,11 +182,19 @@ private:
 	{
 		static inline bool matches(const char *name, ConCommandBase *base)
 		{
-			return strcmp(name, base->GetName()) == 0;
+			const char *conCommandChars = base->GetName();
+			
+			ke::AString conCommandName = ke::AString(conCommandChars).lowercase();
+			ke::AString input = ke::AString(name).lowercase();
+			
+			return conCommandName == input;
 		}
 		static inline uint32_t hash(const detail::CharsAndLength &key)
 		{
-			return key.hash();
+			ke::AString original(key.chars());
+			ke::AString lower = original.lowercase();
+			
+			return detail::CharsAndLength(lower.chars()).hash();
 		}
 	};
 	NameHashSet<ConCommandBase *, ConCommandPolicy> m_CmdFlags;


### PR DESCRIPTION
Fixes a rare crash caused by GetCommandFlags() if there are some commands registered by plugins (Reg*Cmd()) which containing capitals. The same command ending up in the cache multiple times would explain the bug. (https://crash.limetech.org/stats/dc3d4e0530c48bb491d6b448c5a4d8a3)