### PR TITLE
Add offset-reading capability for networked CUtlVector instances

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -340,7 +340,7 @@ bool UTIL_FindInSendTable(SendTable *pTable,
 		if (pname && strcmp(name, pname) == 0)
 		{
 			// get true offset of CUtlVector
-			if (prop->GetOffset() == 0 && pInnerTable && pInnerTable->GetNumProps() && strstr(pInnerTable->GetProp(0)->GetName(), "lengthproxy") != nullptr)
+			if (prop->GetOffset() == 0 && pInnerTable && pInnerTable->GetNumProps() && strncmp(pInnerTable->GetProp(0)->GetName(), "lengthproxy", 11) == 0)
 			{
 				SendProp *pLengthProxy = pInnerTable->GetProp(0);
 				HACK_CSendPropExtra_UtlVector *pExtra = (HACK_CSendPropExtra_UtlVector*) pLengthProxy->GetExtraData();

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -340,7 +340,7 @@ bool UTIL_FindInSendTable(SendTable *pTable,
 		if (pname && strcmp(name, pname) == 0)
 		{
 			// get true offset of CUtlVector
-			if (prop->GetOffset() == 0 && pInnerTable && pInnerTable->GetNumProps() && strncmp(pInnerTable->GetProp(0)->GetName(), "lengthproxy", 11) == 0)
+			if (prop->GetOffset() == 0 && pInnerTable && pInnerTable->GetNumProps() && strcmp(pInnerTable->GetProp(0)->GetName(), "lengthproxy") == 0)
 			{
 				SendProp *pLengthProxy = pInnerTable->GetProp(0);
 				HACK_CSendPropExtra_UtlVector *pExtra = (HACK_CSendPropExtra_UtlVector*) pLengthProxy->GetExtraData();

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -335,10 +335,11 @@ bool UTIL_FindInSendTable(SendTable *pTable,
 			if (utlVecOffsetOffset != -1 && prop->GetOffset() == 0 && pInnerTable && pInnerTable->GetNumProps())
 			{
 				SendProp *pLengthProxy = pInnerTable->GetProp(0);
-				if (pLengthProxy->GetName() && strcmp(pLengthProxy->GetName(), "lengthproxy") == 0 && pLengthProxy->GetExtraData())
+				const char *ipname = pLengthProxy->GetName();
+				if (ipname && strcmp(ipname, "lengthproxy") == 0 && pLengthProxy->GetExtraData())
 				{
 					info->prop = prop;
-					info->actual_offset = offset + *(size_t*) ((intptr_t) pLengthProxy->GetExtraData() + utlVecOffsetOffset);
+					info->actual_offset = offset + *reinterpret_cast<size_t *>(reinterpret_cast<intptr_t>(pLengthProxy->GetExtraData()) + utlVecOffsetOffset);
 					return true;
 				}
 			}

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -145,7 +145,7 @@ void CHalfLife2::OnSourceModAllInitialized_Post()
 	m_CSGOBadList.add("m_nActiveCoinRank");
 	m_CSGOBadList.add("m_nMusicID");
 #endif
-	g_pGameConf->GetOffset("SendPropExtraVecOffset", &utlVecOffsetOffset);
+	g_pGameConf->GetOffset("CSendPropExtra_UtlVector::m_Offset", &utlVecOffsetOffset);
 }
 
 ConfigResult CHalfLife2::OnSourceModConfigChanged(const char *key, const char *value,

--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -20,6 +20,11 @@
 				"class"			"CBasePlayer"
 				"prop"			"m_lifeState"
 			}
+			"CSendPropExtra_UtlVector::m_Offset"
+			{
+				"windows"		"16"
+				"linux"			"16"
+			}
 		}
 	}
 	


### PR DESCRIPTION
This was initially discussed in the SourceMod Discord; PR provides a way to get the actual offset of networked class members of type `CUtlVector` such as `CBaseFlex::m_AnimOverlay` and `CTFPlayer::m_hMyWearables`.

Tested working in TF2 with the following snippet:
```
public void OnPluginStart() {
	int offs = FindSendPropInfo("CTFPlayer", "m_hMyWearables");
	PrintToServer("CTFPlayer::m_hMyWearables = %04x", offs);
	
	offs = FindSendPropInfo("CTFPlayer", "m_ConditionData");
	PrintToServer("CTFPlayer::m_ConditionData = %04x", offs);
}
```

Not pull-ready yet; need recommendations on code style and how to deal with the `CSendPropExtra_UtlVector` gutted from `public/dt_utlvector_send.cpp`.

Heuristic per following message (the `lengthproxy` also holds the extradata, so I opted to use the parent table instead):
> [4:19 PM] asherkin: telling that a prop is an encoded utlvector seems like the hardest part, and it looks like a simple heuristic would be that it's a table with an offset of 0, and the first child entry's name starts with `lengthprop`