### PR TITLE
Prefer python3 over python(2) in checkout-deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages: ['clang-3.8', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib']
+          packages: ['clang-3.8', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib', 'python3-pip']
       env:
         - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
         - SDKS=episode1,css,tf2,l4d2,csgo
@@ -29,7 +29,7 @@ jobs:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-          packages: ['clang-3.4', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib']
+          packages: ['clang-3.4', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev:i386', 'g++-4.9-multilib', 'python3-pip']
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - SDKS=episode1,css,tf2,l4d2,csgo

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,5 @@ script:
   - eval "${MATRIX_EVAL}"
   - eval "${CC} --version"
   - eval "${CXX} --version"
-  - python ../configure.py --enable-${MODE} --sdks=${SDKS} --targets=${ARCH}
+  - python3 ../configure.py --enable-${MODE} --sdks=${SDKS} --targets=${ARCH}
   - ambuild

--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -92,10 +92,10 @@ $SDKS | ForEach-Object {
 }
 
 # Find a suitable installation of Python
-$PYTHON_CMD = Get-Command 'python' -ErrorAction SilentlyContinue
+$PYTHON_CMD = Get-Command 'python3' -ErrorAction SilentlyContinue
 if ($NULL -eq $PYTHON_CMD)
 {
-    $PYTHON_CMD = Get-Command 'python3' -ErrorAction SilentlyContinue
+    $PYTHON_CMD = Get-Command 'python' -ErrorAction SilentlyContinue
     if ($NULL -eq $PYTHON_CMD)
     {
         $PYTHON_CMD = Get-Command 'py' -ErrorAction SilentlyContinue

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -153,11 +153,11 @@ if [ -z "$python_cmd" ]; then
   fi
 fi
 
-`$python_cmd -c "import ambuild2"` 2>&1 1>/dev/null
+$python_cmd -c "import ambuild2" 2>&1 1>/dev/null
 if [ $? -eq 1 ]; then
   echo "AMBuild is required to build SourceMod"
 
-  `$python_cmd -m pip --version` 2>&1 1>/dev/null
+  $python_cmd -m pip --version 2>&1 1>/dev/null
   if [ $? -eq 1 ]; then
     echo "The detected Python installation does not have PIP"
     echo "Installing the latest version of PIP available (VIA \"get-pip.py\")"

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -143,9 +143,9 @@ do
   checkout
 done
 
-python_cmd=`command -v python`
+python_cmd=`command -v python3`
 if [ -z "$python_cmd" ]; then
-  python_cmd=`command -v python3`
+  python_cmd=`command -v python`
 
   if [ -z "$python_cmd" ]; then
     echo "No suitable installation of Python detected"


### PR DESCRIPTION
We require Python 3 and don't want to accidentally use Python 2 if both are available.

Trying to fix travis builds.