### PR TITLE
Fix crash when calling TF2_IsHolidayActive while no map is running

### DIFF
--- a/extensions/tf2/natives.cpp
+++ b/extensions/tf2/natives.cpp
@@ -475,6 +475,11 @@ cell_t TF2_IsPlayerInDuel(IPluginContext *pContext, const cell_t *params)
 // native bool:TF2_IsHolidayActive(TFHoliday:holiday);
 cell_t TF2_IsHolidayActive(IPluginContext *pContext, const cell_t *params)
 {
+	if (!g_pSM->IsMapRunning())
+	{
+		return pContext->ThrowNativeError("Cannot check active holiday when no map is running");
+	}
+
 	void *pGameRules;
 	if (!g_pSDKTools || !(pGameRules = g_pSDKTools->GetGameRules()))
 	{


### PR DESCRIPTION
Currently, the server crashes when attempting to call `TF2_IsHolidayActive` while no map is running. Throw a native error instead.

Can be tested with this snippet:
```sourcepawn
#include <tf2>

public void OnEntityCreated(int entity, const char[] classname)
{
	PrintToServer("Is it Halloween? %d", TF2_IsHolidayActive(TFHoliday_HalloweenOrFullMoon));
}
```