### PR TITLE
Remove OnEntitySpawned forward

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -112,7 +112,6 @@ IServerTools *servertools = NULL;
 
 // global hooks and forwards
 IForward *g_pOnEntityCreated = NULL;
-IForward *g_pOnEntitySpawned = NULL;
 IForward *g_pOnEntityDestroyed = NULL;
 
 #ifdef GAMEDESC_CAN_CHANGE
@@ -242,14 +241,12 @@ bool SDKHooks::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	sharesys->AddInterface(myself, &g_Interface);
 	sharesys->AddCapabilityProvider(myself, this, "SDKHook_DmgCustomInOTD");
 	sharesys->AddCapabilityProvider(myself, this, "SDKHook_LogicalEntSupport");
-	sharesys->AddCapabilityProvider(myself, this, "SDKHook_OnEntitySpawned");
 
 	playerhelpers->AddClientListener(&g_Interface);
 	
 	plsys->AddPluginsListener(&g_Interface);
 
 	g_pOnEntityCreated = forwards->CreateForward("OnEntityCreated", ET_Ignore, 2, NULL, Param_Cell, Param_String);
-	g_pOnEntitySpawned = forwards->CreateForward("OnEntitySpawned", ET_Ignore, 2, NULL, Param_Cell, Param_String);
 	g_pOnEntityDestroyed = forwards->CreateForward("OnEntityDestroyed", ET_Ignore, 1, NULL, Param_Cell);
 #ifdef GAMEDESC_CAN_CHANGE
 	g_pOnGetGameNameDescription = forwards->CreateForward("OnGetGameDescription", ET_Hook, 2, NULL, Param_String);
@@ -339,7 +336,6 @@ void SDKHooks::SDK_OnUnload()
 #endif
 
 	forwards->ReleaseForward(g_pOnEntityCreated);
-	forwards->ReleaseForward(g_pOnEntitySpawned);
 	forwards->ReleaseForward(g_pOnEntityDestroyed);
 #ifdef GAMEDESC_CAN_CHANGE
 	forwards->ReleaseForward(g_pOnGetGameNameDescription);
@@ -352,7 +348,6 @@ void SDKHooks::SDK_OnUnload()
 
 	sharesys->DropCapabilityProvider(myself, this, "SDKHook_DmgCustomInOTD");
 	sharesys->DropCapabilityProvider(myself, this, "SDKHook_LogicalEntSupport");
-	sharesys->DropCapabilityProvider(myself, this, "SDKHook_OnEntitySpawned");
 
 	CUtlVector<IEntityListener *> *entListeners = EntListeners();
 	entListeners->FindAndRemove(this);
@@ -416,7 +411,6 @@ void SDKHooks::OnClientPutInServer(int client)
 	CBaseEntity *pPlayer = gamehelpers->ReferenceToEntity(client);
 
 	HandleEntityCreated(pPlayer, client, gamehelpers->EntityToReference(pPlayer));
-	HandleEntitySpawned(pPlayer, client, gamehelpers->EntityToReference(pPlayer));
 }
 
 void SDKHooks::OnClientDisconnecting(int client)
@@ -880,27 +874,6 @@ void SDKHooks::OnEntityCreated(CBaseEntity *pEntity)
 	{
 		HandleEntityCreated(pEntity, index, ref);
 	}
-}
-
-void SDKHooks::OnEntitySpawned(CBaseEntity *pEntity)
-{
-	// Call OnEntitySpawned forward
-	int ref = gamehelpers->EntityToReference(pEntity);
-	int index = gamehelpers->ReferenceToIndex(ref);
-
-	// This can be -1 for player ents before any players have connected
-	if ((unsigned)index == INVALID_EHANDLE_INDEX || (index > 0 && index <= playerhelpers->GetMaxClients()))
-	{
-		return;
-	}
-
-	if (!IsEntityIndexInRange(index))
-	{
-		g_pSM->LogError(myself, "SDKHooks::OnEntitySpawned - Got entity index out of range (%d)", index);
-		return;
-	}
-
-	HandleEntitySpawned(pEntity, index, ref);
 }
 
 #ifdef GAMEDESC_CAN_CHANGE
@@ -1786,51 +1759,29 @@ bool SDKHooks::Hook_WeaponSwitchPost(CBaseCombatWeapon *pWeapon, int viewmodelin
 void SDKHooks::HandleEntityCreated(CBaseEntity *pEntity, int index, cell_t ref)
 {
 	const char *pName = gamehelpers->GetEntityClassname(pEntity);
-	if (!pName)
-		pName = "";
-	
+	cell_t bcompatRef = gamehelpers->EntityToBCompatRef(pEntity);
+
 	// Send OnEntityCreated to SM listeners
 	SourceHook::List<ISMEntityListener *>::iterator iter;
 	ISMEntityListener *pListener = NULL;
 	for (iter = m_EntListeners.begin(); iter != m_EntListeners.end(); iter++)
 	{
 		pListener = (*iter);
-		pListener->OnEntityCreated(pEntity, pName);
+		pListener->OnEntityCreated(pEntity, pName ? pName : "");
 	}
 
 	// Call OnEntityCreated forward
-	if (g_pOnEntityCreated->GetFunctionCount())
-	{
-		cell_t bcompatRef = gamehelpers->EntityToBCompatRef(pEntity);
-		g_pOnEntityCreated->PushCell(bcompatRef);
-		g_pOnEntityCreated->PushString(pName);
-		g_pOnEntityCreated->Execute(NULL);
-	}
+	g_pOnEntityCreated->PushCell(bcompatRef);
+	g_pOnEntityCreated->PushString(pName ? pName : "");
+	g_pOnEntityCreated->Execute(NULL);
 
 	m_EntityCache[index] = ref;
 }
 
-void SDKHooks::HandleEntitySpawned(CBaseEntity *pEntity, int index, cell_t ref)
-{
-	if (g_pOnEntitySpawned->GetFunctionCount())
-	{
-		const char *pName = gamehelpers->GetEntityClassname(pEntity);
-		if (!pName)
-			pName = "";
-
-		// Call OnEntitySpawned forward
-		if (g_pOnEntitySpawned->GetFunctionCount())
-		{
-			cell_t bcompatRef = gamehelpers->EntityToBCompatRef(pEntity);
-			g_pOnEntitySpawned->PushCell(bcompatRef);
-			g_pOnEntitySpawned->PushString(pName);
-			g_pOnEntitySpawned->Execute(NULL);
-		}
-	}
-}
-
 void SDKHooks::HandleEntityDeleted(CBaseEntity *pEntity)
 {
+	cell_t bcompatRef = gamehelpers->EntityToBCompatRef(pEntity);
+
 	// Send OnEntityDestroyed to SM listeners
 	SourceHook::List<ISMEntityListener *>::iterator iter;
 	ISMEntityListener *pListener = NULL;
@@ -1841,12 +1792,8 @@ void SDKHooks::HandleEntityDeleted(CBaseEntity *pEntity)
 	}
 
 	// Call OnEntityDestroyed forward
-	if (g_pOnEntityDestroyed->GetFunctionCount())
-	{
-		cell_t bcompatRef = gamehelpers->EntityToBCompatRef(pEntity);
-		g_pOnEntityDestroyed->PushCell(bcompatRef);
-		g_pOnEntityDestroyed->Execute(NULL);
-	}
+	g_pOnEntityDestroyed->PushCell(bcompatRef);
+	g_pOnEntityDestroyed->Execute(NULL);
 
 	Unhook(pEntity);
 }

--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -238,7 +238,6 @@ public:  // IFeatureProvider
 
 public:  // IEntityListener
 	virtual void OnEntityCreated(CBaseEntity *pEntity);
-	virtual void OnEntitySpawned(CBaseEntity *pEntity);
 	virtual void OnEntityDeleted(CBaseEntity *pEntity);
 
 public:  // IClientListener
@@ -330,7 +329,6 @@ public:
 	
 private:
 	void HandleEntityCreated(CBaseEntity *pEntity, int index, cell_t ref);
-	void HandleEntitySpawned(CBaseEntity *pEntity, int index, cell_t ref);
 	void HandleEntityDeleted(CBaseEntity *pEntity);
 	void Unhook(CBaseEntity *pEntity);
 	void Unhook(IPluginContext *pContext);

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -349,16 +349,6 @@ typeset SDKHookCB
 forward void OnEntityCreated(int entity, const char[] classname);
 
 /**
- * When an entity is spawned
- *
- * @param entity        Entity index
- * @param classname     Class name
- *
- * @note Check for support at runtime using GetFeatureStatus on SDKHook_OnEntitySpawned capability.
- */
-forward void OnEntitySpawned(int entity, const char[] classname);
-
-/**
  * When an entity is destroyed
  *
  * @param entity        Entity index or edict reference.


### PR DESCRIPTION
`OnEntitySpawned` is 1.11 only, so this is fine given our API stability guarantees.

Unfortunately the forward name clashes with quite a few plugins using the same name for their SDKHook callback. Normally we'd just put up with this but there are difficult to solve binary compatibility issues where those plugins will get the callback double-called, and there is a separate issue where the forward isn't called for all entity spawns (unlike the SDKHook), so most plugins can't switch to the forward anyway.

Resolves #1558.