### PR TITLE
Fix "Command Group" override type admin flags

### DIFF
--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -496,7 +496,7 @@ void ConCmdManager::UpdateAdminCmdFlags(const char *cmd, OverrideType type, Flag
 		for (PluginHookList::iterator iter = group->hooks.begin(); iter != group->hooks.end(); iter++)
 		{
 			CmdHook *hook = *iter;
-			if (remove)
+			if (!remove)
 				hook->admin->eflags = bits;
 			else
 				hook->admin->eflags = hook->admin->flags;


### PR DESCRIPTION
Fixes "Command Group" override type getting set wrong flags upon the creation of the command group override.

One way to test this broken behaviour is to:
1. Create an admin command with ADMFLAG_ROOT admin flags initially and assign it under a command group `MyTestGroup`.
    - `RegAdminCmd("sm_testcommand", Command_Test, ADMFLAG_ROOT, "Description", "MyTestGroup");`
2. Create a command group override within `admin_overrides.cfg` - `"@MyTestGroup" ""`.
3. Make sure you do not have ROOT permissions, boot up the server and observe that you cannot access "sm_testcommand".
