### PR TITLE
Fix sql injection in sql-admin-manager plugin

### DIFF
--- a/plugins/sql-admin-manager.sp
+++ b/plugins/sql-admin-manager.sp
@@ -789,7 +789,7 @@ public Action Command_AddAdmin(int client, int args)
 
 	DBResultSet rs;
 	
-	Format(query, sizeof(query), "SELECT id FROM sm_admins WHERE authtype = '%s' AND identity = '%s'", authtype, identity);
+	Format(query, sizeof(query), "SELECT id FROM sm_admins WHERE authtype = '%s' AND identity = '%s'", authtype, safe_identity);
 	if ((rs = SQL_Query(db, query)) == null)
 	{
 		return DoError(client, db, query, "Admin retrieval query failed");


### PR DESCRIPTION
This bug was found as part of justCTF 2020 in the PainterHell challenge by cypis. Thank you!

Admins with the root flag could inject their own queries towards the admin database connection.

The sql-admin-manager plugin is disabled by default.