### PR TITLE
Fix sm_dump_netprops_xml

### DIFF
--- a/extensions/sdktools/vhelpers.cpp
+++ b/extensions/sdktools/vhelpers.cpp
@@ -412,12 +412,12 @@ void UTIL_DrawSendTable_XML(FILE *fp, SendTable *pTable, int space_count)
 	SendTable *pOtherTable;
 	SendProp *pProp;
 
-	fprintf(fp, " %s<sendtable name=\"%s\">\n", spaces, pTable->GetName());
+	fprintf(fp, " %s<sendtable name='%s'>\n", spaces, pTable->GetName());
 	for (int i = 0; i < pTable->GetNumProps(); i++)
 	{
 		pProp = pTable->GetProp(i);
 
-		fprintf(fp, "  %s<property name=\"%s\">\n", spaces, pProp->GetName());
+		fprintf(fp, "  %s<property name='%s'>\n", spaces, pProp->GetName());
 
 		if ((type_name = GetDTTypeName(pProp->GetType())) != NULL)
 		{
@@ -444,9 +444,9 @@ void UTIL_DrawSendTable_XML(FILE *fp, SendTable *pTable, int space_count)
 
 void UTIL_DrawServerClass_XML(FILE *fp, ServerClass *sc)
 {
-	fprintf(fp, "<serverclass name=\"%s\">\n", sc->GetName());
-	UTIL_DrawSendTable_XML(fp, sc->m_pTable, 0);
-	fprintf(fp, "</serverclass>\n");
+	fprintf(fp, " <serverclass name='%s'>\n", sc->GetName());
+	UTIL_DrawSendTable_XML(fp, sc->m_pTable, 1);
+	fprintf(fp, " </serverclass>\n");
 }
 
 void UTIL_DrawSendTable(FILE *fp, SendTable *pTable, int level = 1)
@@ -540,6 +540,7 @@ CON_COMMAND(sm_dump_netprops_xml, "Dumps the networkable property table as an XM
 
 	fprintf(fp, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n");
 	fprintf(fp, "<!-- Dump of all network properties for \"%s\" as at %s -->\n\n", g_pSM->GetGameFolderName(), buffer);
+	fprintf(fp, "<netprops>\n");
 
 	ServerClass *pBase = gamedll->GetAllServerClasses();
 	while (pBase != NULL)
@@ -548,6 +549,7 @@ CON_COMMAND(sm_dump_netprops_xml, "Dumps the networkable property table as an XM
 		pBase = pBase->m_pNext;
 	}
 
+	fprintf(fp, "</netprops>\n");
 	fclose(fp);
 }
 


### PR DESCRIPTION
Fixes some quirks with `sm_dump_netprops_xml`. I ran into some problems parsing this a few months back.

Adds an main tree.

Netprops can commonly use `"` in their names (`"healing_array"` in TF2 for example), but xml supports using both single and double quotes in attribute values, so now it opts to put in single quotes.

Edit:
I've provided a [sample netprop dump for TF2](https://hatebin.com/oofbfrcmcu) along with a [basic Python script](https://hatebin.com/oofbfrcmcu) so you can compare the difference between them if you'd like. Script will fail with current command functionality.