### PR TITLE
Make all command lookup case-insensitive

### DIFF
--- a/core/ChatTriggers.cpp
+++ b/core/ChatTriggers.cpp
@@ -363,7 +363,7 @@ bool ChatTriggers::PreProcessTrigger(edict_t *pEdict, const char *args)
 	if (!g_ConCmds.LookForSourceModCommand(cmd_buf))
 	{
 		/* Check if we had an "sm_" prefix */
-		if (strncmp(cmd_buf, "sm_", 3) == 0)
+		if (strncasecmp(cmd_buf, "sm_", 3) == 0)
 		{
 			return false;
 		}
@@ -387,15 +387,7 @@ bool ChatTriggers::PreProcessTrigger(edict_t *pEdict, const char *args)
 	/* See if we need to do extra string manipulation */
 	if (prepended)
 	{
-		size_t len;
-
-		/* Check if we need to prepend sm_ */
-		if (prepended)
-		{
-			len = ke::SafeSprintf(m_ToExecute, sizeof(m_ToExecute), "sm_%s", args);
-		} else {
-			len = ke::SafeStrcpy(m_ToExecute, sizeof(m_ToExecute), args);
-		}
+		ke::SafeSprintf(m_ToExecute, sizeof(m_ToExecute), "sm_%s", args);
 	} else {
 		ke::SafeStrcpy(m_ToExecute, sizeof(m_ToExecute), args);
 	}

--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -153,30 +153,13 @@ ConCmdInfo *ConCmdManager::FindInTrie(const char *name)
 	return pInfo;
 }
 
-ConCmdList::iterator ConCmdManager::FindInList(const char *cmd)
-{
-	List<ConCmdInfo *>::iterator iter = m_CmdList.begin();
-
-	while (iter != m_CmdList.end())
-	{
-		if (strcasecmp((*iter)->pCmd->GetName(), cmd) == 0)
-			break;
-		iter++;
-	}
-
-	return iter;
-}
-
 ResultType ConCmdManager::DispatchClientCommand(int client, const char *cmd, int args, ResultType type)
 {
-	ConCmdInfo *pInfo;
+	ConCmdInfo *pInfo = FindInTrie(cmd);
 
-	if ((pInfo = FindInTrie(cmd)) == NULL)
+	if (pInfo == NULL)
 	{
-		ConCmdList::iterator item = FindInList(cmd);
-		if (item == m_CmdList.end())
-			return type;
-		pInfo = *item;
+		return type;
 	}
 
 	cell_t result = type;
@@ -231,17 +214,7 @@ bool ConCmdManager::InternalDispatch(int client, const ICommandArgs *args)
 	ConCmdInfo *pInfo = FindInTrie(cmd);
 	if (pInfo == NULL)
 	{
-        /* Unfortunately, we now have to do a slow lookup because Valve made client commands 
-         * case-insensitive.  We can't even use our sortedness.
-         */
-        if (client == 0 && !engine->IsDedicatedServer())
-            return false;
-
-		ConCmdList::iterator item = FindInList(cmd);
-		if (item == m_CmdList.end())
-			return false;
-
-		pInfo = *item;
+		return false;
 	}
 
 	/* This is a hack to prevent say triggers from firing on messages that were 
@@ -568,10 +541,6 @@ ConCmdInfo *ConCmdManager::AddOrFindCommand(const char *name, const char *descri
 	ConCmdInfo *pInfo;
 	if (!m_Cmds.retrieve(name, &pInfo))
 	{
-		ConCmdList::iterator item = FindInList(name);
-		if (item != m_CmdList.end())
-			return *item;
-
 		pInfo = new ConCmdInfo();
 		/* Find the commandopan */
 		ConCommand *pCmd = FindCommand(name);

--- a/public/sm_namehashset.h
+++ b/public/sm_namehashset.h
@@ -111,12 +111,14 @@ public:
 
 	Result find(const char *aKey)
 	{
-		return table_.find(aKey);
+		CharsAndLength key(aKey);
+		return table_.find(key);
 	}
 
 	Insert findForAdd(const char *aKey)
 	{
-		return table_.findForAdd(aKey);
+		CharsAndLength key(aKey);
+		return table_.findForAdd(key);
 	}
 
 	template <typename U>
@@ -128,7 +130,7 @@ public:
 	bool retrieve(const char *aKey, T *value)
 	{
 		CharsAndLength key(aKey);
-		Result r = table_.find(aKey);
+		Result r = table_.find(key);
 		if (!r.found())
 			return false;
 		*value = *r;
@@ -148,7 +150,7 @@ public:
 	bool contains(const char *aKey)
 	{
 		CharsAndLength key(aKey);
-		Result r = table_.find(aKey);
+		Result r = table_.find(key);
 		return r.found();
 	}
 


### PR DESCRIPTION
SM internally maintained both a case-sensitive and a case-insensitive
lookup method for commands, where the case-sensitive hashmap was used as
a fast path, and case-insensitive iteration over a list used as the slow
path if a command was not found in the hashmap. But only command
dispatch handling used this dual path approach, chat triggers for
example only did a loopup in the hashmap.

Over the years Valve has made more and more of the command dispatch
logic case-insensitive to the point where all console commands are now
case-insensitive, so maintaining case sensitivity when using chat
triggers does not make a lot of sense. There are somewhat popular
plugins that attempt to "correct" this behaviour - but at least one is
having issues after the previous case-sensitivity fixes for commands -
see #1480.

We still have to keep the list around for the sorted help use case and
command iteration, but this PR changes the hashmap to use a
case-insensitive hashing policy (as previously done for convars, and
more recently for game command lookup) and changes all by-name lookup to
exclusively use the hashmap (as there is no need to fall back to the
list any more).

Tested a bunch in TF2, I don't know of any games that still have a
case-sensitive command dispatch pipeline to test. I think the worst case
would be that we'd accept a chat command in the "wrong" case then fail
to execute the underlying command. If that turns out to be an issue in
practice, we should be able to fix it easily enough by replacing the
command name in the buffer with the correct casing of the command we
looked up.

Also fixed a couple of very minor Lookup vs. Key issues in NameHashSet
(noted in #1529) that were being masked due to CharsAndLength's
converting constructor. I tried to make the constructor explicit to
avoid this happening in the future but HashTable's add function relies
on being able to do an implicit conversion so that wasn't possible. We
might want to just rely on the implicit conversion up here as well, but
it doesn't really matter either way.

Fixes #1480, #1529