### PR TITLE
Add OnAdminMenuTitleFormat() forward

### DIFF
--- a/plugins/adminmenu.sp
+++ b/plugins/adminmenu.sp
@@ -50,6 +50,7 @@ public Plugin myinfo =
 /* Forwards */
 GlobalForward hOnAdminMenuReady;
 GlobalForward hOnAdminMenuCreated;
+GlobalForward hOnAdminMenuTitleFormat;
 
 /* Menus */
 TopMenu hAdminMenu;
@@ -77,6 +78,7 @@ public void OnPluginStart()
 	
 	hOnAdminMenuCreated = new GlobalForward("OnAdminMenuCreated", ET_Ignore, Param_Cell);
 	hOnAdminMenuReady = new GlobalForward("OnAdminMenuReady", ET_Ignore, Param_Cell);
+	hOnAdminMenuTitleFormat = new GlobalForward("OnAdminMenuTitleFormat", ET_Ignore, Param_Cell, Param_String, Param_Cell);
 
 	RegAdminCmd("sm_admin", Command_DisplayMenu, ADMFLAG_GENERIC, "Displays the admin menu");
 }
@@ -131,6 +133,12 @@ public void DefaultCategoryHandler(TopMenu topmenu,
 		if (object_id == INVALID_TOPMENUOBJECT)
 		{
 			Format(buffer, maxlength, "%T:", "Admin Menu", param);
+
+			Call_StartForward(hOnAdminMenuTitleFormat);
+			Call_PushCell(param);
+			Call_PushStringEx(buffer, maxlength, SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
+			Call_PushCell(maxlength);
+			Call_Finish();
 		}
 		else if (object_id == obj_playercmds)
 		{

--- a/plugins/include/adminmenu.inc
+++ b/plugins/include/adminmenu.inc
@@ -74,6 +74,15 @@ forward void OnAdminMenuCreated(Handle topmenu);
 forward void OnAdminMenuReady(Handle topmenu);
 
 /**
+ * Called when the admin menu is formatting title in main menu.
+ *
+ * @param client        Index of the client for who title is formatting.
+ * @param buffer        Buffer where admin title should be written.
+ * @param maxlength     Maximum size of the title buffer.
+ */
+forward void OnAdminMenuTitleFormat(int client, char[] buffer, int maxlength);
+
+/**
  * Retrieves the Handle to the admin top menu.
  *
  * @return              Handle to the admin menu's TopMenu,


### PR DESCRIPTION
This PR implements a simple forward for extending admin menu title without requiring a modify plugin.
This forward allows you add any custom content in admin title. For example, primary admin group:
```sourcepawn
#include <sourcemod>
#include <adminmenu>

public void OnPluginStart()
{
    LoadTranslations("adminmenu_groupname.phrases");
}

public void OnAdminMenuTitleFormat(int client, char[] buffer, int maxlength)
{
    AdminId admin = GetUserAdmin(client);
    if (admin == INVALID_ADMIN_ID)
    {
        return; // wut?
    }

    if (admin.GroupCount == 0)
    {
        return; // user doesn't have any admin group.
    }

    // We're suggest first admin group as required for displaying.
    char admingroup_name[64];
    admin.GetGroup(0, admingroup_name, sizeof(admingroup_name));
    Format(buffer, maxlength, "%s\n%T", buffer, "Current Admin Group", client, admingroup_name);
}
```
Example result:
![adminmenu_groupname](https://user-images.githubusercontent.com/12576822/101309809-b20dca80-3866-11eb-9d19-9e82095e7928.png)