### PR TITLE
Add x64 builds to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
         - SDKS=episode1,css,tf2,l4d2,csgo,dota
         - MODE=optimize
-        - ARCH=x86
+        - ARCH=x86,x64
 
     - os: linux
       dist: trusty
@@ -34,7 +34,7 @@ jobs:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - SDKS=episode1,css,tf2,l4d2,csgo,dota
         - MODE=optimize
-        - ARCH=x86
+        - ARCH=x86,x64
 
     - os: osx
       osx_image: xcode7.2
@@ -43,7 +43,7 @@ jobs:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - SDKS=episode1,css,tf2,l4d2,csgo,dota
         - MODE=optimize
-        - ARCH=x86_64,x86
+        - ARCH=x64,x86
 
     # # This is a faster test for the latest g++.
     # - os: linux


### PR DESCRIPTION
A recent regression in libpcre for x64 wasn't caught by our CI, to prevent regressions in x64 builds from slipping by we should probably be building both x86 and x64 for completeness-sake

~~Some builds will likely fail until #1320 lands and we rebase this~~