### PR TITLE
Add MAX_STEAMID_LENGTH

### DIFF
--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -71,6 +71,7 @@ enum AuthIdType
 
 #define MAXPLAYERS      65  /**< Maximum number of players SourceMod supports */
 #define MAX_NAME_LENGTH 128 /**< Maximum buffer required to store a client name */
+#define MAX_AUTHID_LENGTH 64 /**< Maximum buffer required to store any AuthID type */
 
 public const int MaxClients;   /**< Maximum number of players the server supports (dynamic) */
 


### PR DESCRIPTION
I feel like this is sorely missing since I've had to define it in so many plugins I've written.

The maximum theoretical size of a 'valid' SteamID (according to the valve wiki) is 23 bytes including null `STEAM_255:1:2147483647`. 

The only exception that I know of is `STEAM_ID_STOP_IGNORING_RETVALS` which is 31\* bytes including null.

In the interest of keeping that error value meaningful, either:
- It should be changed to fit within 23 bytes, which could potentially break something for no reason.
- There should be only 1 constant for the size of a SteamID that not only fits every type of ID but also the error message.