### PR TITLE
Update to AMBuild 2.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ obj-*/
 *.smx
 *.swp
 *.gdb_history
+objdir

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
         - SDKS=episode1,css,tf2,l4d2,csgo
         - MODE=optimize
-        - ARCH=x86,x64
+        - ARCH=x86,x86_64
 
     - os: linux
       dist: trusty
@@ -34,7 +34,7 @@ jobs:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - SDKS=episode1,css,tf2,l4d2,csgo
         - MODE=optimize
-        - ARCH=x86,x64
+        - ARCH=x86,x86_64
 
     - os: osx
       osx_image: xcode7.2
@@ -43,7 +43,7 @@ jobs:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - SDKS=episode1,css,tf2,l4d2,csgo
         - MODE=optimize
-        - ARCH=x64,x86
+        - ARCH=x86_64,x86
 
     # # This is a faster test for the latest g++.
     # - os: linux
@@ -82,5 +82,5 @@ script:
   - eval "${MATRIX_EVAL}"
   - eval "${CC} --version"
   - eval "${CXX} --version"
-  - python ../configure.py --enable-${MODE} --sdks=${SDKS} --target-arch=${ARCH}
+  - python ../configure.py --enable-${MODE} --sdks=${SDKS} --targets=${ARCH}
   - ambuild

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -1,5 +1,6 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os, sys
+import traceback
 
 class SDK(object):
   def __init__(self, sdk, ext, aDef, name, platform, dir):
@@ -19,20 +20,20 @@ class SDK(object):
     else:
       self.platformSpec = platform
 
-  def shouldBuild(self, target, archs):
-    if target.platform not in self.platformSpec:
-      return False
-    if not len([i for i in self.platformSpec[target.platform] if i in archs]):
-      return False
-    return True
+  def shouldBuild(self, targets):
+    for cxx in targets:
+      if cxx.target.platform in self.platformSpec:
+        if cxx.target.arch in self.platformSpec[cxx.target.platform]:
+          return True
+    return False
 
 WinOnly = ['windows']
 WinLinux = ['windows', 'linux']
 WinLinuxMac = ['windows', 'linux', 'mac']
 CSGO = {
   'windows': ['x86'],
-  'linux': ['x86', 'x64'],
-  'mac': ['x64']
+  'linux': ['x86', 'x86_64'],
+  'mac': ['x86_64']
 }
 
 PossibleSDKs = {
@@ -80,34 +81,19 @@ def ResolveEnvPath(env, folder):
 def Normalize(path):
   return os.path.abspath(os.path.normpath(path))
   
-def SetArchFlags(compiler, arch, platform):
+def SetArchFlags(compiler):
   if compiler.behavior == 'gcc':
-    if arch == 'x86':
-      compiler.cflags += ['-m32']
-      compiler.linkflags += ['-m32']
-      if platform == 'mac':
-        compiler.linkflags += ['-arch', 'i386']
-    elif arch == 'x64':
-      compiler.cflags += ['-m64', '-fPIC']
-      compiler.linkflags += ['-m64']
-      if platform == 'mac':
-        compiler.linkflags += ['-arch', 'x86_64']
+    if compiler.target.arch == 'x86_64':
+      compiler.cflags += ['-fPIC']
   elif compiler.like('msvc'):
-    if builder.target.arch == 'x86':
-      compiler.linkflags += ['/MACHINE:X86']
-    elif builder.target.arch == 'x64':
-      compiler.linkflags += ['/MACHINE:X64']
-    if arch == 'x64':
+    if compiler.target.arch == 'x86_64':
       compiler.defines += ['WIN64']
-
-def AppendArchSuffix(binary, name, arch):
-  if arch == 'x64':
-    binary.localFolder = name + '.x64'
 
 class SMConfig(object):
   def __init__(self):
     self.sdks = {}
     self.binaries = []
+    self.spvm = []
     self.extensions = []
     self.generated_headers = None
     self.mms_root = None
@@ -116,7 +102,31 @@ class SMConfig(object):
     self.spcomp_bins = None
     self.smx_files = {}
     self.versionlib = None
-    self.archs = builder.target.arch.replace('x86_64', 'x64').split(',')
+    self.all_targets = []
+    self.target_archs = set()
+
+
+    if builder.options.targets:
+      target_archs = builder.options.targets.split(',')
+    else:
+      target_archs = ['x86']
+      if builder.backend != 'amb2':
+        target_archs.append('x86_64')
+
+    for arch in target_archs:
+        try:
+            cxx = builder.DetectCxx(target_arch = arch)
+            self.target_archs.add(cxx.target.arch)
+        except Exception as e:
+            # Error if archs were manually overridden.
+            if builder.options.targets:
+                raise
+            print('Skipping target {}: {}'.format(arch, e))
+            continue
+        self.all_targets.append(cxx)
+
+    if not self.all_targets:
+        raise Exception('No suitable C/C++ compiler was found.')
 
   def use_auto_versioning(self):
     if builder.backend != 'amb2':
@@ -149,9 +159,10 @@ class SMConfig(object):
     use_all = sdk_list[0] == 'all'
     use_present = sdk_list[0] == 'present'
 
+    not_found = []
     for sdk_name in PossibleSDKs:
       sdk = PossibleSDKs[sdk_name]
-      if sdk.shouldBuild(builder.target, self.archs):
+      if sdk.shouldBuild(self.all_targets):
         if builder.options.hl2sdk_root:
           sdk_path = os.path.join(builder.options.hl2sdk_root, sdk.folder)
         else:
@@ -159,6 +170,7 @@ class SMConfig(object):
         if sdk_path is None or not os.path.isdir(sdk_path):
           if use_all or sdk_name in sdk_list:
             raise Exception('Could not find a valid path for {0}'.format(sdk.envvar))
+          not_found.append(sdk_name)
           continue
         if use_all or use_present or sdk_name in sdk_list:
           sdk.path = Normalize(sdk_path)
@@ -167,6 +179,9 @@ class SMConfig(object):
     if len(self.sdks) < 1 and len(sdk_list) and not use_none:
       raise Exception('No SDKs were found that build on {0}-{1}, nothing to do.'.format(
         builder.target.platform, builder.target.arch))
+
+    for sdk in not_found:
+      print('Warning: hl2sdk-{} was not found, and will not be included in build.'.format(sdk))
 
     if builder.options.mms_path:
       self.mms_root = builder.options.mms_path
@@ -182,7 +197,7 @@ class SMConfig(object):
     self.mms_root = Normalize(self.mms_root)
 
     if builder.options.hasMySql:
-      if 'x86' in self.archs:
+      if 'x86' in self.target_archs:
         if builder.options.mysql_path:
           self.mysql_root['x86'] = builder.options.mysql_path
         else:
@@ -191,32 +206,31 @@ class SMConfig(object):
             if self.mysql_root['x86']:
               break
         if not self.mysql_root['x86'] or not os.path.isdir(self.mysql_root['x86']):
-          raise Exception('Could not find a path to MySQL!')
+          raise Exception('Could not find a path to MySQL. Configure with --no-mysql to disable it.')
         self.mysql_root['x86'] = Normalize(self.mysql_root['x86'])
 
-      if 'x64' in self.archs:
+      if 'x86_64' in self.target_archs:
         if builder.options.mysql64_path:
-          self.mysql_root['x64'] = builder.options.mysql64_path
+          self.mysql_root['x86_64'] = builder.options.mysql64_path
         else:
           for i in range(10):
-            self.mysql_root['x64'] = ResolveEnvPath('MYSQL55_64', 'mysql-5.' + str(i) + '-x86_64')
-            if self.mysql_root['x64']:
+            self.mysql_root['x86_64'] = ResolveEnvPath('MYSQL55_64', 'mysql-5.' + str(i) + '-x86_64')
+            if self.mysql_root['x86_64']:
               break
-        if not self.mysql_root['x64'] or not os.path.isdir(self.mysql_root['x64']):
+        if not self.mysql_root['x86_64'] or not os.path.isdir(self.mysql_root['x86_64']):
           raise Exception('Could not find a path to 64-bit MySQL!')
-        self.mysql_root['x64'] = Normalize(self.mysql_root['x64'])
+        self.mysql_root['x86_64'] = Normalize(self.mysql_root['x86_64'])
 
   def configure(self):
     builder.AddConfigureFile('pushbuild.txt')
     
-    if not set(self.archs).issubset(['x86', 'x64']):
+    if not set(self.target_archs).issubset(['x86', 'x86_64']):
       raise Exception('Unknown target architecture: {0}'.format(builder.target.arch))
 
-    cxx = builder.DetectCxx()
-    
-    if cxx.like('msvc') and len(self.archs) > 1:
-      raise Exception('Building multiple archs with MSVC is not currently supported')
+    for cxx in self.all_targets:
+        self.configure_cxx(cxx)
 
+  def configure_cxx(self, cxx):
     if cxx.family == 'msvc':
       if cxx.version < 1900:
         raise Exception('Only MSVC 2015 and later are supported, c++14 support is required.')
@@ -241,11 +255,11 @@ class SMConfig(object):
       cxx.defines += ['DEBUG', '_DEBUG']
 
     # Platform-specifics
-    if builder.target.platform == 'linux':
+    if cxx.target.platform == 'linux':
       self.configure_linux(cxx)
-    elif builder.target.platform == 'mac':
+    elif cxx.target.platform == 'mac':
       self.configure_mac(cxx)
-    elif builder.target.platform == 'windows':
+    elif cxx.target.platform == 'windows':
       self.configure_windows(cxx)
 
     # Finish up.
@@ -410,15 +424,15 @@ class SMConfig(object):
   def add_libamtl(self):
     # Add libamtl.
     self.libamtl = {}
-    for arch in self.archs:
-      def get_configure_fn(arch):
-        return lambda builder, name: self.StaticLibrary(builder, name, arch)
-      extra_vars = {'Configure': get_configure_fn(arch)}
+    for cxx in self.all_targets:
+      def get_configure_fn(cxx):
+        return lambda builder, name: self.StaticLibrary(builder, cxx, name)
+      extra_vars = {'Configure': get_configure_fn(cxx)}
       libamtl = builder.Build('public/amtl/amtl/AMBuilder', extra_vars)
-      self.libamtl[arch] = libamtl.binary
+      self.libamtl[cxx.target.arch] = libamtl.binary
 
-  def AddVersioning(self, binary, arch):
-    if builder.target.platform == 'windows':
+  def AddVersioning(self, binary):
+    if binary.compiler.target.platform == 'windows':
       binary.sources += ['version.rc']
       binary.compiler.rcdefines += [
         'BINARY_NAME="{0}"'.format(binary.outputFile),
@@ -426,29 +440,27 @@ class SMConfig(object):
       ]
       if self.use_auto_versioning():
         binary.compiler.rcdefines += ['SM_GENERATED_BUILD']
-    elif builder.target.platform == 'mac':
+    elif binary.compiler.target.platform == 'mac':
       if binary.type == 'library':
         binary.compiler.postlink += [
           '-compatibility_version', '1.0.0',
           '-current_version', self.productVersion
         ]
     if self.use_auto_versioning():
-      binary.compiler.linkflags += [self.versionlib[arch]]
+      binary.compiler.linkflags += [self.versionlib[binary.compiler.target.arch]]
       binary.compiler.sourcedeps += SM.generated_headers
     return binary
     
-  def LibraryBuilder(self, compiler, name, arch):
+  def LibraryBuilder(self, compiler, name):
     binary = compiler.Library(name)
-    AppendArchSuffix(binary, name, arch)
-    self.AddVersioning(binary, arch)
+    self.AddVersioning(binary)
     if binary.compiler.like('msvc'):
       binary.compiler.linkflags += ['/SUBSYSTEM:WINDOWS']
     return binary
 
-  def ProgramBuilder(self, compiler, name, arch):
+  def ProgramBuilder(self, compiler, name):
     binary = compiler.Program(name)
-    AppendArchSuffix(binary, name, arch)
-    self.AddVersioning(binary, arch)
+    self.AddVersioning(binary)
     if '-static-libgcc' in binary.compiler.linkflags:
       binary.compiler.linkflags.remove('-static-libgcc')
     if '-lgcc_eh' in binary.compiler.linkflags:
@@ -459,25 +471,23 @@ class SMConfig(object):
       binary.compiler.linkflags += ['/SUBSYSTEM:CONSOLE']
     return binary
     
-  def StaticLibraryBuilder(self, compiler, name, arch):
-    binary = compiler.StaticLibrary(name)
-    AppendArchSuffix(binary, name, arch)
-    return binary;
+  def StaticLibraryBuilder(self, compiler, name):
+    return compiler.StaticLibrary(name)
 
-  def Library(self, context, name, arch):
-    compiler = context.cxx.clone()
-    SetArchFlags(compiler, arch, builder.target.platform)
-    return self.LibraryBuilder(compiler, name, arch)
+  def Library(self, context, compiler, name):
+    compiler = compiler.clone()
+    SetArchFlags(compiler)
+    return self.LibraryBuilder(compiler, name)
 
-  def Program(self, context, name, arch):
-    compiler = context.cxx.clone()
-    SetArchFlags(compiler, arch, builder.target.platform)
-    return self.ProgramBuilder(compiler, name, arch)
+  def Program(self, context, compiler, name):
+    compiler = compiler.clone()
+    SetArchFlags(compiler)
+    return self.ProgramBuilder(compiler, name)
     
-  def StaticLibrary(self, context, name, arch):
-    compiler = context.cxx.clone()
-    SetArchFlags(compiler, arch, builder.target.platform)
-    return self.StaticLibraryBuilder(compiler, name, arch)
+  def StaticLibrary(self, context, compiler, name):
+    compiler = compiler.clone()
+    SetArchFlags(compiler)
+    return self.StaticLibraryBuilder(compiler, name)
 
   def ConfigureForExtension(self, context, compiler):
     compiler.cxxincludes += [
@@ -490,16 +500,15 @@ class SMConfig(object):
     ]
     return compiler
 
-  def ExtLibrary(self, context, name, arch):
-    binary = self.Library(context, name, arch)
-    SetArchFlags(binary.compiler, arch, builder.target.platform)
+  def ExtLibrary(self, context, compiler, name):
+    binary = self.Library(context, compiler, name)
+    SetArchFlags(compiler)
     self.ConfigureForExtension(context, binary.compiler)
     return binary
 
-  def ConfigureForHL2(self, binary, sdk, arch):
+  def ConfigureForHL2(self, binary, sdk):
     compiler = binary.compiler
-    
-    SetArchFlags(compiler, arch, builder.target.platform)
+    SetArchFlags(compiler)
 
     compiler.cxxincludes += [
       os.path.join(self.mms_root, 'core'),
@@ -537,15 +546,15 @@ class SMConfig(object):
 
     if compiler.like('msvc'):
       compiler.defines += ['COMPILER_MSVC']
-      if arch == 'x86':
+      if compiler.target.arch == 'x86':
         compiler.defines += ['COMPILER_MSVC32']
-      elif arch == 'x64':
+      elif compiler.target.arch == 'x86_64':
         compiler.defines += ['COMPILER_MSVC64']
       compiler.linkflags += ['legacy_stdio_definitions.lib']
     else:
       compiler.defines += ['COMPILER_GCC']
 
-    if arch == 'x64':
+    if compiler.target.arch == 'x86_64':
       compiler.defines += ['X64BITS', 'PLATFORM_64BITS']
 
     # For everything after Swarm, this needs to be defined for entity networking
@@ -554,10 +563,10 @@ class SMConfig(object):
       compiler.defines += ['NETWORK_VARS_ENABLED']
 
     if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2']:
-      if builder.target.platform in ['linux', 'mac']:
+      if compiler.target.platform in ['linux', 'mac']:
         compiler.defines += ['NO_HOOK_MALLOC', 'NO_MALLOC_OVERRIDE']
 
-    if builder.target.platform == 'linux':
+    if compiler.target.platform == 'linux':
       if sdk.name in ['csgo', 'blade']:
         compiler.linkflags.remove('-static-libstdc++')
         compiler.defines += ['_GLIBCXX_USE_CXX11_ABI=0']
@@ -565,25 +574,25 @@ class SMConfig(object):
     for path in paths:
       compiler.cxxincludes += [os.path.join(sdk.path, *path)]
 
-    if builder.target.platform == 'linux':
+    if compiler.target.platform == 'linux':
       if sdk.name == 'episode1':
         lib_folder = os.path.join(sdk.path, 'linux_sdk')
       elif sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'linux32')
-      elif arch == 'x64':
+      elif compiler.target.arch == 'x86_64':
         lib_folder = os.path.join(sdk.path, 'lib', 'linux64')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'linux')
-    elif builder.target.platform == 'mac':
+    elif compiler.target.platform == 'mac':
       if sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'osx32')
-      elif arch == 'x64':
+      elif compiler.target.arch == 'x86_64':
         lib_folder = os.path.join(sdk.path, 'lib', 'osx64')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'mac')
 
-    if builder.target.platform in ['linux', 'mac']:
-      if sdk.name in ['sdk2013', 'bms'] or arch == 'x64':
+    if compiler.target.platform in ['linux', 'mac']:
+      if sdk.name in ['sdk2013', 'bms'] or compiler.target.arch == 'x86_64':
         compiler.postlink += [
           compiler.Dep(os.path.join(lib_folder, 'tier1.a')),
           compiler.Dep(os.path.join(lib_folder, 'mathlib.a'))
@@ -595,32 +604,32 @@ class SMConfig(object):
         ]
 
       if sdk.name in ['blade', 'insurgency', 'doi', 'csgo']:
-        if arch == 'x64':
+        if compiler.target.arch == 'x86_64':
           compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces.a'))]
         else:
           compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces_i486.a'))]
 
     dynamic_libs = []
-    if builder.target.platform == 'linux':
+    if compiler.target.platform == 'linux':
       if sdk.name in ['css', 'hl2dm', 'dods', 'tf2', 'sdk2013', 'bms', 'nucleardawn', 'l4d2', 'insurgency', 'doi']:
         dynamic_libs = ['libtier0_srv.so', 'libvstdlib_srv.so']
-      elif arch == 'x64' and sdk.name in ['csgo', 'blade']:
+      elif compiler.target.arch == 'x86_64' and sdk.name in ['csgo', 'blade']:
         dynamic_libs = ['libtier0_client.so', 'libvstdlib_client.so']
       elif sdk.name in ['l4d', 'blade', 'insurgency', 'doi', 'csgo']:
         dynamic_libs = ['libtier0.so', 'libvstdlib.so']
       else:
         dynamic_libs = ['tier0_i486.so', 'vstdlib_i486.so']
-    elif builder.target.platform == 'mac':
+    elif compiler.target.platform == 'mac':
       compiler.linkflags.append('-liconv')
       dynamic_libs = ['libtier0.dylib', 'libvstdlib.dylib']
-    elif builder.target.platform == 'windows':
+    elif compiler.target.platform == 'windows':
       libs = ['tier0', 'tier1', 'vstdlib', 'mathlib']
       if sdk.name in ['swarm', 'blade', 'insurgency', 'doi', 'csgo']:
         libs.append('interfaces')
       for lib in libs:
-        if arch == 'x86':
+        if compiler.target.arch == 'x86':
           lib_path = os.path.join(sdk.path, 'lib', 'public', lib) + '.lib'
-        elif arch == 'x64':
+        elif compiler.target.arch == 'x86_64':
           lib_path = os.path.join(sdk.path, 'lib', 'public', 'win64', lib) + '.lib'
         compiler.linkflags.append(compiler.Dep(lib_path))
 
@@ -639,27 +648,34 @@ class SMConfig(object):
 
     return binary
 
-  def HL2Library(self, context, name, sdk, arch):
-    binary = self.Library(context, name, arch)
+  def HL2Library(self, context, compiler, name, sdk):
+    binary = self.Library(context, compiler, name)
     self.ConfigureForExtension(context, binary.compiler)
-    return self.ConfigureForHL2(binary, sdk, arch)
+    return self.ConfigureForHL2(binary, sdk)
 
-  def HL2Project(self, context, name):
-    project = context.cxx.LibraryProject(name)
-    self.ConfigureForExtension(context, project.compiler)
-    return project
+  def HL2Config(self, project, compiler, name, sdk):
+    binary = project.Configure(compiler, name,
+                               '{0} - {1} {2}'.format(self.tag, sdk.name, compiler.target.arch))
+    self.AddVersioning(binary)
+    return self.ConfigureForHL2(binary, sdk)
 
-  def HL2Config(self, project, name, sdk, arch):
-    binary = project.Configure(name, '{0} - {1}'.format(self.tag, sdk.name))
-    AppendArchSuffix(binary, name, arch)
-    self.AddVersioning(binary, arch)
-    return self.ConfigureForHL2(binary, sdk, arch)
+  def HL2ExtConfig(self, project, context, compiler, name, sdk):
+    binary = project.Configure(compiler, name,
+                               '{0} - {1} {2}'.format(self.tag, sdk.name, compiler.target.arch))
+    self.AddVersioning(binary)
+    self.ConfigureForHL2(binary, sdk)
+    self.ConfigureForExtension(context, binary.compiler)
+    return binary
 
 SM = SMConfig()
 SM.detectProductVersion()
 SM.detectSDKs()
 SM.configure()
 SM.add_libamtl()
+
+# This will clone the list and each cxx object as we recurse, preventing child
+# scripts from messing up global state.
+builder.targets = builder.CloneableList(SM.all_targets)
 
 if SM.use_auto_versioning():
   SM.generated_headers = builder.Build(
@@ -671,9 +687,27 @@ if SM.use_auto_versioning():
     { 'SM': SM }
   )
 
+class SPRoot(object):
+  # SourcePawn's build scripts are always one-offs, and attach the current target
+  # to the builder, so we have to provide a shim to our StaticLibrary() method.
+  def StaticLibrary(self, builder, name):
+    return SM.StaticLibrary(builder, builder.cxx, name)
+  def Program(self, builder, name):
+    return SM.Program(builder, builder.cxx, name)
+  def Library(self, builder, name):
+    return SM.Library(builder, builder.cxx, name)
+
+  @property
+  def targets(self):
+    return SM.all_targets
+
+  @property
+  def libamtl(self):
+    return SM.libamtl
+
 # Build SourcePawn externally.
 SP = builder.Build('sourcepawn/AMBuildScript', {
-  'external_root': SM,
+  'external_root': SPRoot(),
   'external_amtl': os.path.join(builder.sourcePath, 'public', 'amtl'),
   'external_build': ['core'],
 })
@@ -682,9 +716,9 @@ if len(SP.spcomp) > 1:
 else:
   SM.spcomp = SP.spcomp[list(SP.spcomp.keys())[0]]
 SM.spcomp_bins = list(SP.spcomp.values())
-for arch in SM.archs:
-  SM.binaries += [
-     SP.libsourcepawn[arch]
+for cxx in SM.all_targets:
+  SM.spvm += [
+     SP.libsourcepawn[cxx.target.arch]
   ]
 
 BuildScripts = [

--- a/configure.py
+++ b/configure.py
@@ -12,31 +12,34 @@ except:
 		sys.stderr.write('http://www.alliedmods.net/ambuild\n')
 	sys.exit(1)
 
-def make_objdir_name(p):
-    return 'obj-' + util.Platform() + '-' + p.target_arch
+# Hack to show a decent upgrade message, which wasn't done until 2.2.
+ambuild_version = getattr(run, 'CURRENT_API', '2.1')
+if ambuild_version.startswith('2.1'):
+	sys.stderr.write("AMBuild 2.2 or higher is required; please update\n")
+	sys.exit(1)
 
-parser = run.BuildParser(sourcePath=sys.path[0], api='2.1')
-parser.default_arch = 'x86'
-parser.default_build_folder = make_objdir_name
-parser.options.add_option('--hl2sdk-root', type=str, dest='hl2sdk_root', default=None,
+parser = run.BuildParser(sourcePath=sys.path[0], api='2.2')
+parser.options.add_argument('--hl2sdk-root', type=str, dest='hl2sdk_root', default=None,
 		                   help='Root search folder for HL2SDKs')
-parser.options.add_option('--mysql-path', type=str, dest='mysql_path', default=None,
+parser.options.add_argument('--mysql-path', type=str, dest='mysql_path', default=None,
 		                   help='Path to MySQL 5')
-parser.options.add_option('--mysql64-path', type=str, dest='mysql64_path', default=None,
+parser.options.add_argument('--mysql64-path', type=str, dest='mysql64_path', default=None,
 		                   help='Path to 64-bit MySQL 5')
-parser.options.add_option('--mms-path', type=str, dest='mms_path', default=None,
+parser.options.add_argument('--mms-path', type=str, dest='mms_path', default=None,
                        help='Path to Metamod:Source')
-parser.options.add_option('--enable-debug', action='store_const', const='1', dest='debug',
+parser.options.add_argument('--enable-debug', action='store_const', const='1', dest='debug',
                        help='Enable debugging symbols')
-parser.options.add_option('--enable-optimize', action='store_const', const='1', dest='opt',
+parser.options.add_argument('--enable-optimize', action='store_const', const='1', dest='opt',
                        help='Enable optimization')
-parser.options.add_option('--no-mysql', action='store_false', default=True, dest='hasMySql',
+parser.options.add_argument('--no-mysql', action='store_false', default=True, dest='hasMySql',
                        help='Disable building MySQL extension')
-parser.options.add_option('-s', '--sdks', default='all', dest='sdks',
+parser.options.add_argument('-s', '--sdks', default='present', dest='sdks',
                        help='Build against specified SDKs; valid args are "none", "all", "present",'
-                            ' or comma-delimited list of engine names (default: %default)')
-parser.options.add_option('--breakpad-dump', action='store_true', dest='breakpad_dump',
+                            ' or comma-delimited list of engine names')
+parser.options.add_argument('--breakpad-dump', action='store_true', dest='breakpad_dump',
 											 default=False, help='Dump and upload breakpad symbols')
-parser.options.add_option('--disable-auto-versioning', action='store_true', dest='disable_auto_versioning',
+parser.options.add_argument('--disable-auto-versioning', action='store_true', dest='disable_auto_versioning',
                        default=False, help='Disable the auto versioning script')
+parser.options.add_argument('--targets', type=str, dest='targets', default=None,
+		                      help="Override the target architecture (use commas to separate multiple targets).")
 parser.Configure()

--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -1,7 +1,7 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-project = SM.HL2Project(builder, 'sourcemod')
+project = builder.LibraryProject('sourcemod')
 
 project.sources += [
   'ChatTriggers.cpp',
@@ -45,15 +45,16 @@ project.sources += [
 
 for sdk_name in SM.sdks:
   sdk = SM.sdks[sdk_name]
-  for arch in SM.archs:
-    if not arch in sdk.platformSpec[builder.target.platform]:
+  for cxx in builder.targets:
+    if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:
       continue
 
     binary_name = 'sourcemod.' + sdk.ext
 
-    binary = SM.HL2Config(project, binary_name, sdk, arch)
-    compiler = binary.compiler
+    binary = SM.HL2Config(project, cxx, binary_name, sdk)
+    SM.ConfigureForExtension(builder, binary.compiler)
 
+    compiler = binary.compiler
     compiler.cxxincludes += [
       builder.sourcePath
     ]
@@ -75,22 +76,22 @@ for sdk_name in SM.sdks:
 
     if compiler.like('msvc'):
       compiler.defines += ['_ALLOW_KEYWORD_MACROS']
-    if builder.target.platform == 'linux':
+    if cxx.target.platform == 'linux':
       compiler.postlink += ['-lpthread', '-lrt']
 
     if sdk.name in ['csgo', 'blade']:
-      if builder.target.platform == 'linux':
-        if arch == 'x86':
+      if compiler.target.platform == 'linux':
+        if compiler.target.arch == 'x86':
           lib_path = os.path.join(sdk.path, 'lib', 'linux32', 'release', 'libprotobuf.a')
-        elif arch == 'x64':
+        elif compiler.target.arch == 'x86_64':
           lib_path = os.path.join(sdk.path, 'lib', 'linux64', 'release', 'libprotobuf.a')
         compiler.linkflags += ['-Wl,--exclude-libs=libprotobuf.a']
-      elif builder.target.platform == 'mac':
-        if arch == 'x86':
+      elif compiler.target.platform == 'mac':
+        if compiler.target.arch == 'x86':
           lib_path = os.path.join(sdk.path, 'lib', 'osx32', 'release', 'libprotobuf-libcxx.a')
-        elif arch == 'x64':
+        elif compiler.target.arch == 'x86_64':
           lib_path = os.path.join(sdk.path, 'lib', 'osx64', 'release', 'libprotobuf-libcxx.a')
-      elif builder.target.platform == 'windows':
+      elif compiler.target.platform == 'windows':
         msvc_ver = compiler.version
         vs_year = ''
         if 1900 <= msvc_ver < 2000:
@@ -131,9 +132,9 @@ for sdk_name in SM.sdks:
       binary.sources += pb_sources
       binary.compiler.cxxdefines += ['PROTOBUF_ENABLE']
 
-    if builder.target.platform == 'mac' and sdk.name in ['csgo']:
+    if cxx.target.platform == 'mac' and sdk.name in ['csgo']:
       # We need a proxy library since the game uses libstdc++.
-      pb_binary = SM.HL2Library(builder, 'pbproxy.' + sdk.ext, sdk, arch)
+      pb_binary = SM.HL2Library(builder, cxx, 'pbproxy.' + sdk.ext, sdk)
       pb_binary.sources += pb_sources
       pb_binary.sources += ['pb_proxy.cpp']
       pb_binary.compiler.cxxincludes += pb_includes
@@ -150,9 +151,9 @@ for sdk_name in SM.sdks:
       elif '-std=c++14' in pb_binary.compiler.cxxflags:
         pb_binary.compiler.cxxflags.remove('-std=c++14')
 
-      if arch == 'x86':
+      if cxx.target.arch == 'x86':
         pb_lib_path = os.path.join(sdk.path, 'lib', 'osx32', 'release', 'libprotobuf.a')
-      elif arch == 'x64':
+      elif cxx.target.arch == 'x86_64':
         pb_lib_path = os.path.join(sdk.path, 'lib', 'osx64', 'release', 'libprotobuf.a')
       pb_binary.compiler.linkflags.append(pb_lib_path)
 

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.Library(builder, 'sourcemod.logic', arch)
+for cxx in builder.targets:
+  binary = SM.Library(builder, cxx, 'sourcemod.logic')
   binary.compiler.cxxincludes += [
     builder.sourcePath,
     os.path.join(builder.sourcePath, 'core', 'logic'),
@@ -17,9 +17,9 @@ for arch in SM.archs:
     'SM_LOGIC'
   ]
   
-  if builder.target.platform == 'linux':
+  if binary.compiler.target.platform == 'linux':
     binary.compiler.postlink += ['-lpthread', '-lrt']
-  elif builder.target.platform == 'mac':
+  elif binary.compiler.target.platform == 'mac':
     binary.compiler.cflags += ['-Wno-deprecated-declarations']
     binary.compiler.postlink += ['-framework', 'CoreServices']
 
@@ -86,7 +86,7 @@ for arch in SM.archs:
     'DatabaseConfBuilder.cpp',
   ]
 
-  if arch == 'x64':
+  if binary.compiler.target.arch == 'x86_64':
     binary.sources += ['PseudoAddrManager.cpp']
 
   SM.binaries += [builder.Add(binary)]

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -182,10 +182,16 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 	/* There will always be a path by this point, since it was force-set above. */
 	m_GotBasePath = true;
 
+#if defined PLATFORM_X86
+# define SOURCEPAWN_DLL "sourcepawn.jit.x86"
+#else
+# define SOURCEPAWN_DLL "sourcepawn.vm"
+#endif
+
 	/* Attempt to load the JIT! */
 	char file[PLATFORM_MAX_PATH];
 	char myerror[255];
-	g_SMAPI->PathFormat(file, sizeof(file), "%s/bin/" PLATFORM_ARCH_FOLDER "sourcepawn.jit.x86.%s",
+	g_SMAPI->PathFormat(file, sizeof(file), "%s/bin/" PLATFORM_ARCH_FOLDER SOURCEPAWN_DLL ".%s",
 		GetSourceModPath(),
 		PLATFORM_LIB_EXT
 		);
@@ -195,7 +201,7 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 	{
 		if (error && maxlength)
 		{
-			ke::SafeSprintf(error, maxlength, "%s (failed to load bin/" PLATFORM_ARCH_FOLDER "sourcepawn.jit.x86.%s)", 
+			ke::SafeSprintf(error, maxlength, "%s (failed to load bin/" PLATFORM_ARCH_FOLDER SOURCEPAWN_DLL ".%s)", 
 				myerror,
 				PLATFORM_LIB_EXT);
 		}

--- a/extensions/bintools/AMBuilder
+++ b/extensions/bintools/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'bintools.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'bintools.ext')
   binary.compiler.defines += ['HOOKING_ENABLED']
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
@@ -21,7 +21,7 @@ for arch in SM.archs:
     '../../public/smsdk_ext.cpp'
   ]
   
-  if arch == 'x64':
+  if binary.compiler.target.arch == 'x86_64':
     binary.sources += ['jit_call_x64.cpp']
   else:
     binary.sources += ['jit_call.cpp']

--- a/extensions/clientprefs/AMBuilder
+++ b/extensions/clientprefs/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'clientprefs.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'clientprefs.ext')
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
   ]

--- a/extensions/cstrike/AMBuilder
+++ b/extensions/cstrike/AMBuilder
@@ -1,7 +1,7 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-project = SM.HL2Project(builder, 'game.cstrike.ext')
+project = builder.LibraryProject('game.cstrike.ext')
 project.sources += [
   'extension.cpp',
   'natives.cpp',
@@ -19,16 +19,16 @@ project.sources += [
   '../../public/libudis86/syn.c',
   '../../public/libudis86/udis86.c',
 ]
-project.compiler.defines += ['HAVE_STRING_H'];
 
 for sdk_name in ['css', 'csgo']:
   if sdk_name not in SM.sdks:
     continue
   sdk = SM.sdks[sdk_name]
-  for arch in SM.archs:
-    if not arch in sdk.platformSpec[builder.target.platform]:
+  for cxx in builder.targets:
+    if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:
       continue
 
-    SM.HL2Config(project, 'game.cstrike.ext.' + sdk.ext, sdk, arch)
+    cxx.defines += ['HAVE_STRING_H'];
+    SM.HL2ExtConfig(project, builder, cxx, 'game.cstrike.ext.' + sdk.ext, sdk)
 
 SM.extensions += builder.Add(project)

--- a/extensions/curl/AMBuilder
+++ b/extensions/curl/AMBuilder
@@ -2,8 +2,8 @@
 import os
 
 libcurl = builder.Build('curl-src/lib/AMBuilder')
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'webternet.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'webternet.ext')
   binary.compiler.includes += [
     os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'include')
   ]
@@ -12,10 +12,10 @@ for arch in SM.archs:
     binary.compiler.cxxflags += ['-fno-rtti']
   elif binary.compiler.family == 'msvc':
     binary.compiler.cxxflags += ['/GR-']
-  binary.compiler.postlink += [libcurl[arch].binary]
-  if builder.target.platform == 'linux':
+  binary.compiler.postlink += [libcurl[binary.compiler.target.arch].binary]
+  if binary.compiler.target.platform == 'linux':
     binary.compiler.postlink += ['-lrt']
-  elif builder.target.platform == 'windows':
+  elif binary.compiler.target.platform == 'windows':
     binary.compiler.postlink += ['ws2_32.lib']
 
   binary.sources += [

--- a/extensions/curl/curl-src/lib/AMBuilder
+++ b/extensions/curl/curl-src/lib/AMBuilder
@@ -4,25 +4,25 @@ import os, platform
 builder.SetBuildFolder('libcurl')
 
 rvalue = {}
-for arch in SM.archs:
-  binary = SM.StaticLibrary(builder, 'curl', arch)
+for cxx in builder.targets:
+  binary = SM.StaticLibrary(builder, cxx, 'curl')
   binary.compiler.includes += [
     os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'lib'),
     os.path.join(builder.sourcePath, 'extensions', 'curl', 'curl-src', 'include')
   ]
 
-  if builder.target.platform == 'mac':
+  if binary.compiler.target.platform == 'mac':
     mac_version, ignore, ignore = platform.mac_ver()
     mac_tuple = mac_version.split('.')
     if int(mac_tuple[0]) >= 10 and int(mac_tuple[1]) >= 9:
       binary.compiler.defines += ['BUILTIN_STRLCAT']
-  elif builder.target.platform == 'windows':
+  elif binary.compiler.target.platform == 'windows':
     binary.compiler.defines += [
       'BUILDING_LIBCURL',
       'CURL_STATICLIB',
       'CURL_DISABLE_LDAP',
     ]
-  elif builder.target.platform == 'linux':
+  elif binary.compiler.target.platform == 'linux':
     binary.compiler.defines += ['_GNU_SOURCE']
 
   if binary.compiler.family == 'clang':
@@ -96,5 +96,5 @@ for arch in SM.archs:
     'url.c',
     'version.c'
   ]
-  rvalue[arch] = builder.Add(binary)
+  rvalue[binary.compiler.target.arch] = builder.Add(binary)
 

--- a/extensions/geoip/AMBuilder
+++ b/extensions/geoip/AMBuilder
@@ -1,13 +1,13 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'geoip.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'geoip.ext')
   if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
     binary.compiler.cxxflags += ['-fno-rtti']
   elif binary.compiler.family == 'msvc':
     binary.compiler.cxxflags += ['/GR-']
-  if builder.target.platform == 'windows':
+  if binary.compiler.target.platform == 'windows':
     binary.compiler.postlink += ['wsock32.lib']
 
   binary.sources += [

--- a/extensions/mysql/AMBuilder
+++ b/extensions/mysql/AMBuilder
@@ -2,8 +2,9 @@
 import os
 
 if SM.mysql_root:
-  for arch in SM.archs:
-    binary = SM.ExtLibrary(builder, 'dbi.mysql.ext', arch)
+  for cxx in builder.targets:
+    arch = cxx.target.arch
+    binary = SM.ExtLibrary(builder, cxx, 'dbi.mysql.ext')
     binary.compiler.cxxincludes += [
       os.path.join(SM.mysql_root[arch], 'include'),
       os.path.join(SM.mms_root, 'core', 'sourcehook')
@@ -13,16 +14,16 @@ if SM.mysql_root:
     elif binary.compiler.family == 'msvc':
       binary.compiler.cxxflags += ['/GR-']
 
-    if builder.target.platform == 'linux' or builder.target.platform == 'mac':
+    if binary.compiler.target.platform == 'linux' or binary.compiler.target.platform == 'mac':
       binary.compiler.postlink += [
         os.path.join(SM.mysql_root[arch], 'lib', 'libmysqlclient_r.a'),
         '-lz',
         '-lpthread',
         '-lm',
       ]
-    if builder.target.platform == 'linux':
+    if binary.compiler.target.platform == 'linux':
       binary.compiler.postlink += ['-lrt']
-    elif builder.target.platform == 'windows':
+    elif binary.compiler.target.platform == 'windows':
       binary.compiler.defines += ['WIN32_LEAN_AND_MEAN']
       binary.compiler.postlink += [
         os.path.join(SM.mysql_root[arch], 'lib', 'mysqlclient.lib'),

--- a/extensions/regex/AMBuilder
+++ b/extensions/regex/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'regex.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'regex.ext')
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
   ]
@@ -11,20 +11,21 @@ for arch in SM.archs:
   elif binary.compiler.family == 'msvc':
     binary.compiler.cxxflags += ['/GR-']
 
-  if builder.target.platform == 'linux':
+  arch = binary.compiler.target.arch
+  if binary.compiler.target.platform == 'linux':
     if arch == 'x86':
       path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux', 'libpcre.a')
-    elif arch == 'x64':
+    elif arch == 'x86_64':
       path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_linux64', 'libpcre.a')
-  elif builder.target.platform == 'windows':
+  elif binary.compiler.target.platform == 'windows':
     if arch == 'x86':
       path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_win', 'pcre.lib')
-    elif arch == 'x64':
+    elif arch == 'x86_64':
       path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_win64', 'pcre.lib')
-  elif builder.target.platform == 'mac':
+  elif binary.compiler.target.platform == 'mac':
     if arch == 'x86':
       path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin', 'libpcre.a')
-    elif arch == 'x64':
+    elif arch == 'x86_64':
       path = os.path.join(builder.sourcePath, 'extensions', 'regex', 'lib_darwin64', 'libpcre.a')
   binary.compiler.postlink += [binary.Dep(path)]
 

--- a/extensions/sdkhooks/AMBuilder
+++ b/extensions/sdkhooks/AMBuilder
@@ -1,7 +1,7 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-project = SM.HL2Project(builder, 'sdkhooks.ext')
+project = builder.LibraryProject('sdkhooks.ext')
 project.sources += [
   'extension.cpp',
   'natives.cpp',
@@ -13,11 +13,11 @@ project.sources += [
 for sdk_name in SM.sdks:
   sdk = SM.sdks[sdk_name]
 
-  for arch in SM.archs:
-    if not arch in sdk.platformSpec[builder.target.platform]:
+  for cxx in builder.targets:
+    if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:
       continue
   
-    binary = SM.HL2Config(project, 'sdkhooks.ext.' + sdk.ext, sdk, arch)
+    binary = SM.HL2ExtConfig(project, builder, cxx, 'sdkhooks.ext.' + sdk.ext, sdk)
     binary.compiler.cxxincludes += [
       os.path.join(sdk.path, 'game', 'shared')
     ]

--- a/extensions/sdktools/AMBuilder
+++ b/extensions/sdktools/AMBuilder
@@ -1,7 +1,7 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-project = SM.HL2Project(builder, 'sdktools.ext')
+project = builder.LibraryProject('sdktools.ext')
 project.sources += [
   'extension.cpp',
   'variant-t.cpp',
@@ -34,21 +34,21 @@ project.sources += [
   '../../public/libudis86/syn.c',
   '../../public/libudis86/udis86.c',
 ]
-project.compiler.defines += ['HAVE_STRING_H'];
 
 for sdk_name in SM.sdks:
   sdk = SM.sdks[sdk_name]
 
-  for arch in SM.archs:
-    if not arch in sdk.platformSpec[builder.target.platform]:
+  for cxx in builder.targets:
+    if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:
       continue
 
-    binary = SM.HL2Config(project, 'sdktools.ext.' + sdk.ext, sdk, arch)
+    binary = SM.HL2ExtConfig(project, builder, cxx, 'sdktools.ext.' + sdk.ext, sdk)
     binary.compiler.cxxincludes += [
       os.path.join(sdk.path, 'game', 'shared'),
       os.path.join(builder.sourcePath, 'public', 'jit'),
       os.path.join(builder.sourcePath, 'public', 'jit', 'x86'),
     ]
+    binary.compiler.defines += ['HAVE_STRING_H'];
 
     if sdk.name != 'episode1':
       binary.compiler.defines += ['HOOKING_ENABLED']

--- a/extensions/sqlite/AMBuilder
+++ b/extensions/sqlite/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'dbi.sqlite.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'dbi.sqlite.ext')
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
   ]
@@ -17,7 +17,7 @@ for arch in SM.archs:
     'SQLITE_USE_URI',
     'SQLITE_ALLOW_URI_AUTHORITY',
   ]
-  if builder.target.platform == 'linux':
+  if binary.compiler.target.platform == 'linux':
     binary.compiler.postlink += ['-ldl', '-lpthread']
 
   binary.sources += [

--- a/extensions/tf2/AMBuilder
+++ b/extensions/tf2/AMBuilder
@@ -4,10 +4,10 @@ import os
 if 'tf2' in SM.sdks:
   sdk = SM.sdks['tf2']
   
-  for arch in SM.archs:
-    if not arch in sdk.platformSpec[builder.target.platform]:
+  for cxx in builder.targets:
+    if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:
       continue
-    binary = SM.HL2Library(builder, 'game.tf2.ext.' + sdk.ext, sdk, arch)
+    binary = SM.HL2Library(builder, cxx, 'game.tf2.ext.' + sdk.ext, sdk)
     binary.sources += [
       'extension.cpp',
       'natives.cpp',

--- a/extensions/topmenus/AMBuilder
+++ b/extensions/topmenus/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'topmenus.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'topmenus.ext')
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
   ]

--- a/extensions/updater/AMBuilder
+++ b/extensions/updater/AMBuilder
@@ -1,8 +1,8 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os
 
-for arch in SM.archs:
-  binary = SM.ExtLibrary(builder, 'updater.ext', arch)
+for cxx in builder.targets:
+  binary = SM.ExtLibrary(builder, cxx, 'updater.ext')
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
   ]

--- a/loader/AMBuilder
+++ b/loader/AMBuilder
@@ -1,18 +1,18 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
 import os.path
 
-for arch in SM.archs:
-  if builder.target.platform in ['windows', 'mac']:
+for cxx in builder.targets:
+  if cxx.target.platform in ['windows', 'mac']:
     name = 'sourcemod_mm'
     extra_ldflags = []
-  elif builder.target.platform == 'linux':
+  elif cxx.target.platform == 'linux':
     name = 'sourcemod_mm_i486'
     extra_ldflags = ['-ldl']
 
-  if arch == 'x64':
+  if cxx.target.arch == 'x86_64':
     name = 'sourcemod_mm.x64'
 
-  binary = SM.Library(builder, name, arch)
+  binary = SM.Library(builder, cxx, name)
   binary.compiler.cxxincludes += [
     os.path.join(SM.mms_root, 'core'),
     os.path.join(SM.mms_root, 'sourcehook')

--- a/tools/buildbot/PackageScript
+++ b/tools/buildbot/PackageScript
@@ -38,7 +38,7 @@ folder_list = [
   'cfg/sourcemod',
 ]
 
-if 'x64' in SM.archs:
+if 'x86_64' in SM.target_archs:
   folder_list.extend([
     'addons/sourcemod/bin/x64',
     'addons/sourcemod/extensions/x64',
@@ -52,16 +52,22 @@ for folder in folder_list:
 
 # Copy binaries.
 for cxx_task in SM.binaries:
-  binpath = cxx_task.binary.path
-  if '.x64' + os.sep in binpath and not 'sourcemod_mm' in binpath:
+  if cxx_task.target.arch == 'x86_64':
     builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/bin/x64'])
   else:
     builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/bin'])
 for cxx_task in SM.extensions:
-  if '.x64' + os.sep in cxx_task.binary.path:
+  if cxx_task.target.arch == 'x86_64':
     builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/extensions/x64'])
   else:
     builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/extensions'])
+for cxx_task in SM.spvm:
+  if cxx_task.target.arch == 'x86':
+    dest_path = os.path.join('addons/sourcemod/bin',
+                             'sourcepawn.jit.x86' + os.path.splitext(cxx_task.binary.path)[1])
+    builder.AddCopy(cxx_task.binary, dest_path)
+  elif cxx_task.target.arch == 'x86_64':
+    builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/bin/x64'])
     
 def lipo(binaries, outFolder):
   bins = []
@@ -78,11 +84,11 @@ def lipo(binaries, outFolder):
 	outputs = [os.path.join(outFolder, binary)],
   )
 
-if builder.target.platform == 'mac' and len(SM.archs) > 1:
+if builder.host.platform == 'mac' and len(SM.target_archs) > 1:
   lipo(SM.spcomp_bins, 'addons/sourcemod/scripting')
 else:
   for bin_task in SM.spcomp_bins:
-    if '.x64' + os.sep in bin_task.binary.path:
+    if bin_task.target.arch == 'x86_64':
       file = os.path.basename(bin_task.binary.path) + '64'
       builder.AddCopy(bin_task.binary, os.path.normpath('addons/sourcemod/scripting/' + file))
     else:
@@ -510,7 +516,7 @@ CopyFiles('plugins/playercommands', 'addons/sourcemod/scripting/playercommands',
   ]
 )
 
-if builder.target.platform == 'windows':
+if builder.host.platform == 'windows':
   CopyFiles('tools/batchtool', 'addons/sourcemod/scripting', ['compile.exe'])
 else:
   CopyFiles('plugins', 'addons/sourcemod/scripting', ['compile.sh'])

--- a/tools/buildbot/bootstrap.pl
+++ b/tools/buildbot/bootstrap.pl
@@ -53,10 +53,11 @@ if ($^O =~ /darwin/) {
 }
 
 if ($^O !~ /MSWin/) {
-	push(@conf_argv, '--target-arch=x86,x64');
+	push(@conf_argv, '--targets=x86,x86_64');
 } else {
-	push(@conf_argv, '--target-arch=x86');
+	push(@conf_argv, '--targets=x86');
 }
+push(@conf_argv, '--sdks=all');
 
 my $conf_args = join(' ', @conf_argv);
 

--- a/versionlib/AMBuilder
+++ b/versionlib/AMBuilder
@@ -2,8 +2,8 @@
 import os
 
 rvalue = {}
-for arch in SM.archs:
-  lib = SM.StaticLibrary(builder, 'version', arch)
+for cxx in builder.targets:
+  lib = SM.StaticLibrary(builder, cxx, 'version')
   lib.compiler.includes += [
     os.path.join(builder.sourcePath, 'public')
   ]
@@ -14,4 +14,4 @@ for arch in SM.archs:
   ]
   task = builder.Add(lib)
 
-  rvalue[arch] = task.binary
+  rvalue[lib.compiler.target.arch] = task.binary


### PR DESCRIPTION
This is a pretty big diff because SourceMod had lots of multi-arch
workarounds that can now go away. I've also changed 'x64' to 'x86_64' in
many places since this is how AMBuild normalizes it, and it's far too
late to pick the shorter string, so we might as well suck it up.

The --target-archs parameter has been replaced with --targets. It works
the same way.

The default behavior for SDK inclusion is now "present" instead of
"all" since this lowers the burden of storing many SDKs. Official builds
will still be made with --sdks=all.

Multi-arch builds on Windows now work. However, they will not work on our buildbot yet, we'll need to change how the environment is set up to make that work.