### PR TITLE
better CBaseEntity::m_fFlags definition

### DIFF
--- a/plugins/include/entity_prop_stocks.inc
+++ b/plugins/include/entity_prop_stocks.inc
@@ -127,42 +127,46 @@ enum RenderFx
 // Note: these are only for use with GetEntityFlags and SetEntityFlags
 //       and may not match the game's actual, internal m_fFlags values.
 // PLAYER SPECIFIC FLAGS FIRST BECAUSE WE USE ONLY A FEW BITS OF NETWORK PRECISION
-#define FL_ONGROUND              (1 << 0)   /**< At rest / on the ground */
-#define FL_DUCKING               (1 << 1)   /**< Player flag -- Player is fully crouched */
-#define FL_WATERJUMP             (1 << 2)   /**< player jumping out of water */
-#define FL_ONTRAIN               (1 << 3)   /**< Player is _controlling_ a train, so movement commands should be ignored on client during prediction. */
-#define FL_INRAIN                (1 << 4)   /**< Indicates the entity is standing in rain */
-#define FL_FROZEN                (1 << 5)   /**< Player is frozen for 3rd person camera */
-#define FL_ATCONTROLS            (1 << 6)   /**< Player can't move, but keeps key inputs for controlling another entity */
-#define FL_CLIENT                (1 << 7)   /**< Is a player */
-#define FL_FAKECLIENT            (1 << 8)   /**< Fake client, simulated server side; don't send network messages to them */
-// NOTE if you move things up, make sure to change this value
-#define PLAYER_FLAG_BITS          9
+#define	FL_ONGROUND			  	(1<<0)	// At rest / on the ground
+#define FL_DUCKING				  (1<<1)	// Player flag -- Player is fully crouched
+#define FL_ANIMDUCKING			(1<<2)	// Player flag -- Player is in the process of crouching or uncrouching but could be in transition
+                                    // examples:                                   Fully ducked:  FL_DUCKING &  FL_ANIMDUCKING
+                                    //           Previously fully ducked, unducking in progress:  FL_DUCKING & !FL_ANIMDUCKING
+                                    //                                           Fully unducked: !FL_DUCKING & !FL_ANIMDUCKING
+                                    //           Previously fully unducked, ducking in progress: !FL_DUCKING &  FL_ANIMDUCKING
+#define	FL_WATERJUMP        (1<<3)	// player jumping out of water
+#define FL_ONTRAIN		  		(1<<4) // Player is _controlling_ a train, so movement commands should be ignored on client during prediction.
+#define FL_INRAIN			    	(1<<5)	// Indicates the entity is standing in rain
+#define FL_FROZEN			    	(1<<6) // Player is frozen for 3rd person camera
+#define FL_ATCONTROLS		  	(1<<7) // Player can't move, but keeps key inputs for controlling another entity
+#define	FL_CLIENT			    	(1<<8)	// Is a player
+#define FL_FAKECLIENT		   	(1<<9)	// Fake client, simulated server side; don't send network messages to them
 // NON-PLAYER SPECIFIC (i.e., not used by GameMovement or the client .dll ) -- Can still be applied to players, though
-#define FL_INWATER               (1 << 9)   /**< In water */
-#define FL_FLY                   (1 << 10)  /**< Changes the SV_Movestep() behavior to not need to be on ground */
-#define FL_SWIM                  (1 << 11)  /**< Changes the SV_Movestep() behavior to not need to be on ground (but stay in water) */
-#define FL_CONVEYOR              (1 << 12)
-#define FL_NPC                   (1 << 13)
-#define FL_GODMODE               (1 << 14)
-#define FL_NOTARGET              (1 << 15)
-#define FL_AIMTARGET             (1 << 16)  /**< set if the crosshair needs to aim onto the entity */
-#define FL_PARTIALGROUND         (1 << 17)  /**< not all corners are valid */
-#define FL_STATICPROP            (1 << 18)  /**< Eetsa static prop!  */
-#define FL_GRAPHED               (1 << 19)  /**< worldgraph has this ent listed as something that blocks a connection */
-#define FL_GRENADE               (1 << 20)
-#define FL_STEPMOVEMENT          (1 << 21)  /**< Changes the SV_Movestep() behavior to not do any processing */
-#define FL_DONTTOUCH             (1 << 22)  /**< Doesn't generate touch functions, generates Untouch() for anything it was touching when this flag was set */
-#define FL_BASEVELOCITY          (1 << 23)  /**< Base velocity has been applied this frame (used to convert base velocity into momentum) */
-#define FL_WORLDBRUSH            (1 << 24)  /**< Not moveable/removeable brush entity (really part of the world, but represented as an entity for transparency or something) */
-#define FL_OBJECT                (1 << 25)  /**< Terrible name. This is an object that NPCs should see. Missiles, for example. */
-#define FL_KILLME                (1 << 26)  /**< This entity is marked for death -- will be freed by game DLL */
-#define FL_ONFIRE                (1 << 27)  /**< You know... */
-#define FL_DISSOLVING            (1 << 28)  /**< We're dissolving! */
-#define FL_TRANSRAGDOLL          (1 << 29)  /**< In the process of turning into a client side ragdoll. */
-#define FL_UNBLOCKABLE_BY_PLAYER (1 << 30)  /**< pusher that can't be blocked by the player */
-#define FL_FREEZING              (1 << 31)  /**< We're becoming frozen! */
-#define FL_EP2V_UNKNOWN1         (1 << 31)  /**< Unknown */
+#define	FL_INWATER			   	(1<<10)	// In water
+// NOTE if you move things up, make sure to change this value
+#define PLAYER_FLAG_BITS		11
+
+#define	FL_FLY				    	(1<<11)	// Changes the SV_Movestep() behavior to not need to be on ground
+#define	FL_SWIM				     	(1<<12)	// Changes the SV_Movestep() behavior to not need to be on ground (but stay in water)
+#define	FL_CONVEYOR			  	(1<<13)
+#define	FL_NPC				     	(1<<14)
+#define	FL_GODMODE				  (1<<15)
+#define	FL_NOTARGET			  	(1<<16)
+#define	FL_AIMTARGET			  (1<<17)	// set if the crosshair needs to aim onto the entity
+#define	FL_PARTIALGROUND	 	(1<<18)	// not all corners are valid
+#define FL_STATICPROP		   	(1<<19)	// Eetsa static prop!
+#define FL_GRAPHED			   	(1<<20) // worldgraph has this ent listed as something that blocks a connection
+#define FL_GRENADE				  (1<<21)
+#define FL_STEPMOVEMENT			(1<<22)	// Changes the SV_Movestep() behavior to not do any processing
+#define FL_DONTTOUCH		  	(1<<23)	// Doesn't generate touch functions, generates Untouch() for anything it was touching when this flag was set
+#define FL_BASEVELOCITY			(1<<24)	// Base velocity has been applied this frame (used to convert base velocity into momentum)
+#define FL_WORLDBRUSH		   	(1<<25)	// Not moveable/removeable brush entity (really part of the world, but represented as an entity for transparency or something)
+#define FL_OBJECT			    	(1<<26) // Terrible name. This is an object that NPCs should see. Missiles, for example.
+#define FL_KILLME			    	(1<<27)	// This entity is marked for death -- will be freed by game DLL
+#define FL_ONFIRE			    	(1<<28)	// You know...
+#define FL_DISSOLVING		   	(1<<29) // We're dissolving!
+#define FL_TRANSRAGDOLL			(1<<30) // In the process of turning into a client side ragdoll.
+#define FL_UNBLOCKABLE_BY_PLAYER (1<<31) // pusher that can't be blocked by the player
 // END entity flag #defines
 
 /**

--- a/plugins/include/entity_prop_stocks.inc
+++ b/plugins/include/entity_prop_stocks.inc
@@ -127,48 +127,48 @@ enum RenderFx
 // Note: these are only for use with GetEntityFlags and SetEntityFlags
 //       and may not match the game's actual, internal m_fFlags values.
 // PLAYER SPECIFIC FLAGS FIRST BECAUSE WE USE ONLY A FEW BITS OF NETWORK PRECISION
-#define	FL_ONGROUND              (1<<0)   /**< At rest / on the ground */
-#define FL_DUCKING               (1<<1)   /**< Player flag -- Player is fully crouched */
-#define FL_ANIMDUCKING           (1<<2)   /**< Player flag -- Player is in the process of crouching or uncrouching but could be in transition */
+#define	FL_ONGROUND              (1 << 0)   /**< At rest / on the ground */
+#define FL_DUCKING               (1 << 1)   /**< Player flag -- Player is fully crouched */
+#define FL_ANIMDUCKING           (1 << 2)   /**< Player flag -- Player is in the process of crouching or uncrouching but could be in transition */
                                  // examples:                                   Fully ducked:  FL_DUCKING &  FL_ANIMDUCKING
                                  //           Previously fully ducked, unducking in progress:  FL_DUCKING & !FL_ANIMDUCKING
                                  //                                           Fully unducked: !FL_DUCKING & !FL_ANIMDUCKING
                                  //           Previously fully unducked, ducking in progress: !FL_DUCKING &  FL_ANIMDUCKING
-#define	FL_WATERJUMP             (1<<3)   /**< player jumping out of water */
-#define FL_ONTRAIN               (1<<4)   /**< Player is _controlling_ a train, so movement commands should be ignored on client during prediction. */
-#define FL_INRAIN                (1<<5)   /**< Indicates the entity is standing in rain */
-#define FL_FROZEN                (1<<6)   /**< Player is frozen for 3rd person camera */
-#define FL_ATCONTROLS            (1<<7)   /**< Player can't move, but keeps key inputs for controlling another entity */
-#define	FL_CLIENT                (1<<8)   /**< Is a player */
-#define FL_FAKECLIENT            (1<<9)   /**< Fake client, simulated server side; don't send network messages to them */
+#define	FL_WATERJUMP             (1 << 3)   /**< player jumping out of water */
+#define FL_ONTRAIN               (1 << 4)   /**< Player is _controlling_ a train, so movement commands should be ignored on client during prediction. */
+#define FL_INRAIN                (1 << 5)   /**< Indicates the entity is standing in rain */
+#define FL_FROZEN                (1 << 6)   /**< Player is frozen for 3rd person camera */
+#define FL_ATCONTROLS            (1 << 7)   /**< Player can't move, but keeps key inputs for controlling another entity */
+#define	FL_CLIENT                (1 << 8)   /**< Is a player */
+#define FL_FAKECLIENT            (1 << 9)   /**< Fake client, simulated server side; don't send network messages to them */
 // NON-PLAYER SPECIFIC (i.e., not used by GameMovement or the client .dll ) -- Can still be applied to players, though
-#define	FL_INWATER               (1<<10)  /**< In water */
+#define	FL_INWATER               (1 << 10)  /**< In water */
 // NOTE if you move things up, make sure to change this value
 #define PLAYER_FLAG_BITS          11
-#define	FL_FLY                   (1<<11)   /**< Changes the SV_Movestep() behavior to not need to be on ground */
-#define	FL_SWIM                  (1<<12)   /**< Changes the SV_Movestep() behavior to not need to be on ground (but stay in water) */
-#define	FL_CONVEYOR              (1<<13)
-#define	FL_NPC                   (1<<14)
-#define	FL_GODMODE               (1<<15)
-#define	FL_NOTARGET              (1<<16)
-#define	FL_AIMTARGET             (1<<17)   /**< set if the crosshair needs to aim onto the entity */
-#define	FL_PARTIALGROUND         (1<<18)   /**< not all corners are valid */
-#define FL_STATICPROP            (1<<19)   /**< Eetsa static prop! */
-#define FL_GRAPHED               (1<<20)   /**< worldgraph has this ent listed as something that blocks a connection */
-#define FL_GRENADE               (1<<21)
-#define FL_STEPMOVEMENT          (1<<22)   /**< Changes the SV_Movestep() behavior to not do any processing */
-#define FL_DONTTOUCH             (1<<23)   /**< Doesn't generate touch functions, generates Untouch() for anything it was touching when this flag was set */
-#define FL_BASEVELOCITY          (1<<24)   /**< Base velocity has been applied this frame (used to convert base velocity into momentum) */
-#define FL_WORLDBRUSH            (1<<25)   /**< Not moveable/removeable brush entity (really part of the world, but represented as an entity for transparency or something) */
-#define FL_OBJECT                (1<<26)   /**< Terrible name. This is an object that NPCs should see. Missiles, for example. */
-#define FL_KILLME                (1<<27)   /**< This entity is marked for death -- will be freed by game DLL */
-#define FL_ONFIRE                (1<<28)   /**< You know... */
-#define FL_DISSOLVING            (1<<29)   /**< We're dissolving! */
-#define FL_TRANSRAGDOLL          (1<<30)   /**< In the process of turning into a client side ragdoll. */
-#define FL_UNBLOCKABLE_BY_PLAYER (1<<31)   /**< pusher that can't be blocked by the player */
+#define	FL_FLY                   (1 << 11)   /**< Changes the SV_Movestep() behavior to not need to be on ground */
+#define	FL_SWIM                  (1 << 12)   /**< Changes the SV_Movestep() behavior to not need to be on ground (but stay in water) */
+#define	FL_CONVEYOR              (1 << 13)
+#define	FL_NPC                   (1 << 14)
+#define	FL_GODMODE               (1 << 15)
+#define	FL_NOTARGET              (1 << 16)
+#define	FL_AIMTARGET             (1 << 17)   /**< set if the crosshair needs to aim onto the entity */
+#define	FL_PARTIALGROUND         (1 << 18)   /**< not all corners are valid */
+#define FL_STATICPROP            (1 << 19)   /**< Eetsa static prop! */
+#define FL_GRAPHED               (1 << 20)   /**< worldgraph has this ent listed as something that blocks a connection */
+#define FL_GRENADE               (1 << 21)
+#define FL_STEPMOVEMENT          (1 << 22)   /**< Changes the SV_Movestep() behavior to not do any processing */
+#define FL_DONTTOUCH             (1 << 23)   /**< Doesn't generate touch functions, generates Untouch() for anything it was touching when this flag was set */
+#define FL_BASEVELOCITY          (1 << 24)   /**< Base velocity has been applied this frame (used to convert base velocity into momentum) */
+#define FL_WORLDBRUSH            (1 << 25)   /**< Not moveable/removeable brush entity (really part of the world, but represented as an entity for transparency or something) */
+#define FL_OBJECT                (1 << 26)   /**< Terrible name. This is an object that NPCs should see. Missiles, for example. */
+#define FL_KILLME                (1 << 27)   /**< This entity is marked for death -- will be freed by game DLL */
+#define FL_ONFIRE                (1 << 28)   /**< You know... */
+#define FL_DISSOLVING            (1 << 29)   /**< We're dissolving! */
+#define FL_TRANSRAGDOLL          (1 << 30)   /**< In the process of turning into a client side ragdoll. */
+#define FL_UNBLOCKABLE_BY_PLAYER (1 << 31)   /**< pusher that can't be blocked by the player */
 // backwards compatibility
-#define FL_FREEZING              (1<<31)
-#define FL_EP2V_UNKNOWN1         (1<<31)
+#define FL_FREEZING              (1 << 31)
+#define FL_EP2V_UNKNOWN1         (1 << 31)
 // END entity flag #defines
 
 /**

--- a/plugins/include/entity_prop_stocks.inc
+++ b/plugins/include/entity_prop_stocks.inc
@@ -127,46 +127,48 @@ enum RenderFx
 // Note: these are only for use with GetEntityFlags and SetEntityFlags
 //       and may not match the game's actual, internal m_fFlags values.
 // PLAYER SPECIFIC FLAGS FIRST BECAUSE WE USE ONLY A FEW BITS OF NETWORK PRECISION
-#define	FL_ONGROUND			  	(1<<0)	// At rest / on the ground
-#define FL_DUCKING				  (1<<1)	// Player flag -- Player is fully crouched
-#define FL_ANIMDUCKING			(1<<2)	// Player flag -- Player is in the process of crouching or uncrouching but could be in transition
-                                    // examples:                                   Fully ducked:  FL_DUCKING &  FL_ANIMDUCKING
-                                    //           Previously fully ducked, unducking in progress:  FL_DUCKING & !FL_ANIMDUCKING
-                                    //                                           Fully unducked: !FL_DUCKING & !FL_ANIMDUCKING
-                                    //           Previously fully unducked, ducking in progress: !FL_DUCKING &  FL_ANIMDUCKING
-#define	FL_WATERJUMP        (1<<3)	// player jumping out of water
-#define FL_ONTRAIN		  		(1<<4) // Player is _controlling_ a train, so movement commands should be ignored on client during prediction.
-#define FL_INRAIN			    	(1<<5)	// Indicates the entity is standing in rain
-#define FL_FROZEN			    	(1<<6) // Player is frozen for 3rd person camera
-#define FL_ATCONTROLS		  	(1<<7) // Player can't move, but keeps key inputs for controlling another entity
-#define	FL_CLIENT			    	(1<<8)	// Is a player
-#define FL_FAKECLIENT		   	(1<<9)	// Fake client, simulated server side; don't send network messages to them
+#define	FL_ONGROUND              (1<<0)   /**< At rest / on the ground */
+#define FL_DUCKING               (1<<1)   /**< Player flag -- Player is fully crouched */
+#define FL_ANIMDUCKING           (1<<2)   /**< Player flag -- Player is in the process of crouching or uncrouching but could be in transition */
+                                 // examples:                                   Fully ducked:  FL_DUCKING &  FL_ANIMDUCKING
+                                 //           Previously fully ducked, unducking in progress:  FL_DUCKING & !FL_ANIMDUCKING
+                                 //                                           Fully unducked: !FL_DUCKING & !FL_ANIMDUCKING
+                                 //           Previously fully unducked, ducking in progress: !FL_DUCKING &  FL_ANIMDUCKING
+#define	FL_WATERJUMP             (1<<3)   /**< player jumping out of water */
+#define FL_ONTRAIN               (1<<4)   /**< Player is _controlling_ a train, so movement commands should be ignored on client during prediction. */
+#define FL_INRAIN                (1<<5)   /**< Indicates the entity is standing in rain */
+#define FL_FROZEN                (1<<6)   /**< Player is frozen for 3rd person camera */
+#define FL_ATCONTROLS            (1<<7)   /**< Player can't move, but keeps key inputs for controlling another entity */
+#define	FL_CLIENT                (1<<8)   /**< Is a player */
+#define FL_FAKECLIENT            (1<<9)   /**< Fake client, simulated server side; don't send network messages to them */
 // NON-PLAYER SPECIFIC (i.e., not used by GameMovement or the client .dll ) -- Can still be applied to players, though
-#define	FL_INWATER			   	(1<<10)	// In water
+#define	FL_INWATER               (1<<10)  /**< In water */
 // NOTE if you move things up, make sure to change this value
-#define PLAYER_FLAG_BITS		11
-
-#define	FL_FLY				    	(1<<11)	// Changes the SV_Movestep() behavior to not need to be on ground
-#define	FL_SWIM				     	(1<<12)	// Changes the SV_Movestep() behavior to not need to be on ground (but stay in water)
-#define	FL_CONVEYOR			  	(1<<13)
-#define	FL_NPC				     	(1<<14)
-#define	FL_GODMODE				  (1<<15)
-#define	FL_NOTARGET			  	(1<<16)
-#define	FL_AIMTARGET			  (1<<17)	// set if the crosshair needs to aim onto the entity
-#define	FL_PARTIALGROUND	 	(1<<18)	// not all corners are valid
-#define FL_STATICPROP		   	(1<<19)	// Eetsa static prop!
-#define FL_GRAPHED			   	(1<<20) // worldgraph has this ent listed as something that blocks a connection
-#define FL_GRENADE				  (1<<21)
-#define FL_STEPMOVEMENT			(1<<22)	// Changes the SV_Movestep() behavior to not do any processing
-#define FL_DONTTOUCH		  	(1<<23)	// Doesn't generate touch functions, generates Untouch() for anything it was touching when this flag was set
-#define FL_BASEVELOCITY			(1<<24)	// Base velocity has been applied this frame (used to convert base velocity into momentum)
-#define FL_WORLDBRUSH		   	(1<<25)	// Not moveable/removeable brush entity (really part of the world, but represented as an entity for transparency or something)
-#define FL_OBJECT			    	(1<<26) // Terrible name. This is an object that NPCs should see. Missiles, for example.
-#define FL_KILLME			    	(1<<27)	// This entity is marked for death -- will be freed by game DLL
-#define FL_ONFIRE			    	(1<<28)	// You know...
-#define FL_DISSOLVING		   	(1<<29) // We're dissolving!
-#define FL_TRANSRAGDOLL			(1<<30) // In the process of turning into a client side ragdoll.
-#define FL_UNBLOCKABLE_BY_PLAYER (1<<31) // pusher that can't be blocked by the player
+#define PLAYER_FLAG_BITS          11
+#define	FL_FLY                   (1<<11)   /**< Changes the SV_Movestep() behavior to not need to be on ground */
+#define	FL_SWIM                  (1<<12)   /**< Changes the SV_Movestep() behavior to not need to be on ground (but stay in water) */
+#define	FL_CONVEYOR              (1<<13)
+#define	FL_NPC                   (1<<14)
+#define	FL_GODMODE               (1<<15)
+#define	FL_NOTARGET              (1<<16)
+#define	FL_AIMTARGET             (1<<17)   /**< set if the crosshair needs to aim onto the entity */
+#define	FL_PARTIALGROUND         (1<<18)   /**< not all corners are valid */
+#define FL_STATICPROP            (1<<19)   /**< Eetsa static prop! */
+#define FL_GRAPHED               (1<<20)   /**< worldgraph has this ent listed as something that blocks a connection */
+#define FL_GRENADE               (1<<21)
+#define FL_STEPMOVEMENT          (1<<22)   /**< Changes the SV_Movestep() behavior to not do any processing */
+#define FL_DONTTOUCH             (1<<23)   /**< Doesn't generate touch functions, generates Untouch() for anything it was touching when this flag was set */
+#define FL_BASEVELOCITY          (1<<24)   /**< Base velocity has been applied this frame (used to convert base velocity into momentum) */
+#define FL_WORLDBRUSH            (1<<25)   /**< Not moveable/removeable brush entity (really part of the world, but represented as an entity for transparency or something) */
+#define FL_OBJECT                (1<<26)   /**< Terrible name. This is an object that NPCs should see. Missiles, for example. */
+#define FL_KILLME                (1<<27)   /**< This entity is marked for death -- will be freed by game DLL */
+#define FL_ONFIRE                (1<<28)   /**< You know... */
+#define FL_DISSOLVING            (1<<29)   /**< We're dissolving! */
+#define FL_TRANSRAGDOLL          (1<<30)   /**< In the process of turning into a client side ragdoll. */
+#define FL_UNBLOCKABLE_BY_PLAYER (1<<31)   /**< pusher that can't be blocked by the player */
+// backwards compatibility
+#define FL_FREEZING              (1<<31)
+#define FL_EP2V_UNKNOWN1         (1<<31)
 // END entity flag #defines
 
 /**


### PR DESCRIPTION
Previously FL_ANIMDUCKING was missing and the entire definition list was shifted by 1 after FL_DUCKING.