### PR TITLE
Clarify SQL_EscapeString usage

### DIFF
--- a/plugins/include/dbi.inc
+++ b/plugins/include/dbi.inc
@@ -635,8 +635,8 @@ native bool SQL_GetError(Handle hndl, char[] error, int maxlength);
  * the database's character set.
  *
  * NOTE: SourceMod only guarantees properly escaped strings when the query
- * encloses the string in ''. While drivers tend to allow " instead, the string
- * may be not be escaped (for example, on SQLite)!
+ * encloses the string in ''. While drivers tend to allow "" instead,
+ * the string may be not be escaped (for example, on SQLite)!
  *
  * @param database      A database Handle.
  * @param string        String to quote.


### PR DESCRIPTION
It's hard to see the difference between 2 single-quotes and 1 double-quote unless you highlight it.