### PR TITLE
Correct documentation in adt_trie.inc

### DIFF
--- a/plugins/include/adt_trie.inc
+++ b/plugins/include/adt_trie.inc
@@ -95,7 +95,6 @@ methodmap StringMap < Handle
 
 	// Retrieves an array in a Map.
 	//
-	// @param map        Map Handle.
 	// @param key        Key string.
 	// @param array      Buffer to store array.
 	// @param max_size   Maximum size of array buffer.


### PR DESCRIPTION
Handle map parameter is not needed in this methodmap function.