### PR TITLE
Add parameter to configure updating page permissions in StoreToAddress

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -747,7 +747,7 @@ static cell_t StoreToAddress(IPluginContext *pContext, const cell_t *params)
 
 	NumberType size = static_cast<NumberType>(params[3]);
 
-	// new parameter added after SM 1.10
+	// new parameter added after SM 1.10; defaults to true for backwards compatibility
 	bool updateMemAccess = true;
 	if (params[0] >= 4)
 	{

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -747,18 +747,34 @@ static cell_t StoreToAddress(IPluginContext *pContext, const cell_t *params)
 
 	NumberType size = static_cast<NumberType>(params[3]);
 
+	// new parameter added after SM 1.10
+	bool updateMemAccess = true;
+	if (params[0] >= 4)
+	{
+		updateMemAccess = params[4];
+	}
+
 	switch(size)
 	{
 	case NumberType_Int8:
-		SourceHook::SetMemAccess(addr, sizeof(uint8_t), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		if (updateMemAccess)
+		{
+			SourceHook::SetMemAccess(addr, sizeof(uint8_t), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		}
 		*reinterpret_cast<uint8_t*>(addr) = data;
 		break;
 	case NumberType_Int16:
-		SourceHook::SetMemAccess(addr, sizeof(uint16_t), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		if (updateMemAccess)
+		{
+			SourceHook::SetMemAccess(addr, sizeof(uint16_t), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		}
 		*reinterpret_cast<uint16_t*>(addr) = data;
 		break;
 	case NumberType_Int32:
-		SourceHook::SetMemAccess(addr, sizeof(uint32_t), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		if (updateMemAccess)
+		{
+			SourceHook::SetMemAccess(addr, sizeof(uint32_t), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		}
 		*reinterpret_cast<uint32_t*>(addr) = data;
 		break;
 	default:

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -698,13 +698,15 @@ native any LoadFromAddress(Address addr, NumberType size);
 /**
  * Store up to 4 bytes to a memory address.
  *
- * @param addr          Address to a memory location.
- * @param data          Value to store at the address.
- * @param size          How many bytes should be written.
- *                      If storing a floating-point value, use NumberType_Int32.
- * @error               Address is null or pointing to reserved memory.
+ * @param addr                     Address to a memory location.
+ * @param data                     Value to store at the address.
+ * @param size                     How many bytes should be written.
+ *                                 If storing a floating-point value, use NumberType_Int32.
+ * @param updateMemAccess          If true, SourceMod will set read / write / exec permissions
+ *                                 on the memory page being written to.
+ * @error                          Address is null or pointing to reserved memory.
  */
-native void StoreToAddress(Address addr, any data, NumberType size);
+native void StoreToAddress(Address addr, any data, NumberType size, bool updateMemAccess = true);
 
 methodmap FrameIterator < Handle {
 	// Creates a stack frame iterator to build your own stack traces.


### PR DESCRIPTION
Closes #1375.

This adds a new optional parameter to `StoreToAddress`, allowing plugins to opt out of having SourceMod update page permissions every time it writes to memory.

Tested in TF2 with the following micro benchmark:

<details>
<summary>Micro benchmark source code:</summary>

```
#include <sourcemod>

#pragma semicolon 1
#pragma newdecls required

#include <profiler>

public void OnPluginStart() {
	RegAdminCmd("test_memwrite", MemWrite, ADMFLAG_ROOT);
}

#define NUM_ITERATIONS (1 << 19)

public Action MemWrite(int client, int argc) {
	if (!client) {
		return Plugin_Handled;
	}
	
	int health = GetEntProp(client, Prop_Send, "m_iHealth");
	int healthOffs = FindSendPropInfo("CTFPlayer", "m_iHealth");
	
	Address pHealthOffs = view_as<Address>(view_as<int>(GetEntityAddress(client)) + healthOffs);
	
	Profiler prof = new Profiler();
	
	prof.Start();
	for (int i; i < NUM_ITERATIONS; i++) {
		SetEntData(client, healthOffs, health);
	}
	prof.Stop();
	ReplyToCommand(client, "SetEntData: %f", prof.Time);
	
	prof.Start();
	for (int i; i < NUM_ITERATIONS; i++) {
		StoreToAddress(pHealthOffs, health, NumberType_Int32);
	}
	prof.Stop();
	ReplyToCommand(client, "StoreToAddress(): %f", prof.Time);
	
	prof.Start();
	for (int i; i < NUM_ITERATIONS; i++) {
		StoreToAddress(pHealthOffs, health, NumberType_Int32, false);
	}
	prof.Stop();
	ReplyToCommand(client, "StoreToAddress(NoPageMod): %f", prof.Time);
	
	delete prof;
	
	return Plugin_Handled;
}
```
</details>

Micro benchmark results:

```
SetEntData: 0.044856
StoreToAddress(): 0.372449
StoreToAddress(NoPageMod): 0.009297
```