### PR TITLE
Add temp entity functionality to the sdktools extension interface

### DIFF
--- a/extensions/sdktools/extension.cpp
+++ b/extensions/sdktools/extension.cpp
@@ -621,6 +621,11 @@ public:
 	{
 		return GameRules();
 	}
+
+	virtual ISDKTempEntityManager* GetTempEntityManager()
+	{
+		return &g_TEManager;
+	}
 } g_SDKTools_API;
 
 static void InitSDKToolsAPI()

--- a/extensions/sdktools/tempents.cpp
+++ b/extensions/sdktools/tempents.cpp
@@ -133,7 +133,7 @@ int TempEntityInfo::_FindOffset(const char *name, int *size)
 	return offset;
 }
 
-bool TempEntityInfo::TE_SetEntData(const char *name, int value)
+bool TempEntityInfo::TE_SetEntData(const char *name, const int value)
 {
 	/* Search for our offset */
 	int size;
@@ -183,7 +183,7 @@ bool TempEntityInfo::TE_GetEntData(const char *name, int *value)
 	return true;
 }
 
-bool TempEntityInfo::TE_SetEntDataFloat(const char *name, float value)
+bool TempEntityInfo::TE_SetEntDataFloat(const char *name, const float value)
 {
 	/* Search for our offset */
 	int offset = _FindOffset(name);
@@ -213,7 +213,7 @@ bool TempEntityInfo::TE_GetEntDataFloat(const char *name, float *value)
 	return true;
 }
 
-bool TempEntityInfo::TE_SetEntDataVector(const char *name, float vector[3])
+bool TempEntityInfo::TE_SetEntDataVector(const char *name, const float vector[3])
 {
 	/* Search for our offset */
 	int offset = _FindOffset(name);
@@ -249,7 +249,7 @@ bool TempEntityInfo::TE_GetEntDataVector(const char *name, float vector[3])
 	return true;
 }
 
-bool TempEntityInfo::TE_SetEntDataFloatArray(const char *name, cell_t *array, int size)
+bool TempEntityInfo::TE_SetEntDataFloatArray(const char *name, const float *array, const int size)
 {
 	/* Search for our offset */
 	int offset = _FindOffset(name);
@@ -262,13 +262,13 @@ bool TempEntityInfo::TE_SetEntDataFloatArray(const char *name, cell_t *array, in
 	float *base = (float *)((uint8_t *)m_Me + offset);
 	for (int i=0; i<size; i++)
 	{
-		base[i] = sp_ctof(array[i]);
+		base[i] = array[i];
 	}
 
 	return true;
 }
 
-void TempEntityInfo::Send(IRecipientFilter &filter, float delay)
+void TempEntityInfo::TE_Send(IRecipientFilter &filter, float delay)
 {
 	engine->PlaybackTempEntity(filter, delay, m_Me, m_Sc->m_pTable, m_Sc->m_ClassID);
 }

--- a/extensions/sdktools/tempents.h
+++ b/extensions/sdktools/tempents.h
@@ -37,8 +37,9 @@
 #include <sh_list.h>
 #include <sh_string.h>
 #include <stdio.h>
+#include <ISDKTools.h>
 
-class TempEntityInfo
+class TempEntityInfo : public ISDKTempEntityManager::ISDKTempEntityInfo
 {
 public:
 	TempEntityInfo(const char *name, void *me);
@@ -46,14 +47,14 @@ public:
 	const char *GetName();
 	ServerClass *GetServerClass();
 	bool IsValidProp(const char *name);
-	bool TE_SetEntData(const char *name, int value);
-	bool TE_SetEntDataFloat(const char *name, float value);
-	bool TE_SetEntDataVector(const char *name, float vector[3]);
-	bool TE_SetEntDataFloatArray(const char *name, cell_t *array, int size);
+	bool TE_SetEntData(const char *name, const int value);
+	bool TE_SetEntDataFloat(const char *name, const float value);
+	bool TE_SetEntDataVector(const char *name, const float vector[3]);
+	bool TE_SetEntDataFloatArray(const char *name, const float *array, const int size);
 	bool TE_GetEntData(const char *name, int *value);
 	bool TE_GetEntDataFloat(const char *name, float *value);
 	bool TE_GetEntDataVector(const char *name, float vector[3]);
-	void Send(IRecipientFilter &filter, float delay);
+	void TE_Send(IRecipientFilter &filter, const float delay);
 private:
 	int _FindOffset(const char *name, int *size=NULL);
 private:
@@ -62,7 +63,7 @@ private:
 	SourceHook::String m_Name;
 };
 
-class TempEntityManager
+class TempEntityManager : public ISDKTempEntityManager
 {
 public:
 	TempEntityManager() : m_NameOffs(0), m_NextOffs(0), m_GetClassNameOffs(0), m_Loaded(false) {}

--- a/extensions/sdktools/tenatives.cpp
+++ b/extensions/sdktools/tenatives.cpp
@@ -425,7 +425,13 @@ static cell_t smn_TEWriteFloatArray(IPluginContext *pContext, const cell_t *para
 	cell_t *addr;
 	pContext->LocalToPhysAddr(params[2], &addr);
 
-	if (!g_CurrentTE->TE_SetEntDataFloatArray(prop, addr, params[3]))
+	std::vector<float> value(static_cast<size_t>(params[3]));
+	for (int i = 0; i < params[3]; i++)
+	{
+		value[i] = sp_ctof(addr[i]);
+	}
+	
+	if (!g_CurrentTE->TE_SetEntDataFloatArray(prop, value.data(), params[3]))
 	{
 		return pContext->ThrowNativeError("Temp entity property \"%s\" not found", prop);
 	}
@@ -469,7 +475,7 @@ static cell_t smn_TESend(IPluginContext *pContext, const cell_t *params)
 	g_TERecFilter.Reset();
 	g_TERecFilter.Initialize(cl_array, numClients);
 
-	g_CurrentTE->Send(g_TERecFilter, sp_ctof(params[3]));
+	g_CurrentTE->TE_Send(g_TERecFilter, sp_ctof(params[3]));
 	g_CurrentTE = NULL;
 
 	return 1;

--- a/public/extensions/ISDKTools.h
+++ b/public/extensions/ISDKTools.h
@@ -35,7 +35,7 @@
 #include <IShareSys.h>
 
 #define SMINTERFACE_SDKTOOLS_NAME		"ISDKTools"
-#define SMINTERFACE_SDKTOOLS_VERSION	2
+#define SMINTERFACE_SDKTOOLS_VERSION	3
 
 class IServer;
 
@@ -46,6 +46,87 @@ class IServer;
 
 namespace SourceMod
 {
+	/**
+	 * @brief Manager for temporary entities.
+	 */
+	class ISDKTempEntityManager
+	{
+	public:
+		/**
+		 * @brief Wraps information about a temp entity.
+		 */
+		class ISDKTempEntityInfo
+		{
+		public:
+			/**
+			 * @brief Gets the type of the described TE.
+			 *
+			 * @return			Name of the TE's type.
+			 */
+			virtual const char* GetName() = 0;
+
+			/**
+			 * @brief Sets an integer value in the given temp entity.
+			 *
+			 * @param name		Name of the property to set.
+			 * @param value		Property value.
+			 * @return			True, if the property exists.
+			 */
+			virtual bool TE_SetEntData(const char* name, const int value) = 0;
+
+			/**
+			 * @brief Sets a float value in the given temp entity.
+			 *
+			 * @param name		Name of the property to set.
+			 * @param value		Property value.
+			 * @return			True, if the property exists.
+			 */
+			virtual bool TE_SetEntDataFloat(const char* name, const float value) = 0;
+
+			/**
+			 * @brief Sets a vector value in the given temp entity.
+			 *
+			 * @param name		Name of the property to set.
+			 * @param value		Property value.
+			 * @return			True, if the property exists.
+			 */
+			virtual bool TE_SetEntDataVector(const char* name, const float vector[3]) = 0;
+
+			/**
+			 * @brief Sets a float array value in the given temp entity.
+			 *
+			 * @param name		Name of the property to set.
+			 * @param array		Property value array.
+			 * @param size		Number of elements in array.
+			 * @return			True, if the property exists.
+			 */
+			virtual bool TE_SetEntDataFloatArray(const char* name, const float* array, const int size) = 0;
+
+			/**
+			 * @brief Send the temp entity.
+			 *
+			 * @param filter	Filter object for clients.
+			 * @param delay		Delay in seconds to send the TE.
+			 */
+			virtual void TE_Send(IRecipientFilter& filter, const float delay) = 0;
+		};
+
+		/**
+		 * @brief Checks if the temp entity system is available.
+		 *
+		 * @return			True if the temp entity system is available.
+		 */
+		virtual bool IsAvailable() = 0;
+
+		/**
+		 * @brief Creates a new ISDKTempEntityInfo pointer based on the temp entities name.
+		 *
+		 * @param name		Name of the TE type.
+		 * @return			ISDKTempEntityInfo pointer.
+		 */
+		virtual ISDKTempEntityInfo* GetTempEntityInfo(const char* name) = 0;
+	};
+	
 	/**
 	 * @brief SDKTools API.
 	 */
@@ -68,6 +149,13 @@ namespace SourceMod
 		 * @return			CGameRules pointer or NULL if not found.
 		 */
 		virtual void* GetGameRules() = 0;
+
+		/**
+		 * @brief Returns a pointer to SDKTools' ISDKTempEntityManager.
+		 *
+		 * @return			ISDKTempEntityManager pointer.
+		 */
+		virtual ISDKTempEntityManager* GetTempEntityManager() = 0;
 	};
 }
 


### PR DESCRIPTION
Add a simple temp entity interface to sdktools interface.
The interface just uses the functions used to implement the natives and thus works pretty much the same way.

```cpp
static void Beam(IRecipientFilter& filter, float delay,
	const Vector& pos1, const Vector& pos2, int modelindex, int haloindex, int startframe, int framerate,
	float life, float width, float endWidth, float fadelength, float amplitude, int r, int g, int b, int a, int speed, int flags = 0)
{
	auto tempentmanager = sdktools->GetTempEntityManager();
	if (!tempentmanager->IsAvailable())
	{
		rootconsole->ConsolePrint("Temp entities are not available!");
	}
	auto tempent = tempentmanager->GetTempEntityInfo("BeamPoints");
	
	tempent->TE_SetEntDataVector("m_vecStartPoint", static_cast<const float*>(pos1.Base()));
	tempent->TE_SetEntDataVector("m_vecEndPoint", static_cast<const float*>(pos2.Base()));
	tempent->TE_SetEntData("m_nModelIndex", modelindex);
	tempent->TE_SetEntData("m_nHaloIndex", haloindex);
	tempent->TE_SetEntData("m_nStartFrame", startframe);
	tempent->TE_SetEntData("m_nFrameRate", framerate);
	tempent->TE_SetEntDataFloat("m_fLife", life);
	tempent->TE_SetEntDataFloat("m_fWidth", width);
	tempent->TE_SetEntDataFloat("m_fEndWidth", endWidth);
	tempent->TE_SetEntDataFloat("m_fAmplitude", amplitude);
	tempent->TE_SetEntData("r", r);
	tempent->TE_SetEntData("g", g);
	tempent->TE_SetEntData("b", b);
	tempent->TE_SetEntData("a", a);
	tempent->TE_SetEntData("m_nSpeed", speed);
	tempent->TE_SetEntData("m_nFadeLength", fadelength);
	tempent->TE_Send(filter, delay);
}
```