### PR TITLE
Expand GetClientMenu() to include Menu handle

### DIFF
--- a/core/logic/smn_menus.cpp
+++ b/core/logic/smn_menus.cpp
@@ -1219,7 +1219,17 @@ static cell_t GetClientMenu(IPluginContext *pContext, const cell_t *params)
 		style = menus->GetDefaultStyle();
 	}
 
-	return style->GetClientMenu(params[1], NULL);
+	IBaseMenu *menu = NULL;
+	MenuSource source = style->GetClientMenu(params[1], (void **)&menu);
+
+	if (params[0] >= 3)
+	{
+		cell_t *addr;
+		pContext->LocalToPhysAddr(params[3], &addr);
+		*(Handle_t *)addr = menu ? menu->GetHandle() : BAD_HANDLE;
+	}
+
+	return source;
 }
 
 static cell_t CancelClientMenu(IPluginContext *pContext, const cell_t *params)

--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -947,10 +947,11 @@ native Menu CreateMenuEx(Handle hStyle=INVALID_HANDLE, MenuHandler handler, Menu
  *
  * @param client        Client index.
  * @param hStyle        MenuStyle Handle, or INVALID_HANDLE to use the default style.
+ * @param hMenu         Optional menu Handle reference, only filled if return is MenuSource_Normal.
  * @return              A MenuSource value.
  * @error               Invalid Handle other than null.
  */
-native MenuSource GetClientMenu(int client, Handle hStyle=null);
+native MenuSource GetClientMenu(int client, Handle hStyle=null, Handle &hMenu=null);
 
 /**
  * Cancels a menu on a client.  This will only affect non-external menus.


### PR DESCRIPTION
There currently isn't a way to get a client's *exact* menu, so I wanted to implement that for my use case.

I wanted to close a certain menu when a round ended, since there's no way to get an exact menu, I had to settle for checking if `GetClientMenu(client) != MenuSource_None`. Works, but what if there's a vote right before the end of the round?

I wasn't sure if it would be better to create a new native or expand on `GetClientMenu`, so if that's preferred, please let me know.

Test script:
```c#
public void OnPluginStart()
{
    RegConsoleCmd("sm_makemenu", CmdMakeMenu);
    RegConsoleCmd("sm_mymenu", CmdMyMenu);
}

public Action CmdMakeMenu(int client, int args)
{
    Menu menu = new Menu(MakeMenuHandler);
    char buffer[64]; FormatEx(buffer, sizeof(buffer), "Menu: %x", menu);
    menu.SetTitle(buffer);
    menu.AddItem("", "Bananas");
    menu.AddItem("", "Grapes");
    menu.Display(client, MENU_TIME_FOREVER);
    return Plugin_Handled;
}

public int MakeMenuHandler(Menu menu, MenuAction action, int client, int select)
{
    if (action == MenuAction_End)
        delete menu;
}

public Action CmdMyMenu(int client, int args)
{
    Menu menu;
    MenuSource src = GetClientMenu(client, .hMenu = menu);
    if (src == MenuSource_Normal)
        ReplyToCommand(client, "%x", menu);
    else
        ReplyToCommand(client, "No menu");
}
```