### PR TITLE
Always use our cached name value

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -2282,11 +2282,6 @@ void CPlayer::SetName(const char *name)
 
 const char *CPlayer::GetName()
 {
-	if (m_Info && m_pEdict->GetUnknown())
-	{
-		return m_Info->GetName();
-	}
-	
 	return m_Name.c_str();
 }
 


### PR DESCRIPTION
In #545 we started automatically fixing up invalid UTF8 characters
caused by truncated names from Steam, but since the dawn of time CPlayer
has preferred directly returning the engine's name pointer if we have
once available, so our corrected name is almost never used.

Lightly tested in CS:GO and TF2 with no ill effects. Fixes #1315