### PR TITLE
fix issues when loading randomcycle from disabled folder

### DIFF
--- a/plugins/randomcycle.sp
+++ b/plugins/randomcycle.sp
@@ -4,7 +4,7 @@
  * SourceMod Random Map Cycle Plugin
  * Randomly picks a map from the mapcycle.
  *
- * SourceMod (C)2004-2014 AlliedModders LLC.  All rights reserved.
+ * SourceMod (C)2004-2021 AlliedModders LLC.  All rights reserved.
  * =============================================================================
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -50,6 +50,7 @@ ConVar g_Cvar_ExcludeMaps;
 ArrayList g_MapList = null;
 ArrayList g_OldMapList = null;
 int g_mapListSerial = -1;
+Handle g_MapTimer = null;
 
 public void OnPluginStart()
 {
@@ -76,7 +77,10 @@ public void OnConfigsExecuted()
 		}
 	}
 	
-	CreateTimer(5.0, Timer_RandomizeNextmap); // Small delay to give Nextmap time to complete OnMapStart()
+	if (g_MapTimer == null)
+	{
+		g_MapTimer = CreateTimer(5.0, Timer_RandomizeNextmap); // Small delay to give Nextmap time to complete OnMapStart()
+	}
 }
 
 public Action Timer_RandomizeNextmap(Handle timer)
@@ -107,5 +111,6 @@ public Action Timer_RandomizeNextmap(Handle timer)
 
 	LogAction(-1, -1, "RandomCycle has chosen %s for the nextmap.", map);	
 
+	g_MapTimer = null;
 	return Plugin_Stop;
 }

--- a/plugins/randomcycle.sp
+++ b/plugins/randomcycle.sp
@@ -76,7 +76,7 @@ public void OnConfigsExecuted()
 		}
 	}
 	
-	CreateTimer(5.0, Timer_RandomizeNextmap, TIMER_FLAG_NO_MAPCHANGE); // Small delay to give Nextmap time to complete OnMapStart()
+	CreateTimer(5.0, Timer_RandomizeNextmap, _, TIMER_FLAG_NO_MAPCHANGE); // Small delay to give Nextmap time to complete OnMapStart()
 }
 
 public Action Timer_RandomizeNextmap(Handle timer)

--- a/plugins/randomcycle.sp
+++ b/plugins/randomcycle.sp
@@ -50,7 +50,6 @@ ConVar g_Cvar_ExcludeMaps;
 ArrayList g_MapList = null;
 ArrayList g_OldMapList = null;
 int g_mapListSerial = -1;
-Handle g_MapTimer = null;
 
 public void OnPluginStart()
 {
@@ -77,10 +76,7 @@ public void OnConfigsExecuted()
 		}
 	}
 	
-	if (g_MapTimer == null)
-	{
-		g_MapTimer = CreateTimer(5.0, Timer_RandomizeNextmap); // Small delay to give Nextmap time to complete OnMapStart()
-	}
+	CreateTimer(5.0, Timer_RandomizeNextmap, TIMER_FLAG_NO_MAPCHANGE); // Small delay to give Nextmap time to complete OnMapStart()
 }
 
 public Action Timer_RandomizeNextmap(Handle timer)
@@ -111,6 +107,5 @@ public Action Timer_RandomizeNextmap(Handle timer)
 
 	LogAction(-1, -1, "RandomCycle has chosen %s for the nextmap.", map);	
 
-	g_MapTimer = null;
 	return Plugin_Stop;
 }


### PR DESCRIPTION
currently, when loading randomcycle, it runs `Timer_RandomizeNextmap` twice, leading to odd behavior where the map gets changed twice after timelimit is reached. This fixes that issue by only allowing the timer to be run once per map.