### PR TITLE
Update OnLibraryAdded and OnLibraryRemoved docs

### DIFF
--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -452,7 +452,7 @@ native void RegPluginLibrary(const char[] name);
  * Returns whether a library exists.  This function should be considered
  * expensive; it should only be called on plugin to determine availability
  * of resources.  Use OnLibraryAdded()/OnLibraryRemoved() to detect changes
- * in optional resources.
+ * in libraries.
  *
  * @param name          Library name of a plugin or extension.
  * @return              True if exists, false otherwise.
@@ -473,8 +473,8 @@ native bool LibraryExists(const char[] name);
 native int GetExtensionFileStatus(const char[] name, char[] error="", int maxlength=0);
 
 /**
- * Called after a library is added that the current plugin references
- * optionally. A library is either a plugin name or extension name, as
+ * Called after a library is added.
+ * A library is either a plugin name or extension name, as
  * exposed via its include file.
  *
  * @param name          Library name.
@@ -482,8 +482,8 @@ native int GetExtensionFileStatus(const char[] name, char[] error="", int maxlen
 forward void OnLibraryAdded(const char[] name);
 
 /**
- * Called right before a library is removed that the current plugin references
- * optionally.  A library is either a plugin name or extension name, as
+ * Called right before a library is removed.
+ * A library is either a plugin name or extension name, as
  * exposed via its include file.
  *
  * @param name          Library name.


### PR DESCRIPTION
`OnLibraryAdded` and `OnLibraryRemoved` are called whether or not an optional dependency exists