### PR TITLE
Add ArrayList.SetStringEx

### DIFF
--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -161,6 +161,16 @@ methodmap ArrayList < Handle {
 	// @error               Invalid index.
 	public native void SetString(int index, const char[] value);
 
+	// Sets a string value in an array, specifying which block to write to.
+	//
+	// @param index         Index in the array.
+	// @param value         String value to set.
+	// @param block         Block to write to.
+	// @param maxlength     Maximum size of the buffer (in bytes).
+	// @return              Number of characters copied.
+	// @error               Invalid index, or invalid block.
+	public native int SetStringEx(int index, const char[] value, int block, int maxlength);
+
 	// Sets an array of cells in an array.
 	//
 	// @param index         Index in the array.


### PR DESCRIPTION
Add a SetString method to ArrayList to allow you to specify the block.

Currently in order to mimic the behaviour of `ArrayList.Set(index, value, SomeEnumStruct::Field);` for strings you would have to copy the entire enum struct out of the array, modify the string, and then copy it back again.

But this PR just lets you do:
`ArrayList.SetStringEx(index, "some string", SomeEnumStruct::Field, sizeof(SomeEnumStruct::Field))`
Which is a bit verbose, but more efficient.

Tested with this code:
```sourcepawn
#include <sourcemod>

#pragma semicolon 1
#pragma newdecls required

public Plugin myinfo = {
    name        = "",
    author      = "",
    description = "",
    version     = "0.0.0",
    url         = ""
};

enum struct SomeStruct
{
    int a;
    char textLong[16];
    int b;
    char textShort[4];
    int c;
}

void PrintList(const char[] msg, ArrayList list)
{
    PrintToServer("------%s------", msg);
    PrintToServer("\xB3%-6s\xB3%-11s\xB3%-24s\xB3%-11s\xB3%-24s\xB3%-11s", "Index", "a", "textLong[16]", "b", "textShort[4]", "c");

    char longBuff[64];
    char shortBuff[64];
    for (int i = 0; i < list.Length; ++i)
    {
        SomeStruct s;
        list.GetArray(i, s, sizeof(s));

        Format(longBuff, sizeof(longBuff), "\"%s\"", s.textLong);
        Format(shortBuff, sizeof(shortBuff), "\"%s\"", s.textShort);

        PrintToServer("\xB3%-6i\xB3%-11i\xB3%-24s\xB3%-11i\xB3%-24s\xB3%-11i", i, s.a, longBuff, s.b, shortBuff, s.c);
    }
}

public void OnPluginStart()
{
    ArrayList list = new ArrayList(sizeof(SomeStruct));

    // Create default SomeStruct
    SomeStruct s;
    list.PushArray(s, sizeof(s));
    PrintList("Default struct", list);

    // Normal usage
    list.Set(0, 2147483647, SomeStruct::a);
    list.Set(0, 2147483647, SomeStruct::b);
    list.Set(0, 2147483647, SomeStruct::c);
    list.SetStringEx(0, "Some string1", SomeStruct::textLong, sizeof(SomeStruct::textLong));
    list.SetStringEx(0, "abc", SomeStruct::textShort, sizeof(SomeStruct::textShort));
    PrintList("Normal usage", list);

    // Empty strings
    list.Set(0, 2147483647, SomeStruct::a);
    list.Set(0, 2147483647, SomeStruct::b);
    list.Set(0, 2147483647, SomeStruct::c);
    list.SetStringEx(0, "", SomeStruct::textLong, sizeof(SomeStruct::textLong));
    list.SetStringEx(0, "", SomeStruct::textShort, sizeof(SomeStruct::textShort));
    PrintList("Empty strings", list);

    // Oversized strings
    list.Set(0, 2147483647, SomeStruct::a);
    list.Set(0, 2147483647, SomeStruct::b);
    list.Set(0, 2147483647, SomeStruct::c);
    list.SetStringEx(0, "Some string2 that is very much too large", SomeStruct::textLong, sizeof(SomeStruct::textLong));
    list.SetStringEx(0, "def, this is also too large", SomeStruct::textShort, sizeof(SomeStruct::textShort));
    PrintList("Oversized strings", list);


    // Out of bounds block ---- Throws native error
    //list.Set(0, 2147483647, SomeStruct::a);
    //list.Set(0, 2147483647, SomeStruct::b);
    //list.Set(0, 2147483647, SomeStruct::c);
    //list.SetStringEx(0, "Some string3", SomeStruct::c + 1, sizeof(SomeStruct::textLong));
    //list.SetStringEx(0, "ghi", SomeStruct::c + 1, sizeof(SomeStruct::textShort));
    //PrintList("Out of bounds block (error)", list);

    // Non-string block ---- Bug, no error
    //list.Set(0, 2147483647, SomeStruct::a);
    //list.Set(0, 2147483647, SomeStruct::b);
    //list.Set(0, 2147483647, SomeStruct::c);
    //list.SetStringEx(0, "Some string4", SomeStruct::a, sizeof(SomeStruct::textLong));
    //PrintList("Non-string block (bug)", list);
}
```
![image](https://user-images.githubusercontent.com/13011795/147400428-2474379e-4705-44c5-805a-6712c7f4fba9.png)