### PR TITLE
Fix 'GiveNamedItem' in the game left4dead2.

### DIFF
--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -229,6 +229,39 @@ static cell_t GiveNamedItem(IPluginContext *pContext, const cell_t *params)
 
 	return gamehelpers->EntityToBCompatRef(pEntity);
 }
+#elif SOURCE_ENGINE == SE_LEFT4DEAD2
+// CBaseEntity *CTerrorPlayer::GiveNamedItem( const char *pchName, int iSubType, bool bForce, CBaseEntity *pUnk)
+static cell_t GiveNamedItem(IPluginContext *pContext, const cell_t *params)
+{
+	static ValveCall *pCall = NULL;
+	if (!pCall)
+	{
+		ValvePassInfo pass[5];
+		InitPass(pass[0], Valve_String, PassType_Basic, PASSFLAG_BYVAL);
+		InitPass(pass[1], Valve_POD, PassType_Basic, PASSFLAG_BYVAL);
+		InitPass(pass[2], Valve_Bool, PassType_Basic, PASSFLAG_BYVAL);
+		InitPass(pass[3], Valve_CBaseEntity, PassType_Basic, PASSFLAG_BYVAL);
+		InitPass(pass[4], Valve_CBaseEntity, PassType_Basic, PASSFLAG_BYVAL);
+		
+		if (!CreateBaseCall("GiveNamedItem", ValveCall_Player, &pass[4], pass, 4, &pCall)) {
+			return pContext->ThrowNativeError("\"GiveNamedItem\" not supported by this mod");
+		} else if (!pCall) {
+			return pContext->ThrowNativeError("\"GiveNamedItem\" wrapper failed to initialize");
+		}
+	}
+
+	CBaseEntity *pEntity = NULL;
+	START_CALL();
+	DECODE_VALVE_PARAM(1, thisinfo, 0);
+	DECODE_VALVE_PARAM(2, vparams, 0);
+	DECODE_VALVE_PARAM(3, vparams, 1);
+	*(bool *)(vptr + 12) = false;
+	*(void **)(vptr + 16) = NULL;
+	
+	FINISH_CALL_SIMPLE(&pEntity);
+	
+	return gamehelpers->EntityToBCompatRef(pEntity);
+}
 #else
 // CBaseEntity	*GiveNamedItem( const char *szName, int iSubType = 0 )
 static cell_t GiveNamedItem(IPluginContext *pContext, const cell_t *params)

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -256,7 +256,7 @@ static cell_t GiveNamedItem(IPluginContext *pContext, const cell_t *params)
 	DECODE_VALVE_PARAM(2, vparams, 0);
 	DECODE_VALVE_PARAM(3, vparams, 1);
 	*(bool *)(vptr + sizeof(void *) + sizeof(void *) + sizeof(int)) = false;
-	*(void **)(vptr + sizeof(void *) + sizeof(void *) + sizeof(int) + sizeof(int)) = NULL;
+	*(void **)(vptr + sizeof(void *) + sizeof(void *) + sizeof(int) + sizeof(bool)) = NULL;
 	FINISH_CALL_SIMPLE(&pEntity);
 	
 	return gamehelpers->EntityToBCompatRef(pEntity);

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -255,9 +255,8 @@ static cell_t GiveNamedItem(IPluginContext *pContext, const cell_t *params)
 	DECODE_VALVE_PARAM(1, thisinfo, 0);
 	DECODE_VALVE_PARAM(2, vparams, 0);
 	DECODE_VALVE_PARAM(3, vparams, 1);
-	*(bool *)(vptr + 12) = false;
-	*(void **)(vptr + 16) = NULL;
-	
+	*(bool *)(vptr + sizeof(void *) + sizeof(void *) + sizeof(int)) = false;
+	*(void **)(vptr + sizeof(void *) + sizeof(void *) + sizeof(int) + sizeof(int)) = NULL;
 	FINISH_CALL_SIMPLE(&pEntity);
 	
 	return gamehelpers->EntityToBCompatRef(pEntity);

--- a/gamedata/sdktools.games/game.left4dead2.txt
+++ b/gamedata/sdktools.games/game.left4dead2.txt
@@ -117,14 +117,15 @@
 	}
 	
 	"left4dead2"
-	{		
+	{
 		"Offsets"
 		{
+			/* CTerrorPlayer::GiveNamedItem(char const*, int, bool, CBaseEntity*) */
 			"GiveNamedItem"
 			{
-				"windows"	"508"
-				"linux"		"509"
-				"mac"		"509"
+				"windows"	"431"
+				"linux"		"432"
+				"mac"		"432"
 			}
 			"RemovePlayerItem"
 			{


### PR DESCRIPTION
The method 'CCSPlayer::GiveNamedItem(char const*, int, CBaseEntity*)' does not work in game left4dead2, any given weapon or item immediately falls to the ground, besides, the code is missing a parameter to call this method (even with the added parameter does not give a weapon or item to hands). Another method 'CTerrorPlayer::GiveNamedItem(char const*, int, bool, CBaseEntity*)' works great, besides it makes it possible to give out all the items that exist in the game.