### PR TITLE
Add ArrayStack.Clear native

### DIFF
--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -83,6 +83,22 @@ static cell_t CreateStack(IPluginContext *pContext, const cell_t *params)
 	return hndl;
 }
 
+static cell_t ClearStack(IPluginContext *pContext, const cell_t *params)
+{
+	CellArray *array;
+	HandleError err;
+	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
+
+	if ((err = handlesys->ReadHandle(params[1], htCellStack, &sec, (void **)&array)) != HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
+	}
+
+	array->clear();
+
+	return 1;
+}
+
 static cell_t CloneStack(IPluginContext *pContext, const cell_t *params)
 {
 	CellArray *oldArray;
@@ -425,6 +441,7 @@ REGISTER_NATIVES(cellStackNatives)
 
 	// Transitional syntax support.
 	{"ArrayStack.ArrayStack",		CreateStack},
+	{"ArrayStack.Clear",			ClearStack},
 	{"ArrayStack.Clone",			CloneStack},
 	{"ArrayStack.Pop",				ArrayStack_Pop},
 	{"ArrayStack.PopString",		ArrayStack_PopString},

--- a/plugins/include/adt_stack.inc
+++ b/plugins/include/adt_stack.inc
@@ -54,6 +54,9 @@ methodmap ArrayStack < Handle
 	//                     new Array[X][32]
 	public native ArrayStack(int blocksize=1);
 
+	// Clears a stack of all entries.
+	public native void Clear();
+
 	// Clones an stack, returning a new handle with the same size and data.
 	// This should NOT be confused with CloneHandle. This is a completely new
 	// handle with the same data but no relation to the original. It should


### PR DESCRIPTION
Provide an ArrayStack.Clear method since this really has no reason not to exist.
Left out the non-methodmap native since I was told it wasn't needed.

I didn't write a test plugin since because ArrayStack just uses a CellArray under the hood, this _completely_ re-uses the code from ArrayList.Clear. I assume that's ok?

