### PR TITLE
AuthID unified converter as native

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1521,6 +1521,61 @@ void PlayerManager::RecheckAnyAdmins()
 	}
 }
 
+bool PlayerManager::GetUnifiedAuthId(const char *ident, char *out, size_t maxlen)
+{
+	int len = strlen(ident);
+	if (!strcmp(ident, "BOT"))
+	{
+		// Bots
+		strncpy(out, ident, maxlen);
+		return true;
+	}
+	else if (len >= 11 && !strncmp(ident, "STEAM_", 6) && ident[8] != '_')
+	{
+		// non-bot/lan Steam2 Id, strip off the STEAM_* part
+		ke::SafeStrcpy(out, maxlen, &ident[8]);
+		return true;
+	}
+	else if (len >= 7 && !strncmp(ident, "[U:", 3) && ident[len-1] == ']')
+	{
+		// Steam3 Id, replicate the Steam2 Post-"STEAM_" part
+		uint32_t accountId = strtoul(&ident[5], nullptr, 10);
+		ke::SafeSprintf(out, maxlen, "%u:%u", accountId & 1, accountId >> 1);
+		return true;
+	}
+	else
+	{
+		// 64-bit CSteamID, replicate the Steam2 Post-"STEAM_" part
+
+		// some constants from steamclientpublic.h
+		static const uint32_t k_EAccountTypeIndividual = 1;
+		static const int k_EUniverseInvalid = 0;
+		static const int k_EUniverseMax = 5;
+		static const unsigned int k_unSteamUserWebInstance	= 4;
+
+		uint64_t steamId = strtoull(ident, nullptr, 10);
+		if (steamId > 0)
+		{
+			// Make some attempt at being sure it's a valid id rather than other number,
+			// even though we're only going to use the lower 32 bits.
+			uint32_t accountId = steamId & 0xFFFFFFFF;
+			uint32_t accountType = (steamId >> 52) & 0xF;
+			int universe = steamId >> 56;
+			uint32_t accountInstance = (steamId >> 32) & 0xFFFFF;
+			if (accountId > 0
+				&& universe > k_EUniverseInvalid && universe < k_EUniverseMax
+				&& accountType == k_EAccountTypeIndividual && accountInstance <= k_unSteamUserWebInstance
+				)
+			{
+				ke::SafeSprintf(out, maxlen, "%u:%u", accountId & 1, accountId >> 1);
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 unsigned int PlayerManager::GetReplyTo()
 {
 	return g_ChatTriggers.GetReplyTo();

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -212,6 +212,7 @@ public: //IPlayerManager
 	int GetClientFromSerial(unsigned int serial);
 	void ClearAdminId(AdminId id);
 	void RecheckAnyAdmins();
+    bool GetUnifiedAuthId(const char *ident, char *out, size_t maxlen);
 public:
 	inline int MaxClients()
 	{

--- a/core/logic/AdminCache.h
+++ b/core/logic/AdminCache.h
@@ -202,7 +202,6 @@ private:
 	bool GetMethodIndex(const char *name, unsigned int *_index);
 	const char *GetMethodName(unsigned int index);
 	void NameFlag(const char *str, AdminFlag flag);
-	bool GetUnifiedSteamIdentity(const char *ident, char *out, size_t maxlen);
 public:
 	typedef StringHashMap<FlagBits> FlagMap;
 

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -1609,6 +1609,19 @@ static cell_t sm_GetClientFromSerial(IPluginContext *pContext, const cell_t *par
 	return playerhelpers->GetClientFromSerial(params[1]);
 }
 
+static cell_t sm_GetUnifiedAuthId(IPluginContext *pContext, const cell_t *params)
+{
+	char *ident;
+	pContext->LocalToString(params[1], &ident);
+
+	char buf[64];
+	strcpy(buf, "0:0");
+	cell_t reply = playerhelpers->GetUnifiedAuthId(ident, buf, sizeof(buf));
+
+	pContext->StringToLocal(params[2], static_cast<size_t>(params[3]), buf);
+	return reply;
+}
+
 
 REGISTER_NATIVES(playernatives)
 {
@@ -1661,6 +1674,7 @@ REGISTER_NATIVES(playernatives)
 	{ "FormatActivitySource", FormatActivitySource },
 	{ "GetClientSerial", sm_GetClientSerial },
 	{ "GetClientFromSerial", sm_GetClientFromSerial },
+	{ "GetUnifiedAuthId", sm_GetUnifiedAuthId },
 	{NULL,						NULL}
 };
 

--- a/plugins/admin-sql-prefetch.sp
+++ b/plugins/admin-sql-prefetch.sp
@@ -117,7 +117,12 @@ void FetchUsers(Database db)
 		rs.FetchString(4, flags, sizeof(flags));
 		rs.FetchString(5, name, sizeof(name));
 		immunity = rs.FetchInt(6);
-		
+
+		if (StrEqual(authtype, "steam") && identity[0] == 'S')
+		{
+			Format(identity, sizeof(identity), "STEAM_0:%s", identity);
+		}
+
 		/* Use a pre-existing admin if we can */
 		if ((adm = FindAdminByIdentity(authtype, identity)) == INVALID_ADMIN_ID)
 		{

--- a/plugins/admin-sql-threaded.sp
+++ b/plugins/admin-sql-threaded.sp
@@ -468,6 +468,7 @@ void FetchUser(Database db, int client)
 	char safe_name[(MAX_NAME_LENGTH * 2) - 1];
 	char steamid[32];
 	char steamidalt[32];
+	char steamidstd[32];
 	char ipaddr[24];
 	
 	/**
@@ -499,10 +500,12 @@ void FetchUser(Database db, int client)
 	len += Format(query[len], sizeof(query)-len, " OR (a.authtype = 'name' AND a.identity = '%s')", safe_name);
 	if (steamid[0] != '\0')
 	{
+		// For support obsolete data, keep this.
 		strcopy(steamidalt, sizeof(steamidalt), steamid);
 		steamidalt[6] = (steamid[6] == '0') ? '1' : '0';
+		GetUnifiedAuthId(steamid, steamidstd, sizeof(steamidstd));
 
-		len += Format(query[len], sizeof(query)-len, " OR (a.authtype = 'steam' AND (a.identity = '%s' OR a.identity = '%s'))", steamid, steamidalt);
+		len += Format(query[len], sizeof(query)-len, " OR (a.authtype = 'steam' AND (a.identity = '%s' OR a.identity = '%s' OR a.identity = '%s'))", steamid, steamidalt, steamidstd);
 	}
 	len += Format(query[len], sizeof(query)-len, " GROUP BY a.id");
 	

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -820,3 +820,13 @@ native int GetClientSerial(int client);
  * @return              Client index, or 0 for invalid serial.
  */
 native int GetClientFromSerial(int serial);
+
+/**
+ * Returns the unified SteamID identity format based
+ * on passed (account id part of Steam2 identity).
+ *
+ * @param ident         SteamID identity (64, 2, 3).
+ * @param buffer        Buffer to store the converted Auth ID.
+ * @param maxlen        Maximum number of characters for converted buffer.
+ */
+native bool GetUnifiedAuthId(const char[] ident, char[] buffer, int maxlen);

--- a/plugins/sql-admin-manager.sp
+++ b/plugins/sql-admin-manager.sp
@@ -765,6 +765,13 @@ public Action Command_DelAdmin(int client, int args)
 	char identity[65];
 	char safe_identity[140];
 	GetCmdArg(2, identity, sizeof(identity));
+
+	if (StrEqual(authtype, "steam"))
+	{
+		strcopy(safe_identity, sizeof(safe_identity), identity);
+		GetUnifiedAuthId(safe_identity, identity, sizeof(identity));
+	}
+
 	db.Escape(identity, safe_identity, sizeof(safe_identity));
 	
 	char query[255];
@@ -844,6 +851,12 @@ public Action Command_AddAdmin(int client, int args)
 	char safe_identity[140];
 	GetCmdArg(3, identity, sizeof(identity));
 	
+	if (StrEqual(authtype, "steam"))
+	{
+		strcopy(safe_identity, sizeof(safe_identity), identity);
+		GetUnifiedAuthId(safe_identity, identity, sizeof(identity));
+	}
+
 	char query[256];
 	Database db = Connect();
 	if (db == null)

--- a/public/IPlayerHelpers.h
+++ b/public/IPlayerHelpers.h
@@ -41,7 +41,7 @@
 #include <IAdminSystem.h>
 
 #define SMINTERFACE_PLAYERMANAGER_NAME		"IPlayerManager"
-#define SMINTERFACE_PLAYERMANAGER_VERSION	21
+#define SMINTERFACE_PLAYERMANAGER_VERSION	22
 
 struct edict_t;
 class IPlayerInfo;
@@ -628,6 +628,16 @@ namespace SourceMod
 		 * @brief Reruns admin checks on all players.
 		 */
 		virtual void RecheckAnyAdmins() =0;
+
+		/**
+		 * @brief Returns the unified SteamID identity format based
+		 * on passed (account id part of Steam2 identity).
+		 *
+		 * @param ident		SteamID identity (64, 2, 3)
+		 * @param out		Buffer where unified SteamID should be written.
+		 * @param maxlen	Buffer length
+		 */
+		virtual bool GetUnifiedAuthId(const char *ident, char *out, size_t maxlen) =0;
 	};
 }
 


### PR DESCRIPTION
#1520 reminds us of the internal function of SourceMod to convert SteamID in any format - to unified one (part of the account ID from v2):
```
STEAM_0:0:55665612 -> 0:55665612
STEAM_1:0:55665612 -> 0:55665612
[U:1:111331224] -> 0:55665612
76561198071596952 -> 0:55665612
```
This PR just moves this method to `PlayerManager` class, exposes to `IPlayerManager` interface (with interface version bump), implements native for scripters and adopts AdminCache and SQL admin loaders with manager to use this method.