### PR TITLE
Implement forward OnNextMapChanged

### DIFF
--- a/core/NextMap.cpp
+++ b/core/NextMap.cpp
@@ -75,6 +75,10 @@ void NextMapManager::OnSourceModAllInitialized_Post()
 		SH_ADD_HOOK(ConCommand, Dispatch, pCmd, SH_STATIC(CmdChangeLevelCallback), false);
 		changeLevelCmd = pCmd;
 	}
+	
+	m_pOnNextMapChanged = forwardsys->CreateForward("OnNextMapChanged", ET_Ignore, 0, NULL);
+	
+	g_ConVarManager.AddConVarChangeListener("sm_nextmap", this);
 }
 
 void NextMapManager::OnSourceModShutdown()
@@ -98,6 +102,10 @@ void NextMapManager::OnSourceModShutdown()
 		delete (MapChangeData *)*iter;
 		iter = m_mapHistory.erase(iter);
 	}
+	
+	forwardsys->ReleaseForward(m_pOnNextMapChanged);
+	
+	g_ConVarManager.RemoveConVarChangeListener("sm_nextmap", this);
 }
 
 const char *NextMapManager::GetNextMap()
@@ -113,8 +121,20 @@ bool NextMapManager::SetNextMap(const char *map)
 	}
 
 	sm_nextmap.SetValue(map);
+	
+	NextMapChanged();
 
 	return true;
+}
+
+void NextMapManager::NextMapChanged()
+{	
+	m_pOnNextMapChanged->Execute(NULL);
+}
+
+void NextMapManager::OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue)
+{	
+	NextMapChanged();
 }
 
 #if SOURCE_ENGINE != SE_DARKMESSIAH

--- a/core/NextMap.cpp
+++ b/core/NextMap.cpp
@@ -121,8 +121,6 @@ bool NextMapManager::SetNextMap(const char *map)
 	}
 
 	sm_nextmap.SetValue(map);
-	
-	NextMapChanged();
 
 	return true;
 }

--- a/core/NextMap.h
+++ b/core/NextMap.h
@@ -32,6 +32,8 @@
 #ifndef _INCLUDE_SOURCEMOD_NEXTMAP_H_
 #define _INCLUDE_SOURCEMOD_NEXTMAP_H_
 
+#include <IForwardSys.h>
+#include "ConVarManager.h"
 #include "sm_globals.h"
 #include <eiface.h>
 #include "sh_list.h"
@@ -65,7 +67,9 @@ void CmdChangeLevelCallback(const CCommand &command);
 void CmdChangeLevelCallback();
 #endif
 
-class NextMapManager : public SMGlobalClass
+class NextMapManager : 
+	public SMGlobalClass,
+	public IConVarChangeListener
 {
 public:
 	NextMapManager();
@@ -79,9 +83,12 @@ public:
 	void OnSourceModAllInitialized_Post();
 	void OnSourceModShutdown();
 	void OnSourceModLevelChange(const char *mapName);
+	
+	void OnConVarChanged(ConVar *pConVar, const char *oldValue, float flOldValue);
 
 	const char *GetNextMap();
 	bool SetNextMap(const char *map);
+	void NextMapChanged();
 
 	void ForceChangeLevel(const char *mapName, const char* changeReason);
 
@@ -97,6 +104,8 @@ public:
 private:
 	MapChangeData m_tempChangeInfo;
 	char lastMap[32];
+	
+	IForward *m_pOnNextMapChanged;
 };
 
 extern NextMapManager g_NextMap;

--- a/plugins/include/nextmap.inc
+++ b/plugins/include/nextmap.inc
@@ -54,6 +54,11 @@ native bool SetNextMap(const char[] map);
 native bool GetNextMap(char[] map, int maxlen);
 
 /**
+ * Notification that the SourceMod's internal nextmap has changed.
+ */
+forward void OnNextMapChanged();
+
+/**
  * Changes the current map and records the reason for the change with maphistory
  *
  * @param map           Map to change to.


### PR DESCRIPTION
Implement forward OnNextMapChanged in order to be notified on plugins when the next map has been changed internally by SetNextMap() native or by cvar change "sm_nextmap". Resolves #1395 