### PR TITLE
Properly document admin_levels.cfg regarding rcon

### DIFF
--- a/configs/admin_levels.cfg
+++ b/configs/admin_levels.cfg
@@ -23,7 +23,19 @@ Levels
 		"chat"			"j"			//Special chat privileges
 		"vote"			"k"			//Voting
 		"password"		"l"			//Password the server
-		"rcon"			"m"			//Remote console
+		
+		/*
+		 * Rcon allows executing commands as the server itself.
+		 * Rcon administrators can get the rcon password,
+		 * amybody who has the rcon password can control the server as if he is a rcon admin,
+		 * and also do this without being online in the server
+		 * This should only be given to trusted administrators.  
+		 * Since the server never obeys immunity, rcon users can target anyone regardless of immunity,
+		 * however, they themselves are not automatically immune.
+		 * Example: "sm_rcon sm_ban BAILOPAN" will ban BAILOPAN even if he has a higher immunity than me.
+		 */
+		"rcon"			"m"			
+		
 		"cheats"		"n"			//Change sv_cheats and related commands
 		
 		/**

--- a/configs/admin_levels.cfg
+++ b/configs/admin_levels.cfg
@@ -27,7 +27,7 @@ Levels
 		/*
 		 * Rcon allows executing commands as the server itself.
 		 * Rcon administrators can get the rcon password,
-		 * amybody who has the rcon password can control the server as if he is a rcon admin,
+		 * anybody who has the rcon password can control the server as if he is a rcon admin,
 		 * and also do this without being online in the server
 		 * This should only be given to trusted administrators.  
 		 * Since the server never obeys immunity, rcon users can target anyone regardless of immunity,

--- a/configs/admin_levels.cfg
+++ b/configs/admin_levels.cfg
@@ -26,7 +26,7 @@ Levels
 		
 		/*
 		 * Rcon allows executing commands as the server itself.
-		 * Admins wtih rcon can execute most commands restricted to their flags.
+		 * Admins wtih rcon can execute most commands restricted to their flags, even root.
 		 * This should only be given to trusted administrators.
 		 */
 		"rcon"			"m"			

--- a/configs/admin_levels.cfg
+++ b/configs/admin_levels.cfg
@@ -26,13 +26,8 @@ Levels
 		
 		/*
 		 * Rcon allows executing commands as the server itself.
-		 * Rcon administrators can get the rcon password,
-		 * anybody who has the rcon password can control the server as if they are rcon admin,
-		 * and also do this without being online in the server.
-		 * This should only be given to trusted administrators.  
-		 * Since the server never obeys immunity, rcon users can target anyone regardless of immunity,
-		 * however, they themselves are not automatically immune.
-		 * Example: "sm_rcon sm_ban BAILOPAN" will ban BAILOPAN even if he has a higher immunity than me.
+		 * Admins wtih rcon can execute most commands restricted to their flags.
+		 * This should only be given to trusted administrators.
 		 */
 		"rcon"			"m"			
 		

--- a/configs/admin_levels.cfg
+++ b/configs/admin_levels.cfg
@@ -27,8 +27,8 @@ Levels
 		/*
 		 * Rcon allows executing commands as the server itself.
 		 * Rcon administrators can get the rcon password,
-		 * anybody who has the rcon password can control the server as if he is a rcon admin,
-		 * and also do this without being online in the server
+		 * anybody who has the rcon password can control the server as if they are rcon admin,
+		 * and also do this without being online in the server.
 		 * This should only be given to trusted administrators.  
 		 * Since the server never obeys immunity, rcon users can target anyone regardless of immunity,
 		 * however, they themselves are not automatically immune.


### PR DESCRIPTION
Not enough server owners know what rcon does and "Remote console" is possibly the worst way to document root's brother.