### PR TITLE
Cache copy of library on first symbol/signature lookup

### DIFF
--- a/core/logic/MemoryUtils.h
+++ b/core/logic/MemoryUtils.h
@@ -32,6 +32,8 @@
 
 #include "common_logic.h"
 #include <IMemoryUtils.h>
+#include <am-hashmap.h>
+#include <memory>
 #if defined PLATFORM_LINUX || defined PLATFORM_APPLE
 #include <sh_vector.h>
 #include "sm_symtable.h"
@@ -49,6 +51,7 @@ struct DynLibInfo
 {
 	void *baseAddress;
 	size_t memorySize;
+	std::unique_ptr<char[]> originalCopy;
 };
 
 #if defined PLATFORM_LINUX || defined PLATFORM_APPLE
@@ -73,7 +76,7 @@ public: // IMemoryUtils
 	void *FindPattern(const void *libPtr, const char *pattern, size_t len);
 	void *ResolveSymbol(void *handle, const char *symbol);
 public:
-	bool GetLibraryInfo(const void *libPtr, DynLibInfo &lib);
+	const DynLibInfo *GetLibraryInfo(const void *libPtr);
 #if defined PLATFORM_LINUX || defined PLATFORM_APPLE
 private:
 	CVector<LibSymbolTable *> m_SymTables;
@@ -83,6 +86,8 @@ private:
 	SInt32 m_OSXMinor;
 #endif
 #endif
+	typedef ke::HashMap<void *, DynLibInfo, ke::PointerPolicy<void> > LibraryInfoMap;
+	LibraryInfoMap m_InfoMap;
 };
 
 extern MemoryUtils g_MemUtils;


### PR DESCRIPTION
Always perform signature searches on an unaltered copy of the binary. This avoids signature mismatches if the same function is detoured twice and thus the first bytes of the function were replaced by the detour. It is implemented by creating a copy of the current (hopefully unaltered) state of the library on first symbol or signature lookup through `IMemoryUtils` and using that copy to find matching signatures.

Now you're able to find signatures even if something else already messed with the bytes. Before this patch, code like this would fail to locate the signature again after the memory was altered (assuming both gamedata files are identical).

```sourcepawn
public void OnPluginStart() {
    GameData gd = new GameData("test1.games");
    Address testfunc = gd.GetMemSig("testfunc");
    PrintToServer("Found sig: %x", testfunc);
    delete gd;

    StoreToAddress(testfunc, 0xff, NumberType_Int32);

    gd = new GameData("test2.games");
    testfunc = gd.GetMemSig("testfunc");
    PrintToServer("Found sig again: %x", testfunc);
    delete gd;
}
```

So it's not necessary to wildcard the first 6 bytes of a signature to still find it even if the function was detoured by something else. This is only true for SourceMod and its extensions or rather anything using the `IMemoryUtils` to find a signature in memory. It'd be desired to have such an interface exposed in MetaMod:Source for all other server plugins to use in the future.