### PR TITLE
Fix missed old syntax parameter in menus

### DIFF
--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -518,7 +518,7 @@ native bool AddMenuItem(Handle menu,
  * @error               Invalid Handle or menu position.
  */
 native bool InsertMenuItem(Handle menu,
-						position,
+						int position,
 						const char[] info,
 						const char[] display,
 						int style=ITEMDRAW_DEFAULT);


### PR DESCRIPTION
Just noticed this when I was going through the includes, It's just a missing int for InsertMenuItem