### PR TITLE
Remove cloning of Dota 2 SDK in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
           packages: ['clang-3.8', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib']
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
-        - SDKS=episode1,css,tf2,l4d2,csgo,dota
+        - SDKS=episode1,css,tf2,l4d2,csgo
         - MODE=optimize
         - ARCH=x86,x64
 
@@ -32,7 +32,7 @@ jobs:
           packages: ['clang-3.4', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib']
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
-        - SDKS=episode1,css,tf2,l4d2,csgo,dota
+        - SDKS=episode1,css,tf2,l4d2,csgo
         - MODE=optimize
         - ARCH=x86,x64
 
@@ -41,7 +41,7 @@ jobs:
       language: cpp
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
-        - SDKS=episode1,css,tf2,l4d2,csgo,dota
+        - SDKS=episode1,css,tf2,l4d2,csgo
         - MODE=optimize
         - ARCH=x64,x86
 
@@ -75,7 +75,7 @@ jobs:
         - ARCH=x86
 
 before_script:
-  - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh && cd $CHECKOUT_DIR
+  - CHECKOUT_DIR=$PWD && cd .. && $CHECKOUT_DIR/tools/checkout-deps.sh -s ${SDKS} && cd $CHECKOUT_DIR
 script:
   - mkdir build && cd build
   - PATH="~/.local/bin:$PATH"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ install:
 - cmd: git submodule update --init --recursive
 - cmd: git pull --recurse-submodules
 - cmd: cd ..
-- ps: sourcemod/tools/checkout-deps.ps1 -SDKs episode1,css,tf2,l4d2,csgo,dota
+- ps: sourcemod/tools/checkout-deps.ps1 -SDKs episode1,css,tf2,l4d2,csgo
 - cmd: cd sourcemod
 build_script:
 - cmd: call "%VS140COMNTOOLS%/vsvars32.bat"
 - cmd: mkdir build
 - cmd: cd build
-- cmd: c:\python27\python.exe ../configure.py --enable-optimize --no-mysql --sdks=episode1,css,tf2,l4d2,csgo,dota
+- cmd: c:\python27\python.exe ../configure.py --enable-optimize --no-mysql --sdks=episode1,css,tf2,l4d2,csgo
 - cmd: ambuild

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -3,6 +3,17 @@
 
 trap "exit" INT
 
+# List of HL2SDK branch names to download.
+# ./checkout-deps.sh -s tf2,css
+while getopts ":s:" opt; do
+  case $opt in
+    s) IFS=', ' read -r -a sdks <<< "$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+
 ismac=0
 iswin=0
 
@@ -97,15 +108,17 @@ repo="https://github.com/alliedmodders/metamod-source"
 origin=
 checkout
 
-sdks=( csgo hl2dm nucleardawn l4d2 dods l4d css tf2 insurgency sdk2013 doi )
-
-if [ $ismac -eq 0 ]; then
-  # Add these SDKs for Windows or Linux
-  sdks+=( orangebox blade episode1 bms )
-
-  # Add more SDKs for Windows only
-  if [ $iswin -eq 1 ]; then
-    sdks+=( darkm swarm bgt eye contagion )
+if [ -z ${sdks+x} ]; then
+  sdks=( csgo hl2dm nucleardawn l4d2 dods l4d css tf2 insurgency sdk2013 doi )
+  
+  if [ $ismac -eq 0 ]; then
+    # Add these SDKs for Windows or Linux
+    sdks+=( orangebox blade episode1 bms )
+  
+    # Add more SDKs for Windows only
+    if [ $iswin -eq 1 ]; then
+      sdks+=( darkm swarm bgt eye contagion )
+    fi
   fi
 fi
 


### PR DESCRIPTION
SourceMod doesn't support Source 1 Dota 2 anymore #496 and neither Source 2. Speed up CI by only cloning the hl2sdks that are tested.

This adds a `-s sdk1,sdk2` parameter to the checkout-deps.sh script similar to the `-SDKs` option of the powershell script to select specific sdks to update instead of all.