### PR TITLE
SourceMod SDK: introduction into Valve memory system 

### DIFF
--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -138,6 +138,10 @@ for sdk_name in SM.sdks:
       binary.sources += pb_sources
       binary.compiler.cxxdefines += ['PROTOBUF_ENABLE']
 
+    # Instead of using the external SourceMod SDK.
+    if cxx.target.platform in ['linux', 'mac']:
+      binary.sources += [os.path.join(sdk.path, 'public', 'tier0', 'memoverride.cpp')]
+
     if cxx.target.platform == 'mac' and sdk.name in ['csgo']:
       # We need a proxy library since the game uses libstdc++.
       pb_binary = SM.HL2Library(builder, cxx, 'pbproxy.' + sdk.ext, sdk)

--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -474,8 +474,9 @@ bool SDKExtension::SDK_OnMetamodPauseChange(bool paused, char *error, size_t max
 
 #endif
 
+#if defined(__linux__) || defined(__APPLE__)
 /* Overload a few things to prevent libstdc++ linking */
-#if defined __linux__ || defined __APPLE__
+#if !defined(SOURCE_ENGINE) || defined(NO_MALLOC_OVERRIDE) || defined(META_NO_HL2SDK)
 extern "C" void __cxa_pure_virtual(void)
 {
 }
@@ -499,5 +500,7 @@ void operator delete[](void * ptr)
 {
 	free(ptr);
 }
-#endif
-
+#else
+#include <tier0/memoverride.cpp>
+#endif // !defined(SOURCE_ENGINE) || defined(NO_MALLOC_OVERRIDE) || defined(META_NO_HL2SDK)
+#endif // defined(__linux__) || defined(__APPLE__)


### PR DESCRIPTION
These changes to the overload of memory operators are necessary for components that include HL2SDK and subsequently static linking with the `tier1`! It was originally written to use the `Valve memory system` from `tier0`, so that through it there was an abstract opportunity to profile working with memory (`g_pMemAlloc`) to find leaks.

AMTL was not overloaded - it has a separate working environment with memory.