### PR TITLE
Execute ConVarQueryFinished if client disconnects

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -236,19 +236,18 @@ void ConVarManager::OnPluginUnloaded(IPlugin *plugin)
 
 void ConVarManager::OnClientDisconnected(int client)
 {
-	IPluginFunction *pCallback = NULL;
 	/* Remove convar queries for this client that haven't returned results yet */
 	for (List<ConVarQuery>::iterator iter = m_ConVarQueries.begin(); iter != m_ConVarQueries.end();)
 	{
 		ConVarQuery &query = (*iter);
 		if (query.client == client)
 		{
-			pCallback = query.pCallback;
+			IPluginFunction *pCallback = query.pCallback;
 			if (pCallback)
 			{
 				cell_t ret;
 
-				pCallback->PushCell(InvalidQueryCvarCookie);
+				pCallback->PushCell(0);
 				pCallback->PushCell(client);
 				pCallback->PushCell(eQueryCvarValueStatus_Cancelled);
 				pCallback->PushString("");

--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -247,7 +247,7 @@ void ConVarManager::OnClientDisconnected(int client)
 			{
 				cell_t ret;
 
-				pCallback->PushCell(0);
+				pCallback->PushCell(query.cookie);
 				pCallback->PushCell(client);
 				pCallback->PushCell(eQueryCvarValueStatus_Cancelled);
 				pCallback->PushString("");

--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -251,8 +251,8 @@ void ConVarManager::OnClientDisconnected(int client)
 				pCallback->PushCell(InvalidQueryCvarCookie);
 				pCallback->PushCell(client);
 				pCallback->PushCell(eQueryCvarValueStatus_Cancelled);
-				pCallback->PushString("\0");
-				pCallback->PushString("\0");
+				pCallback->PushString("");
+				pCallback->PushString("");
 				pCallback->PushCell(query.value);
 				pCallback->Execute(&ret);
 			}

--- a/plugins/include/convars.inc
+++ b/plugins/include/convars.inc
@@ -49,7 +49,7 @@ enum ConVarBounds
  */
 enum ConVarQueryResult
 {
-	ConVarQuery_Cancelled = -1,			//< Client disconnected during query */
+	ConVarQuery_Cancelled = -1,         //< Client disconnected during query */
 	ConVarQuery_Okay = 0,               //< Retrieval of client convar value was successful. */
 	ConVarQuery_NotFound,               //< Client convar was not found. */
 	ConVarQuery_NotValid,               //< A console command with the same name was found, but there is no convar. */

--- a/plugins/include/convars.inc
+++ b/plugins/include/convars.inc
@@ -49,6 +49,7 @@ enum ConVarBounds
  */
 enum ConVarQueryResult
 {
+	ConVarQuery_Cancelled = -1,			//< Client disconnected during query */
 	ConVarQuery_Okay = 0,               //< Retrieval of client convar value was successful. */
 	ConVarQuery_NotFound,               //< Client convar was not found. */
 	ConVarQuery_NotValid,               //< A console command with the same name was found, but there is no convar. */


### PR DESCRIPTION
So people passing handles to the extra data can close them, adds a new return value to check if this happened