### PR TITLE
Update IPlugin reference on cmd hook removal

### DIFF
--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -121,8 +121,13 @@ void ConCmdManager::OnPluginDestroyed(IPlugin *plugin)
 		if (hook->admin)
 			hook->admin->group->hooks.remove(hook);
 
-		if (hook->info->hooks.empty())
+		if (hook->info->hooks.empty()) {
 			RemoveConCmd(hook->info, hook->info->pCmd->GetName(), true);
+		}
+		else { // update plugin reference to next hook in line
+			auto next = *hook->info->hooks.begin();
+			next->info->pPlugin = next->plugin;
+		}
 
 		iter = pList->erase(iter);
 		delete hook;
@@ -360,7 +365,7 @@ bool ConCmdManager::AddAdminCommand(IPluginFunction *pFunction,
 	}
 	RefPtr<CommandGroup> cmdgroup = i->value;
 
-	CmdHook *pHook = new CmdHook(CmdHook::Client, pInfo, pFunction, description);
+	CmdHook *pHook = new CmdHook(CmdHook::Client, pInfo, pFunction, description, pPlugin);
 	pHook->admin = std::make_unique<AdminCmdInfo>(cmdgroup, adminflags);
 
 	/* First get the command group override, if any */
@@ -399,7 +404,7 @@ bool ConCmdManager::AddServerCommand(IPluginFunction *pFunction,
 	if (!pInfo)
 		return false;
 
-	CmdHook *pHook = new CmdHook(CmdHook::Server, pInfo, pFunction, description);
+	CmdHook *pHook = new CmdHook(CmdHook::Server, pInfo, pFunction, description, pPlugin);
 
 	pInfo->hooks.append(pHook);
 	RegisterInPlugin(pHook);

--- a/core/ConCmdManager.h
+++ b/core/ConCmdManager.h
@@ -80,10 +80,11 @@ struct CmdHook : public ke::InlineListNode<CmdHook>
 		Client
 	};
 
-	CmdHook(Type type, ConCmdInfo *cmd, IPluginFunction *fun, const char *description)
+	CmdHook(Type type, ConCmdInfo *cmd, IPluginFunction *fun, const char *description, IPlugin *plugin)
 		: type(type),
 		  info(cmd),
 		  pf(fun),
+		  plugin(plugin),
 		  helptext(description)
 	{
 	}
@@ -91,6 +92,7 @@ struct CmdHook : public ke::InlineListNode<CmdHook>
 	Type type;
 	ConCmdInfo *info;
 	IPluginFunction *pf;				/* function hook */
+	IPlugin *plugin;					/* owning plugin */
 	std::string helptext;				/* help text */
 	std::unique_ptr<AdminCmdInfo> admin;	/* admin requirements, if any */
 };


### PR DESCRIPTION
Fixes #1387 

When two separate plugins hook the same cmd and one of those plugins are unloaded (or reloaded), then the IPlugin reference is never updated on the `CmdInfo` object, therefore when we try to get the plugin handle afterwards we explode. This patch identifies plugins on the hook level as well, that way when the owning plugin is unloaded we can update the IPlugin reference to the next hook in line.