### PR TITLE
Switch internal SM concept of frames to use Think

### DIFF
--- a/core/TimerSys.h
+++ b/core/TimerSys.h
@@ -82,6 +82,7 @@ public: //ITimerSystem
 public:
 	void RunFrame();
 	void RemoveMapChangeTimers();
+	void Think(bool unused);
 	void GameFrame(bool simulating);
 private:
 	List<ITimer *> m_SingleTimers;
@@ -92,6 +93,8 @@ private:
 	/* This is stuff for our manual ticking escapades. */
 	bool m_bHasMapTickedYet;	/** Has the map ticked yet? */
 	bool m_bHasMapSimulatedYet;	/** Has the map simulated yet? */
+	bool m_bWasSimulating;	/** Was the last GameFrame simulating */
+	unsigned m_uFramesAhead; /** Number of frames Think is ahead of GameFrame */
 	float m_fLastTickedTime;	/** Last time that the game currently gave 
 									us while ticking.
 									*/

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -46,7 +46,6 @@
 #include <amtl/os/am-path.h>
 #include <bridge/include/IExtensionBridge.h>
 #include <bridge/include/IScriptManager.h>
-#include <bridge/include/IProviderCallbacks.h>
 #include <bridge/include/ILogger.h>
 
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);
@@ -291,6 +290,7 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 void SourceModBase::StartSourceMod(bool late)
 {
 	SH_ADD_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
+	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 	SH_ADD_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
 
 	enginePatch = SH_GET_CALLCLASS(engine);
@@ -362,8 +362,6 @@ void SourceModBase::StartSourceMod(bool late)
 	{
 		g_pSourcePawn2->InstallWatchdogTimer(atoi(timeout) * 1000);
 	}
-
-	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
 static bool g_LevelEndBarrier = false;
@@ -598,8 +596,8 @@ void SourceModBase::ShutdownServices()
 	}
 
 	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
+	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 	SH_REMOVE_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
-	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
 void SourceModBase::LogMessage(IExtension *pExt, const char *format, ...)


### PR DESCRIPTION
This has been asked for and debated in some form since Valve introduced
hibernation into the Source engine. The changes here are based on quite
a deep dive into the engine's frame/think logic (mainly in CS:GO which
has "legacy" hibernation and TF2 which has modern "frameless" ticking)
and all seem to be sane.

I think I've managed to maintain all the oddities around time keeping,
and the simulated bool (even though we don't really use it for anything)
should have a sane value. There is a slight behaviour change for
anything needing exact timings as we're now run earlier in the frame
before gpGlobals are updated, this should generally be fine but it might
affect some plugins such as bhop timers that are trying to be extremely
precise (often more precise than the underlying data they're using).

We'll probably want to add a native for plugins to detect if the server
is not completely simulating so they can opt out of work, but I think
defaulting to having things work like this makes more sense than adding
a 2nd set of per-frame forwards and natives (#540), and this makes
timers and any extension callbacks work automatically.