### PR TITLE
Revert "Switch internal SM concept of frames to use Think"

### DIFF
--- a/core/TimerSys.h
+++ b/core/TimerSys.h
@@ -82,7 +82,6 @@ public: //ITimerSystem
 public:
 	void RunFrame();
 	void RemoveMapChangeTimers();
-	void Think(bool unused);
 	void GameFrame(bool simulating);
 private:
 	List<ITimer *> m_SingleTimers;
@@ -93,8 +92,6 @@ private:
 	/* This is stuff for our manual ticking escapades. */
 	bool m_bHasMapTickedYet;	/** Has the map ticked yet? */
 	bool m_bHasMapSimulatedYet;	/** Has the map simulated yet? */
-	bool m_bWasSimulating;	/** Was the last GameFrame simulating */
-	unsigned m_uFramesAhead; /** Number of frames Think is ahead of GameFrame */
 	float m_fLastTickedTime;	/** Last time that the game currently gave 
 									us while ticking.
 									*/

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -46,6 +46,7 @@
 #include <amtl/os/am-path.h>
 #include <bridge/include/IExtensionBridge.h>
 #include <bridge/include/IScriptManager.h>
+#include <bridge/include/IProviderCallbacks.h>
 #include <bridge/include/ILogger.h>
 
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);
@@ -290,7 +291,6 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 void SourceModBase::StartSourceMod(bool late)
 {
 	SH_ADD_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
-	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 	SH_ADD_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
 
 	enginePatch = SH_GET_CALLCLASS(engine);
@@ -362,6 +362,8 @@ void SourceModBase::StartSourceMod(bool late)
 	{
 		g_pSourcePawn2->InstallWatchdogTimer(atoi(timeout) * 1000);
 	}
+
+	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
 static bool g_LevelEndBarrier = false;
@@ -596,8 +598,8 @@ void SourceModBase::ShutdownServices()
 	}
 
 	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SourceModBase::LevelShutdown), false);
-	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::Think), false);
 	SH_REMOVE_HOOK(IServerGameDLL, GameFrame, gamedll, SH_MEMBER(&g_Timers, &TimerSystem::GameFrame), false);
+	SH_REMOVE_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 
 void SourceModBase::LogMessage(IExtension *pExt, const char *format, ...)


### PR DESCRIPTION
I think all the problems here are around `realtime` being used to update `g_fUniversalTime` and that feeding into the timer run calculations, but it takes several days for things to go wonky enough here that it is just too time consuming to investigate right now.

Notes for the next person to try this:
* The feedback on the concept here was generally very positive and people *want this to work*.
* Some people are adamant about about timers being aligned to simulation time, despite them being measured in seconds.
* For the love of god do not imply changes have been tested on anything less than every game and obscure Source mod ever released for weeks of time each.
* The old Source engine time keeping is really bad, (for L4D2) frame execution runs in a 1ms sleep loop where it accumulates time until it hits `fps_max` (which a number of servers set to 0, so it triggers every time), then it runs an engine frame (`::Think`) which then decides how many game frames to run based on the target tickrate (anything from 30 to 128). All in, this means it almost never hits exact game frame start timing and variance is all over the place.
* `realtime` accumulates in a float, which is probably the cause of the most of the issues seen - we tried to account for that in the same way we do `curtime`, but I suspect the engine was just failing to accumulate properly due to the tight frame loop (whereas `curtime` accumulates much later in the process where more time has elapsed).
* Hibernation in some games (*cough* L4D2, CS:GO) completely destroys all the engine's time keeping against reality as it inserts a 20ms sleep very late in the process (right before it would have run a game frame) which isn't accounted for anywhere else - this is why the console is sluggish in these games.
* `Plat_FloatTime` seems sane, and returns a double.

I think the next attempt should look like this:
* Use the Think hook changes from this PR to implement a callback that is run continuously even when hibernating.
* In there, cache `Plat_FloatTime` into a global, call it the reference time for that frame. Update pretty much everything other than timers using "universal time" to use that.
* Dispatch all the *internal* SM time-based logic off that callback, but nothing exposed (this'll require decoupling the existing frame hook list). This'll make DBI work correctly during hibernation, which is a top priority.
* Add a new extension API to register a think hook so that extensions can do background work, which is the other top priority and really the most important bit of these changes.
* Add a new timer flag `TIMER_FLAG_REAL_TIME` that works based on the frame reference time instead of "universal time" (both one-shot and repeating), for the few plugins that want true always-running execution and the ability to dispatch new work during hibernation.

Requiring an API version bump and not being able to make existing extensions magically just work is unfortunate, but the nuance of the engine being able to run multiple game frames per think in the older games probably means `OnGameFrame` and friends should stay as they currently are.

Reverts alliedmodders/sourcemod#1540