### PR TITLE
Update Team Fortress 2 gamedata

### DIFF
--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -7,33 +7,33 @@
 		{
 			"CanBeAutobalanced"
 			{
-				"windows"	"465"
-				"linux"		"466"
-				"mac"		"466"
+				"windows"	"468"
+				"linux"		"469"
+				"mac"		"469"
 			}
 			"EndTouch"
 			{
-				"windows"	"100"
-				"linux"		"101"
-				"mac"		"101"
+				"windows"	"103"
+				"linux"		"104"
+				"mac"		"104"
 			}
 			"FireBullets"
 			{
-				"windows"	"112"
-				"linux"		"113"
-				"mac"		"113"
+				"windows"	"115"
+				"linux"		"116"
+				"mac"		"116"
 			}
 			"GetMaxHealth"
 			{
-				"windows"	"117"
-				"linux"		"118"
-				"mac"		"118"				
+				"windows"	"120"
+				"linux"		"121"
+				"mac"		"121"
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"177"
-				"linux"		"179"
-				"mac"		"179"
+				"windows"	"180"
+				"linux"		"182"
+				"mac"		"182"
 			}
 			"OnTakeDamage"
 			{
@@ -43,27 +43,27 @@
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"276"
-				"linux"		"277"
-				"mac"		"277"
+				"windows"	"279"
+				"linux"		"280"
+				"mac"		"280"
 			}
 			"PreThink"
 			{
-				"windows"	"337"
-				"linux"		"338"
-				"mac"		"338"
+				"windows"	"340"
+				"linux"		"341"
+				"mac"		"341"
 			}
 			"PostThink"
 			{
-				"windows"	"338"
-				"linux"		"339"
-				"mac"		"339"
+				"windows"	"341"
+				"linux"		"342"
+				"mac"		"342"
 			}
 			"Reload"
 			{
-				"windows"	"277"
-				"linux"		"283"
-				"mac"		"283"
+				"windows"	"280"
+				"linux"		"286"
+				"mac"		"286"
 			}
 			"SetTransmit"
 			{
@@ -85,9 +85,9 @@
 			}
 			"StartTouch"
 			{
-				"windows"	"98"
-				"linux"		"99"
-				"mac"		"99"
+				"windows"	"101"
+				"linux"		"102"
+				"mac"		"102"
 			}
 			"Think"
 			{
@@ -97,9 +97,9 @@
 			}
 			"Touch"
 			{
-				"windows"	"99"
-				"linux"		"100"
-				"mac"		"100"
+				"windows"	"102"
+				"linux"		"103"
+				"mac"		"103"
 			}
 			"TraceAttack"
 			{
@@ -109,51 +109,51 @@
 			}
 			"Use"
 			{
-				"windows"	"97"
-				"linux"		"98"
-				"mac"		"98"
+				"windows"	"100"
+				"linux"		"101"
+				"mac"		"101"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"157"
-				"linux"		"158"
-				"mac"		"158"
+				"windows"	"160"
+				"linux"		"161"
+				"mac"		"161"
 			}
 			"Blocked"
 			{
-				"windows"	"102"
-				"linux"		"103"
-				"mac"		"103"
+				"windows"	"105"
+				"linux"		"106"
+				"mac"		"106"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"270"
-				"linux"		"271"
-				"mac"		"271"
+				"windows"	"273"
+				"linux"		"274"
+				"mac"		"274"
 			}
 			"Weapon_CanUse"
-			{
-				"windows"	"264"
-				"linux"		"265"
-				"mac"		"265"
-			}
-			"Weapon_Drop"
 			{
 				"windows"	"267"
 				"linux"		"268"
 				"mac"		"268"
 			}
-			"Weapon_Equip"
+			"Weapon_Drop"
 			{
-				"windows"	"265"
-				"linux"		"266"
-				"mac"		"266"
+				"windows"	"270"
+				"linux"		"271"
+				"mac"		"271"
 			}
-			"Weapon_Switch"
+			"Weapon_Equip"
 			{
 				"windows"	"268"
 				"linux"		"269"
 				"mac"		"269"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"271"
+				"linux"		"272"
+				"mac"		"272"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -18,57 +18,57 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"402"
-				"linux"		"406"
-				"mac"		"406"
+				"windows"	"408"
+				"linux"		"409"
+				"mac"		"409"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"274"
-				"linux"		"275"
-				"mac"		"275"
+				"windows"	"277"
+				"linux"		"278"
+				"mac"		"278"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"272"
-				"linux"		"273"
-				"mac"		"273"
+				"windows"	"275"
+				"linux"		"276"
+				"mac"		"276"
 			}
 			"Ignite"
 			{
-				"windows"	"213"
-				"linux"		"214"
-				"mac"		"214"
+				"windows"	"216"
+				"linux"		"217"
+				"mac"		"217"
 			}
 			"Extinguish"
 			{
-				"windows"	"217"
-				"linux"		"218"
-				"mac"		"218"
+				"windows"	"220"
+				"linux"		"221"
+				"mac"		"221"
 			}
 			"Teleport"
 			{
-				"windows"	"108"
-				"linux"		"109"
-				"mac"		"109"
+				"windows"	"111"
+				"linux"		"112"
+				"mac"		"112"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"446"
-				"linux"		"446"
-				"mac"		"446"
+				"windows"	"449"
+				"linux"		"449"
+				"mac"		"449"
 			}
 			"GetVelocity"
 			{
-				"windows"	"140"
-				"linux"		"141"
-				"mac"		"141"
+				"windows"	"143"
+				"linux"		"144"
+				"mac"		"144"
 			}
 			"EyeAngles"
 			{
-				"windows"	"131"
-				"linux"		"132"
-				"mac"		"132"
+				"windows"	"134"
+				"linux"		"135"
+				"mac"		"135"
 			}
 			"SetEntityModel"
 			{
@@ -84,9 +84,9 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"265"
-				"linux"		"266"
-				"mac"		"266"
+				"windows"	"268"
+				"linux"		"269"
+				"mac"		"269"
 			}
 			"Activate"
 			{
@@ -96,15 +96,15 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"423"
-				"linux"		"424"
-				"mac"		"424"
+				"windows"	"426"
+				"linux"		"427"
+				"mac"		"427"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"256"
-				"linux"		"257"
-				"mac"		"257"
+				"windows"	"259"
+				"linux"		"260"
+				"mac"		"260"
 			}
 		}
 		

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -113,21 +113,21 @@
 		{
 			"ForceRespawn"
 			{
-				"windows"	"330"
-				"linux"		"331"
-				"mac"		"331"
+				"windows"	"333"
+				"linux"		"334"
+				"mac"		"334"
 			}
 			"CalcIsAttackCriticalHelper"
 			{
-				"windows"	"391"
-				"linux"		"398"
-				"mac"		"398"
+				"windows"	"394"
+				"linux"		"401"
+				"mac"		"401"
 			}
 			"CalcIsAttackCriticalHelperNoCrits"
 			{
-				"windows"	"392"
-				"linux"		"399"
-				"mac"		"399"
+				"windows"	"395"
+				"linux"		"402"
+				"mac"		"402"
 			}
 			
 			// CTFGameRules::IsHolidayActive
@@ -140,9 +140,9 @@
 
 			"RemoveWearable"
 			{
-				"windows"	"432"
-				"linux"		"433"
-				"mac"		"433"
+				"windows"	"435"
+				"linux"		"436"
+				"mac"		"436"
 			}
 		}
 	}


### PR DESCRIPTION
Update on 2021-11-16 broke things again due to the addition of 3 new virtual functions to `CBaseEntity`.

```
CBaseEntity::IsProjectileCollisionTarget() const
CBaseEntity::IsFuncLOD() const
CBaseEntity::IsBaseProjectile() const
```

Shift all virtual offsets over 86 up by 3.