### PR TITLE
Enable nextmap for Black Mesa

### DIFF
--- a/plugins/nextmap.sp
+++ b/plugins/nextmap.sp
@@ -65,7 +65,6 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 			|| StrEqual(game, "left4dead2", false)
 			|| StrEqual(game, "garrysmod", false)
 			|| StrEqual(game, "swarm", false)
-			|| StrEqual(game, "bms", false)
 			|| StrEqual(game, "reactivedrop", false)
 			|| engine == Engine_Insurgency
 			|| engine == Engine_DOI)


### PR DESCRIPTION
Black Mesa now ships with mapcycle.txt., so the check can be removed.
Tested and working.

https://github.com/alliedmodders/sourcemod/pull/331/commits/909598920ba28722f3612266b42416fc798a605c