### PR TITLE
Add new TF2 Holiday Soldier

### DIFF
--- a/extensions/tf2/holiday.cpp
+++ b/extensions/tf2/holiday.cpp
@@ -160,6 +160,7 @@ void HolidayManager::OnPluginLoaded(IPlugin *plugin)
 	PopulateHolidayVar(pRuntime, "TFHoliday_HalloweenOrFullMoon");
 	PopulateHolidayVar(pRuntime, "TFHoliday_HalloweenOrFullMoonOrValentines");
 	PopulateHolidayVar(pRuntime, "TFHoliday_AprilFools");
+	PopulateHolidayVar(pRuntime, "TFHoliday_Soldier");
 }
 
 void HolidayManager::OnPluginUnloaded(IPlugin *plugin)

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -165,6 +165,7 @@
 			"TFHoliday_HalloweenOrFullMoon"				"9"
 			"TFHoliday_HalloweenOrFullMoonOrValentines"	"10"
 			"TFHoliday_AprilFools"		"11"
+			"TFHoliday_Soldier"			"12"
 		}
 	}
 }

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -227,6 +227,7 @@ public const TFHoliday TFHoliday_FullMoon;
 public const TFHoliday TFHoliday_HalloweenOrFullMoon;
 public const TFHoliday TFHoliday_HalloweenOrFullMoonOrValentines;
 public const TFHoliday TFHoliday_AprilFools;
+public const TFHoliday TFHoliday_Soldier;
 
 enum TFObjectType
 {


### PR DESCRIPTION
TF2 2020-05-01 update added a new holiday, soldier for a tribute to Rick May.
Right at the bottom of the holiday list, and tested in TF2 windows.
![soldier](https://user-images.githubusercontent.com/33488710/80848187-52817980-8c0a-11ea-9812-a1e9577106f0.png)
