### PR TITLE
Prevent multiple calls to SDK_OnAllLoaded

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -304,7 +304,7 @@ bool CExtension::Load(char *error, size_t maxlength)
 	/* Check if we're past load time */
 	if (!bridge->IsMapLoading())
 	{
-		m_pAPI->OnExtensionsAllLoaded();
+		MarkAllLoaded();
 	}
 
 	return true;


### PR DESCRIPTION
Fixes #1273 


We needed to set `m_bFullyLoaded` in order to prevent `CExtensionManager::MarkAllLoaded` from calling `MarkAllLoaded` twice.