### PR TITLE
Load plugins marked as dependencies before their dependents

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1138,6 +1138,8 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 						Purge(found);
 						found->FinishEviction();
 					}
+					pPlugin->EvictWithError(Plugin_Failed, "Could not find required plugin \"%s\"", name);
+					return false;
 				}
 				found->AddDependent(pPlugin);
 			}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1125,10 +1125,6 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 						break;
 					}
 				}
-				if (!found) {
-					pPlugin->EvictWithError(Plugin_Failed, "Could not find required plugin \"%s\"", name);
-					return false;
-				}
 
 				/* Ensure required plugins finish loading before their dependents */
 				if (found->GetStatus() == Plugin_Loaded) {
@@ -1137,7 +1133,11 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 						g_Logger.LogError("[SM] Unable to load plugin \"%s\": %s", found->GetFilename(), found->GetErrorMsg());
 						Purge(found);
 						found->FinishEviction();
+						found = nullptr;
 					}
+				}
+
+				if (!found) {
 					pPlugin->EvictWithError(Plugin_Failed, "Could not find required plugin \"%s\"", name);
 					return false;
 				}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1130,6 +1130,15 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 					return false;
 				}
 
+				/* Ensure required plugins finish loading before their dependencies */
+				if (found->GetStatus() == Plugin_Loaded) {
+					char error[256] = {0};
+					if (!RunSecondPass(found)) {
+						g_Logger.LogError("[SM] Unable to load plugin \"%s\": %s", found->GetFilename(), found->GetErrorMsg());
+						Purge(found);
+						found->FinishEviction();
+					}
+				}
 				found->AddDependent(pPlugin);
 			}
 		}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1130,7 +1130,7 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 					return false;
 				}
 
-				/* Ensure required plugins finish loading before their dependencies */
+				/* Ensure required plugins finish loading before their dependents */
 				if (found->GetStatus() == Plugin_Loaded) {
 					char error[256] = {0};
 					if (!RunSecondPass(found)) {

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -1127,7 +1127,7 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 				}
 
 				/* Ensure required plugins finish loading before their dependents */
-				if (found->GetStatus() == Plugin_Loaded) {
+				if (found && found->GetStatus() == Plugin_Loaded) {
 					char error[256] = {0};
 					if (!RunSecondPass(found)) {
 						g_Logger.LogError("[SM] Unable to load plugin \"%s\": %s", found->GetFilename(), found->GetErrorMsg());
@@ -1141,6 +1141,7 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 					pPlugin->EvictWithError(Plugin_Failed, "Could not find required plugin \"%s\"", name);
 					return false;
 				}
+
 				found->AddDependent(pPlugin);
 			}
 		}


### PR DESCRIPTION
Fixes the root issue of nosoop/SM-TFEconDataCompat#4 ([comment](https://github.com/nosoop/SM-TFEconDataCompat/issues/4#issuecomment-1030630455)), among others.

Given a plugin that depends on a shared plugin that depends on an extension native, the dependent plugin is initialized before the shared plugin.  The dependent plugin may call into the shared plugin at `OnPluginStart`, which will fail since the natives the shared plugin depends on aren't bound.

This patch forces the second loading pass on the plugin's dependencies before its own second loading pass completes.

Compiled and tested this patch on my test TF2 instance with no known side effects.