### PR TITLE
Add native GetOS

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -946,6 +946,42 @@ static cell_t LogStackTrace(IPluginContext *pContext, const cell_t *params)
 	return 0;
 }
 
+enum OS
+{
+	OS_Unknown,
+	OS_Windows_x86,
+	OS_Windows_x86_64,
+	OS_Linux_x86,
+	OS_Linux_x86_64,
+	OS_Apple_x86,
+	OS_Apple_x86_64
+};
+
+static cell_t GetOS(IPluginContext *pContext, const cell_t *params)
+{
+#if defined PLATFORM_WINDOWS
+#ifdef PLATFORM_X86
+	return OS_Windows_x86;
+#else
+	return OS_Windows_x86_64;
+#endif
+#elif defined PLATFORM_LINUX
+#ifdef PLATFORM_X86
+	return OS_Linux_x86;
+#else
+	return OS_Linux_x86_64;
+#endif
+#elif defined PLATFORM_APPLE
+#ifdef PLATFORM_X86
+	return OS_Apple_x86;
+#else
+	return OS_Apple_x86_64;
+#endif
+#else
+	return OS_Unknown;
+#endif
+}
+
 REGISTER_NATIVES(coreNatives)
 {
 	{"ThrowError",				ThrowError},
@@ -977,6 +1013,7 @@ REGISTER_NATIVES(coreNatives)
 	{"IsNullVector",			IsNullVector},
 	{"IsNullString",			IsNullString},
 	{"LogStackTrace",           LogStackTrace},
+	{"GetOS",                   GetOS},
 	
 	{"FrameIterator.FrameIterator",				FrameIterator_Create},
 	{"FrameIterator.Next",						FrameIterator_Next},

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -691,6 +691,27 @@ native any LoadFromAddress(Address addr, NumberType size);
  */
 native void StoreToAddress(Address addr, any data, NumberType size);
 
+/**
+ * OS statuses.
+ */
+enum OS
+{
+	OS_Unknown,
+	OS_Windows_x86,
+	OS_Windows_x86_64,
+	OS_Linux_x86,
+	OS_Linux_x86_64,
+	OS_Apple_x86,
+	OS_Apple_x86_64
+};
+
+/**
+ * Returns the operating system the plugin is running.
+ *
+ * @return              OS status.
+ */
+native OS GetOS();
+
 methodmap FrameIterator < Handle {
 	// Creates a stack frame iterator to build your own stack traces.
 	// @return              New handle to a FrameIterator.


### PR DESCRIPTION
This will help you find out which OS the plugin is running on, and will save plugins from crutches.
https://github.com/GAMMACASE/MomSurfFix/blob/4037f73f53566859edc9361f02b512a98f74ce4e/addons/sourcemod/gamedata/momsurffix2.games.txt#L68
https://github.com/qubka/Zombie-Plague/blob/7c55343164216a26879d4c78291e53259c33627e/gamedata/plugin.zombieplague.txt#L54
https://github.com/quasemago/CSGO_WeaponStickers/blob/41282cac31dda0fd455c0efb656e1150cd842b3f/addons/sourcemod/gamedata/csgo_weaponstickers.games.txt#L7