### PR TITLE
Take into account the returned value in SDKHook_Think callbacks

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -1458,7 +1458,11 @@ void SDKHooks::Hook_StartTouchPost(CBaseEntity *pOther)
 
 void SDKHooks::Hook_Think()
 {
-	Call(META_IFACEPTR(CBaseEntity), SDKHook_Think);
+	cell_t result = Call(META_IFACEPTR(CBaseEntity), SDKHook_Think);
+
+	if(result >= Pl_Handled)
+		RETURN_META(MRES_SUPERCEDE);
+
 	RETURN_META(MRES_IGNORED);
 }
 

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -237,11 +237,12 @@ typeset SDKHookCB
 	function void (int client);
 
 	// Spawn
+	// Think
 	function Action (int entity);
 
 	// GroundEntChanged
 	// SpawnPost
-	// Think/Post
+	// ThinkPost
 	// VPhysicsUpdate/Post
 	function void (int entity);
 


### PR DESCRIPTION
To disable entirely the call of "**EntityX::Think()**", using the property "**m_nNextThinkTick**" is enough.
But sometimes I want to use the "**EntityX::Think()**" to do something else, i.e. to replace it with my own code.

In SDKHook_Think callbacks, the returned value need to be taken into account to do this.
