### PR TITLE
Fix out of bounds write in CDataPack::Write*Array

### DIFF
--- a/core/logic/CDataPack.cpp
+++ b/core/logic/CDataPack.cpp
@@ -116,7 +116,7 @@ void CDataPack::PackCellArray(cell_t const *vals, cell_t count)
 	val.type = CDataPackType::CellArray;
 
 	val.pData.aval = new cell_t [count + 1];
-	memcpy(&val.pData.aval[1], vals, sizeof(cell_t) * (count + 1));
+	memcpy(&val.pData.aval[1], vals, sizeof(cell_t) * count);
 	val.pData.aval[0] = count;
 	elements.emplace(elements.begin() + position, val);
 	position++;
@@ -128,7 +128,7 @@ void CDataPack::PackFloatArray(cell_t const *vals, cell_t count)
 	val.type = CDataPackType::FloatArray;
 
 	val.pData.aval = new cell_t [count + 1];
-	memcpy(&val.pData.aval[1], vals, sizeof(cell_t) * (count + 1));
+	memcpy(&val.pData.aval[1], vals, sizeof(cell_t) * count);
 	val.pData.aval[0] = count;
 	elements.emplace(elements.begin() + position, val);
 	position++;
@@ -294,7 +294,7 @@ bool CDataPack::RemoveItem(size_t pos)
 		case CDataPackType::CellArray:
 		case CDataPackType::FloatArray:
 		{
-			delete elements[pos].pData.aval;
+			delete [] elements[pos].pData.aval;
 			break;
 		}
 	}


### PR DESCRIPTION
WriteCellArray and WriteFloatArray were allocating N+1 slots, but due to
a copy-paste error were writing N+2 slots. Much later in the process the
CRT would catch this and cause a crash - this was pretty painful to
debug but thankfully running SRCDS in CRT debug mode caught it much
sooner in CDataPack::RemoveItem.

Thanks to @dysphie for the initial report.