### PR TITLE
Add defines for Cookie name and description max length

### DIFF
--- a/plugins/include/clientprefs.inc
+++ b/plugins/include/clientprefs.inc
@@ -74,6 +74,9 @@ enum CookieMenuAction
 	CookieMenuAction_SelectOption = 1
 };
 
+#define COOKIE_MAX_NAME_LENGTH 30 		/**< Maximum Cookie name length. */
+#define COOKIE_MAX_DESCRIPTION_LENGTH 255 	/**< Maximum Cookie description length. */
+
 /**
  * Cookie Menu Callback prototype
  *


### PR DESCRIPTION
I added the following defines because there is almost no information about the max lengths of the cookie's name and description.

The only way place i found out the max lengths was inside the `CREATE TABLE` query inside the extension module.
(https://github.com/alliedmodders/sourcemod/blob/master/extensions/clientprefs/extension.cpp#L227-L334)

This way it will be easier to know the max lengths and also help avoiding a problem that happens when registering a cookie with a name longer than the max length.