### PR TITLE
Add native IsLateLoadTime

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include "common_logic.h"
 #include "Logger.h"
+#include "PluginSys.h"
 
 #include <ISourceMod.h>
 #include <ITranslator.h>
@@ -302,6 +303,11 @@ static cell_t GetPluginFilename(IPluginContext *pContext, const cell_t *params)
 	pContext->StringToLocalUTF8(params[2], params[3], pPlugin->GetFilename(), NULL);
 
 	return 1;
+}
+
+static cell_t IsLateLoadTime(IPluginContext *pContext, const cell_t *params)
+{
+	return g_PluginSys.IsLateLoadTime() ? 1 : 0;
 }
 
 static cell_t IsPluginDebugging(IPluginContext *pContext, const cell_t *params)
@@ -956,6 +962,7 @@ REGISTER_NATIVES(coreNatives)
 	{"ReadPlugin",				ReadPlugin},
 	{"GetPluginStatus",			GetPluginStatus},
 	{"GetPluginFilename",		GetPluginFilename},
+	{"IsLateLoadTime",			IsLateLoadTime},
 	{"IsPluginDebugging",		IsPluginDebugging},
 	{"GetPluginInfo",			GetPluginInfo},
 	{"SetFailState",			SetFailState},

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -281,6 +281,13 @@ native PluginStatus GetPluginStatus(Handle plugin);
 native void GetPluginFilename(Handle plugin, char[] buffer, int maxlength);
 
 /**
+ * Retrieves whether or not the plugin is loaded "late" (after map load).
+ *
+ * @return              True if loaded "late", false otherwise.
+ */
+native bool IsLateLoadTime();
+
+/**
  * Retrieves whether or not a plugin is being debugged.
  *
  * @param plugin        Plugin Handle (INVALID_HANDLE uses the calling plugin).


### PR DESCRIPTION
Adding this to reduce the amount of code required in a plugin to perform an action if the plugin was loaded late as this can be a general problem for handling a plugin when it is reloaded.
This saves having to store the late load state your self from the `AskPluginLoad2` forward.

Currently:
```sourcepawn
bool g_bLateLoaded = false;

public APLRes AskPluginLoad2(Handle plugin, bool late, char[] error, int err_max)
{
    g_bLateLoaded = late;
}

public void OnPluginStart()
{
    if (g_bLateLoaded)
    {
        // Do stuff on late load
    }
}
```

After this addition:
```sourcepawn
public void OnPluginStart()
{
    if (IsLateLoadTime())
    {
        // Do stuff on late load
    }
}
```