### PR TITLE
Mark unloaded extensions as not fully loaded (fixes #1574)

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -240,6 +240,8 @@ void CLocalExtension::Unload()
 		m_pLib->CloseLibrary();
 		m_pLib = NULL;
 	}
+
+	m_bFullyLoaded = false;
 }
 
 bool CRemoteExtension::Reload(char *error, size_t maxlength)


### PR DESCRIPTION
When extensions are reloaded (as opposed to an unload + load), IExtensionInterface::OnExtensionsAllLoaded is not called. (usually implemented as SDK_OnAllLoaded). With a real unload, the extension object in the extension manager is destroyed. However, with a reload, it gets reused, so this needs to be reset.