### PR TITLE
Update note about non-existing SQL_MoreResults

### DIFF
--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -797,7 +797,7 @@ native bool SQL_FieldNameToNum(Handle query, const char[] name, int &field);
  * Fetches a row from the current result set.  This must be 
  * successfully called before any results are fetched.
  *
- * If this function fails, SQL_MoreResults() can be used to
+ * If this function fails, SQL_FetchMoreResults() can be used to
  * tell if there was an error or the result set is finished.
  * 
  * @param query         A query (or statement) Handle.

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -162,7 +162,7 @@ methodmap DBResultSet < Handle
 	// Fetches a row from the current result set.  This must be 
 	// successfully called before any results are fetched.
 	//
-	// If this function fails, _MoreResults can be used to
+	// If this function fails, _MoreRows can be used to
 	// tell if there was an error or the result set is finished.
 	// 
 	// @return             True if a row was fetched, false otherwise.
@@ -797,7 +797,7 @@ native bool SQL_FieldNameToNum(Handle query, const char[] name, int &field);
  * Fetches a row from the current result set.  This must be 
  * successfully called before any results are fetched.
  *
- * If this function fails, SQL_FetchMoreResults() can be used to
+ * If this function fails, SQL_MoreRows() can be used to
  * tell if there was an error or the result set is finished.
  * 
  * @param query         A query (or statement) Handle.

--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -162,7 +162,7 @@ methodmap DBResultSet < Handle
 	// Fetches a row from the current result set.  This must be 
 	// successfully called before any results are fetched.
 	//
-	// If this function fails, _MoreRows can be used to
+	// If this function fails, MoreRows can be used to
 	// tell if there was an error or the result set is finished.
 	// 
 	// @return             True if a row was fetched, false otherwise.


### PR DESCRIPTION
`SQL_MoreResults` does not exist. The note should refer to `SQL_FetchMoreResults` instead. This was found by Naleksuh and Addie: https://discord.com/channels/335290997317697536/335290997317697536/793685290509139988