### PR TITLE
Handle detour patches across page boundaries

### DIFF
--- a/public/CDetour/detourhelpers.h
+++ b/public/CDetour/detourhelpers.h
@@ -56,7 +56,7 @@ inline void ProtectMemory(void *addr, int length, int prot)
 #if defined PLATFORM_POSIX
 	long pageSize = sysconf(_SC_PAGESIZE);
 	void *startPage = ke::AlignedBase(addr, pageSize);
-	void *endPage = ke::AlignedBase((intptr_t)addr + length, pageSize);
+	void *endPage = ke::AlignedBase((void *)((intptr_t)addr + length), pageSize);
 	mprotect(startPage, ((intptr_t)endPage - (intptr_t)startPage) + pageSize, prot);
 #elif defined PLATFORM_WINDOWS
 	DWORD old_prot;

--- a/public/CDetour/detourhelpers.h
+++ b/public/CDetour/detourhelpers.h
@@ -56,7 +56,7 @@ inline void ProtectMemory(void *addr, int length, int prot)
 #if defined PLATFORM_POSIX
 	long pageSize = sysconf(_SC_PAGESIZE);
 	void *startPage = ke::AlignedBase(addr, pageSize);
-	void *endPage = ke::AlignedBase(addr + length, pageSize);
+	void *endPage = ke::AlignedBase((intptr_t)addr + length, pageSize);
 	mprotect(startPage, ((intptr_t)endPage - (intptr_t)startPage) + pageSize, prot);
 #elif defined PLATFORM_WINDOWS
 	DWORD old_prot;


### PR DESCRIPTION
On Linux if a detour crossed a page boundary we would only change the
memory protection of the first page (as we were aligning the address as
required, but not taking into account the length).

I don't have an easy way to test this but it looks correct. `addr + len`
doesn't appear to need to be aligned though, so another option could be
to use `(addr - startPage) + length` as len.

Also fixed a non-zero offset being passed into CDetour's ApplyPatch
function - this is never done internally anywhere, but it doesn't hurt
to fix it.

Fixes #984