### PR TITLE
Change ShouldCollide to a posthook

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -729,7 +729,7 @@ HookReturn SDKHooks::Hook(int entity, SDKHookType type, IPluginFunction *callbac
 				hookid = SH_ADD_MANUALVPHOOK(Weapon_Switch, pEnt, SH_MEMBER(&g_Interface, &SDKHooks::Hook_WeaponSwitchPost), true);
 				break;
 			case SDKHook_ShouldCollide:
-				hookid = SH_ADD_MANUALVPHOOK(ShouldCollide, pEnt, SH_MEMBER(&g_Interface, &SDKHooks::Hook_ShouldCollide), false);
+				hookid = SH_ADD_MANUALVPHOOK(ShouldCollide, pEnt, SH_MEMBER(&g_Interface, &SDKHooks::Hook_ShouldCollide), true);
 				break;
 			case SDKHook_Blocked:
 				hookid = SH_ADD_MANUALVPHOOK(Blocked, pEnt, SH_MEMBER(&g_Interface, &SDKHooks::Hook_Blocked), false);


### PR DESCRIPTION
Fixes #1650

As pointed by @asherkin over discord the use of `META_RESULT_OVERRIDE_RET` or `META_RESULT_ORIG_RET` within a non post hook is wrong. This PR fixes that.

I'm not super familiar with sourcehook, so my fix could be horribly wrong. If I'm wrong, at the very least this PR will kick off a discussion? I was also tempted to replace the `META_RESULT_ORIG_RET` line with an `SH_CALL` instead, but this would end to essentially turning the function into a post hook.

_Smallest PR in the small west ?_