### PR TITLE
NPOTB: Fix no SDK target exception

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -224,7 +224,7 @@ class SMConfig(object):
     builder.AddConfigureFile('pushbuild.txt')
     
     if not set(self.target_archs).issubset(['x86', 'x86_64']):
-      raise Exception('Unknown target architecture: {0}'.format(builder.target.arch))
+      raise Exception('Unknown target architecture: {0}'.format(self.target_archs))
 
     for cxx in self.all_targets:
         self.configure_cxx(cxx)

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -177,8 +177,7 @@ class SMConfig(object):
           self.sdks[sdk_name] = sdk
 
     if len(self.sdks) < 1 and len(sdk_list) and not use_none:
-      raise Exception('No SDKs were found that build on {0}-{1}, nothing to do.'.format(
-        builder.target.platform, builder.target.arch))
+      raise Exception('No SDKs were found that build on target(s) {0}. Nothing to do.'.format(", ".join(self.target_archs)))
 
     for sdk in not_found:
       print('Warning: hl2sdk-{} was not found, and will not be included in build.'.format(sdk))

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -177,7 +177,8 @@ class SMConfig(object):
           self.sdks[sdk_name] = sdk
 
     if len(self.sdks) < 1 and len(sdk_list) and not use_none:
-      raise Exception('No SDKs were found that build on target(s) {0}. Nothing to do.'.format(", ".join(self.target_archs)))
+      raise Exception('No SDKs were found that build on {0}-{1}, nothing to do.'.format(
+        builder.target.platform, builder.target.arch))
 
     for sdk in not_found:
       print('Warning: hl2sdk-{} was not found, and will not be included in build.'.format(sdk))


### PR DESCRIPTION
Another small regression from #1336 


Fixes #1343

I wasn't sure exactly how to format this, or how to get the platform from inside of this context - so instead of displaying platform we just show what build targets couldn't be found. I figure ignoring the platform here is fine