### PR TITLE
Update Makefile

### DIFF
--- a/public/sample_ext/Makefile
+++ b/public/sample_ext/Makefile
@@ -15,6 +15,8 @@ HL2SDK_L4D2 = ../../../hl2sdk-l4d2
 HL2SDK_CSGO = ../../../hl2sdk-csgo
 MMSOURCE19 = ../../../mmsource-1.9
 
+ENGINE = 
+
 #####################################
 ### EDIT BELOW FOR OTHER PROJECTS ###
 #####################################
@@ -109,7 +111,7 @@ else
 	LIB_SUFFIX = .$(LIB_EXT)
 endif
 
-INCLUDE += -I. -I.. -Isdk -I$(SMSDK)/public -I$(SMSDK)/sourcepawn/include
+INCLUDE += -I. -I.. -Isdk -I$(SMSDK)/public -I$(SMSDK)/sourcepawn/include -I$(SMSDK)/public/amtl/amtl -I$(SMSDK)/public/amtl
 
 ifeq "$(USEMETA)" "true"
 	LINK_HL2 = $(HL2LIB)/tier1_i486.a $(LIB_PREFIX)vstdlib$(LIB_SUFFIX) $(LIB_PREFIX)tier0$(LIB_SUFFIX)
@@ -131,7 +133,7 @@ LINK += -m32 -lm -ldl
 CFLAGS += -DPOSIX -Dstricmp=strcasecmp -D_stricmp=strcasecmp -D_strnicmp=strncasecmp -Dstrnicmp=strncasecmp \
 	-D_snprintf=snprintf -D_vsnprintf=vsnprintf -D_alloca=alloca -Dstrcmpi=strcasecmp -DCOMPILER_GCC -Wall -Werror \
 	-Wno-overloaded-virtual -Wno-switch -Wno-unused -msse -DSOURCEMOD_BUILD -DHAVE_STDINT_H -m32
-CPPFLAGS += -Wno-non-virtual-dtor -fno-exceptions -fno-rtti -std=c++11
+CPPFLAGS += -Wno-non-virtual-dtor -fno-exceptions -fno-rtti -std=c++14
 
 ################################################
 ### DO NOT EDIT BELOW HERE FOR MOST PROJECTS ###


### PR DESCRIPTION
fix these bugs below:
fatal error: am-string.h: No such file or directory
fatal error: am-bits.h: No such file or directory

In file included from ../IExtensionSys.h:37,
                 from ../smsdk_ext.h:41,
                 from smsdk_ext.cpp:34:
../../public/amtl/amtl/am-string.h: In function ‘std::unique_ptr<char []> ke::detail::SprintfArgsImpl(size_t*, const char*, va_list)’:
../../public/amtl/amtl/am-string.h:110:28: error: ‘make_unique’ is not a member of ‘std’
  110 |         auto buffer = std::make_unique<char[]>(1);
      |                            ^~~~~~~~~~~
../../public/amtl/amtl/am-string.h:110:28: note: ‘std::make_unique’ is only available from C++14 onwards
../../public/amtl/amtl/am-string.h:110:40: error: expected primary-expression before ‘char’
  110 |         auto buffer = std::make_unique<char[]>(1);
      |                                        ^~~~
../../public/amtl/amtl/am-string.h:116:24: error: ‘make_unique’ is not a member of ‘std’
  116 |     auto buffer = std::make_unique<char[]>(len + 1);
      |                        ^~~~~~~~~~~
../../public/amtl/amtl/am-string.h:116:24: note: ‘std::make_unique’ is only available from C++14 onwards
../../public/amtl/amtl/am-string.h:116:36: error: expected primary-expression before ‘char’
  116 |     auto buffer = std::make_unique<char[]>(len + 1);