### PR TITLE
Fixed unauthorized menu usages

### DIFF
--- a/plugins/basebans/ban.sp
+++ b/plugins/basebans/ban.sp
@@ -94,7 +94,7 @@ void DisplayBanTargetMenu(int client)
 	char title[100];
 	Format(title, sizeof(title), "%T:", "Ban player", client);
 	menu.SetTitle(title);
-	menu.ExitBackButton = true;
+	menu.ExitBackButton = CheckCommandAccess(client, "sm_admin", ADMFLAG_GENERIC, false);
 
 	AddTargetsToMenu2(menu, client, COMMAND_FILTER_NO_BOTS|COMMAND_FILTER_CONNECTED);
 

--- a/plugins/basecommands/kick.sp
+++ b/plugins/basecommands/kick.sp
@@ -52,7 +52,7 @@ void DisplayKickMenu(int client)
 	char title[100];
 	Format(title, sizeof(title), "%T:", "Kick player", client);
 	menu.SetTitle(title);
-	menu.ExitBackButton = true;
+	menu.ExitBackButton = CheckCommandAccess(client, "sm_admin", ADMFLAG_GENERIC, false);
 	
 	AddTargetsToMenu(menu, client, false, false);
 	

--- a/plugins/basecommands/who.sp
+++ b/plugins/basecommands/who.sp
@@ -94,7 +94,7 @@ void DisplayWhoMenu(int client)
 	char title[100];
 	Format(title, sizeof(title), "%T:", "Identify player", client);
 	menu.SetTitle(title);
-	menu.ExitBackButton = true;
+	menu.ExitBackButton = CheckCommandAccess(client, "sm_admin", ADMFLAG_GENERIC, false);
 	
 	AddTargetsToMenu2(menu, 0, COMMAND_FILTER_CONNECTED);
 	


### PR DESCRIPTION
Let's say we have kick flag but don't have admin menu flag.
When we type !kick, menu opens with a back button, when we click back button, we go parent menu without admin menu flag