### PR TITLE
[ZPS] Gamedata update for sdktools/sdkhooks

### DIFF
--- a/gamedata/sdkhooks.games/game.zpanic.txt
+++ b/gamedata/sdkhooks.games/game.zpanic.txt
@@ -1,24 +1,23 @@
 "Games"
 {
-	/* Zombic Panic Source 3.0.7 (Hotfix-3) */
 	"zps"
 	{
 		"Offsets"
 		{
 			"EndTouch"
 			{
-				"windows"	"113"
-				"linux"		"114"
+				"windows"	"110"
+				"linux"		"111"
 			}
 			"FireBullets"
 			{
-				"windows"	"125"
-				"linux"		"126"
+				"windows"	"123"
+				"linux"		"125"
 			}
 			"OnTakeDamage"
 			{
-				"windows"	"74"
-				"linux"		"75"
+				"windows"	"72"
+				"linux"		"73"
 			}
 			"PreThink"
 			{
@@ -32,23 +31,23 @@
 			}
 			"SetTransmit"
 			{
-				"windows"	"26"
-				"linux"		"27"
-			}
-			"ShouldCollide"
-			{
-				"windows"	"22"
-				"linux"		"23"
-			}
-			"Spawn"
-			{
 				"windows"	"28"
 				"linux"		"29"
 			}
+			"ShouldCollide"
+			{
+				"windows"	"16"
+				"linux"		"17"
+			}
+			"Spawn"
+			{
+				"windows"	"30"
+				"linux"		"31"
+			}
 			"StartTouch"
 			{
-				"windows"	"111"
-				"linux"		"112"
+				"windows"	"108"
+				"linux"		"109"
 			}
 			"Think"
 			{
@@ -57,8 +56,8 @@
 			}
 			"Touch"
 			{
-				"windows"	"112"
-				"linux"		"113"
+				"windows"	"109"
+				"linux"		"110"
 			}
 			"TraceAttack"
 			{
@@ -67,13 +66,13 @@
 			}
 			"Use"
 			{
-				"windows"	"110"
-				"linux"		"111"
+				"windows"	"107"
+				"linux"		"108"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"170"
-				"linux"		"171"
+				"windows"	"171"
+				"linux"		"172"
 			}
 			"Weapon_CanSwitchTo"
 			{
@@ -82,23 +81,23 @@
 			}
 			"Weapon_CanUse"
 			{
-				"windows"	"274"
-				"linux"		"275"
-			}
-			"Weapon_Drop"
-			{
-				"windows"	"277"
-				"linux"		"278"
-			}
-			"Weapon_Equip"
-			{
 				"windows"	"275"
 				"linux"		"276"
 			}
-			"Weapon_Switch"
+			"Weapon_Drop"
 			{
 				"windows"	"278"
 				"linux"		"279"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"276"
+				"linux"		"277"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"279"
+				"linux"		"280"
 			}
 		}
 	}

--- a/gamedata/sdkhooks.games/game.zpanic.txt
+++ b/gamedata/sdkhooks.games/game.zpanic.txt
@@ -11,8 +11,8 @@
 			}
 			"FireBullets"
 			{
-				"windows"	"123"
-				"linux"		"125"
+				"windows"	"124"
+				"linux"		"124"
 			}
 			"OnTakeDamage"
 			{

--- a/gamedata/sdktools.games/game.zpanic.txt
+++ b/gamedata/sdktools.games/game.zpanic.txt
@@ -53,8 +53,8 @@
 			}
 			"GetVelocity"
 			{
-				"windows"	"153"
-				"linux"		"154"
+				"windows"	"154"
+				"linux"		"155"
 			}
 			"EyeAngles"
 			{

--- a/gamedata/sdktools.games/game.zpanic.txt
+++ b/gamedata/sdktools.games/game.zpanic.txt
@@ -89,58 +89,11 @@
 		}
 		"Signatures"
 		{
-			"FindEntityByClassname"
-			{
-				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\xF9\x8B\x4D\x2A\x85\xC9\x74\x2A\x8B\x01\xFF\x2A\x2A\x8B\x2A\x81\xE6\x2A\x2A\x2A\x2A\x46\x03\xF6\x8B\x34\x2A\xEB\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x85\xF6\x74\x2A\x8B\x5D\x2A\x8B\x3E\x85\xFF\x75\x2A\x68\x2A\x2A\x2A\x2A\xFF\x2A\x2A\x2A\x2A\x2A\x83\xC4\x2A\xEB\x2A\x39"
-				"linux"		"@_ZN17CGlobalEntityList21FindEntityByClassnameEP11CBaseEntityPKc"
-			}
 			"FireOutput"
 			{
 				"library"	"server"
 				"windows"	"\x55\x8B\xEC\x81\xEC\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\xC5\x89\x2A\x2A\x53\x8B\x5D\x2A\x8B\xC1\x8B\x2A\x2A\x56\x57"
 				"linux"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
-			}
-		}
-	}
-	
-	"zps"
-	{
-		"Offsets"
-		{
-			/* Offset into CBaseTempEntity constructor */
-			"s_pTempEntities"
-			{
-				"windows"	"19"
-			}
-			"GetTEName"
-			{
-				"windows"	"4"
-				"linux"		"4"
-			}
-			"GetTENext"
-			{
-				"windows"	"8"
-				"linux"		"8"
-			}
-			"TE_GetServerClass"
-			{
-				"windows"	"0"
-				"linux"		"0"
-			}
-		}
-
-		"Signatures"
-		{
-			"CBaseTempEntity"
-			{
-				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x8B\x45\x2A\xC7\x2A\x2A\x2A\x2A\x2A\x8B\x2A\x89"
-			}
-			"s_pTempEntities"
-			{
-				"library"	"server"
-				"linux"		"@_ZN15CBaseTempEntity15s_pTempEntitiesE"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.zpanic.txt
+++ b/gamedata/sdktools.games/game.zpanic.txt
@@ -18,18 +18,18 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"552"
-				"linux"		"553"
+				"windows"	"420"
+				"linux"		"421"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"289"
-				"linux"		"290"
+				"windows"	"288"
+				"linux"		"289"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"284"
-				"linux"		"285"
+				"windows"	"283"
+				"linux"		"284"
 			}
 			"Ignite"
 			{
@@ -43,13 +43,13 @@
 			}
 			"Teleport"
 			{
-				"windows"	"121"
-				"linux"		"122"
+				"windows"	"118"
+				"linux"		"119"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"465"
-				"linux"		"465"
+				"windows"	"461"
+				"linux"		"461"
 			}
 			"GetVelocity"
 			{
@@ -58,33 +58,33 @@
 			}
 			"EyeAngles"
 			{
-				"windows"	"144"
-				"linux"		"145"
+				"windows"	"145"
+				"linux"		"146"
 			}
 			"AcceptInput"
 			{
-				"windows"	"42"
-				"linux"		"43"
+				"windows"	"44"
+				"linux"		"45"
 			}
 			"SetEntityModel"
 			{
-				"windows"	"30"
-				"linux"		"31"
+				"windows"	"32"
+				"linux"		"33"
 			}
 			"WeaponEquip"
 			{
-				"windows"	"275"
-				"linux"		"276"
+				"windows"	"276"
+				"linux"		"277"
 			}
 			"Activate"
 			{
-				"windows"	"39"
-				"linux"		"40"
+				"windows"	"41"
+				"linux"		"42"
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"443"
-				"linux"		"444"
+				"windows"	"440"
+				"linux"		"441"
 			}
 		}
 		"Signatures"
@@ -92,7 +92,7 @@
 			"FindEntityByClassname"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\xF9\x8B\x4D\x2A\x85\xC9\x74\x2A\x8B\x01\xFF\x2A\x2A\x8B\x2A\x81\xE6\x2A\x2A\x2A\x2A\x46\x03\xF6\x8B\x34\x2A\xEB\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x85\xF6\x74\x2A\x8B\x5D\x2A\x8B\x3E\x85\xFF\x75\x2A\x68\x2A\x2A\x2A\x2A\xFF\x2A\x2A\x2A\x2A\x83\xC4\x2A\xEB\x2A\x39"
+				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\xF9\x8B\x4D\x2A\x85\xC9\x74\x2A\x8B\x01\xFF\x2A\x2A\x8B\x2A\x81\xE6\x2A\x2A\x2A\x2A\x46\x03\xF6\x8B\x34\x2A\xEB\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x85\xF6\x74\x2A\x8B\x5D\x2A\x8B\x3E\x85\xFF\x75\x2A\x68\x2A\x2A\x2A\x2A\xFF\x2A\x2A\x2A\x2A\x2A\x83\xC4\x2A\xEB\x2A\x39"
 				"linux"		"@_ZN17CGlobalEntityList21FindEntityByClassnameEP11CBaseEntityPKc"
 			}
 			"FireOutput"


### PR DESCRIPTION
Hello,

ZPS has recently been updated to version 3.1 which brought about changes to the gamedata files. Here is what was updated:

- Updated offsets for sdkools/sdkhooks (Windows and Linux)
- Updated "FindEntityByClassname" windows signature for sdktools.

I ran a few tests with several plugins to make sure of the changes and, so far, everything seems to be working. If there are any questions/concerns, please let me know.