### PR TITLE
Removed incorrect parameter in description

### DIFF
--- a/plugins/include/convars.inc
+++ b/plugins/include/convars.inc
@@ -250,7 +250,6 @@ methodmap ConVar < Handle
 
 	// Removes a hook for when a console variable's value is changed.
 	//
-	// @param convar    Handle to the convar.
 	// @param callback  An OnConVarChanged function pointer.
 	// @error           No active hook on convar.
 	public native void RemoveChangeHook(ConVarChanged callback);


### PR DESCRIPTION
This PR removes the `handle` parameter from the description of the `GetString` method in the `ConVar` methodmap, as it does not match the prototype of the method.