### PR TITLE
Fix reading/writing string_t array netprops

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -2186,10 +2186,10 @@ static cell_t GetEntPropString(IPluginContext *pContext, const cell_t *params)
 		{
 			FIND_PROP_SEND(DPT_String, "string");
 
-			if (info.prop->GetProxyFn())
+			if (pProp->GetProxyFn())
 			{
 				DVariant var;
-				info.prop->GetProxyFn()(info.prop, pEntity, (const void *) ((intptr_t) pEntity + offset), &var, element, params[1]);
+				pProp->GetProxyFn()(pProp, pEntity, (const void *) ((intptr_t) pEntity + offset), &var, element, params[1]);
 				src = var.m_pString;
 			}
 			else
@@ -2315,10 +2315,10 @@ static cell_t SetEntPropString(IPluginContext *pContext, const cell_t *params)
 			}
 
 			bIsStringIndex = false;
-			if (info.prop->GetProxyFn())
+			if (pProp->GetProxyFn())
 			{
 				DVariant var;
-				info.prop->GetProxyFn()(info.prop, pEntity, (const void *) ((intptr_t) pEntity + offset), &var, element, params[1]);
+				pProp->GetProxyFn()(pProp, pEntity, (const void *) ((intptr_t) pEntity + offset), &var, element, params[1]);
 				if (var.m_pString == ((string_t *) ((intptr_t) pEntity + offset))->ToCStr())
 				{
 					bIsStringIndex = true;


### PR DESCRIPTION
When a netprop is an array the name resolves to the outer DataTable
array, which we then need to recurse into to find the actual prop.

For string_t props we need their sendprop info to call the proxy
function to get their real storage address, but when accessing an array
we were trying to read the prop off the outer DataTable prop, rather
than the real string_t prop. Fix this by using the pProp variable that
FIND_PROP_SEND helpfully provides for us.

Tested by writing/reading the `m_szCrosshairCodes` array, which got
changed to a string_t prop sometime since #1372.

Fixes #1484