### PR TITLE
Prevent _GNU_SOURCE redefinition

### DIFF
--- a/public/asm/asm.c
+++ b/public/asm/asm.c
@@ -2,7 +2,9 @@
 #include "libudis86/udis86.h"
 
 #ifndef WIN32
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+	#define _GNU_SOURCE
+#endif
 #include <dlfcn.h>
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
This should fix some of our recently broken builds