### PR TITLE
Notify on frame-delayed plugin reloads

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -2032,7 +2032,8 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 					//the unload/reload attempt next frame will print a message
 					case PluginState::WaitingToUnload:
 					case PluginState::WaitingToUnloadAndReload:
-						return;
+						rootmenu->ConsolePrint("[SM] Plugin %s will be reloaded on the next frame.", name);
+						break;
 
 					default:
 						rootmenu->ConsolePrint("[SM] Failed to reload plugin %s.", name);


### PR DESCRIPTION
Fixes #1289

Just like for `load` and `unload`, we should be notifying that the waiting plugin will be reloaded on the next frame.