### PR TITLE
Return array type info with FindSendPropInfo

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -320,15 +320,20 @@ bool UTIL_FindInSendTable(SendTable *pTable,
 						  sm_sendprop_info_t *info,
 						  unsigned int offset)
 {
-	const char *pname;
 	int props = pTable->GetNumProps();
-	SendProp *prop;
-
-	for (int i=0; i<props; i++)
+	for (int i = 0; i < props; i++)
 	{
-		prop = pTable->GetProp(i);
-		pname = prop->GetName();
+		SendProp *prop = pTable->GetProp(i);
+
+		// Skip InsideArray props (SendPropArray / SendPropArray2),
+		// we'll find them later by their containing array.
+		if (prop->IsInsideArray()) {
+			continue;
+		}
+
+		const char *pname = prop->GetName();
 		SendTable *pInnerTable = prop->GetDataTable();
+
 		if (pname && strcmp(name, pname) == 0)
 		{
 			// get true offset of CUtlVector

--- a/plugins/include/entity.inc
+++ b/plugins/include/entity.inc
@@ -428,6 +428,7 @@ native int FindSendPropOffs(const char[] cls, const char[] prop);
  *                      for strings.
  * @param local_offset  Optional parameter to store the local offset, as
  *                      FindSendPropOffs() would return.
+ * @param array_size    Optional parameter to store array size, 0 if not an array.
  * @return              On success, returns an absolutely computed offset.
  *                      If no offset is available, 0 is returned.
  *                      If the property is not found, -1 is returned.
@@ -436,7 +437,8 @@ native int FindSendPropInfo(const char[] cls,
 						const char[] prop,
 						PropFieldType &type=view_as<PropFieldType>(0),
 						int &num_bits=0,
-						int &local_offset=0);
+						int &local_offset=0,
+						int &array_size=0);
 
 /**
  * Given an entity, finds a datamap property offset.
@@ -700,7 +702,7 @@ native int SetEntPropString(int entity, PropType type, const char[] prop, const 
  * @param entity        Entity/edict index.
  * @param type          Property type.
  * @param prop          Property name.
- * @return              Size of array (in elements) or 1 if property is not an array.
+ * @return              Size of array (in elements) or 0 if property is not an array.
  * @error               Invalid entity or property not found.
  */
 native int GetEntPropArraySize(int entity, PropType type, const char[] prop);


### PR DESCRIPTION
FindSendPropInfo currently isn't very useful with array props, it'll
return the correct offset but the type will be unknown and the bit count
zero. Instead, populate type and num_bits with the underlying array type
info same as we'd handle it when reading/writing the prop. Closes #1258.

This also adds the preliminary support for Source's legacy / virtual
array props for issue #1386. They can now be looked up correctly with
FindSendPropInfo and it returns the correct type / size / offset.