### PR TITLE
Fix compiling with tf2_stocks

### DIFF
--- a/plugins/include/tf2_stocks.inc
+++ b/plugins/include/tf2_stocks.inc
@@ -431,7 +431,7 @@ stock int TF2_GetPlayerResourceData(int client, TFResourceType type)
 		return -1;
 	}
 
-	int entity = TF2_GetResourceEntity();
+	int entity = GetPlayerResourceEntity();
 
 	if (entity == -1)
 	{
@@ -468,7 +468,7 @@ stock bool TF2_SetPlayerResourceData(int client, TFResourceType type, any value)
 		return false;
 	}
 
-	int entity = TF2_GetResourceEntity();
+	int entity = GetPlayerResourceEntity();
 
 	if (entity == -1)
 	{


### PR DESCRIPTION
Because 1.11 SP compiler now throws warning and errors on unused stocks, `tf2_stocks` include has deprecated stock function that was using deprecated native function.

Replace native to what deprecated warning is telling us, `Use GetPlayerResourceEntity instead`.