### PR TITLE
Update L4D2 Gamedata for 2.2.0.0

### DIFF
--- a/gamedata/sdkhooks.games/game.l4d2.txt
+++ b/gamedata/sdkhooks.games/game.l4d2.txt
@@ -18,141 +18,141 @@
 		{
 			"Blocked"
 			{
-				"windows"	"110"
-				"linux"		"111"
-				"mac"		"111"
+				"windows"	"111"
+				"linux"		"112"
+				"mac"		"112"
 			}
 			"EndTouch"
 			{
-				"windows"	"108"
-				"linux"		"109"
-				"mac"		"109"
+				"windows"	"109"
+				"linux"		"110"
+				"mac"		"110"
 			}
 			"FireBullets"
 			{
-				"windows"	"121"
-				"linux"		"122"
-				"mac"		"122"
+				"windows"	"122"
+				"linux"		"123"
+				"mac"		"123"
 			}
 			"GetMaxHealth"
 			{
-				"windows"	"125"
-				"linux"		"126"
-				"mac"		"126"
+				"windows"	"126"
+				"linux"		"127"
+				"mac"		"127"
 			}
 			"OnTakeDamage"
 			{
-				"windows"	"71"
-				"linux"		"72"
-				"mac"		"72"
+				"windows"	"72"
+				"linux"		"73"
+				"mac"		"73"
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"291"
-				"linux"		"292"
-				"mac"		"292"
+				"windows"	"292"
+				"linux"		"293"
+				"mac"		"293"
 			}
 			"PreThink"
-			{
-				"windows"	"355"
-				"linux"		"356"
-				"mac"		"356"
-			}
-			"PostThink"
 			{
 				"windows"	"356"
 				"linux"		"357"
 				"mac"		"357"
 			}
+			"PostThink"
+			{
+				"windows"	"357"
+				"linux"		"358"
+				"mac"		"358"
+			}
 			"Reload"
 			{
-				"windows"	"280"
-				"linux"		"281"
-				"mac"		"281"
+				"windows"	"281"
+				"linux"		"282"
+				"mac"		"282"
 			}
 			"SetTransmit"
 			{
-				"windows"	"21"
-				"linux"		"22"
-				"mac"		"22"
+				"windows"	"22"
+				"linux"		"23"
+				"mac"		"23"
 			}
 			"ShouldCollide"
 			{
-				"windows"	"17"
-				"linux"		"18"
-				"mac"		"18"
+				"windows"	"18"
+				"linux"		"19"
+				"mac"		"19"
 			}
 			"Spawn"
 			{
-				"windows"	"23"
-				"linux"		"24"
-				"mac"		"24"
+				"windows"	"24"
+				"linux"		"25"
+				"mac"		"25"
 			}
 			"StartTouch"
-			{
-				"windows"	"106"
-				"linux"		"107"
-				"mac"		"107"
-			}
-			"Think"
-			{
-				"windows"	"55"
-				"linux"		"56"
-				"mac"		"56"
-			}
-			"Touch"
 			{
 				"windows"	"107"
 				"linux"		"108"
 				"mac"		"108"
 			}
+			"Think"
+			{
+				"windows"	"56"
+				"linux"		"57"
+				"mac"		"57"
+			}
+			"Touch"
+			{
+				"windows"	"108"
+				"linux"		"109"
+				"mac"		"109"
+			}
 			"TraceAttack"
 			{
-				"windows"	"69"
-				"linux"		"70"
-				"mac"		"70"
+				"windows"	"70"
+				"linux"		"71"
+				"mac"		"71"
 			}
 			"Use"
 			{
-				"windows"	"105"
-				"linux"		"106"
-				"mac"		"106"
+				"windows"	"106"
+				"linux"		"107"
+				"mac"		"107"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"165"
-				"linux"		"166"
-				"mac"		"166"
+				"windows"	"166"
+				"linux"		"167"
+				"mac"		"167"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"285"
-				"linux"		"286"
-				"mac"		"286"
+				"windows"	"286"
+				"linux"		"287"
+				"mac"		"287"
 			}
 			"Weapon_CanUse"
-			{
-				"windows"	"279"
-				"linux"		"280"
-				"mac"		"280"
-			}
-			"Weapon_Drop"
-			{
-				"windows"	"282"
-				"linux"		"283"
-				"mac"		"283"
-			}
-			"Weapon_Equip"
 			{
 				"windows"	"280"
 				"linux"		"281"
 				"mac"		"281"
 			}
-			"Weapon_Switch"
+			"Weapon_Drop"
 			{
 				"windows"	"283"
 				"linux"		"284"
 				"mac"		"284"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"281"
+				"linux"		"282"
+				"mac"		"282"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"284"
+				"linux"		"285"
+				"mac"		"285"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.left4dead2.txt
+++ b/gamedata/sdktools.games/game.left4dead2.txt
@@ -122,93 +122,93 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"507"
-				"linux"		"508"
-				"mac"		"508"
+				"windows"	"508"
+				"linux"		"509"
+				"mac"		"509"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"289"
-				"linux"		"290"
-				"mac"		"290"
+				"windows"	"290"
+				"linux"		"291"
+				"mac"		"291"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"287"
-				"linux"		"288"
-				"mac"		"288"
+				"windows"	"288"
+				"linux"		"289"
+				"mac"		"289"
 			}
 			"Ignite"
 			{
-				"windows"	"222"
-				"linux"		"223"
-				"mac"		"223"
+				"windows"	"223"
+				"linux"		"224"
+				"mac"		"224"
 			}
 			"Extinguish"
 			{
-				"windows"	"225"
-				"linux"		"226"
-				"mac"		"226"
+				"windows"	"226"
+				"linux"		"227"
+				"mac"		"227"
 			}
 			"Teleport"
 			{
-				"windows"	"117"
-				"linux"		"118"
-				"mac"		"118"
+				"windows"	"118"
+				"linux"		"119"
+				"mac"		"119"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"475"
-				"linux"		"475"
-				"mac"		"475"
+				"windows"	"476"
+				"linux"		"476"
+				"mac"		"476"
 			}
 			"GetVelocity"
 			{
-				"windows"	"149"
-				"linux"		"150"
-				"mac"		"150"
+				"windows"	"150"
+				"linux"		"151"
+				"mac"		"151"
 			}
 			"EyeAngles"
 			{
-				"windows"	"140"
-				"linux"		"141"
-				"mac"		"141"
+				"windows"	"141"
+				"linux"		"142"
+				"mac"		"142"
 			}
 			"AcceptInput"
 			{
-				"windows"	"43"
-				"linux"		"44"
-				"mac"		"44"
+				"windows"	"44"
+				"linux"		"45"
+				"mac"		"45"
 			}
 			"SetEntityModel"
 			{
-				"windows"	"26"
-				"linux"		"27"
-				"mac"		"27"
+				"windows"	"27"
+				"linux"		"28"
+				"mac"		"28"
 			}
 			"WeaponEquip"
 			{
-				"windows"	"280"
-				"linux"		"281"
-				"mac"		"281"
+				"windows"	"281"
+				"linux"		"282"
+				"mac"		"282"
 			}
 			"Activate"
 			{
-				"windows"	"35"
-				"linux"		"36"
-				"mac"		"36"
+				"windows"	"36"
+				"linux"		"37"
+				"mac"		"37"
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"453"
-				"linux"		"454"
-				"mac"		"454"
+				"windows"	"454"
+				"linux"		"455"
+				"mac"		"455"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"273"
-				"linux"		"274"
-				"mac"		"274"
+				"windows"	"274"
+				"linux"		"275"
+				"mac"		"275"
 			}
 		}
 		


### PR DESCRIPTION
Updates Gamedata for upcoming Left4Dead2 update, which is set to release on 2020/09/24.

There's a new vtable entry early in CBaseEntity that pushes everything else up. 

Verified that latest sourcemod 1.10 stable runs on windows srcds & loads all default plugins. Verified "!slay" works with these gamedata changes.

Did more extensive testing on Linux srcds with sourcemod 1.10 and ran into no issues.

Did not test MacOS but the additional vtable entry appears there as well.