### PR TITLE
Remove entity lump manipulation from OnLevelInit

### DIFF
--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -270,7 +270,6 @@ public:
 #ifdef GAMEDESC_CAN_CHANGE
 	const char *Hook_GetGameDescription();
 #endif
-	const char *Hook_GetMapEntitiesString();
 	bool Hook_LevelInit(char const *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame, bool background);
 
 	/**

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -379,8 +379,8 @@ forward Action OnGetGameDescription(char gameDesc[64]);
  * When the level is initialized
  *
  * @param mapName       Name of the map
- * @param mapEntities   Entities of the map
- * @return              Plugin_Changed if mapEntities has been edited, else no change.
+ * @param mapEntities   Unused, always empty
+ * @return              Unused, return value is ignored
  */
 forward Action OnLevelInit(const char[] mapName, char mapEntities[2097152]);
 

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -382,6 +382,7 @@ forward Action OnGetGameDescription(char gameDesc[64]);
  * @param mapEntities   Unused, always empty
  * @return              Unused, return value is ignored
  */
+#pragma deprecated Use OnMapInit() instead
 forward Action OnLevelInit(const char[] mapName, char mapEntities[2097152]);
 
 /**

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -182,10 +182,14 @@ forward void OnPluginPauseChange(bool pause);
 forward void OnGameFrame();
 
 /**
- * Called when the map is loaded.
+ * Called when the map starts loading.
  *
- * @note This used to be OnServerLoad(), which is now deprecated.
- *       Plugins still using the old forward will work.
+ * @param mapName Name of the map
+ */
+forward void OnMapInit(const char[] mapName);
+
+/**
+ * Called when the map is loaded.
  */
 forward void OnMapStart();
 


### PR DESCRIPTION
Newer Source engine versions now use a dynamically allocated buffer for
the map entity lump, and some maps have over 16MB of entity data - far
larger than our 2MB limit.

There is no sane way we can currently handle this, so just remove the
functionality from the forward until a more comprehensive API can be
designed.

The change in behaviour to the OnLevelInit forward params isn't obvious
when compiling a plugin, deprecate it to make it a lot more obvious that
something has changed.

Some plugins rely just on the timing of OnLevelInit rather than doing
anything with the entity lump, for these plugins offer a new OnMapInit
forward that is implemented in core rather than sdkhooks. If / when we
offer a new entity lump manipulation API in the future this'll be the
forward where it can be used to make changes.

Fixes #1470