### PR TITLE
Improve logging on map/generic votes

### DIFF
--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -51,6 +51,8 @@ public Plugin myinfo =
 #define VOTE_NO "###no###"
 #define VOTE_YES "###yes###"
 
+#define GENERIC_COUNT 5
+
 Menu g_hVoteMenu = null;
 
 ConVar g_Cvar_Limits[3] = {null, ...};
@@ -182,12 +184,14 @@ public Action Command_Vote(int client, int args)
 	char text[256];
 	GetCmdArgString(text, sizeof(text));
 
-	char answers[5][64];
+	char answers[GENERIC_COUNT][64];
 	int answerCount;	
 	int len = BreakString(text, g_voteArg, sizeof(g_voteArg));
 	int pos = len;
 	
-	while (args > 1 && pos != -1 && answerCount < 5)
+	char answers_list[GENERIC_COUNT * 64] = "";
+	
+	while (args > 1 && pos != -1 && answerCount < GENERIC_COUNT)
 	{	
 		pos = BreakString(text[len], answers[answerCount], sizeof(answers[]));
 		answerCount++;
@@ -197,10 +201,6 @@ public Action Command_Vote(int client, int args)
 			len += pos;
 		}	
 	}
-
-	LogAction(client, -1, "\"%L\" initiated a generic vote.", client);
-	ShowActivity2(client, "[SM] ", "%t", "Initiate Vote", g_voteArg);
-	
 	g_voteType = question;
 	
 	g_hVoteMenu = new Menu(Handler_VoteCallback, MENU_ACTIONS_ALL);
@@ -210,14 +210,19 @@ public Action Command_Vote(int client, int args)
 	{
 		g_hVoteMenu.AddItem(VOTE_YES, "Yes");
 		g_hVoteMenu.AddItem(VOTE_NO, "No");
+		Format(answers_list, sizeof(answers_list), " \"Yes\" \"No\"");
 	}
 	else
 	{
 		for (int i = 0; i < answerCount; i++)
 		{
 			g_hVoteMenu.AddItem(answers[i], answers[i]);
+			Format(answers_list, sizeof(answers_list), "%s \"%s\"", answers_list, answers[i]);
 		}	
 	}
+	
+	LogAction(client, -1, "\"%L\" initiated a generic vote (question \"%s\" / answers%s).", client, g_voteArg, answers_list);
+	ShowActivity2(client, "[SM] ", "%t", "Initiate Vote", g_voteArg);
 	
 	g_hVoteMenu.ExitButton = false;
 	g_hVoteMenu.DisplayVoteToAll(20);		

--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -52,6 +52,7 @@ public Plugin myinfo =
 #define VOTE_YES "###yes###"
 
 #define GENERIC_COUNT 5
+#define ANSWER_SIZE 64
 
 Menu g_hVoteMenu = null;
 
@@ -184,12 +185,12 @@ public Action Command_Vote(int client, int args)
 	char text[256];
 	GetCmdArgString(text, sizeof(text));
 
-	char answers[GENERIC_COUNT][64];
+	char answers[GENERIC_COUNT][ANSWER_SIZE];
 	int answerCount;	
 	int len = BreakString(text, g_voteArg, sizeof(g_voteArg));
 	int pos = len;
 	
-	char answers_list[GENERIC_COUNT * 64] = "";
+	char answers_list[GENERIC_COUNT * (ANSWER_SIZE + 3)];
 	
 	while (args > 1 && pos != -1 && answerCount < GENERIC_COUNT)
 	{	

--- a/plugins/basevotes/votemap.sp
+++ b/plugins/basevotes/votemap.sp
@@ -31,6 +31,8 @@
  * Version: $Id$
  */
 
+#define MAPS_COUNT 5
+
 Menu g_MapList;
 int g_mapCount;
 
@@ -39,7 +41,14 @@ bool g_VoteMapInUse;
 
 void DisplayVoteMapMenu(int client, int mapCount, char[][] maps)
 {
-	LogAction(client, -1, "\"%L\" initiated a map vote.", client);
+	char maps_list[MAPS_COUNT * PLATFORM_MAX_PATH] = "";
+	
+	for (int i = 0; i < mapCount; i++)
+	{
+		Format(maps_list, sizeof(maps_list), "%s %s", maps_list, maps[i]);
+	}
+	
+	LogAction(client, -1, "\"%L\" initiated a map vote for%s.", client, maps_list);
 	ShowActivity2(client, "[SM] ", "%t", "Initiated Vote Map");
 	
 	g_voteType = map;
@@ -111,7 +120,7 @@ public int MenuHandler_Confirm(Menu menu, MenuAction action, int param1, int par
 	}
 	else if (action == MenuAction_Select)
 	{
-		char maps[5][PLATFORM_MAX_PATH];
+		char maps[MAPS_COUNT][PLATFORM_MAX_PATH];
 		int selectedmaps = g_SelectedMaps.Length;
 		
 		for (int i = 0; i < selectedmaps; i++)
@@ -163,7 +172,7 @@ public int MenuHandler_Map(Menu menu, MenuAction action, int param1, int param2)
 		g_SelectedMaps.PushString(info);
 		
 		/* Redisplay the list */
-		if (g_SelectedMaps.Length < 5)
+		if (g_SelectedMaps.Length < MAPS_COUNT)
 		{
 			g_MapList.Display(param1, MENU_TIME_FOREVER);
 		}
@@ -237,11 +246,11 @@ public Action Command_Votemap(int client, int args)
 	char text[256];
 	GetCmdArgString(text, sizeof(text));
 
-	char maps[5][PLATFORM_MAX_PATH];
+	char maps[MAPS_COUNT][PLATFORM_MAX_PATH];
 	int mapCount;	
 	int len, pos;
 	
-	while (pos != -1 && mapCount < 5)
+	while (pos != -1 && mapCount < MAPS_COUNT)
 	{	
 		pos = BreakString(text[len], maps[mapCount], sizeof(maps[]));
 		

--- a/plugins/basevotes/votemap.sp
+++ b/plugins/basevotes/votemap.sp
@@ -41,7 +41,7 @@ bool g_VoteMapInUse;
 
 void DisplayVoteMapMenu(int client, int mapCount, char[][] maps)
 {
-	char maps_list[MAPS_COUNT * PLATFORM_MAX_PATH] = "";
+	char maps_list[MAPS_COUNT * (PLATFORM_MAX_PATH + 1)];
 	
 	for (int i = 0; i < mapCount; i++)
 	{


### PR DESCRIPTION
Logging action is useful for servers’ owners with large number of admins. Actually, map votes and generic votes are not very verbose on what have been done. This request tries to improve the logging of those votes by adding maps names and question with answers in the log.