### PR TITLE
Do not require quotes around message in sm_psay

### DIFF
--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -277,18 +277,17 @@ public Action Command_SmPsay(int client, int args)
 		return Plugin_Handled;	
 	}	
 	
-	char text[192], arg[64], message[192];
+	char text[192], arg[64];
 	GetCmdArgString(text, sizeof(text));
 
 	int len = BreakString(text, arg, sizeof(arg));
-	BreakString(text[len], message, sizeof(message));
 	
 	int target = FindTarget(client, arg, true, false);
 		
 	if (target == -1)
 		return Plugin_Handled;	
 	
-	SendPrivateChat(client, target, message);
+	SendPrivateChat(client, target, text[len]);
 	
 	return Plugin_Handled;	
 }


### PR DESCRIPTION
`sm_psay` is the only basechat command that requires quotes around a message with multiple words.