### PR TITLE
Add VProf to frame functions

### DIFF
--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -220,7 +220,7 @@ void TimerSystem::OnSourceModLevelEnd()
 
 void TimerSystem::GameFrame(bool simulating)
 {
-	VPROF("SourceMod::TimerSystem::GameFrame");
+	VPROF_ENTER_SCOPE("SourceMod::TimerSystem::GameFrame");
 
 	if (simulating && m_bHasMapTickedYet)
 	{
@@ -252,11 +252,13 @@ void TimerSystem::GameFrame(bool simulating)
 	{
 		m_pOnGameFrame->Execute(NULL);
 	}
+
+	VPROF_EXIT_SCOPE();
 }
 
 void TimerSystem::RunFrame()
 {
-	VPROF("SourceMod::TimerSystem::RunFrame");
+	VPROF_ENTER_SCOPE("SourceMod::TimerSystem::RunFrame");
 
 	ITimer *pTimer;
 	TimerIter iter;
@@ -299,6 +301,8 @@ void TimerSystem::RunFrame()
 		}
 		iter++;
 	}
+
+	VPROF_EXIT_SCOPE();
 }
 
 ITimer *TimerSystem::CreateTimer(ITimedEvent *pCallbacks, float fInterval, void *pData, int flags)

--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -36,6 +36,7 @@
 #include "ConVarManager.h"
 #include "logic_bridge.h"
 
+#define VPROF_ENABLED
 #include <tier0/vprof.h>
 
 #define TIMER_MIN_ACCURACY		0.1

--- a/core/TimerSys.cpp
+++ b/core/TimerSys.cpp
@@ -36,6 +36,8 @@
 #include "ConVarManager.h"
 #include "logic_bridge.h"
 
+#include <tier0/vprof.h>
+
 #define TIMER_MIN_ACCURACY		0.1
 
 TimerSystem g_Timers;
@@ -217,6 +219,8 @@ void TimerSystem::OnSourceModLevelEnd()
 
 void TimerSystem::GameFrame(bool simulating)
 {
+	VPROF("SourceMod::TimerSystem::GameFrame");
+
 	if (simulating && m_bHasMapTickedYet)
 	{
 		g_fUniversalTime += gpGlobals->curtime - m_fLastTickedTime;
@@ -251,6 +255,8 @@ void TimerSystem::GameFrame(bool simulating)
 
 void TimerSystem::RunFrame()
 {
+	VPROF("SourceMod::TimerSystem::RunFrame");
+
 	ITimer *pTimer;
 	TimerIter iter;
 

--- a/core/frame_hooks.cpp
+++ b/core/frame_hooks.cpp
@@ -39,6 +39,8 @@
 #include <IThreader.h>
 #include "sourcemod.h"
 
+#include <tier0/vprof.h>
+
 static IMutex *frame_mutex;
 static Queue<FrameAction> *frame_queue;
 static Queue<FrameAction> *frame_actions;
@@ -73,6 +75,8 @@ void AddFrameAction(const FrameAction & action)
 
 void RunFrameHooks(bool simulating)
 {
+	VPROF("SourceMod::RunFrameHooks");
+
 	/* It's okay if this check races. */
 	if (frame_queue->size())
 	{

--- a/core/frame_hooks.cpp
+++ b/core/frame_hooks.cpp
@@ -39,6 +39,7 @@
 #include <IThreader.h>
 #include "sourcemod.h"
 
+#define VPROF_ENABLED
 #include <tier0/vprof.h>
 
 static IMutex *frame_mutex;

--- a/core/frame_hooks.cpp
+++ b/core/frame_hooks.cpp
@@ -76,7 +76,7 @@ void AddFrameAction(const FrameAction & action)
 
 void RunFrameHooks(bool simulating)
 {
-	VPROF("SourceMod::RunFrameHooks");
+	VPROF_ENTER_SCOPE("SourceMod::RunFrameHooks");
 
 	/* It's okay if this check races. */
 	if (frame_queue->size())
@@ -124,4 +124,6 @@ void RunFrameHooks(bool simulating)
 		g_Players.RunAuthChecks();
 		g_LastAuthCheck = curtime;
 	}
+
+	VPROF_EXIT_SCOPE();
 }

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -745,10 +745,11 @@ void SourceModBase::RemoveGameFrameHook(GAME_FRAME_HOOK hook)
 
 void SourceModBase::ProcessGameFrameHooks(bool simulating)
 {
-	VPROF("SourceMod::SourceModBase::ProcessGameFrameHooks");
+	VPROF_ENTER_SCOPE("SourceMod::SourceModBase::ProcessGameFrameHooks");
 
 	if (m_frame_hooks.size() == 0)
 	{
+		VPROF_EXIT_SCOPE();
 		return;
 	}
 
@@ -756,6 +757,8 @@ void SourceModBase::ProcessGameFrameHooks(bool simulating)
 	{
 		m_frame_hooks[i](simulating);
 	}
+
+	VPROF_EXIT_SCOPE();
 }
 
 size_t SourceModBase::Format(char *buffer, size_t maxlength, const char *fmt, ...)

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -49,6 +49,8 @@
 #include <bridge/include/IProviderCallbacks.h>
 #include <bridge/include/ILogger.h>
 
+#include <tier0/vprof.h>
+
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);
 SH_DECL_HOOK0_void(IServerGameDLL, LevelShutdown, SH_NOATTRIB, false);
 SH_DECL_HOOK1_void(IServerGameDLL, GameFrame, SH_NOATTRIB, false, bool);
@@ -742,6 +744,8 @@ void SourceModBase::RemoveGameFrameHook(GAME_FRAME_HOOK hook)
 
 void SourceModBase::ProcessGameFrameHooks(bool simulating)
 {
+	VPROF("SourceMod::SourceModBase::ProcessGameFrameHooks");
+
 	if (m_frame_hooks.size() == 0)
 	{
 		return;

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -49,6 +49,7 @@
 #include <bridge/include/IProviderCallbacks.h>
 #include <bridge/include/ILogger.h>
 
+#define VPROF_ENABLED
 #include <tier0/vprof.h>
 
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);


### PR DESCRIPTION
I was wondering how much SM slows down the server.
The added VProf will only be used during profiling.
Maybe someone will come in handy.

Сan run profiling via 
```
sm prof start
```
and stop with the output of statistics in `vprof.log`
```
sm prof stop

con_logfile "vprof.log"
sm prof dump vprof
con_logfile ""
```
