### PR TITLE
Fix build against released MM:S branches

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -197,7 +197,9 @@ class SMConfig(object):
     if builder.options.mms_path:
       self.mms_root = builder.options.mms_path
     else:
-      self.mms_root = ResolveEnvPath('MMSOURCE110', 'mmsource-1.10')
+      self.mms_root = ResolveEnvPath('MMSOURCE111', 'mmsource-1.11')
+      if not self.mms_root:
+        self.mms_root = ResolveEnvPath('MMSOURCE110', 'mmsource-1.10')
       if not self.mms_root:
         self.mms_root = ResolveEnvPath('MMSOURCE_DEV', 'metamod-source')
       if not self.mms_root:

--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -334,11 +334,13 @@ DLL_EXPORT METAMOD_PLUGIN *CreateInterface_MMS(const MetamodVersionInfo *mvi, co
 			filename = FILENAME_1_6_DOI;
 			break;
 		}
+#ifdef SOURCE_ENGINE_MOCK
 	case SOURCE_ENGINE_MOCK:
 		{
 			filename = FILENAME_1_6_MOCK;
 			break;
 		}
+#endif
 	default:
 		{
 			return NULL;


### PR DESCRIPTION
`SOURCE_ENGINE_MOCK` is part of the MM:S API and only available in 1.12
which is the dev branch of MM:S. We can build the mock SM build without
it anyway, but this is still a little gross as it is just missing loader
support which could be confusing.

This also changes AMBuildScript to first look for a checkout of MM:S
1.11 which has been the stable branch for a while, 1.10 is still allowed
as a fallback as that seems to still build without issue.