### PR TITLE
TF2Tools: Prevent CalcIsAttackCriticalHelper* from being called twice

### DIFF
--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -205,6 +205,7 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 	g_critForward->PushString(gamehelpers->GetEntityClassname(pWeapon)); //Weapon classname
 	g_critForward->PushCellByRef(&returnValue); //return value
 
+	int origReturnValue = returnValue;
 	cell_t result = 0;
 
 	g_critForward->Execute(&result);
@@ -214,5 +215,5 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 		RETURN_META_VALUE(MRES_SUPERCEDE, returnValue);
 	}
 	
-	RETURN_META_VALUE(MRES_IGNORED, false);
+	RETURN_META_VALUE(MRES_SUPERCEDE, origReturnValue);
 }

--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -191,6 +191,7 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 		returnValue = SH_MCALL(pWeapon, CalcIsAttackCriticalHelper)() ? 1 : 0;
 	}
 
+	int origReturnValue = returnValue;
 	int ownerIndex = -1;
 	CBaseHandle &hndl = *(CBaseHandle *) ((intptr_t)pWeapon + info.actual_offset);
 	CBaseEntity *pHandleEntity = gamehelpers->ReferenceToEntity(hndl.GetEntryIndex());
@@ -205,7 +206,6 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 	g_critForward->PushString(gamehelpers->GetEntityClassname(pWeapon)); //Weapon classname
 	g_critForward->PushCellByRef(&returnValue); //return value
 
-	int origReturnValue = returnValue;
 	cell_t result = 0;
 
 	g_critForward->Execute(&result);


### PR DESCRIPTION
`CritManager::Hook_CalcIsAttackCriticalHelpers()` is a pre-hook that calls the appropriate helper function, then passes the result over to plugins to determine whether the value should be changed.

The issue is that `MRES_IGNORED` is used to return after calling the helper function if the result is `Pl_Continue`, causing the helper function to be called a second time after the function, resulting in the server's crit calculations desyncing from the clients'.  This PR stores the original return value and supercedes so it only ever gets called once.

Tested on a fresh server with the below plugin to listen for crits (and to force the hook to be enabled).  Without the fix, a Soldier's rocket may have glow without the sound or vice-versa; with the fix applied, the rocket will have both or neither.

```
#pragma semicolon 1
#include <sourcemod>

#include <tf2>

#pragma newdecls required

public Action TF2_CalcIsAttackCritical(int client, int weapon, char[] weaponname, bool& result) {
	PrintToChat(client, "%s crit: %b", weaponname, result);
	return Plugin_Continue;
}
```
thx @FlaminSarge for giving me something to do