### PR TITLE
Add NULL check to GetEntPropString return.

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -2201,9 +2201,15 @@ static cell_t GetEntPropString(IPluginContext *pContext, const cell_t *params)
 		}
 	}
 
-	size_t len;
-	pContext->StringToLocalUTF8(params[4], params[5], src, &len);
-	return len;
+	if (src)
+	{
+		size_t len;
+		pContext->StringToLocalUTF8(params[4], params[5], src, &len);
+		return len;
+	}
+
+	pContext->StringToLocal(params[4], params[5], "");
+	return 0;
 }
 
 static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)


### PR DESCRIPTION
This can be NULL for non-interned strings that don't have a value set.

Ran into this after #1372 fixed working with these at all.