### PR TITLE
Exposed SDKCall_Server call type to use CBaseServer methods

### DIFF
--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -335,6 +335,16 @@ static cell_t SDKCall(IPluginContext *pContext, const cell_t *params)
 				startparam++;
 			}
 			break;
+		case ValveCall_Server:
+            {
+                if (iserver == NULL)
+                {
+                    vc->stk_put(ptr);
+                    return pContext->ThrowNativeError("Server unsupported or not available; file a bug report");
+                }
+                *(void **)ptr = iserver;
+            }
+            break;
 		case ValveCall_GameRules:
 			{
 				void *pGameRules = GameRules();

--- a/extensions/sdktools/vdecoder.h
+++ b/extensions/sdktools/vdecoder.h
@@ -79,6 +79,7 @@ enum ValveCallType
 	ValveCall_Static,		/**< Static call */
 	ValveCall_Entity,		/**< Thiscall (CBaseEntity implicit first parameter) */
 	ValveCall_Player,		/**< Thiscall (CBasePlayer implicit first parameter) */
+	ValveCall_Server,       /**< Thiscall (CBaseServer implicit first parameter) */
 	ValveCall_GameRules,	/**< Thiscall (CGameRules implicit first paramater) */
 	ValveCall_EntityList,	/**< Thiscall (CGlobalEntityList implicit first paramater) */
 	ValveCall_Raw, 		/**< Thiscall (address explicit first parameter) */

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -58,6 +58,7 @@ enum SDKCallType
 	SDKCall_Static,         /**< Static call */
 	SDKCall_Entity,         /**< CBaseEntity call */
 	SDKCall_Player,         /**< CBasePlayer call */
+	SDKCall_Server,         /**< CBaseServer call */
 	SDKCall_GameRules,      /**< CGameRules call */
 	SDKCall_EntityList,     /**< CGlobalEntityList call */
 	SDKCall_Raw             /**< |this| pointer with an arbitrary address */


### PR DESCRIPTION
Successfully tested on L4D2 Linux with:
```
#include <sourcemod>
#include <sdktools>

Handle g_hSDK_GetNumPlayers = null;

public void OnPluginStart() {
	StartPrepSDKCall(SDKCall_Server);
	PrepSDKCall_SetSignature(SDKLibrary_Engine, "@_ZN11CBaseServer13GetNumPlayersEv", 0);
	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
	g_hSDK_GetNumPlayers = EndPrepSDKCall();

	RegConsoleCmd("sm_numplayers", NumPlayers);
}

public Action NumPlayers(int client, int args)
{
	PrintToChatAll("NumPlayers: %i", SDKCall(g_hSDK_GetNumPlayers));
	PrintToServer("NumPlayers: %i", SDKCall(g_hSDK_GetNumPlayers));

	return Plugin_Handled;
}
```

Thanks to Nuki for providing the code.