### PR TITLE
Remove OnEntitySpawned C++ listener

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -1831,18 +1831,11 @@ void SDKHooks::HandleEntityCreated(CBaseEntity *pEntity, int index, cell_t ref)
 
 void SDKHooks::HandleEntitySpawned(CBaseEntity *pEntity, int index, cell_t ref)
 {
-	if (g_pOnEntitySpawned->GetFunctionCount() || m_EntListeners.size())
+	if (g_pOnEntitySpawned->GetFunctionCount())
 	{
 		const char *pName = gamehelpers->GetEntityClassname(pEntity);
 		if (!pName)
 			pName = "";
-
-		// Send OnEntitySpawned to SM listeners
-		for (SourceHook::List<ISMEntityListener *>::iterator iter = m_EntListeners.begin(); iter != m_EntListeners.end(); iter++)
-		{
-			ISMEntityListener *pListener = (*iter);
-			pListener->OnEntitySpawned(pEntity, pName);
-		}
 
 		// Call OnEntitySpawned forward
 		if (g_pOnEntitySpawned->GetFunctionCount())

--- a/public/extensions/ISDKHooks.h
+++ b/public/extensions/ISDKHooks.h
@@ -36,7 +36,7 @@
 #include <IShareSys.h>
 
 #define SMINTERFACE_SDKHOOKS_NAME		"ISDKHooks"
-#define SMINTERFACE_SDKHOOKS_VERSION	2
+#define SMINTERFACE_SDKHOOKS_VERSION	1
 
 class CBaseEntity;
 
@@ -69,16 +69,6 @@ namespace SourceMod
 		 * @param	pEntity		CBaseEntity entity.
 		 */
 		virtual void OnEntityDestroyed(CBaseEntity *pEntity)
-		{
-		}
-
-		/**
-		 * @brief	When an entity is spawned
-		 *
-		 * @param	pEntity		CBaseEntity entity.
-		 * @param	classname	Entity classname.
-		 */
-		virtual void OnEntitySpawned(CBaseEntity *pEntity, const char *classname)
 		{
 		}
 	};


### PR DESCRIPTION
This is causing crashes with existing extensions using entity listeners.

Currently no one is asking for a C++ hook here, if it is desired it
needs to be done with proper versioning of the listener interface, which
is going to be a little bit more complicated without an initial hard
break.

https://forums.alliedmods.net/showpost.php?p=2715337&postcount=789
https://discordapp.com/channels/335290997317697536/335290997317697536/748101258186850334

This is a partial revert of #1078.