### PR TITLE
Detect invalid menu item selections in L4D-based games

### DIFF
--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -197,7 +197,7 @@
 		}
 	}
 	
-		"#default"
+	"#default"
 	{
 		"#supported"
 		{
@@ -364,6 +364,21 @@
 		"Keys"
 		{
 			"RadioMenuMaxPageItems"	"6"
+		}
+	}
+
+	"#default"
+	{
+		"#supported"
+		{
+			"engine"	"left4dead"
+			"engine"	"left4dead2"
+			"engine"	"nucleardawn"
+		}
+
+		"Keys"
+		{
+			"RadioMenuClosesOnInvalidSlot"	"yes"
 		}
 	}
 }


### PR DESCRIPTION
Some games have implemented CHudMenu::SelectMenuItem to close the menu
even if an invalid slot has been selected, which causes us a problem as
we'll never get any notification from the client and we'll keep the menu
alive on our end indefinitely. For these games, pretend that every slot
is valid for selection so we're guaranteed to get a menuselect command.
We don't want to do this for every game as the common SelectMenuItem
implementation ignores invalid selections and keeps the menu open, which
is a much nicer user experience.

Fixes #1385