### PR TITLE
Exposed SDKCall_Engine call type to use CVEngineServer methods

### DIFF
--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -336,15 +336,25 @@ static cell_t SDKCall(IPluginContext *pContext, const cell_t *params)
 			}
 			break;
 		case ValveCall_Server:
-            {
-                if (iserver == NULL)
-                {
-                    vc->stk_put(ptr);
-                    return pContext->ThrowNativeError("Server unsupported or not available; file a bug report");
-                }
-                *(void **)ptr = iserver;
-            }
-            break;
+			{
+				if (iserver == NULL)
+				{
+					vc->stk_put(ptr);
+					return pContext->ThrowNativeError("Server unsupported or not available; file a bug report");
+				}
+				*(void **)ptr = iserver;
+			}
+			break;
+		case ValveCall_Engine:
+			{
+				if (engine == NULL)
+				{
+					vc->stk_put(ptr);
+					return pContext->ThrowNativeError("Engine unsupported or not available; file a bug report");
+				}
+				*(void **)ptr = engine;
+			}
+			break;
 		case ValveCall_GameRules:
 			{
 				void *pGameRules = GameRules();

--- a/extensions/sdktools/vdecoder.h
+++ b/extensions/sdktools/vdecoder.h
@@ -83,6 +83,7 @@ enum ValveCallType
 	ValveCall_EntityList,	/**< Thiscall (CGlobalEntityList implicit first paramater) */
 	ValveCall_Raw, 		/**< Thiscall (address explicit first parameter) */
 	ValveCall_Server,       /**< Thiscall (CBaseServer implicit first parameter) */
+	ValveCall_Engine,       /**< Thiscall (CVEngineServer implicit first parameter) */
 };
 
 /**

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -61,7 +61,8 @@ enum SDKCallType
 	SDKCall_GameRules,      /**< CGameRules call */
 	SDKCall_EntityList,     /**< CGlobalEntityList call */
 	SDKCall_Raw,            /**< |this| pointer with an arbitrary address */
-	SDKCall_Server          /**< CBaseServer call */
+	SDKCall_Server,         /**< CBaseServer call */
+	SDKCall_Engine          /**< CVEngineServer call */
 };
 
 enum SDKLibrary


### PR DESCRIPTION
Similar to https://github.com/alliedmodders/sourcemod/pull/1612 :)

I think this will be useful when used in plugins, where a pointer engine is needed. It will be convenient to use for vtable offsets to make it easier to call the necessary functions.