### PR TITLE
Add GameData.GetMemSig

### DIFF
--- a/core/logic/smn_gameconfigs.cpp
+++ b/core/logic/smn_gameconfigs.cpp
@@ -162,6 +162,38 @@ static cell_t smn_GameConfGetAddress(IPluginContext *pCtx, const cell_t *params)
 #endif
 }
 
+static cell_t smn_GameConfGetMemSig(IPluginContext *pCtx, const cell_t *params)
+{
+	Handle_t hndl = static_cast<Handle_t>(params[1]);
+	HandleError herr;
+	HandleSecurity sec;
+	IGameConfig *gc;
+
+	sec.pOwner = NULL;
+	sec.pIdentity = g_pCoreIdent;
+
+	if ((herr=handlesys->ReadHandle(hndl, g_GameConfigsType, &sec, (void **)&gc))
+		!= HandleError_None)
+	{
+		return pCtx->ThrowNativeError("Invalid game config handle %x (error %d)", hndl, herr);
+	}
+
+	char *key;
+	void *val;
+	pCtx->LocalToString(params[2], &key);
+
+	if (!gc->GetMemSig(key, &val))
+	{
+		return 0;
+	}
+
+#ifdef PLATFORM_X86
+	return (cell_t)val;
+#else
+	return pseudoAddr.ToPseudoAddress(val);
+#endif
+}
+
 static GameConfigsNatives s_GameConfigsNatives;
 
 REGISTER_NATIVES(gameconfignatives)
@@ -176,5 +208,6 @@ REGISTER_NATIVES(gameconfignatives)
 	{"GameData.GetOffset",			smn_GameConfGetOffset},
 	{"GameData.GetKeyValue",		smn_GameConfGetKeyValue},
 	{"GameData.GetAddress",			smn_GameConfGetAddress},
+	{"GameData.GetMemSig", 			smn_GameConfGetMemSig},
 	{NULL,							NULL}
 };

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -113,6 +113,12 @@ methodmap GameData < Handle
 	// @param name          Name of the property to find.
 	// @return              An address calculated on success, or 0 on failure.
 	public native Address GetAddress(const char[] name);
+
+	// Returns a function address calculated from a signature.
+	//
+	// @param name          Name of the property to find.
+	// @return              An address calculated on success, or 0 on failure.
+	public native Address GetMemSig(const char[] name);
 };
 
 /**


### PR DESCRIPTION
Adds a method of acquiring a function address via its signature from a GameData handle. I find this most useful with DHook detours, especially the "half-made" ones (detours that use gamedata solely for its signature and not parameters or anything else) that can use this for more streamlined creation.

Would convert something like this
```cs
GameData conf = LoadGameConfigFile("tf2.condmgr");
Handle hook = DHookCreateDetour(Address_Null, CallConv_THISCALL, ReturnType_Void, ThisPointer_Address);
DHookSetFromConf(hook, conf, SDKLibrary_Server, "CTFPlayerShared::AddCond");
// ... Etc
delete conf;
```
to
```cs
GameData conf = LoadGameConfigFile("tf2.condmgr");
Address addr = conf.GetMemSig("CTFPlayerShared::AddCond");
Handle hook = DHookCreateDetour(addr, CallConv_THISCALL, ReturnType_Void, ThisPointer_Address);
// ... Etc
delete conf;
```

The current way of getting addresses like such would require you to stick in a new "Addresses" section that points to the signature you want, then use GameData.GetAddress. Pretty QOL IMO.

Got it to build on both Windows and Linux though I've only tested on Windows.

Here's the test script I used
```cs
#include <sdktools>
#include <dhooks>

Handle hHndl;
public void OnPluginStart()
{
	GameData conf = LoadGameConfigFile("tf2.condmgr");
	Address addr = conf.GetMemSig("CTFPlayerShared::AddCond");
	PrintToServer("0x%X", addr);

	if (addr)
	{
		StartPrepSDKCall(SDKCall_Raw);
		PrepSDKCall_SetAddress(addr);
		PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
		PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
		PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
		hHndl = EndPrepSDKCall();
	}

	Handle hook = DHookCreateDetour(addr, CallConv_THISCALL, ReturnType_Void, ThisPointer_Address);
	DHookAddParam(hook, HookParamType_Int);
	DHookAddParam(hook, HookParamType_Float);
	DHookAddParam(hook, HookParamType_Int);
	DHookEnableDetour(hook, false, OnConditionAdded);

	for (int i = MaxClients; i; --i)
		if (IsClientInGame(i))
			SDKCall(hHndl, GetEntityAddress(i) + view_as< Address >(FindSendPropInfo("CTFPlayer", "m_Shared")), 10, -1.0, 0);

	delete conf;
}

public MRESReturn OnConditionAdded(Address pThis, Handle hParams)
{
	PrintToServer("OnConditionAdded => CALLED:\n0x%X %d %.1f %d", pThis, DHookGetParam(hParams, 1), DHookGetParam(hParams, 2), DHookGetParam(hParams, 3));
}
```

```
"CTFPlayerShared::AddCond"	// (ETFCond, float, CBaseEntity*)
{
	"library" 	"server"
	"windows" 	"\x55\x8B\xEC\x83\xEC\x08\x56\x8B\xF1\x8B\x8E\x90\x01\x00\x00\x85\xC9"
	"linux" 	"@_ZN15CTFPlayerShared7AddCondE7ETFCondfP11CBaseEntity"
}
```