### PR TITLE
Update CheckCommandAccess to not perform override lookup on empty string

### DIFF
--- a/core/logic/AdminCache.cpp
+++ b/core/logic/AdminCache.cpp
@@ -2053,7 +2053,7 @@ bool AdminCache::CheckAdminCommandAccess(AdminId adm, const char *cmd, FlagBits 
 				/* First get group-level override */
 				override = GetGroupCommandOverride(gid, cmd, Override_CommandGroup, &rule);
 				/* Now get the specific command override */
-				if (!override && GetGroupCommandOverride(gid, cmd, Override_Command, &rule))
+				if (GetGroupCommandOverride(gid, cmd, Override_Command, &rule))
 				{
 					override = true;
 				}

--- a/core/logic/AdminCache.cpp
+++ b/core/logic/AdminCache.cpp
@@ -2038,32 +2038,36 @@ bool AdminCache::CheckAdminCommandAccess(AdminId adm, const char *cmd, FlagBits 
 			return true;
 		}
 
-		/* Check for overrides
-		* :TODO: is it worth optimizing this?
-		*/
-		unsigned int groups = GetAdminGroupCount(adm);
-		GroupId gid;
-		OverrideRule rule;
-		bool override = false;
-		for (unsigned int i = 0; i<groups; i++)
+		if (cmd[0] != '\0')
 		{
-			gid = GetAdminGroup(adm, i, NULL);
-			/* First get group-level override */
-			override = GetGroupCommandOverride(gid, cmd, Override_CommandGroup, &rule);
-			/* Now get the specific command override */
-			if (GetGroupCommandOverride(gid, cmd, Override_Command, &rule))
+			/* Check for overrides if cmd name not empty
+			 * :TODO: is it worth optimizing this?
+			 */
+			unsigned int groups = GetAdminGroupCount(adm);
+			GroupId gid;
+			OverrideRule rule;
+			bool override = false;
+			for (unsigned int i = 0; i<groups; i++)
 			{
-				override = true;
-			}
-			if (override)
-			{
-				if (rule == Command_Allow)
+				gid = GetAdminGroup(adm, i, NULL);
+				/* First get group-level override */
+				override = GetGroupCommandOverride(gid, cmd, Override_CommandGroup, &rule);
+				/* Now get the specific command override */
+				if (!override && GetGroupCommandOverride(gid, cmd, Override_Command, &rule))
 				{
-					return true;
+					override = true;
 				}
-				else if (rule == Command_Deny)
+			
+				if (override)
 				{
-					return false;
+					if (rule == Command_Allow)
+					{
+						return true;
+					}
+					else if (rule == Command_Deny)
+					{
+						return false;
+					}
 				}
 			}
 		}

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -543,8 +543,8 @@ native bool ReadCommandIterator(Handle iter,
  * flags using the override system.
  *
  * @param client        Client index.
- * @param command       Command name.  If the command is not found, the default 
- *                      flags are used.
+ * @param command       Command name.  If an empty string or if the command is not found, 
+ *                      the default flags are used.
  * @param flags         Flag string to use as a default, if the command or override 
  *                      is not found.
  * @param override_only If true, SourceMod will not attempt to find a matching 


### PR DESCRIPTION
Command name shouldn't be empty when performing a lookup. This PR will skip the lookup if string is empty and fallback to default flag.

If there might be a better way to approach this, please let me know.