### PR TITLE
Expose SourcePawn JIT metadata config

### DIFF
--- a/configs/core.cfg
+++ b/configs/core.cfg
@@ -145,5 +145,15 @@
 	 * Disable this option at your own risk.
 	 */
 	"FollowCSGOServerGuidelines"	"yes"
-}
 
+	/**
+	 * Controls whether the SourcePawn runtime will generate additional metadata about
+	 * JIT-compiled functions for performance profiling or debugging purposes.
+	 *
+	 * "none"    - Don't generate any additional JIT metadata
+	 * "default" - Generate basic perf metadata (on Linux) and delete it automatically on quit
+	 * "perf"    - Generate basic perf metadata (Linux only - function names)
+	 * "jitdump" - Generate extended perf metadata (Linux only - function names, bytecode, and source information)
+	 */
+	"JITMetadata"	"default"
+}


### PR DESCRIPTION
Adds a new option to core.cfg to configure the debug/profiling metadata written by the JIT.

Depends on alliedmodders/sourcepawn#533.