### PR TITLE
Update gamedata after latest CSGO update (22/09/21)

### DIFF
--- a/gamedata/sdkhooks.games/engine.csgo.txt
+++ b/gamedata/sdkhooks.games/engine.csgo.txt
@@ -34,10 +34,10 @@
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"177"
-				"linux"		"179"
-				"linux64"	"179"
-				"mac64"		"179"
+				"windows"	"178"
+				"linux"		"180"
+				"linux64"	"180"
+				"mac64"		"180"
 			}
 			"OnTakeDamage"
 			{
@@ -48,24 +48,24 @@
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"298"
-				"linux"		"299"
-				"linux64"	"299"
-				"mac64"		"299"
+				"windows"	"299"
+				"linux"		"300"
+				"linux64"	"300"
+				"mac64"		"300"
 			}
 			"PreThink"
-			{
-				"windows"	"371"
-				"linux"		"372"
-				"linux64"	"372"
-				"mac64"		"372"
-			}
-			"PostThink"
 			{
 				"windows"	"372"
 				"linux"		"373"
 				"linux64"	"373"
 				"mac64"		"373"
+			}
+			"PostThink"
+			{
+				"windows"	"373"
+				"linux"		"374"
+				"linux64"	"374"
+				"mac64"		"374"
 			}
 			"Reload"
 			{
@@ -132,45 +132,45 @@
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"156"
-				"linux"		"157"
-				"linux64"	"157"
-				"mac64"		"157"
+				"windows"	"157"
+				"linux"		"158"
+				"linux64"	"158"
+				"mac64"		"158"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"290"
-				"linux"		"291"
-				"linux64"	"291"
-				"mac64"		"291"
+				"windows"	"291"
+				"linux"		"292"
+				"linux64"	"292"
+				"mac64"		"292"
 			}
 			"Weapon_CanUse"
-			{
-				"windows"	"284"
-				"linux"		"285"
-				"linux64"	"285"
-				"mac64"		"285"
-			}
-			"Weapon_Drop"
-			{
-				"windows"	"287"
-				"linux"		"288"
-				"linux64"	"288"
-				"mac64"		"288"
-			}
-			"Weapon_Equip"
 			{
 				"windows"	"285"
 				"linux"		"286"
 				"linux64"	"286"
 				"mac64"		"286"
 			}
-			"Weapon_Switch"
+			"Weapon_Drop"
 			{
 				"windows"	"288"
 				"linux"		"289"
 				"linux64"	"289"
 				"mac64"		"289"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"286"
+				"linux"		"287"
+				"linux64"	"287"
+				"mac64"		"287"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"289"
+				"linux"		"290"
+				"linux64"	"290"
+				"mac64"		"290"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -292,7 +292,7 @@
 			}
 			"CommitSuicide"
 			{
-				"windows"	"507"
+				"windows"	"508"
 				"linux"		"508"
 				"linux64"	"508"
 				"mac64"		"508"

--- a/gamedata/sdktools.games/engine.csgo.txt
+++ b/gamedata/sdktools.games/engine.csgo.txt
@@ -250,38 +250,38 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"457"
-				"linux"		"458"
-				"linux64"	"458"
-				"mac64"		"458"
+				"windows"	"458"
+				"linux"		"459"
+				"linux64"	"459"
+				"mac64"		"459"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"296"
-				"linux"		"297"
-				"linux64"	"297"
-				"mac64"		"297"
+				"windows"	"297"
+				"linux"		"298"
+				"linux64"	"298"
+				"mac64"		"298"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"292"
-				"linux"		"293"
-				"linux64"	"293"
-				"mac64"		"293"
+				"windows"	"293"
+				"linux"		"294"
+				"linux64"	"294"
+				"mac64"		"294"
 			}
 			"Ignite"
 			{
-				"windows"	"226"
-				"linux"		"227"
-				"linux64"	"227"
-				"mac64"		"227"
+				"windows"	"227"
+				"linux"		"228"
+				"linux64"	"228"
+				"mac64"		"228"
 			}
 			"Extinguish"
 			{
-				"windows"	"229"
-				"linux"		"230"
-				"linux64"	"230"
-				"mac64"		"230"
+				"windows"	"230"
+				"linux"		"231"
+				"linux64"	"231"
+				"mac64"		"231"
 			}
 			"Teleport"
 			{
@@ -293,9 +293,9 @@
 			"CommitSuicide"
 			{
 				"windows"	"507"
-				"linux"		"507"
-				"linux64"	"507"
-				"mac64"		"507"
+				"linux"		"508"
+				"linux64"	"508"
+				"mac64"		"508"
 			}
 			"GetVelocity"
 			{
@@ -327,10 +327,10 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"285"
-				"linux"		"286"
-				"linux64"	"286"
-				"mac64"		"286"
+				"windows"	"286"
+				"linux"		"287"
+				"linux64"	"287"
+				"mac64"		"287"
 			}
 			"Activate"
 			{
@@ -341,17 +341,17 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"477"
-				"linux"		"478"
-				"linux64"	"478"
-				"mac64"		"478"
+				"windows"	"478"
+				"linux"		"479"
+				"linux64"	"479"
+				"mac64"		"479"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"278"
-				"linux"		"279"
-				"linux64"	"279"
-				"mac64"		"279"
+				"windows"	"279"
+				"linux"		"280"
+				"linux64"	"280"
+				"mac64"		"280"
 			}
 		}
 		"Signatures"


### PR DESCRIPTION
Unsure why diff change acts weird for the sdkhooks gamedata, encoding and line endings should be the same. Tested both on linux and windows according to SMs discord.