### PR TITLE
SetCollisionGroup -> SetEntityCollisionGroup

### DIFF
--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -1499,8 +1499,8 @@ static cell_t GivePlayerAmmo(IPluginContext *pContext, const cell_t *params)
 	return ammoGiven;
 }
 
-// SetCollisionGroup(int entity, int collisionGroup)
-static cell_t SetCollisionGroup(IPluginContext *pContext, const cell_t *params)
+// SetEntityCollisionGroup(int entity, int collisionGroup)
+static cell_t SetEntityCollisionGroup(IPluginContext *pContext, const cell_t *params)
 {
 	static ICallWrapper *pSetCollisionGroup = NULL;
 	if (!pSetCollisionGroup)
@@ -1508,7 +1508,7 @@ static cell_t SetCollisionGroup(IPluginContext *pContext, const cell_t *params)
 		void *addr;
 		if (!g_pGameConf->GetMemSig("SetCollisionGroup", &addr) || !addr)
 		{
-			return pContext->ThrowNativeError("\"SetCollisionGroup\" not supported by this mod");
+			return pContext->ThrowNativeError("\"SetEntityCollisionGroup\" not supported by this mod");
 		}
 		PassInfo pass[2];
 		// Entity
@@ -1523,7 +1523,7 @@ static cell_t SetCollisionGroup(IPluginContext *pContext, const cell_t *params)
 
 		if (!(pSetCollisionGroup = g_pBinTools->CreateCall(addr, CallConv_ThisCall, NULL, pass, 2)))
 		{
-			return pContext->ThrowNativeError("\"SetCollisionGroup\" wrapper failed to initialize");
+			return pContext->ThrowNativeError("\"SetEntityCollisionGroup\" wrapper failed to initialize");
 		}
 	}
 
@@ -1569,6 +1569,6 @@ sp_nativeinfo_t g_Natives[] =
 	{"SetClientName",           SetClientName},
 	{"GetPlayerResourceEntity", GetPlayerResourceEntity},
 	{"GivePlayerAmmo",		GivePlayerAmmo},
-	{"SetCollisionGroup",		SetCollisionGroup},
+	{"SetEntityCollisionGroup",	SetEntityCollisionGroup},
 	{NULL,						NULL},
 };

--- a/plugins/include/sdktools_functions.inc
+++ b/plugins/include/sdktools_functions.inc
@@ -359,4 +359,4 @@ native int GivePlayerAmmo(int client, int amount, int ammotype, bool suppressSou
  * @param collisionGroup    Collision group to use.
  * @error                   Invalid entity or lack of mod support.
  */
-native void SetCollisionGroup(int entity, int collisionGroup);
+native void SetEntityCollisionGroup(int entity, int collisionGroup);


### PR DESCRIPTION
Some comments after #1507 was accepted addressed that `SetCollisionGroup` should be renamed to `SetEntityCollisionGroup` to align with other similar natives.