### PR TITLE
Kill CDataPack cache

### DIFF
--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -46,25 +46,6 @@ CDataPack::~CDataPack()
 	Initialize();
 }
 
-static std::vector<std::unique_ptr<CDataPack>> sDataPackCache;
-
-CDataPack *CDataPack::New()
-{
-  if (sDataPackCache.empty())
-	return new CDataPack();
-
-  CDataPack *pack = sDataPackCache.back().release();
-  sDataPackCache.pop_back();
-  pack->Initialize();
-  return pack;
-}
-
-void
-CDataPack::Free(CDataPack *pack)
-{
-  sDataPackCache.emplace_back(pack);
-}
-
 void CDataPack::Initialize()
 {
 	position = 0;

--- a/core/logic/CDataPack.h
+++ b/core/logic/CDataPack.h
@@ -54,9 +54,6 @@ public:
 	CDataPack();
 	~CDataPack();
 
-    static CDataPack *New();
-    static void Free(CDataPack *pack);
-
 public: // Originally IDataReader
 	/**
 	 * @brief Resets the position in the data stream to the beginning.

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -61,7 +61,7 @@ public:
 	}
 	void OnHandleDestroy(HandleType_t type, void *object)
 	{
-		CDataPack::Free(reinterpret_cast<CDataPack *>(object));
+		delete reinterpret_cast<CDataPack *>(object);
 	}
 	bool GetHandleApproxSize(HandleType_t type, void *object, unsigned int *pSize)
 	{
@@ -73,7 +73,7 @@ public:
 
 static cell_t smn_CreateDataPack(IPluginContext *pContext, const cell_t *params)
 {
-	CDataPack *pDataPack = CDataPack::New();
+	CDataPack *pDataPack = new CDataPack();
 
 	if (!pDataPack)
 	{


### PR DESCRIPTION
Killing CDataPack's cache has been something on my list for a while - I'm not exactly sure when this became so easy (probably once IDataPack died), but here we are.

Technically, before this patch, we'd hold on to datapacks forever and their memory was never freed, we'd just save them for reuse. I do not think we're concerned anymore with the cost of allocating and deallocating this memory as-needed, so I'm just removing some bloat here.