### PR TITLE
Fix clientprefs prefab menu crash

### DIFF
--- a/extensions/clientprefs/menus.cpp
+++ b/extensions/clientprefs/menus.cpp
@@ -40,7 +40,7 @@ void ClientMenuHandler::OnMenuSelect(IBaseMenu *menu, int client, unsigned int i
 
 	const char *info = menu->GetItemInfo(item, &draw);
 
-	if (!info)
+	if (info == NULL)
 	{
 		return;
 	}

--- a/extensions/clientprefs/menus.cpp
+++ b/extensions/clientprefs/menus.cpp
@@ -40,6 +40,11 @@ void ClientMenuHandler::OnMenuSelect(IBaseMenu *menu, int client, unsigned int i
 
 	const char *info = menu->GetItemInfo(item, &draw);
 
+	if (!info)
+	{
+		return;
+	}
+	
 	AutoMenuData *data = (AutoMenuData *)strtoul(info, NULL, 16);
 
 	if (data->handler->forward != NULL)


### PR DESCRIPTION
While working with `clientprefs` and Cookies i stubbled upon a [bug](https://discord.com/channels/335290997317697536/335290997317697536/870399001806123019):

1. you register a cookie (and add it to the prefab menu).
2. you open the prefab menu.
3. you unload the plugin (resulting the cookie to be removed).
4. you click on the removed cookie in the menu.
5. server crashed.

From what i found in the crash dumps i got: [1](https://crash.limetech.org/4nmm6lkdvmox), [2](https://crash.limetech.org/t5pjlbafhaey).

I saw that the variable `info` is NULL and it's sent to the `strtoul()` function which causes the crash to happen. (`SIGSEGV /SEGV_MAPERR accessing 0x0`)

while discussing this in the discord asherkin [pointed out](https://discord.com/channels/335290997317697536/335290997317697536/870403278263976048) to me that he doesn't think the bug is in the clientprefs extension, hence it probably won't be fixed there, but after applying this check everything seem to work just fine and the server doesn't crash anymore.