### PR TITLE
[CS:GO] Remove control chars from gamedata

### DIFF
--- a/gamedata/sm-cstrike.games/game.csgo.txt
+++ b/gamedata/sm-cstrike.games/game.csgo.txt
@@ -204,10 +204,10 @@
 		{
 			"CScore"
 			{
-				"windows"	"51‬"
-				"linux"		"51‬"
-				"linux64"	"51‬"
-				"mac64"		"51‬"
+				"windows"	"51"
+				"linux"		"51"
+				"linux64"	"51"
+				"mac64"		"51"
 			}
 		}
 	}
@@ -223,10 +223,10 @@
 		{
 			"MVPs"
 			{
-				"windows"	"11‬"
-				"linux"		"11‬"
-				"linux64"	"11‬"
-				"mac64"		"11‬"
+				"windows"	"11"
+				"linux"		"11"
+				"linux64"	"11"
+				"mac64"		"11"
 			}
 		}
 	}


### PR DESCRIPTION
Someone copied some control chars into the gamedata when updating signatures.