### PR TITLE
Fix "ForcePlayerSuicide" crash in NMRiH

### DIFF
--- a/gamedata/sdktools.games/game.nmrih.txt
+++ b/gamedata/sdktools.games/game.nmrih.txt
@@ -106,8 +106,8 @@
 			"CommitSuicide"
 			{
 				"windows"	"459"
-				"linux"		"460"
-				"mac"		"460"
+				"linux"		"459"
+				"mac"		"459"
 			}
 			"GetVelocity"
 			{


### PR DESCRIPTION
Unfortunately the previous gamedata patch had a faulty offset that slipped thru testing, my bad. 
This fixes ForcePlayerSuicide crashing on Linux