### PR TITLE
Fix up gamedata CRC functionality

### DIFF
--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -115,6 +115,8 @@ public:
 	virtual void ConsolePrint(const char *fmt, ...) = 0;
 	virtual void ConsolePrintVa(const char *fmt, va_list ap) = 0;
 
+	virtual void FormatSourceBinaryName(const char *basename, char *buffer, size_t maxlength) = 0;
+
 	// Game engine helper functions.
 	virtual bool IsClientConVarQueryingSupported() = 0;
 	virtual int QueryClientConVar(int client, const char *cvar) = 0;

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -85,15 +85,12 @@ static const char *g_pParseEngine = NULL;
 
 #if defined PLATFORM_WINDOWS
 #define PLATFORM_NAME				"windows" PLATFORM_ARCH_SUFFIX
-#define PLATFORM_SERVER_BINARY		"server.dll"
 #elif defined PLATFORM_LINUX
 #define PLATFORM_NAME				"linux" PLATFORM_ARCH_SUFFIX
 #define PLATFORM_COMPAT_ALT			"mac" PLATFORM_ARCH_SUFFIX	/* Alternate platform name if game data is missing for primary one */
-#define PLATFORM_SERVER_BINARY		"server_i486.so"
 #elif defined PLATFORM_APPLE
 #define PLATFORM_NAME				"mac" PLATFORM_ARCH_SUFFIX
 #define PLATFORM_COMPAT_ALT			"linux" PLATFORM_ARCH_SUFFIX
-#define PLATFORM_SERVER_BINARY		"server.dylib"
 #endif
 
 struct TempSigInfo
@@ -315,7 +312,10 @@ SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *n
 				FILE *fp;
 				char path[PLATFORM_MAX_PATH];
 
-				g_pSM->BuildPath(Path_Game, path, sizeof(path), "bin/" PLATFORM_SERVER_BINARY);
+				char binName[64];
+				bridge->FormatSourceBinaryName(name, binName, sizeof(binName));
+
+				g_pSM->BuildPath(Path_Game, path, sizeof(path), "bin/%s", binName);
 				if ((fp = fopen(path, "rb")) == NULL)
 				{
 					ke::SafeSprintf(error, sizeof(error), "Could not open binary: %s", path);

--- a/core/logic/sm_crc32.cpp
+++ b/core/logic/sm_crc32.cpp
@@ -89,6 +89,6 @@ unsigned int UTIL_CRC32(const void *pdata, size_t data_length)
 		crc = CRCTable[c] ^ (crc >> 8);
 	}
 
-	return crc;
+	return ~crc;
 }
 

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -772,6 +772,12 @@ CoreProviderImpl::DefineCommand(const char *name, const char *help, const Comman
 	commands_.push_back(impl);
 }
 
+void CoreProviderImpl::FormatSourceBinaryName(const char *basename, char *buffer, size_t maxlength)
+{
+	bool use_prefix = (!strcasecmp(basename, "tier0") || !strcasecmp(basename, "vstdlib"));
+	ke::SafeSprintf(buffer, maxlength, "%s%s%s%s", use_prefix ? SOURCE_BIN_PREFIX : "", basename, SOURCE_BIN_SUFFIX, SOURCE_BIN_EXT);
+}
+
 void CoreProviderImpl::InitializeHooks()
 {
 	hooks_.Start();

--- a/core/provider.h
+++ b/core/provider.h
@@ -67,6 +67,7 @@ public:
 	int QueryClientConVar(int client, const char *cvar) override;
 	bool IsClientConVarQueryingSupported() override;
 	void DefineCommand(const char *cmd, const char *help, const SourceMod::CommandFunc &callback) override;
+	void FormatSourceBinaryName(const char *basename, char *buffer, size_t maxlength) override;
 
 	ke::RefPtr<CommandHook> AddCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);
 	ke::RefPtr<CommandHook> AddPostCommandHook(ConCommand *cmd, const CommandHook::Callback &callback);


### PR DESCRIPTION
- Changes the CRC implementation to match what appears to be most other popular implementations.
- Fixes server bin name lookup, broken for most engines.