### PR TITLE
Fix PrepSDKCall_SetSignature on Windows

### DIFF
--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -141,14 +141,23 @@ static cell_t PrepSDKCall_SetSignature(IPluginContext *pContext, const cell_t *p
 			return 0;
 		}
 
-		if (bridge->SymbolsAreHidden())
-		{
-			s_call_addr = memutils->ResolveSymbol(handle, &sig[1]);
-		}
-		else
-		{
-			s_call_addr = dlsym(handle, &sig[1]);
-		}
+#if SOURCE_ENGINE == SE_CSS            \
+	|| SOURCE_ENGINE == SE_HL2DM       \
+	|| SOURCE_ENGINE == SE_DODS        \
+	|| SOURCE_ENGINE == SE_SDK2013     \
+	|| SOURCE_ENGINE == SE_BMS         \
+	|| SOURCE_ENGINE == SE_TF2         \
+	|| SOURCE_ENGINE == SE_LEFT4DEAD   \
+	|| SOURCE_ENGINE == SE_LEFT4DEAD2  \
+	|| SOURCE_ENGINE == SE_NUCLEARDAWN \
+	|| SOURCE_ENGINE == SE_BLADE       \
+	|| SOURCE_ENGINE == SE_INSURGENCY  \
+	|| SOURCE_ENGINE == SE_DOI         \
+	|| SOURCE_ENGINE == SE_CSGO
+		s_call_addr = memutils->ResolveSymbol(handle, &sig[1]);
+#else
+		s_call_addr = dlsym(handle, &sig[1]);
+#endif
 
 		dlclose(handle);
 		#endif

--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -121,15 +121,13 @@ static cell_t PrepSDKCall_SetSignature(IPluginContext *pContext, const cell_t *p
 
 	if (sig[0] == '@')
 	{
-		#if defined PLATFORM_WINDOWS
+#if defined PLATFORM_WINDOWS
 		MEMORY_BASIC_INFORMATION mem;
-		if(VirtualQuery(addrInBase, &mem, sizeof(mem)))
+		if (VirtualQuery(addrInBase, &mem, sizeof(mem)))
 		{
 			s_call_addr = memutils->ResolveSymbol(mem.AllocationBase, &sig[1]);
 		}
-		#endif
-
-		#if defined PLATFORM_POSIX
+#elif defined PLATFORM_POSIX
 		Dl_info info;
 		if (dladdr(addrInBase, &info) == 0)
 		{
@@ -157,10 +155,10 @@ static cell_t PrepSDKCall_SetSignature(IPluginContext *pContext, const cell_t *p
 		s_call_addr = memutils->ResolveSymbol(handle, &sig[1]);
 #else
 		s_call_addr = dlsym(handle, &sig[1]);
-#endif
+#endif /* SOURCE_ENGINE */
 
 		dlclose(handle);
-		#endif
+#endif
 
 		return (s_call_addr != NULL) ? 1 : 0;
 	}

--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -119,9 +119,17 @@ static cell_t PrepSDKCall_SetSignature(IPluginContext *pContext, const cell_t *p
 	char *sig;
 	pContext->LocalToString(params[2], &sig);
 
-#if defined PLATFORM_POSIX
 	if (sig[0] == '@')
 	{
+		#if defined PLATFORM_WINDOWS
+		MEMORY_BASIC_INFORMATION mem;
+		if(VirtualQuery(addrInBase, &mem, sizeof(mem)))
+		{
+			s_call_addr = memutils->ResolveSymbol(mem.AllocationBase, &sig[1]);
+		}
+		#endif
+
+		#if defined PLATFORM_POSIX
 		Dl_info info;
 		if (dladdr(addrInBase, &info) == 0)
 		{
@@ -132,28 +140,21 @@ static cell_t PrepSDKCall_SetSignature(IPluginContext *pContext, const cell_t *p
 		{
 			return 0;
 		}
-#if SOURCE_ENGINE == SE_CSS            \
-	|| SOURCE_ENGINE == SE_HL2DM       \
-	|| SOURCE_ENGINE == SE_DODS        \
-	|| SOURCE_ENGINE == SE_SDK2013     \
-	|| SOURCE_ENGINE == SE_BMS         \
-	|| SOURCE_ENGINE == SE_TF2         \
-	|| SOURCE_ENGINE == SE_LEFT4DEAD   \
-	|| SOURCE_ENGINE == SE_LEFT4DEAD2  \
-	|| SOURCE_ENGINE == SE_NUCLEARDAWN \
-	|| SOURCE_ENGINE == SE_BLADE       \
-	|| SOURCE_ENGINE == SE_INSURGENCY  \
-	|| SOURCE_ENGINE == SE_DOI         \
-	|| SOURCE_ENGINE == SE_CSGO
-		s_call_addr = memutils->ResolveSymbol(handle, &sig[1]);
-#else
-		s_call_addr = dlsym(handle, &sig[1]);
-#endif
+
+		if (bridge->SymbolsAreHidden())
+		{
+			s_call_addr = memutils->ResolveSymbol(handle, &sig[1]);
+		}
+		else
+		{
+			s_call_addr = dlsym(handle, &sig[1]);
+		}
+
 		dlclose(handle);
+		#endif
 
 		return (s_call_addr != NULL) ? 1 : 0;
 	}
-#endif
 
 	s_call_addr = memutils->FindPattern(addrInBase, sig, params[3]);
 


### PR DESCRIPTION
Server will be crash with next code on windows
![2020-09-01_19-12-23](https://user-images.githubusercontent.com/22251516/91832647-03ffec80-ec89-11ea-8099-1c150807e4c8.png)

@asherkin answered this
https://canary.discordapp.com/channels/335290997317697536/335290997317697536/746316421134548993

    #include <sdktools>

    public void OnPluginStart()
    {
        StartPrepSDKCall(SDKCall_Static);
        PrepSDKCall_SetSignature(SDKLibrary_Engine, "@CreateInterface", 0);
        PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
        PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
        PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);

        Handle h= EndPrepSDKCall();

        int IVModelRender = SDKCall(h, "VEngineModel016", 0);

        PrintToServer("IVModelRender 0x%X", IVModelRender);

        delete h;
    }

This PR fixed it
![2020-09-01_19-10-03](https://user-images.githubusercontent.com/22251516/91831562-91424180-ec87-11ea-94b1-1dab6e473eda.png)
