### PR TITLE
[Untested] New cvar to exclude spectators in rock the vote

### DIFF
--- a/plugins/rockthevote.sp
+++ b/plugins/rockthevote.sp
@@ -140,7 +140,7 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
 
 public Action Event_PlayerTeam(Event event, const char[] name, bool dontBroadcast)
 {
-	if(!_Cvar_ExcludeSpectators.BoolValue)
+	if(!g_Cvar_ExcludeSpectators.BoolValue)
 		return;
 		
 	if(event.GetBool("disconnect"))

--- a/plugins/rockthevote.sp
+++ b/plugins/rockthevote.sp
@@ -53,6 +53,7 @@ ConVar g_Cvar_InitialDelay;
 ConVar g_Cvar_Interval;
 ConVar g_Cvar_ChangeTime;
 ConVar g_Cvar_RTVPostVoteAction;
+ConVar g_Cvar_ExcludeSpectators;
 
 bool g_RTVAllowed = false;	// True if RTV is available to players. Used to delay rtv votes.
 int g_Voters = 0;				// Total voters connected. Doesn't include fake clients.
@@ -73,6 +74,7 @@ public void OnPluginStart()
 	g_Cvar_Interval = CreateConVar("sm_rtv_interval", "240.0", "Time (in seconds) after a failed RTV before another can be held", 0, true, 0.00);
 	g_Cvar_ChangeTime = CreateConVar("sm_rtv_changetime", "0", "When to change the map after a succesful RTV: 0 - Instant, 1 - RoundEnd, 2 - MapEnd", _, true, 0.0, true, 2.0);
 	g_Cvar_RTVPostVoteAction = CreateConVar("sm_rtv_postvoteaction", "0", "What to do with RTV's after a mapvote has completed. 0 - Allow, success = instant change, 1 - Deny", _, true, 0.0, true, 1.0);
+	g_Cvar_ExcludeSpectators = CreateConVar("sm_rtv_exclude_spectators", "0", "Should the plugin not count spectators as players on the decision of minimum players to rock the vote, and if the vote is sent to them. 0 - Spectators are regular players. 1 - Spectators are treated as away from keyboard, meaning they are treated as disconnected", _, true, 0.0, true, 1.0);
 	
 	RegConsoleCmd("sm_rtv", Command_RTV);
 	


### PR DESCRIPTION
Me and a lot of server owners use spectator team as a place to be afk for a bit. Spectators that are afk clog rtv as they aren't truly in the server.

This PR allows server owners to prevent spectators from clogging it up.