### PR TITLE
Update CGameConfig members to use std::string instead of fixed-size char arrays

### DIFF
--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -374,7 +374,7 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 				if (strcmp(name, "linux") != 0 && strcmp(name, "windows") != 0 && strcmp(name, "mac") != 0 &&
 					strcmp(name, "linux64") != 0 && strcmp(name, "windows64") != 0 && strcmp(name, "mac64") != 0)
 				{
-					logger->LogError("[SM] Error while parsing Address section for \"%s\" (%s):", m_Address, m_CurFile);
+					logger->LogError("[SM] Error while parsing Address section for \"%s\" (%s):", m_Address.c_str(), m_CurFile);
 					logger->LogError("[SM] Unrecognized platform \"%s\"", name);
 				}
 				m_IgnoreLevel = 1;
@@ -476,7 +476,7 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 			int limit = sizeof(m_AddressRead)/sizeof(m_AddressRead[0]);
 			if (m_AddressLastIsOffset)
 			{
-				logger->LogError("[SM] Error parsing Address \"%s\", 'offset' entry must be the last entry (gameconf \"%s\")", m_Address, m_CurFile);
+				logger->LogError("[SM] Error parsing Address \"%s\", 'offset' entry must be the last entry (gameconf \"%s\")", m_Address.c_str(), m_CurFile);
 			}
 			else if (m_AddressReadCount < limit)
 			{
@@ -489,7 +489,7 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 			}
 			else
 			{
-				logger->LogError("[SM] Error parsing Address \"%s\", does not support more than %d read offsets (gameconf \"%s\")", m_Address, limit, m_CurFile);
+				logger->LogError("[SM] Error parsing Address \"%s\", does not support more than %d read offsets (gameconf \"%s\")", m_Address.c_str(), limit, m_CurFile);
 			}
 		} else if (strcmp(key, "signature") == 0) {
 			m_AddressSignature = value;

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -1078,7 +1078,7 @@ CGameConfig::AddressConf::AddressConf(std::string&& sigName, unsigned readCount,
 {
 	unsigned readLimit = minOf(readCount, sizeof(this->read) / sizeof(this->read[0]));
 
-	this->signatureName = std::move(sigName);
+	this->signatureName = sigName;
 	this->readCount = readLimit;
 	memcpy(&this->read[0], read, sizeof(this->read[0])*readLimit);
 

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -548,8 +548,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 	case PSTATE_GAMEDEFS_OFFSETS_OFFSET:
 		{
 			/* Parse the offset... */
-			if (m_Class[0] != '\0'
-				&& m_Prop[0] != '\0')
+			if (!m_Class.empty() && !m_Prop.empty())
 			{
 				SendProp *pProp = gamehelpers->FindInSendTable(m_Class.c_str(), m_Prop.c_str());
 				if (pProp)
@@ -690,7 +689,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 		{
 			m_ParseState = PSTATE_GAMEDEFS_ADDRESSES;
 
-			if (m_Address[0] != '\0' && m_AddressSignature[0] != '\0')
+			if (!m_Address.empty() && !m_AddressSignature.empty())
 			{
 				AddressConf addrConf(std::move(m_AddressSignature), m_AddressReadCount, m_AddressRead, m_AddressLastIsOffset);
 				m_Addresses.replace(m_Address.c_str(), addrConf);

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -692,7 +692,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 
 			if (m_Address[0] != '\0' && m_AddressSignature[0] != '\0')
 			{
-				AddressConf addrConf(m_AddressSignature, m_AddressSignature.length(), m_AddressReadCount, m_AddressRead, m_AddressLastIsOffset);
+				AddressConf addrConf(m_AddressSignature, m_AddressReadCount, m_AddressRead, m_AddressLastIsOffset);
 				m_Addresses.replace(m_Address.c_str(), addrConf);
 			}
 
@@ -1074,7 +1074,7 @@ static inline unsigned minOf(unsigned a, unsigned b)
 	return a <= b ? a : b;
 }
 
-CGameConfig::AddressConf::AddressConf(std::string sigName, unsigned sigLength, unsigned readCount, int *read, bool lastIsOffset)
+CGameConfig::AddressConf::AddressConf(std::string sigName, unsigned readCount, int *read, bool lastIsOffset)
 {
 	unsigned readLimit = minOf(readCount, sizeof(this->read) / sizeof(this->read[0]));
 

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -354,7 +354,7 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 	case PSTATE_GAMEDEFS_ADDRESSES:
 		{
 			m_Address.clear();
-			m_AddressSignature[0] = '\0';
+			m_AddressSignature.clear();
 			m_AddressReadCount = 0;
 			m_AddressLastIsOffset = false;
 

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -692,7 +692,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 
 			if (m_Address[0] != '\0' && m_AddressSignature[0] != '\0')
 			{
-				AddressConf addrConf(m_AddressSignature, m_AddressReadCount, m_AddressRead, m_AddressLastIsOffset);
+				AddressConf addrConf(std::move(m_AddressSignature), m_AddressReadCount, m_AddressRead, m_AddressLastIsOffset);
 				m_Addresses.replace(m_Address.c_str(), addrConf);
 			}
 
@@ -1074,7 +1074,7 @@ static inline unsigned minOf(unsigned a, unsigned b)
 	return a <= b ? a : b;
 }
 
-CGameConfig::AddressConf::AddressConf(std::string sigName, unsigned readCount, int *read, bool lastIsOffset)
+CGameConfig::AddressConf::AddressConf(std::string&& sigName, unsigned readCount, int *read, bool lastIsOffset)
 {
 	unsigned readLimit = minOf(readCount, sizeof(this->read) / sizeof(this->read[0]));
 

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -1078,7 +1078,7 @@ CGameConfig::AddressConf::AddressConf(std::string sigName, unsigned readCount, i
 {
 	unsigned readLimit = minOf(readCount, sizeof(this->read) / sizeof(this->read[0]));
 
-	this->signatureName = sigName;
+	this->signatureName = std::move(sigName);
 	this->readCount = readLimit;
 	memcpy(&this->read[0], read, sizeof(this->read[0])*readLimit);
 

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -559,17 +559,14 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 					m_Props.replace(m_offset.c_str(), pProp);
 				} else {
 					/* Check if it's a non-default game and no offsets exist */
-					const char* offset;
 					if (((strcmp(m_Game.c_str(), "*") != 0) && strcmp(m_Game.c_str(), "#default") != 0)
-						&& (!m_Offsets.retrieve(offset)))
+						&& (!m_Offsets.retrieve(m_offset.c_str())))
 					{
 						logger->LogError("[SM] Unable to find property %s.%s (file \"%s\") (mod \"%s\")", 
 							m_Class.c_str(),
 							m_Prop.c_str(),
 							m_CurFile,
 							m_Game.c_str());
-					} else {
-						m_offset = offset;
 					}
 				}
 			}

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -233,15 +233,15 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 		}
 	case PSTATE_GAMEDEFS:
 		{
-			if (name == "Offsets")
+			if (strcmp(name, "Offsets") == 0)
 			{
 				m_ParseState = PSTATE_GAMEDEFS_OFFSETS;
 			}
-			else if (name == "Keys")
+			else if (strcmp(name, "Keys") == 0)
 			{
 				m_ParseState = PSTATE_GAMEDEFS_KEYS;
 			}
-			else if (name == "#supported" && m_Game != "#default")
+			else if ((strcmp(name, "#supported") == 0) && (strcmp(m_Game.c_str(), "#default") == 0))
 			{
 				m_ParseState = PSTATE_GAMEDEFS_SUPPORTED;
 				/* Ignore this section unless we get a game. */
@@ -251,16 +251,16 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 				had_engine = false;
 				matched_engine = false;
 			}
-			else if (name == "Signatures")
+			else if (strcmp(name, "Signatures") == 0)
 			{
 				m_ParseState = PSTATE_GAMEDEFS_SIGNATURES;
 			}
-			else if (name == "CRC")
+			else if (strcmp(name, "CRC") == 0)
 			{
 				m_ParseState = PSTATE_GAMEDEFS_CRC;
 				bShouldBeReadingDefault = false;
 			}
-			else if (name == "Addresses")
+			else if (strcmp(name, "Addresses") == 0)
 			{
 				m_ParseState = PSTATE_GAMEDEFS_ADDRESSES;
 			}
@@ -409,10 +409,10 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 
 	if (m_ParseState == PSTATE_GAMEDEFS_OFFSETS_OFFSET)
 	{
-		if (key == "class")
+		if (strcmp(key, "class") == 0)
 		{
 			m_Class = value;
-		} else if (key == "prop") {
+		} else if (strcmp(key, "prop") == 0) {
 			m_Prop = value;
 		} else if (IsPlatformCompatible(key, &matched_platform)) {
 			m_Offsets.replace(m_offset.c_str(), static_cast<int>(strtol(value, NULL, 0)));
@@ -428,7 +428,7 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 			m_Keys.replace(m_Key.c_str(), std::move(vstr));
 		}
 	} else if (m_ParseState == PSTATE_GAMEDEFS_SUPPORTED) {
-		if (key == "game")
+		if (strcmp(key, "game") == 0)
 		{
 			had_game = true;
 			if (DoesGameMatch(value))
@@ -440,7 +440,7 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 				bShouldBeReadingDefault = true;
 			}
 		}
-		else if (key == "engine")
+		else if (strcmp(key, "engine") == 0)
 		{
 			had_engine = true;
 			if (DoesEngineMatch(value))
@@ -480,7 +480,7 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 			}
 			else if (m_AddressReadCount < limit)
 			{
-				if (key == "offset")
+				if (strcmp(key, "offset") == 0)
 				{
 					m_AddressLastIsOffset = true;
 				}
@@ -491,7 +491,7 @@ SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key
 			{
 				logger->LogError("[SM] Error parsing Address \"%s\", does not support more than %d read offsets (gameconf \"%s\")", m_Address, limit, m_CurFile);
 			}
-		} else if (key == "signature") {
+		} else if (strcmp(key, "signature") == 0) {
 			strncopy(m_AddressSignature, value, sizeof(m_AddressSignature));
 		}
 	} else if (m_ParseState == PSTATE_GAMEDEFS_CUSTOM) {
@@ -560,7 +560,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 				} else {
 					/* Check if it's a non-default game and no offsets exist */
 					const char* offset;
-					if (m_Game == "*" && m_Game != "#default"
+					if (((strcmp(m_Game.c_str(), "*") != 0) && strcmp(m_Game.c_str(), "#default") != 0)
 						&& (!m_Offsets.retrieve(offset)))
 					{
 						logger->LogError("[SM] Unable to find property %s.%s (file \"%s\") (mod \"%s\")", 
@@ -568,8 +568,9 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 							m_Prop,
 							m_CurFile,
 							m_Game);
+					} else {
+						m_offset = offset;
 					}
-					m_offset = offset;
 				}
 			}
 			m_ParseState = PSTATE_GAMEDEFS_OFFSETS;

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -1078,7 +1078,7 @@ CGameConfig::AddressConf::AddressConf(std::string&& sigName, unsigned readCount,
 {
 	unsigned readLimit = minOf(readCount, sizeof(this->read) / sizeof(this->read[0]));
 
-	this->signatureName = sigName;
+	this->signatureName = std::move(sigName);
 	this->readCount = readLimit;
 	memcpy(&this->read[0], read, sizeof(this->read[0])*readLimit);
 

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -338,7 +338,7 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 			if (error[0] != '\0')
 			{
 				m_IgnoreLevel = 1;
-				logger->LogError("[SM] Error while parsing CRC section for \"%s\" (%s):", m_Game, m_CurFile);
+				logger->LogError("[SM] Error while parsing CRC section for \"%s\" (%s):", m_Game.c_str(), m_CurFile);
 				logger->LogError("[SM] %s", error);
 			} else {
 				m_ParseState = PSTATE_GAMEDEFS_CRC_BINARY;
@@ -564,10 +564,10 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 						&& (!m_Offsets.retrieve(offset)))
 					{
 						logger->LogError("[SM] Unable to find property %s.%s (file \"%s\") (mod \"%s\")", 
-							m_Class,
-							m_Prop,
+							m_Class.c_str(),
+							m_Prop.c_str(),
 							m_CurFile,
-							m_Game);
+							m_Game.c_str());
 					} else {
 						m_offset = offset;
 					}

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -241,7 +241,7 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 			{
 				m_ParseState = PSTATE_GAMEDEFS_KEYS;
 			}
-			else if ((strcmp(name, "#supported") == 0) && (strcmp(m_Game.c_str(), "#default") == 0))
+			else if ((strcmp(name, "#supported") == 0) && (m_Game == "#default"))
 			{
 				m_ParseState = PSTATE_GAMEDEFS_SUPPORTED;
 				/* Ignore this section unless we get a game. */
@@ -559,7 +559,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 					m_Props.replace(m_offset.c_str(), pProp);
 				} else {
 					/* Check if it's a non-default game and no offsets exist */
-					if (((strcmp(m_Game.c_str(), "*") != 0) && strcmp(m_Game.c_str(), "#default") != 0)
+					if ((m_Game != "*" && m_Game != "#default")
 						&& (!m_Offsets.retrieve(m_offset.c_str())))
 					{
 						logger->LogError("[SM] Unable to find property %s.%s (file \"%s\") (mod \"%s\")", 

--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -110,7 +110,7 @@ private:
 		int read[8];
 		bool lastIsOffset;
 
-		AddressConf(std::string sigName, unsigned readCount, int *read, bool lastIsOffset);
+		AddressConf(std::string&& sigName, unsigned readCount, int *read, bool lastIsOffset);
 
 		AddressConf() {}
 	};

--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -105,18 +105,18 @@ private:
 	/* Support for reading Addresses */
 	struct AddressConf
 	{
-		char signatureName[64];
+		std::string signatureName;
 		int readCount;
 		int read[8];
 		bool lastIsOffset;
 
-		AddressConf(char *sigName, unsigned sigLength, unsigned readCount, int *read, bool lastIsOffset);
+		AddressConf(std::string sigName, unsigned sigLength, unsigned readCount, int *read, bool lastIsOffset);
 
 		AddressConf() {}
 	};
 
-	char m_Address[64];
-	char m_AddressSignature[64];
+	std::string m_Address;
+	std::string m_AddressSignature;
 	int m_AddressReadCount;
 	int m_AddressRead[8];
 	bool m_AddressLastIsOffset;

--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -86,11 +86,11 @@ private:
 	/* Parse states */
 	int m_ParseState;
 	unsigned int m_IgnoreLevel;
-	char m_Class[64];
-	char m_Prop[64];
-	char m_offset[64];
-	char m_Game[256];
-	char m_Key[64];
+	std::string m_Class;
+	std::string m_Prop;
+	std::string m_offset;
+	std::string m_Game;
+	std::string m_Key;
 	bool bShouldBeReadingDefault;
 	bool had_game;
 	bool matched_game;

--- a/core/logic/GameConfigs.h
+++ b/core/logic/GameConfigs.h
@@ -110,7 +110,7 @@ private:
 		int read[8];
 		bool lastIsOffset;
 
-		AddressConf(std::string sigName, unsigned sigLength, unsigned readCount, int *read, bool lastIsOffset);
+		AddressConf(std::string sigName, unsigned readCount, int *read, bool lastIsOffset);
 
 		AddressConf() {}
 	};


### PR DESCRIPTION
Fixes #1381.

~~Currently marked as a draft since it's untested and there's still some fixed-size char arrays I need to look into under `AddressConf`.  Will test once those remaining things are looked at.~~ Tested in a TF2 server loaded up with a lot of gamedata.