### PR TITLE
Add sm_dump_datamaps_xml

### DIFF
--- a/extensions/sdktools/vhelpers.cpp
+++ b/extensions/sdktools/vhelpers.cpp
@@ -999,7 +999,7 @@ CON_COMMAND(sm_dump_datamaps_xml, "Dumps the data map list as an XML file")
 
 	if (args.ArgC() < 2)
 	{
-		META_CONPRINT("Usage: sm_dump_datamaps <file>\n");
+		META_CONPRINT("Usage: sm_dump_datamaps_xml <file>\n");
 		return;
 	}
 


### PR DESCRIPTION
There's an `sm_dump_netprops_xml` but not an `sm_dump_datamaps_xml` and since I went a bit nuts parsing a plain text file, I thought it would be useful to extend it into a parsable format.

This also adds the element offset for sub-class tables since I needed them for my exact purpose.