### PR TITLE
Fix crash when creating threads with Thread_AutoRelease

### DIFF
--- a/core/logic/ThreadSupport.cpp
+++ b/core/logic/ThreadSupport.cpp
@@ -376,6 +376,7 @@ void CompatThread::Run()
 		// There should be no handles outstanding, so it's safe to self-destruct.
 		thread_->detach();
 		delete this;
+		return;
 	}
 
 	lock.lock();


### PR DESCRIPTION
Setting the Thread_AutoRelease flag (default when using IThreader::MakeThread) caused a use-after-free after running the thread body.

This fixes Accelerator on SourceMod 1.11 🥳 