### PR TITLE
Fix ArrayList return types

### DIFF
--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -159,7 +159,7 @@ methodmap ArrayList < Handle {
 	// @param value         String value to set.
 	// @return              Number of characters copied.
 	// @error               Invalid index.
-	public native void SetString(int index, const char[] value);
+	public native int SetString(int index, const char[] value);
 
 	// Sets an array of cells in an array.
 	//
@@ -169,7 +169,7 @@ methodmap ArrayList < Handle {
 	//                      blocksize.  Otherwise, the size passed is used.
 	// @return              Number of cells copied.
 	// @error               Invalid index.
-	public native void SetArray(int index, const any[] values, int size=-1);
+	public native int SetArray(int index, const any[] values, int size=-1);
 
 	// Shifts an array up.  All array contents after and including the given
 	// index are shifted up by one, and the given index is then "free."


### PR DESCRIPTION
[ArrayList.SetString](https://github.com/alliedmodders/sourcemod/blob/86363dd3ecf27d57ad1bfe01d63fee68b435291a/core/logic/smn_adt_array.cpp#L383) and [ArrayList.SetArray](https://github.com/alliedmodders/sourcemod/blob/86363dd3ecf27d57ad1bfe01d63fee68b435291a/core/logic/smn_adt_array.cpp#L416) both have int return types but their methodmap natives use void.

There might be others but I only found these 2.