### PR TITLE
Update documentation for consistency

### DIFF
--- a/plugins/include/dhooks.inc
+++ b/plugins/include/dhooks.inc
@@ -375,7 +375,8 @@ methodmap DHookParam < Handle
 
 	// Get param address (Use only for ptr param types)
 	//
-	// @param num           Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+	// @param num           Param number to get. (Example if the function has 2 params and you need the value
+	//                      of the first param num would be 1.)
 	//
 	// @return              Address of the parameter.
 	// @error               Invalid handle. Invalid param number. Invalid param type.
@@ -668,7 +669,8 @@ native DynamicDetour DHookCreateDetour(Address funcaddr, CallingConvention callC
  * @param name              Name of the function in the gamedata to load.
  *
  * @return                  Setup handle for the detour or INVALID_HANDLE if offset/signature/address wasn't found.
- * @error                   Failed to create detour setup handle, invalid gamedata handle, invalid callback function or failed to find function in gamedata.
+ * @error                   Failed to create detour setup handle, invalid gamedata handle, invalid callback function or
+ *                          failed to find function in gamedata.
  */
 native DHookSetup DHookCreateFromConf(Handle gameconf, const char[] name);
 
@@ -689,7 +691,8 @@ native bool DHookSetFromConf(Handle setup, Handle gameconf, SDKFuncConfSource so
  * Enable the detour of the function described in the hook setup handle.
  *
  * @param setup             Hook setup handle
- * @param post              true to make the hook a post hook. (If you need to change the retunr value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return
+ *                          value use a post hook! If you need to change params and return use a pre and post hook!)
  * @param callback          Callback function
  *
  * @return                  true if detour was enabled, false otherwise.
@@ -726,9 +729,11 @@ native void DHookAddParam(Handle setup, HookParamType type, int size=-1, DHookPa
  * Hook entity
  *
  * @param setup             Setup handle to use to add the hook.
- * @param post              true to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return
+ *                          value use a post hook! If you need to change params and return use a pre and post hook!)
  * @param entity            Entity index to hook on.
- * @param removalcb         Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
+ * @param removalcb         Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and
+ *                          will call this callback)
  * @param callback          Optional callback function, if not set here must be set when creating the hook.
  *
  * @return                  INVALID_HOOK_ID on fail a hookid on success
@@ -740,8 +745,10 @@ native int DHookEntity(Handle setup, bool post, int entity, DHookRemovalCB remov
  * Hook gamerules
  *
  * @param setup             Setup handle to use to add the hook.
- * @param post              true to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
- * @param removalcb         Callback for when the hook is removed (Game rules hooks are auto-removed on map end and will call this callback)
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return
+ *                          value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param removalcb         Callback for when the hook is removed (Game rules hooks are auto-removed on map end and will
+ *                          call this callback)
  * @param callback          Optional callback function, if not set here must be set when creating the hook.
  *
  * @return                  INVALID_HOOK_ID on fail a hookid on success
@@ -753,9 +760,11 @@ native int DHookGamerules(Handle setup, bool post, DHookRemovalCB removalcb=INVA
  * Hook a raw pointer
  *
  * @param setup             Setup handle to use to add the hook.
- * @param post              true to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return 
+ *                          alue use a post hook! If you need to change params and return use a pre and post hook!)
  * @param addr              This pointer address.
- * @param removalcb         Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
+ * @param removalcb         Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and
+ *                          will call this callback)
  * @param callback          Optional callback function, if not set here must be set when creating the hook.
  *
  * @return                  INVALID_HOOK_ID on fail a hookid on success
@@ -777,7 +786,8 @@ native bool DHookRemoveHookID(int hookid);
  * Get param value (Use only for: int, entity, bool or float param types)
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first
+ *                          param num would be 1. 0 Will return the number of params stored)
  *
  * @return                  value if num greater than 0. If 0 returns paramcount.
  * @error                   Invalid handle. Invalid param number. Invalid param type.
@@ -788,7 +798,8 @@ native any DHookGetParam(Handle hParams, int num);
  * Get vector param value
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first
+ *                          param num would be 1.)
  * @param vec               Vector buffer to store result.
  *
  * @error                   Invalid handle. Invalid param number. Invalid param type.
@@ -799,7 +810,8 @@ native void DHookGetParamVector(Handle hParams, int num, float vec[3]);
  * Get string param value
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first
+ *                          param num would be 1.)
  * @param buffer            String buffer to store result
  * @param size              Buffer size
  *
@@ -811,7 +823,8 @@ native void DHookGetParamString(Handle hParams, int num, char[] buffer, int size
  * Set param value (Use only for: int, entity, bool or float param types)
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the
+ *                          first param num would be 1.)
  * @param value             Value to set it as (only pass int, bool, float or entity index)
  *
  * @error                   Invalid handle. Invalid param number. Invalid param type.
@@ -822,7 +835,8 @@ native void DHookSetParam(Handle hParams, int num, any value);
  * Set vector param value
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the
+ *                          first param num would be 1.)
  * @param vec               Value to set vector as.
  *
  * @error                   Invalid handle. Invalid param number. Invalid param type.
@@ -833,7 +847,8 @@ native void DHookSetParamVector(Handle hParams, int num, float vec[3]);
  * Set string param value
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the
+ *                          first param num would be 1.)
  * @param value             Value to set string as.
  *
  * @error                   Invalid handle. Invalid param number. Invalid param type.
@@ -984,7 +999,8 @@ native bool DHookIsNullParam(Handle hParams, int num);
  * Get param address (Use only for ptr param types)
  *
  * @param hParams           Handle to params structure
- * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first
+ *                          param num would be 1.)
  * 
  * @return                  Address of the parameter.
  * @error                   Invalid handle. Invalid param number. Invalid param type.

--- a/plugins/include/dhooks.inc
+++ b/plugins/include/dhooks.inc
@@ -9,7 +9,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -70,8 +70,8 @@ enum ReturnType
 	ReturnType_Int,
 	ReturnType_Bool,
 	ReturnType_Float,
-	ReturnType_String, //Note this is a string_t
-	ReturnType_StringPtr, //Note this is a string_t *
+	ReturnType_String,    // Note this is a string_t
+	ReturnType_StringPtr, // Note this is a string_t *
 	ReturnType_CharPtr,
 	ReturnType_Vector,
 	ReturnType_VectorPtr,
@@ -85,8 +85,8 @@ enum HookParamType
 	HookParamType_Int,
 	HookParamType_Bool,
 	HookParamType_Float,
-	HookParamType_String, //Note this is a string_t
-	HookParamType_StringPtr, //Note this is a string_t *
+	HookParamType_String,    // Note this is a string_t
+	HookParamType_StringPtr, // Note this is a string_t *
 	HookParamType_CharPtr,
 	HookParamType_VectorPtr,
 	HookParamType_CBaseEntity,
@@ -119,34 +119,34 @@ enum CallingConvention
 
 enum HookMode
 {
-	Hook_Pre,                   // Callback will be executed BEFORE the original function.
-	Hook_Post                   // Callback will be executed AFTER the original function.
+	Hook_Pre,                   /**< Callback will be executed BEFORE the original function. */
+	Hook_Post                   /**< Callback will be executed AFTER the original function. */
 };
 
 enum MRESReturn
 {
-	MRES_ChangedHandled = -2,	// Use changed values and return MRES_Handled
-	MRES_ChangedOverride,		// Use changed values and return MRES_Override
-	MRES_Ignored,				// plugin didn't take any action
-	MRES_Handled,				// plugin did something, but real function should still be called
-	MRES_Override,				// call real function, but use my return value
-	MRES_Supercede				// skip real function; use my return value
+	MRES_ChangedHandled = -2,   /**< Use changed values and return MRES_Handled */
+	MRES_ChangedOverride,       /**< Use changed values and return MRES_Override */
+	MRES_Ignored,               /**< plugin didn't take any action */
+	MRES_Handled,               /**< plugin did something, but real function should still be called */
+	MRES_Override,              /**< call real function, but use my return value */
+	MRES_Supercede              /**< skip real function; use my return value */
 };
 
 enum DHookPassFlag
 {
-	DHookPass_ByVal = 		(1<<0),		/**< Passing by value */
-	DHookPass_ByRef = 		(1<<1),		/**< Passing by reference */
-	DHookPass_ODTOR =		(1<<2),		/**< Object has a destructor */
-	DHookPass_OCTOR =		(1<<3),		/**< Object has a constructor */
-	DHookPass_OASSIGNOP	=	(1<<4),		/**< Object has an assignment operator */
+	DHookPass_ByVal =     (1<<0),    /**< Passing by value */
+	DHookPass_ByRef =     (1<<1),    /**< Passing by reference */
+	DHookPass_ODTOR =     (1<<2),    /**< Object has a destructor */
+	DHookPass_OCTOR =     (1<<3),    /**< Object has a constructor */
+	DHookPass_OASSIGNOP = (1<<4),    /**< Object has an assignment operator */
 };
 
 enum DHookRegister
 {
 	// Don't change the register and use the default for the calling convention.
 	DHookRegister_Default,
-	
+
 	// 8-bit general purpose registers
 	DHookRegister_AL,
 	DHookRegister_CL,
@@ -156,7 +156,7 @@ enum DHookRegister
 	DHookRegister_CH,
 	DHookRegister_DH,
 	DHookRegister_BH,
-	
+
 	// 32-bit general purpose registers
 	DHookRegister_EAX,
 	DHookRegister_ECX,
@@ -166,7 +166,7 @@ enum DHookRegister
 	DHookRegister_EBP,
 	DHookRegister_ESI,
 	DHookRegister_EDI,
-	
+
 	// 128-bit XMM registers
 	DHookRegister_XMM0,
 	DHookRegister_XMM1,
@@ -176,17 +176,17 @@ enum DHookRegister
 	DHookRegister_XMM5,
 	DHookRegister_XMM6,
 	DHookRegister_XMM7,
-	
+
 	// 80-bit FPU registers
 	DHookRegister_ST0
 };
 
 typeset ListenCB
 {
-	//Deleted
+	// Deleted
 	function void (int entity);
-	
-	//Created
+
+	// Created
 	function void (int entity, const char[] classname);
 };
 
@@ -194,46 +194,47 @@ typeset DHookRemovalCB
 {
 	function void (int hookid);
 };
+
 typeset DHookCallback
 {
-	//Function Example: void Ham::Test() with this pointer ignore
+	// Function Example: void Ham::Test() with this pointer ignore
 	function MRESReturn ();
-	
-	//Function Example: void Ham::Test() with this pointer passed
+
+	// Function Example: void Ham::Test() with this pointer passed
 	function MRESReturn (int pThis);
-	
-	//Function Example: void Ham::Test(int cake) with this pointer ignore
+
+	// Function Example: void Ham::Test(int cake) with this pointer ignore
 	function MRESReturn (DHookParam hParams);
-	
-	//Function Example: void Ham::Test(int cake) with this pointer passed
+
+	// Function Example: void Ham::Test(int cake) with this pointer passed
 	function MRESReturn (int pThis, DHookParam hParams);
-	
-	//Function Example: int Ham::Test() with this pointer ignore
+
+	// Function Example: int Ham::Test() with this pointer ignore
 	function MRESReturn (DHookReturn hReturn);
-	
-	//Function Example: int Ham::Test() with this pointer passed
+
+	// Function Example: int Ham::Test() with this pointer passed
 	function MRESReturn (int pThis, DHookReturn hReturn);
-	
-	//Function Example: int Ham::Test(int cake) with this pointer ignore
+
+	// Function Example: int Ham::Test(int cake) with this pointer ignore
 	function MRESReturn (DHookReturn hReturn, DHookParam hParams);
-	
-	//Function Example: int Ham::Test(int cake) with this pointer passed
+
+	// Function Example: int Ham::Test(int cake) with this pointer passed
 	function MRESReturn (int pThis, DHookReturn hReturn, DHookParam hParams);
-	
-	//Address NOW
-	
-	//Function Example: void Ham::Test() with this pointer passed
+
+	// Address NOW
+
+	// Function Example: void Ham::Test() with this pointer passed
 	function MRESReturn (Address pThis);
-	
-	//Function Example: void Ham::Test(int cake) with this pointer passed
+
+	// Function Example: void Ham::Test(int cake) with this pointer passed
 	function MRESReturn (Address pThis, DHookParam hParams);
-	
-	//Function Example: int Ham::Test() with this pointer passed
+
+	// Function Example: int Ham::Test() with this pointer passed
 	function MRESReturn (Address pThis, DHookReturn hReturn);
-	
-	//Function Example: int Ham::Test(int cake) with this pointer passed
+
+	// Function Example: int Ham::Test(int cake) with this pointer passed
 	function MRESReturn (Address pThis, DHookReturn hReturn, DHookParam hParams);
-	
+
 };
 
 // Represents the parameters of the hooked function.
@@ -265,7 +266,7 @@ methodmap DHookParam < Handle
 	// @param num           Parameter number to get, starting at 1.
 	// @param buffer        String buffer to store result.
 	// @param size          Buffer size.
-	// 
+	//
 	// @error               Invalid handle, invalid param number or invalid param type.
 	public native void GetString(int num, char[] buffer, int size);
 
@@ -368,16 +369,16 @@ methodmap DHookParam < Handle
 	//
 	// @param num           Parameter number to check, starting at 1.
 	//
-	// @return              True if null, false otherwise.
+	// @return              true if null, false otherwise.
 	// @error               Non-pointer parameter.
 	public native bool IsNull(int num);
 
 	// Get param address (Use only for ptr param types)
-	// 
-	// @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
-	// 
-	// @error Invalid handle. Invalid param number. Invalid param type.
-	// @return address of the parameter.
+	//
+	// @param num           Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+	//
+	// @return              Address of the parameter.
+	// @error               Invalid handle. Invalid param number. Invalid param type.
 	public native Address GetAddress(int num);
 };
 
@@ -449,7 +450,7 @@ methodmap DHookSetup < Handle
 	// @param source        Whether to look in Offsets, Signatures, or Addresses.
 	// @param name          Name of the property to find.
 	//
-	// @return              True on success, false if nothing was found.
+	// @return              true on success, false if nothing was found.
 	// @error               Invalid setup or gamedata handle.
 	public native bool SetFromConf(Handle gameconf, SDKFuncConfSource source, const char[] name);
 
@@ -459,7 +460,7 @@ methodmap DHookSetup < Handle
 	// @param size              Used for Objects (not Object ptr) to define the size of the object.
 	// @param flag              Used to change the pass type (ignored by detours).
 	// @param custom_register   The register this argument is passed in instead of the stack (ignored by vhooks).
-	// 
+	//
 	// @error                   Invalid setup handle or too many params added (request upping the max in thread).
 	public native void AddParam(HookParamType type, int size=-1, DHookPassFlag flag=DHookPass_ByVal, DHookRegister custom_register=DHookRegister_Default);
 };
@@ -467,7 +468,7 @@ methodmap DHookSetup < Handle
 // A DynamicHook allows to hook a virtual function on any C++ object.
 // Currently CBaseEntity and CGameRules have a convenience API for easy entity hooking,
 // but it's possible to provide a raw this-pointer to hook any object in memory too.
-// 
+//
 // Internally this intercepts function calls by replacing the function pointer
 // in the virtual table of the object with our own function.
 methodmap DynamicHook < DHookSetup
@@ -478,7 +479,7 @@ methodmap DynamicHook < DHookSetup
  	// @param hooktype      Type of hook.
 	// @param returntype    Type of return value.
 	// @param thistype      Type of this pointer or ignore (ignore can be used if not needed).
-	// 
+	//
 	// @error               Failed to create hook setup handle or invalid callback function.
 	public native DynamicHook(int offset, HookType hooktype, ReturnType returntype, ThisPointerType thistype);
 
@@ -500,14 +501,14 @@ methodmap DynamicHook < DHookSetup
 	// If you need to read the return value of the function, choose a post hook.
 	//
 	// @param mode          The desired hook mode - pre or post.
-	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                      A pre hook calls your callback BEFORE the original function is called.
 	//                        You can access the parameters, set the return value, and skip the original function.
 	//                      A post hook calls your callback AFTER the original function executed.
 	//                        You can access the parameters and get/set the return value.
 	// @param entity        Entity index to hook on.
 	// @param callback      Callback function.
 	// @param removalcb     Optional callback for when the hook is removed.
-	// 
+	//
 	// @return              A hookid on success, INVALID_HOOK_ID otherwise.
 	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
 	public native int HookEntity(HookMode mode, int entity, DHookCallback callback, DHookRemovalCB removalcb=INVALID_FUNCTION);
@@ -518,13 +519,13 @@ methodmap DynamicHook < DHookSetup
 	// If you need to read the return value of the function, choose a post hook.
 	//
 	// @param mode          The desired hook mode - pre or post.
-	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                      A pre hook calls your callback BEFORE the original function is called.
 	//                        You can access the parameters, set the return value, and skip the original function.
 	//                      A post hook calls your callback AFTER the original function executed.
 	//                        You can access the parameters and get/set the return value.
 	// @param callback      Callback function.
 	// @param removalcb     Optional callback for when the hook is removed.
-	// 
+	//
 	// @return              A hookid on success, INVALID_HOOK_ID otherwise.
 	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
 	public native int HookGamerules(HookMode mode, DHookCallback callback, DHookRemovalCB removalcb=INVALID_FUNCTION);
@@ -533,23 +534,23 @@ methodmap DynamicHook < DHookSetup
 	// If you need to read the return value of the function, choose a post hook.
 	//
 	// @param mode          The desired hook mode - pre or post.
-	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                      A pre hook calls your callback BEFORE the original function is called.
 	//                        You can access the parameters, set the return value, and skip the original function.
 	//                      A post hook calls your callback AFTER the original function executed.
 	//                        You can access the parameters and get/set the return value.
 	// @param addr          This pointer address.
 	// @param callback      Callback function.
-	// 
+	//
 	// @return              A hookid on success, INVALID_HOOK_ID otherwise.
 	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
 	public native int HookRaw(HookMode mode, Address addr, DHookCallback callback);
 
 	// Remove hook by hook id:
 	// This will NOT fire the removal callback!
-	// 
+	//
 	// @param hookid        Hook id to remove.
-	// 
-	// @return              True on success, false otherwise
+	//
+	// @return              true on success, false otherwise
 	public static native bool RemoveHook(int hookid);
 };
 
@@ -561,7 +562,7 @@ methodmap DynamicHook < DHookSetup
 // Internally this works by replacing the first instructions of the function
 // with a jump to our own code. This means that the signature used to find
 // the function address in the first place might not match anymore after a detour.
-// If you need to detour the same function in different plugins make sure to 
+// If you need to detour the same function in different plugins make sure to
 // wildcard \x2a the first 6 bytes of the signature to accommodate for the patched
 // jump introduced by the detour.
 methodmap DynamicDetour < DHookSetup
@@ -594,13 +595,13 @@ methodmap DynamicDetour < DHookSetup
 	// If you need to read the return value of the function, choose a post hook.
 	//
 	// @param mode          The desired hook mode - pre or post.
-	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                      A pre hook calls your callback BEFORE the original function is called.
 	//                        You can access the parameters, set the return value, and skip the original function.
 	//                      A post hook calls your callback AFTER the original function executed.
 	//                        You can access the parameters and get/set the return value.
 	// @param callback      Callback function.
 	//
-	// @return              True if detour was enabled, false otherwise.
+	// @return              true if detour was enabled, false otherwise.
 	// @error               Hook handle is not setup for a detour.
 	public native bool Enable(HookMode mode, DHookCallback callback);
 
@@ -609,375 +610,385 @@ methodmap DynamicDetour < DHookSetup
 	// @param mode          The hook mode to disable - pre or post.
 	// @param callback      Callback function.
 	//
-	// @return              True if detour was disabled, false otherwise.
+	// @return              true if detour was disabled, false otherwise.
 	// @error               Hook handle is not setup for a detour or function is not detoured.
 	public native bool Disable(HookMode mode, DHookCallback callback);
 };
 
-/* Adds an entity listener hook
+/**
+ * Adds an entity listener hook
  *
- * @param type			Type of listener to add
- * @param callback		Callback to use
- *
- * @noreturn
-*/
+ * @param type              Type of listener to add
+ * @param callback          Callback to use
+ */
 native void DHookAddEntityListener(ListenType type, ListenCB callback);
 
-/* Removes an entity listener hook
+/**
+ * Removes an entity listener hook
  *
- * @param type			Type of listener to remove
- * @param callback		Callback this listener was using
+ * @param type              Type of listener to remove
+ * @param callback          Callback this listener was using
  *
- * @return True if one was removed false otherwise.
-*/
+ * @return                  true if one was removed, false otherwise
+ */
 native bool DHookRemoveEntityListener(ListenType type, ListenCB callback);
 
-/* Creates a hook
+/**
+ * Creates a hook
  *
- * @param offset		vtable offset of function to hook
- * @param hooktype		Type of hook
- * @param returntype	Type of return value
- * @param thistype		Type of this pointer or ignore (ignore can be used if not needed)
- * @param callback		Optional callback function, if not set here must be set when hooking.
- * 
- * @return Returns setup handle for the hook.
- * @error Failed to create hook setup handle or invalid callback function.
-*/
+ * @param offset            vtable offset of function to hook
+ * @param hooktype          Type of hook
+ * @param returntype        Type of return value
+ * @param thistype          Type of this pointer or ignore (ignore can be used if not needed)
+ * @param callback          Optional callback function, if not set here must be set when hooking.
+ *
+ * @return                  Returns setup handle for the hook.
+ * @error                   Failed to create hook setup handle or invalid callback function.
+ */
 native DynamicHook DHookCreate(int offset, HookType hooktype, ReturnType returntype, ThisPointerType thistype, DHookCallback callback=INVALID_FUNCTION);
 
 /**
  * Creates a detour
  *
- * @param funcaddr		The address of the function to detour.
- *						Can be Address_Null if you want to load the address from gamedata using DHookSetFromConf.
- * @param callConv		Calling convention of the function.
- * @param returnType	Type of the return value.
- * @param thisType		Type of this pointer or ignore (ignore can be used if not needed)
+ * @param funcaddr          The address of the function to detour.
+ *                          Can be Address_Null if you want to load the address from gamedata using DHookSetFromConf.
+ * @param callConv          Calling convention of the function.
+ * @param returnType        Type of the return value.
+ * @param thisType          Type of this pointer or ignore (ignore can be used if not needed)
  *
- * @return				Setup handle for the detour.
- * @error				Failed to create detour setup handle.
- */	
+ * @return                  Setup handle for the detour.
+ * @error                   Failed to create detour setup handle.
+ */
 native DynamicDetour DHookCreateDetour(Address funcaddr, CallingConvention callConv, ReturnType returntype, ThisPointerType thisType);
 
 /**
  * Setup a detour or hook for a function as described in a "Functions" section in gamedata.
  *
- * @param gameconf		GameConfig handle
- * @param name			Name of the function in the gamedata to load.
+ * @param gameconf          GameConfig handle
+ * @param name              Name of the function in the gamedata to load.
  *
- * @return				Setup handle for the detour or INVALID_HANDLE if offset/signature/address wasn't found.
- * @error				Failed to create detour setup handle, invalid gamedata handle, invalid callback function or failed to find function in gamedata.
+ * @return                  Setup handle for the detour or INVALID_HANDLE if offset/signature/address wasn't found.
+ * @error                   Failed to create detour setup handle, invalid gamedata handle, invalid callback function or failed to find function in gamedata.
  */
 native DHookSetup DHookCreateFromConf(Handle gameconf, const char[] name);
 
 /**
  * Load details for a vhook or detour from a gamedata file.
  *
- * @param setup			Hook setup handle to set the offset or address on.
- * @param gameconf		GameConfig handle
- * @param source		Whether to look in Offsets or Signatures.
- * @param name			Name of the property to find.
+ * @param setup             Hook setup handle to set the offset or address on.
+ * @param gameconf          GameConfig handle
+ * @param source            Whether to look in Offsets or Signatures.
+ * @param name              Name of the property to find.
  *
- * @return				True on success, false if nothing was found.
- * @error				Invalid setup or gamedata handle.
+ * @return                  true on success, false if nothing was found.
+ * @error                   Invalid setup or gamedata handle.
  */
 native bool DHookSetFromConf(Handle setup, Handle gameconf, SDKFuncConfSource source, const char[] name);
 
 /**
  * Enable the detour of the function described in the hook setup handle.
  *
- * @param setup			Hook setup handle
- * @param post			True to make the hook a post hook. (If you need to change the retunr value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
- * @param callback		Callback function
+ * @param setup             Hook setup handle
+ * @param post              true to make the hook a post hook. (If you need to change the retunr value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param callback          Callback function
  *
- * @return				True if detour was enabled, false otherwise.
- * @error				Hook handle is not setup for a detour.
+ * @return                  true if detour was enabled, false otherwise.
+ * @error                   Hook handle is not setup for a detour.
  */
 native bool DHookEnableDetour(Handle setup, bool post, DHookCallback callback);
 
 /**
  * Disable the detour of the function described in the hook setup handle.
  *
- * @param setup			Hook setup handle
- * @param post			True to disable a post hook.
- * @param callback		Callback function
+ * @param setup             Hook setup handle
+ * @param post              true to disable a post hook.
+ * @param callback          Callback function
  *
- * @return				True if detour was disabled, false otherwise.
- * @error				Hook handle is not setup for a detour or function is not detoured.
+ * @return                  true if detour was disabled, false otherwise.
+ * @error                   Hook handle is not setup for a detour or function is not detoured.
  */
 native bool DHookDisableDetour(Handle setup, bool post, DHookCallback callback);
 
-/* Adds param to a hook setup
+/**
+ * Adds param to a hook setup
  *
- * @param setup				Setup handle to add the param to.
- * @param type				Param type
- * @param size				Used for Objects (not Object ptr) to define the size of the object.
- * @param flag				Used to change the pass type.
- * @param custom_register	The register this argument is passed in instead of the stack.
- * 
- * @error	Invalid setup handle or too many params added (request upping the max in thread)
- * @noreturn
-*/
+ * @param setup             Setup handle to add the param to.
+ * @param type              Param type
+ * @param size              Used for Objects (not Object ptr) to define the size of the object.
+ * @param flag              Used to change the pass type.
+ * @param custom_register   The register this argument is passed in instead of the stack.
+ *
+ * @error                   Invalid setup handle or too many params added (request upping the max in thread)
+ */
 native void DHookAddParam(Handle setup, HookParamType type, int size=-1, DHookPassFlag flag=DHookPass_ByVal, DHookRegister custom_register=DHookRegister_Default);
 
-/* Hook entity
- * 
- * @param setup			Setup handle to use to add the hook.
- * @param post			True to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
- * @param entity		Entity index to hook on.
- * @param removalcb		Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
- * @param callback		Optional callback function, if not set here must be set when creating the hook.
- * 
- * @error Invalid setup handle, invalid address, invalid hook type or invalid callback.
- * @return INVALID_HOOK_ID on fail a hookid on success
-*/
+/**
+ * Hook entity
+ *
+ * @param setup             Setup handle to use to add the hook.
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param entity            Entity index to hook on.
+ * @param removalcb         Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
+ * @param callback          Optional callback function, if not set here must be set when creating the hook.
+ *
+ * @return                  INVALID_HOOK_ID on fail a hookid on success
+ * @error                   Invalid setup handle, invalid address, invalid hook type or invalid callback.
+ */
 native int DHookEntity(Handle setup, bool post, int entity, DHookRemovalCB removalcb=INVALID_FUNCTION, DHookCallback callback=INVALID_FUNCTION);
 
-/* Hook gamerules
- * 
- * @param setup			Setup handle to use to add the hook.
- * @param post			True to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
- * @param removalcb		Callback for when the hook is removed (Game rules hooks are auto-removed on map end and will call this callback)
- * @param callback		Optional callback function, if not set here must be set when creating the hook.
- * 
- * @error Invalid setup handle, invalid address, invalid hook type or invalid callback.
- * @return INVALID_HOOK_ID on fail a hookid on success
-*/
+/**
+ * Hook gamerules
+ *
+ * @param setup             Setup handle to use to add the hook.
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param removalcb         Callback for when the hook is removed (Game rules hooks are auto-removed on map end and will call this callback)
+ * @param callback          Optional callback function, if not set here must be set when creating the hook.
+ *
+ * @return                  INVALID_HOOK_ID on fail a hookid on success
+ * @error                   Invalid setup handle, invalid address, invalid hook type or invalid callback.
+ */
 native int DHookGamerules(Handle setup, bool post, DHookRemovalCB removalcb=INVALID_FUNCTION, DHookCallback callback=INVALID_FUNCTION);
 
-/* Hook a raw pointer
- * 
- * @param setup			Setup handle to use to add the hook.
- * @param post			True to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
- * @param addr			This pointer address.
- * @param removalcb		Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
- * @param callback		Optional callback function, if not set here must be set when creating the hook.
- * 
- * @error Invalid setup handle, invalid address, invalid hook type or invalid callback.
- * @return INVALID_HOOK_ID on fail a hookid on success
-*/
+/**
+ * Hook a raw pointer
+ *
+ * @param setup             Setup handle to use to add the hook.
+ * @param post              true to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param addr              This pointer address.
+ * @param removalcb         Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
+ * @param callback          Optional callback function, if not set here must be set when creating the hook.
+ *
+ * @return                  INVALID_HOOK_ID on fail a hookid on success
+ * @error                   Invalid setup handle, invalid address, invalid hook type or invalid callback.
+ */
 native int DHookRaw(Handle setup, bool post, Address addr, DHookRemovalCB removalcb=INVALID_FUNCTION, DHookCallback callback=INVALID_FUNCTION);
 
-/* Remove hook by hook id
- * 
- * @param hookid		Hook id to remove
- * 
- * @return true on success false otherwise
- * @note This will not fire the removal callback!
-*/
+/**
+ * Remove hook by hook id
+ *
+ * @param hookid            Hook id to remove
+ *
+ * @return                  true on success, false otherwise
+ * @note                    This will not fire the removal callback!
+ */
 native bool DHookRemoveHookID(int hookid);
 
-/* Get param value (Use only for: int, entity, bool or float param types)
- * 
- * @param hParams		Handle to params structure
- * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @return value if num greater than 0. If 0 returns paramcount.
-*/
+/**
+ * Get param value (Use only for: int, entity, bool or float param types)
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+ *
+ * @return                  value if num greater than 0. If 0 returns paramcount.
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native any DHookGetParam(Handle hParams, int num);
 
-/* Get vector param value
- * 
- * @param hParams		Handle to params structure
- * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
- * @param vec			Vector buffer to store result.
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @noreturn
-*/
+/**
+ * Get vector param value
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param vec               Vector buffer to store result.
+ *
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native void DHookGetParamVector(Handle hParams, int num, float vec[3]);
 
-/* Get string param value
- * 
- * @param hParams		Handle to params structure
- * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
- * @param buffer		String buffer to store result
- * @param size			Buffer size
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @noreturn
-*/
+/**
+ * Get string param value
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param buffer            String buffer to store result
+ * @param size              Buffer size
+ *
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native void DHookGetParamString(Handle hParams, int num, char[] buffer, int size);
 
-/* Set param value (Use only for: int, entity, bool or float param types)
- * 
- * @param hParams		Handle to params structure
- * @param num			Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
- * @param value			Value to set it as (only pass int, bool, float or entity index)
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @noreturn
-*/
+/**
+ * Set param value (Use only for: int, entity, bool or float param types)
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param value             Value to set it as (only pass int, bool, float or entity index)
+ *
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native void DHookSetParam(Handle hParams, int num, any value);
 
-/* Set vector param value
- * 
- * @param hParams		Handle to params structure
- * @param num			Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
- * @param vec			Value to set vector as.
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @noreturn
-*/
+/**
+ * Set vector param value
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param vec               Value to set vector as.
+ *
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native void DHookSetParamVector(Handle hParams, int num, float vec[3]);
 
-/* Set string param value
- * 
- * @param hParams		Handle to params structure
- * @param num			Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
- * @param value			Value to set string as.
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @noreturn
-*/
+/**
+ * Set string param value
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param value             Value to set string as.
+ *
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native void DHookSetParamString(Handle hParams, int num, char[] value);
 
-/* Get return value (Use only for: int, entity, bool or float return types)
- * 
- * @param hReturn		Handle to return structure
- * 
- * @error Invalid Handle, invalid type.
- * @return Returns default value if prehook returns actual value if post hook.
-*/
+/**
+ * Get return value (Use only for: int, entity, bool or float return types)
+ *
+ * @param hReturn           Handle to return structure
+ *
+ * @error                   Invalid Handle, invalid type.
+ * @return                  Returns default value if prehook returns actual value if post hook.
+ */
 native any DHookGetReturn(Handle hReturn);
 
-/* Get return vector value
- * 
- * @param hReturn		Handle to return structure
- * @param vec			Vector buffer to store result in. (In pre hooks will be default value (0.0,0.0,0.0))
- * 
- * @error Invalid Handle, invalid type.
- * @noreturn
-*/
+/**
+ * Get return vector value
+ *
+ * @param hReturn           Handle to return structure
+ * @param vec               Vector buffer to store result in. (In pre hooks will be default value (0.0,0.0,0.0))
+ *
+ * @error                   Invalid Handle, invalid type.
+ */
 native void DHookGetReturnVector(Handle hReturn, float vec[3]);
 
-/* Get return string value
- * 
- * @param hReturn		Handle to return structure
- * @param buffer		String buffer to store result in. (In pre hooks will be default value "")
- * @param size			String buffer size
- * 
- * @error Invalid Handle, invalid type.
- * @noreturn
-*/
+/**
+ * Get return string value
+ *
+ * @param hReturn           Handle to return structure
+ * @param buffer            String buffer to store result in. (In pre hooks will be default value "")
+ * @param size              String buffer size
+ *
+ * @error                   Invalid Handle, invalid type.
+ */
 native void DHookGetReturnString(Handle hReturn, char[] buffer, int size);
 
-/* Set return value (Use only for: int, entity, bool or float return types)
- * 
- * @param hReturn		Handle to return structure
- * @param value			Value to set return as
- * 
- * @error Invalid Handle, invalid type.
- * @noreturn
-*/
+/**
+ * Set return value (Use only for: int, entity, bool or float return types)
+ *
+ * @param hReturn           Handle to return structure
+ * @param value             Value to set return as
+ *
+ * @error                   Invalid Handle, invalid type.
+ */
 native void DHookSetReturn(Handle hReturn, any value);
 
-/* Set return vector value
- * 
- * @param hReturn		Handle to return structure
- * @param vec			Value to set return vector as
- * 
- * @error Invalid Handle, invalid type.
- * @noreturn
-*/
+/**
+ * Set return vector value
+ *
+ * @param hReturn           Handle to return structure
+ * @param vec               Value to set return vector as
+ *
+ * @error                   Invalid Handle, invalid type.
+ */
 native void DHookSetReturnVector(Handle hReturn, float vec[3]);
 
-/* Set return string value
- * 
- * @param hReturn		Handle to return structure
- * @param value			Value to set return string as
- * 
- * @error Invalid Handle, invalid type.
- * @noreturn
-*/
+/**
+ * Set return string value
+ *
+ * @param hReturn           Handle to return structure
+ * @param value             Value to set return string as
+ *
+ * @error                   Invalid Handle, invalid type.
+ */
 native void DHookSetReturnString(Handle hReturn, char[] value);
 
 //WE SHOULD WRAP THESE AROUND STOCKS FOR NON PTR AS WE SUPPORT BOTH WITH THESE NATIVE'S
 
-/* Gets an objects variable value
+/**
+ * Gets an objects variable value
  *
- * @param hParams		Handle to params structure
- * @param num			Param number to get.
- * @param offset		Offset within the object to the var to get.
- * @param type			Type of var it is
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get.
+ * @param offset            Offset within the object to the var to get.
+ * @param type              Type of var it is
  *
- * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
- * @return Value of the objects var. If EHANDLE type or entity returns entity index.
-*/
+ * @error                   Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ * @return                  Value of the objects var. If EHANDLE type or entity returns entity index.
+ */
 native any DHookGetParamObjectPtrVar(Handle hParams, int num, int offset, ObjectValueType type);
 
-/* Sets an objects variable value
+/**
+ * Sets an objects variable value
  *
- * @param hParams		Handle to params structure
- * @param num			Param number to set.
- * @param offset		Offset within the object to the var to set.
- * @param type			Type of var it is
- * @param value			The value to set the var to.
+ * @param hParams           Handle to params structure
+ * @param num               Param number to set.
+ * @param offset            Offset within the object to the var to set.
+ * @param type              Type of var it is
+ * @param value             The value to set the var to.
  *
- * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
- * @noreturn
-*/
+ * @error                   Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ */
 native void DHookSetParamObjectPtrVar(Handle hParams, int num, int offset, ObjectValueType type, any value);
 
-/* Gets an objects vector variable value
+/**
+ * Gets an objects vector variable value
  *
- * @param hParams		Handle to params structure
- * @param num			Param number to get.
- * @param offset		Offset within the object to the var to get.
- * @param type			Type of var it is
- * @param buffer		Buffer to store the result vector
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get.
+ * @param offset            Offset within the object to the var to get.
+ * @param type              Type of var it is
+ * @param buffer            Buffer to store the result vector
  *
- * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
- * @noreturn
-*/
+ * @error                   Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ */
 native void DHookGetParamObjectPtrVarVector(Handle hParams, int num, int offset, ObjectValueType type, float buffer[3]);
 
-/* Sets an objects vector variable value
+/**
+ * Sets an objects vector variable value
  *
- * @param hParams		Handle to params structure
- * @param num			Param number to set.
- * @param offset		Offset within the object to the var to set.
- * @param type			Type of var it is
- * @param value			The value to set the vector var to.
+ * @param hParams           Handle to params structure
+ * @param num               Param number to set.
+ * @param offset            Offset within the object to the var to set.
+ * @param type              Type of var it is
+ * @param value             The value to set the vector var to.
  *
- * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
- * @noreturn
-*/
+ * @error                   Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ */
 native void DHookSetParamObjectPtrVarVector(Handle hParams, int num, int offset, ObjectValueType type, float value[3]);
 
-/* Gets an objects string variable value
+/**
+ * Gets an objects string variable value
  *
- * @param hParams		Handle to params structure
- * @param num			Param number to get.
- * @param offset		Offset within the object to the var to get.
- * @param type			Type of var it is
- * @param buffer		Buffer to store the result vector
- * @param size			Size of the buffer
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get.
+ * @param offset            Offset within the object to the var to get.
+ * @param type              Type of var it is
+ * @param buffer            Buffer to store the result vector
+ * @param size              Size of the buffer
  *
- * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
- * @noreturn
-*/
+ * @error                   Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ */
 native void DHookGetParamObjectPtrString(Handle hParams, int num, int offset, ObjectValueType type, char[] buffer, int size);
 
-/* Checks if a pointer param is null
+/**
+ * Checks if a pointer param is null
  *
- * @param hParams		Handle to params structure
- * @param num			Param number to check.
+ * @param hParams           Handle to params structure
+ * @param num               Param number to check.
  *
- * @error Non pointer param
- * @return True if null false otherwise.
-*/
+ * @return                  true if null, false otherwise.
+ * @error                   Non pointer param
+ */
 native bool DHookIsNullParam(Handle hParams, int num);
 
-/* Get param address (Use only for ptr param types)
+/**
+ * Get param address (Use only for ptr param types)
+ *
+ * @param hParams           Handle to params structure
+ * @param num               Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
  * 
- * @param hParams		Handle to params structure
- * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
- * 
- * @error Invalid handle. Invalid param number. Invalid param type.
- * @return address of the parameter.
-*/
+ * @return                  Address of the parameter.
+ * @error                   Invalid handle. Invalid param number. Invalid param type.
+ */
 native Address DHookGetParamAddress(Handle hParams, int num);
 
 public Extension __ext_dhooks =

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -466,6 +466,8 @@ native void CreateNative(const char[] name, NativeCall func);
  * @param error         Error code to use.
  * @param fmt           Error message format.
  * @param ...           Format arguments.
+ * @noreturn
+ * @error               Always!
  */
 native int ThrowNativeError(int error, const char[] fmt, any ...);
 

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -348,6 +348,7 @@ native void SetFailState(const char[] string, any ...);
  *
  * @param fmt           String format.
  * @param ...           Format arguments.
+ * @noreturn
  * @error               Always!
  */
 native void ThrowError(const char[] fmt, any ...);

--- a/public/IGameConfigs.h
+++ b/public/IGameConfigs.h
@@ -158,7 +158,6 @@ namespace SourceMod
 		 *
 		 * @param sectionname	Section name to hook.
 		 * @param listener		Listener callback.
-		 * @noreturn
 		 */
 		virtual void AddUserConfigHook(const char *sectionname, ITextListener_SMC *listener) =0;
 
@@ -167,7 +166,6 @@ namespace SourceMod
 		 *
 		 * @param sectionname	Section name to unhook.
 		 * @param listener		Listener callback.
-		 * @noreturn
 		 */
 		virtual void RemoveUserConfigHook(const char *sectionname, ITextListener_SMC *listener) =0;
 

--- a/public/IGameHelpers.h
+++ b/public/IGameHelpers.h
@@ -188,7 +188,6 @@ namespace SourceMod
 		 *
 		 * @param hndl			CBaseHandle object.
 		 * @param pEnt			Edict pointer.
-		 * @noreturn
 		 */
 		virtual void SetHandleEntity(CBaseHandle &hndl, edict_t *pEnt) =0;
 

--- a/public/asm/asm.c
+++ b/public/asm/asm.c
@@ -24,7 +24,6 @@
 *
 * @param dest		Destination buffer where a call opcode + addr (5 bytes) has just been written.
 * @param pc		The program counter value that needs to be set (usually the next address from the source).
-* @noreturn
 */
 void check_thunks(unsigned char *dest, unsigned char *pc)
 {


### PR DESCRIPTION
- Modifies whitespace (change tabs to spaces for non initial indents, fix alignments, create consistency with rest of SM docs)
- Change `/*` to `/**` for consistency and to indicate comment doc
- Split long comments across multiple lines
- Removes incorrect `@noreturn` doc usages
- Add `@noreturn` and `@error` to Throw(Native)Error
- Fix typo (retunr -> return)