### PR TITLE
Harden plugin loading path requirements

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -631,6 +631,12 @@ IExtension *CExtensionManager::FindExtensionByName(const char *ext)
 
 IExtension *CExtensionManager::LoadExtension(const char *file, char *error, size_t maxlength)
 {
+	if (strstr(file, "..") != NULL)
+	{
+		ke::SafeStrcpy(error, maxlength, "Cannot load extensions outside the \"extensions\" folder.");
+		return NULL;
+	}
+
 	/* Remove platform extension if it's there. Compat hack. */
 	const char *ext = libsys->GetFileExtension(file);
 	if (strcmp(ext, PLATFORM_LIB_EXT) == 0)

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -639,7 +639,7 @@ IExtension *CExtensionManager::LoadExtension(const char *file, char *error, size
 
 	/* Remove platform extension if it's there. Compat hack. */
 	const char *ext = libsys->GetFileExtension(file);
-	if (strcmp(ext, PLATFORM_LIB_EXT) == 0)
+	if (ext && strcmp(ext, PLATFORM_LIB_EXT) == 0)
 	{
 		char path2[PLATFORM_MAX_PATH];
 		ke::SafeStrcpy(path2, sizeof(path2), file);

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -974,6 +974,20 @@ IPlugin *CPluginManager::LoadPlugin(const char *path, bool debug, PluginType typ
 	LoadRes res;
 
 	*wasloaded = false;
+
+	if (strstr(path, "..") != NULL)
+	{
+		ke::SafeStrcpy(error, maxlength, "Cannot load plugins outside the \"plugins\" folder");
+		return NULL;
+	}
+
+	const char *ext = libsys->GetFileExtension(path);
+	if (!ext || strcmp(ext, "smx") != 0)
+	{
+		ke::SafeStrcpy(error, maxlength, "Plugin files must have the \".smx\" file extension");
+		return NULL;
+	}
+
 	if ((res=LoadPlugin(&pl, path, true, PluginType_MapUpdated)) == LoadRes_Failure)
 	{
 		ke::SafeStrcpy(error, maxlength, pl->GetErrorMsg());


### PR DESCRIPTION
Restrict loading of plugins to the `sourcemod/plugins` folder and require the `.smx` file extension.

Symlinks inside the `plugins` folder are fine. Apply the same path restriction to extensions as well.

This behavior was abused as part of justCTF 2020 in the PainterHell challenge by cypis. Thank you!