### PR TITLE
NormalSHook erroring on non-IsInGame clients

### DIFF
--- a/extensions/sdktools/vsound.cpp
+++ b/extensions/sdktools/vsound.cpp
@@ -388,6 +388,17 @@ void SoundHooks::OnEmitSound(IRecipientFilter &filter, int iEntIndex, int iChann
 			}
 		case Pl_Changed:
 			{
+				if (size < 0 || size > SM_ARRAYSIZE(players))
+				{
+					pFunc->GetParentContext()->BlamePluginError(pFunc, "Callback-provided size %d is invalid", size);
+
+#if SOURCE_ENGINE >= SE_PORTAL2
+					RETURN_META_VALUE(MRES_IGNORED, -1);
+#else
+					return;
+#endif
+				}
+
 				/* Client validation */
 				for (int i = 0; i < size; i++)
 				{
@@ -397,17 +408,18 @@ void SoundHooks::OnEmitSound(IRecipientFilter &filter, int iEntIndex, int iChann
 					if (!pPlayer)
 					{
 						pFunc->GetParentContext()->BlamePluginError(pFunc, "Callback-provided client index %d is invalid", client);
-					} else if (!pPlayer->IsInGame()) {
-						pFunc->GetParentContext()->BlamePluginError(pFunc, "Client %d is not in game", client);
-					} else {
-						continue;
-					}
 
 #if SOURCE_ENGINE >= SE_PORTAL2
-					RETURN_META_VALUE(MRES_IGNORED, -1 );
+						RETURN_META_VALUE(MRES_IGNORED, -1);
 #else
-					return;
+						return;
 #endif
+					} else if (!pPlayer->IsInGame()) {
+						// Shift array down to remove non-ingame client
+						memmove(&players[i], &players[i+1], (size-i-1) * sizeof(int));
+						--i;
+						--size;
+					}
 				}
 
 #if SOURCE_ENGINE >= SE_PORTAL2
@@ -540,6 +552,17 @@ void SoundHooks::OnEmitSound2(IRecipientFilter &filter, int iEntIndex, int iChan
 			}
 		case Pl_Changed:
 			{
+				if (size < 0 || size > SM_ARRAYSIZE(players))
+				{
+					pFunc->GetParentContext()->BlamePluginError(pFunc, "Callback-provided size %d is invalid", size);
+
+#if SOURCE_ENGINE >= SE_PORTAL2
+					RETURN_META_VALUE(MRES_IGNORED, -1);
+#else
+					return;
+#endif
+				}
+
 				/* Client validation */
 				for (int i = 0; i < size; i++)
 				{
@@ -549,17 +572,18 @@ void SoundHooks::OnEmitSound2(IRecipientFilter &filter, int iEntIndex, int iChan
 					if (!pPlayer)
 					{
 						pFunc->GetParentContext()->BlamePluginError(pFunc, "Client index %d is invalid", client);
-					} else if (!pPlayer->IsInGame()) {
-						pFunc->GetParentContext()->BlamePluginError(pFunc, "Client %d is not in game", client);
-					} else {
-						continue;
-					}
 
 #if SOURCE_ENGINE >= SE_PORTAL2
-					RETURN_META_VALUE(MRES_IGNORED, -1 );
+						RETURN_META_VALUE(MRES_IGNORED, -1);
 #else
-					return;
+						return;
 #endif
+					} else if (!pPlayer->IsInGame()) {
+						// Shift array down to remove non-ingame client
+						memmove(&players[i], &players[i+1], (size-i-1) * sizeof(int));
+						--i;
+						--size;
+					}
 				}
 
 #if SOURCE_ENGINE >= SE_PORTAL2


### PR DESCRIPTION
`IEngineSound::EmitSound` seems to be called with clients in the filter that might not be `IsInGame()` which can throw an error when using a `NormalSHook` and returning `Plugin_Changed` since all the clients will will be checked if `IsInGame()`.

Using `CBroadcastRecipientFilter` would add all players than can be grabbed with `UTIL_PlayerByIndex` and is probably cause of `EmitSound` having clients that are not `IsInGame()`.

This PR has been changed to remove clients from the `players` array that are not `IsInGame()`. Also a check for the callback-provided `size` variable has been added

<details>
<summary>previously</summary>
Removing the `IsInGame()` check should be fine since `EmitSound` eventually uses `CGameClient::IsActive()` to only send to active clients.

`EmitSound` -> `EmitSoundInternal` -> `SV_StartSound` ->`sv.BroadcastSound`
```
CGameClient *pClient = Client( index - 1 );

// client must be fully connect to hear sounds
if ( !pClient->IsActive() )
{
	continue;
}

pClient->SendSound( sound, filter.IsReliable() );
```

`CGameClient` -> `CBaseClient`
`virtual	bool	IsActive( void ) const { return m_nSignonState == SIGNONSTATE_FULL; };`
</details>