### PR TITLE
Lift raw pointers out of DatabaseConfBuilder

### DIFF
--- a/core/logic/Database.h
+++ b/core/logic/Database.h
@@ -71,7 +71,7 @@ public: //IDBManager
 	void AddDriver(IDBDriver *pDrivera);
 	void RemoveDriver(IDBDriver *pDriver);
 	const DatabaseInfo *FindDatabaseConf(const char *name);
-	ConfDbInfo *GetDatabaseConf(const char *name);
+	ke::Maybe<ke::RefPtr<ConfDbInfo>> GetDatabaseConf(const char *name);
 	bool Connect(const char *name, IDBDriver **pdr, IDatabase **pdb, bool persistent, char *error, size_t maxlength);
 	unsigned int GetDriverCount();
 	IDBDriver *GetDriver(unsigned int index);

--- a/core/logic/Database.h
+++ b/core/logic/Database.h
@@ -71,7 +71,7 @@ public: //IDBManager
 	void AddDriver(IDBDriver *pDrivera);
 	void RemoveDriver(IDBDriver *pDriver);
 	const DatabaseInfo *FindDatabaseConf(const char *name);
-	ke::Maybe<ke::RefPtr<ConfDbInfo>> GetDatabaseConf(const char *name);
+	ke::RefPtr<ConfDbInfo> GetDatabaseConf(const char *name);
 	bool Connect(const char *name, IDBDriver **pdr, IDatabase **pdb, bool persistent, char *error, size_t maxlength);
 	unsigned int GetDriverCount();
 	IDBDriver *GetDriver(unsigned int index);

--- a/core/logic/DatabaseConfBuilder.cpp
+++ b/core/logic/DatabaseConfBuilder.cpp
@@ -36,8 +36,8 @@
 #define DBPARSE_LEVEL_DATABASE	2
 
 DatabaseConfBuilder::DatabaseConfBuilder()
-	: m_ParseList(nullptr),
-	  m_InfoList(new ConfDbInfoList())
+	: m_ParseList(),
+	  m_InfoList()
 {
 }
 
@@ -50,7 +50,7 @@ DatabaseConfBuilder::~DatabaseConfBuilder()
 {
 }
 
-ConfDbInfoList *DatabaseConfBuilder::GetConfigList()
+ConfDbInfoList &DatabaseConfBuilder::GetConfigList()
 {
 	return m_InfoList;
 }
@@ -75,7 +75,7 @@ void DatabaseConfBuilder::ReadSMC_ParseStart()
 	m_ParseLevel = 0;
 	m_ParseState = DBPARSE_LEVEL_NONE;
 	
-	m_ParseList = new ConfDbInfoList();
+	m_ParseList.clear();
 }
  
 SMCResult DatabaseConfBuilder::ReadSMC_NewSection(const SMCStates *states, const char *name)
@@ -116,7 +116,7 @@ SMCResult DatabaseConfBuilder::ReadSMC_KeyValue(const SMCStates *states, const c
 	{
 		if (strcmp(key, "driver_default") == 0)
 		{
-			m_ParseList->SetDefaultDriver(value);
+			m_ParseList.SetDefaultDriver(value);
 		}
 	} else if (m_ParseState == DBPARSE_LEVEL_DATABASE) {
 		if (strcmp(key, "driver") == 0)
@@ -161,7 +161,7 @@ SMCResult DatabaseConfBuilder::ReadSMC_LeavingSection(const SMCStates *states)
 		
 		/* Save it.. */
 		m_ParseCurrent->AddRef();
-		m_ParseList->push_back(m_ParseCurrent);
+		m_ParseList.push_back(m_ParseCurrent);
 		m_ParseCurrent = nullptr;
 		
 		/* Go up one level */
@@ -176,9 +176,7 @@ SMCResult DatabaseConfBuilder::ReadSMC_LeavingSection(const SMCStates *states)
 
 void DatabaseConfBuilder::ReadSMC_ParseEnd(bool halted, bool failed)
 {
-	m_InfoList->ReleaseMembers();
-	delete m_InfoList;
+	m_InfoList.clear();
 	m_InfoList = m_ParseList;
-	
-	m_ParseList = nullptr;
+	m_ParseList.clear();
 }

--- a/core/logic/DatabaseConfBuilder.h
+++ b/core/logic/DatabaseConfBuilder.h
@@ -38,6 +38,8 @@
 
 #include <am-vector.h>
 #include <am-string.h>
+#include <am-maybe.h>
+#include <am-refcounting.h>
 #include <am-refcounting-threadsafe.h>
 
 class ConfDbInfo : public ke::RefcountedThreadsafe<ConfDbInfo>
@@ -56,7 +58,7 @@ public:
 	DatabaseInfo info;
 };
 
-class ConfDbInfoList : public std::vector<ConfDbInfo *>
+class ConfDbInfoList : public std::vector<ke::RefPtr<ConfDbInfo>>
 {
 	/* Allow internal usage of ConfDbInfoList */
 	friend class DBManager;
@@ -66,37 +68,34 @@ private:
 		return m_DefDriver;
 	}
 	
-	ConfDbInfo *GetDatabaseConf(const char *name) {
+	ke::Maybe<ke::RefPtr<ConfDbInfo>> GetDatabaseConf(const char *name) {
+		auto retval = ke::Maybe<ke::RefPtr<ConfDbInfo>>();
 		for (size_t i = 0; i < this->size(); i++)
 		{
-			ConfDbInfo *current = this->at(i);
+			ke::RefPtr<ConfDbInfo> current = this->at(i);
 			/* If we run into the default configuration, then we'll save it
 			 * for the next call to GetDefaultConfiguration */ 
 			if (strcmp(current->name.c_str(), "default") == 0)
 			{
-				m_DefaultConfig = current;
+				m_DefaultConfig.init(current);
 			}
 			if (strcmp(current->name.c_str(), name) == 0)
 			{
-				return current;
+				retval.init(current);
+				return retval;
 			}
 		}
-		return nullptr;
+		return retval;
 	}
-	ConfDbInfo *GetDefaultConfiguration() {
+
+	ke::Maybe<ke::RefPtr<ConfDbInfo>> GetDefaultConfiguration() {
 		return m_DefaultConfig;
 	}
 	void SetDefaultDriver(const char *input) {
 		m_DefDriver = std::string(input);
 	}
-	void ReleaseMembers() {
-		for (size_t i = 0; i < this->size(); i++) {
-			ConfDbInfo *current = this->at(i);
-			current->Release();
-		}
-	}
 private:
-	ConfDbInfo *m_DefaultConfig;
+	ke::Maybe<ke::RefPtr<ConfDbInfo>> m_DefaultConfig;
 	std::string m_DefDriver;
 };
 
@@ -108,7 +107,7 @@ public:
 	~DatabaseConfBuilder();
 	void StartParse();
 	void SetPath(char* path);
-	ConfDbInfoList *GetConfigList();
+	ConfDbInfoList &GetConfigList();
 public: //ITextListener_SMC
 	void ReadSMC_ParseStart();
 	SMCResult ReadSMC_NewSection(const SMCStates *states, const char *name);
@@ -120,10 +119,10 @@ private:
 	unsigned int m_ParseLevel;
 	unsigned int m_ParseState;
 	ConfDbInfo *m_ParseCurrent;
-	ConfDbInfoList *m_ParseList;
+	ConfDbInfoList m_ParseList;
 private:
 	std::string m_Filename;
-	ConfDbInfoList *m_InfoList;
+	ConfDbInfoList m_InfoList;
 };
 
 #endif //_INCLUDE_DATABASE_CONF_BUILDER_H_

--- a/core/logic/DatabaseConfBuilder.h
+++ b/core/logic/DatabaseConfBuilder.h
@@ -38,7 +38,6 @@
 
 #include <am-vector.h>
 #include <am-string.h>
-#include <am-maybe.h>
 #include <am-refcounting.h>
 #include <am-refcounting-threadsafe.h>
 
@@ -68,8 +67,7 @@ private:
 		return m_DefDriver;
 	}
 	
-	ke::Maybe<ke::RefPtr<ConfDbInfo>> GetDatabaseConf(const char *name) {
-		auto retval = ke::Maybe<ke::RefPtr<ConfDbInfo>>();
+	ke::RefPtr<ConfDbInfo> GetDatabaseConf(const char *name) {
 		for (size_t i = 0; i < this->size(); i++)
 		{
 			ke::RefPtr<ConfDbInfo> current = this->at(i);
@@ -77,25 +75,24 @@ private:
 			 * for the next call to GetDefaultConfiguration */ 
 			if (strcmp(current->name.c_str(), "default") == 0)
 			{
-				m_DefaultConfig.init(current);
+				m_DefaultConfig = current;
 			}
 			if (strcmp(current->name.c_str(), name) == 0)
 			{
-				retval.init(current);
-				return retval;
+				return current;
 			}
 		}
-		return retval;
+		return nullptr;
 	}
 
-	ke::Maybe<ke::RefPtr<ConfDbInfo>> GetDefaultConfiguration() {
+	ke::RefPtr<ConfDbInfo> GetDefaultConfiguration() {
 		return m_DefaultConfig;
 	}
 	void SetDefaultDriver(const char *input) {
 		m_DefDriver = std::string(input);
 	}
 private:
-	ke::Maybe<ke::RefPtr<ConfDbInfo>> m_DefaultConfig;
+	ke::RefPtr<ConfDbInfo> m_DefaultConfig;
 	std::string m_DefDriver;
 };
 

--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -318,7 +318,7 @@ public:
 		me = scripts->FindPluginByContext(m_pFunction->GetParentContext()->GetContext());
 		
 		m_pInfo = g_DBMan.GetDatabaseConf(dbname);
-		if (!m_pInfo)
+		if (!m_pInfo.isValid())
 		{
 			g_pSM->Format(error, sizeof(error), "Could not find database config \"%s\"", dbname);
 		}
@@ -333,9 +333,9 @@ public:
 	}
 	void RunThreadPart()
 	{
-		if (m_pInfo)
+		if (m_pInfo.isValid())
 		{
-			m_pDatabase = m_pDriver->Connect(&m_pInfo->info, false, error, sizeof(error));
+			m_pDatabase = m_pDriver->Connect(&m_pInfo.get().get()->info, false, error, sizeof(error));
 		}
 	}
 	void CancelThinkPart()
@@ -386,7 +386,7 @@ public:
 		delete this;
 	}
 private:
-	ke::RefPtr<ConfDbInfo> m_pInfo;
+	ke::Maybe<ke::RefPtr<ConfDbInfo>> m_pInfo;
 	IPlugin *me;
 	IPluginFunction *m_pFunction;
 	IDBDriver *m_pDriver;
@@ -1427,7 +1427,8 @@ static cell_t SQL_CheckConfig(IPluginContext *pContext, const cell_t *params)
 	char *name;
 	pContext->LocalToString(params[1], &name);
 
-	return (g_DBMan.GetDatabaseConf(name) != nullptr) ? 1 : 0;
+	ke::Maybe<ke::RefPtr<ConfDbInfo>> conf = g_DBMan.GetDatabaseConf(name);
+	return conf.isValid();
 }
 
 static cell_t SQL_ConnectCustom(IPluginContext *pContext, const cell_t *params)

--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -318,7 +318,7 @@ public:
 		me = scripts->FindPluginByContext(m_pFunction->GetParentContext()->GetContext());
 		
 		m_pInfo = g_DBMan.GetDatabaseConf(dbname);
-		if (!m_pInfo.isValid())
+		if (!m_pInfo)
 		{
 			g_pSM->Format(error, sizeof(error), "Could not find database config \"%s\"", dbname);
 		}
@@ -333,9 +333,9 @@ public:
 	}
 	void RunThreadPart()
 	{
-		if (m_pInfo.isValid())
+		if (m_pInfo)
 		{
-			m_pDatabase = m_pDriver->Connect(&m_pInfo.get().get()->info, false, error, sizeof(error));
+			m_pDatabase = m_pDriver->Connect(&m_pInfo->info, false, error, sizeof(error));
 		}
 	}
 	void CancelThinkPart()
@@ -386,7 +386,7 @@ public:
 		delete this;
 	}
 private:
-	ke::Maybe<ke::RefPtr<ConfDbInfo>> m_pInfo;
+	ke::RefPtr<ConfDbInfo> m_pInfo;
 	IPlugin *me;
 	IPluginFunction *m_pFunction;
 	IDBDriver *m_pDriver;
@@ -1427,8 +1427,7 @@ static cell_t SQL_CheckConfig(IPluginContext *pContext, const cell_t *params)
 	char *name;
 	pContext->LocalToString(params[1], &name);
 
-	ke::Maybe<ke::RefPtr<ConfDbInfo>> conf = g_DBMan.GetDatabaseConf(name);
-	return conf.isValid();
+	return (g_DBMan.GetDatabaseConf(name) != nullptr) ? 1 : 0;
 }
 
 static cell_t SQL_ConnectCustom(IPluginContext *pContext, const cell_t *params)


### PR DESCRIPTION
This patch `ke::RefPtr`'s the database configs in storage instead of storing raw `ConfDbInfo*`s. I'm not certain if the original form caused any problems, but in my recent review of this area I was very dissatisfied.

Also, the config lists have been converted to be value types instead of pointers. I'm not certain why I made these lists pointers, but this patch overall makes this section much safer.

untested