### PR TITLE
Use Python 3.x for 1.10 Windows builds

### DIFF
--- a/tools/buildbot/bootstrap.pl
+++ b/tools/buildbot/bootstrap.pl
@@ -64,7 +64,7 @@ if ($argn > 0 && $^O !~ /MSWin/) {
 	$result = `CC=$ARGV[0] CXX=$ARGV[0] python ../build/configure.py $conf_args`;
 } else {
 	if ($^O =~ /MSWin/) {
-		$result = `C:\\Python27\\Python.exe ..\\build\\configure.py $conf_args`;
+		$result = `C:\\Python38\\Python.exe ..\\build\\configure.py $conf_args`;
 	} else {
 		$result = `CC=clang CXX=clang python ../build/configure.py $conf_args`;
 	}


### PR DESCRIPTION
This should work around a bug explained by dvander below.

```
<dvander> the reason is that ambuild 2.2 uses the multiprocessing module which is extremely buggy on 2.7, and on windows it accidentally loads the database in every process
```

Launching configuration with python3 should solve this step.