### PR TITLE
Fix GetDataDescMap not work on Day Of Infamy

### DIFF
--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -96,6 +96,7 @@
 			"engine"			"alienswarm"
 			"engine"			"blade"
 			"engine"			"insurgency"
+			"engine"			"doi"
 			"engine"			"csgo"
 			"engine"			"sdk2013"
 			"engine"			"contagion"


### PR DESCRIPTION
During the Split Day of Infamy to separate engine build #718 on 3 Nov 2017, it has been forgiven to add the engine doi on list. All funcs using datamap fails since like FindDataMapInfo etc