### PR TITLE
Fix NMRiH 'GivePlayerAmmo' crash on Windows

### DIFF
--- a/gamedata/sdktools.games/game.nmrih.txt
+++ b/gamedata/sdktools.games/game.nmrih.txt
@@ -153,7 +153,7 @@
 			}
 			"GiveAmmo"
 			{
-				"windows"	"254"
+				"windows"	"255"
 				"linux"		"255"
 				"mac"		"255"
 			}


### PR DESCRIPTION
`GiveAmmo` on Windows is off by 1 and leads to a crash. Linux offsets don't need updating