### PR TITLE
Fix FindSendPropOffs with SendPropArray props

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -818,6 +818,12 @@ static cell_t FindSendPropOffs(IPluginContext *pContext, const cell_t *params)
 		return -1;
 	}
 
+	// Before we added support for DPT_Array props, FindInSendTable would have given us the inner array prop itself.
+	// To maintain compatibility with older plugins still using us, pluck out the inner array prop ourselves.
+	if (pSend->GetType() == DPT_Array && pSend->GetArrayProp()) {
+		return pSend->GetArrayProp()->GetOffset();
+	}
+
 	return pSend->GetOffset();
 }
 


### PR DESCRIPTION
FindSendPropOffs is deprecated and FindSendPropInfo behaves correctly
here, but there are still a lot of old plugins using FindSendPropOffs.
One of the SendPropArray props broken by the changes here is
m_hViewModel which there are known plugins in the wild accessing.

Resolves #1701.

<details>
<summary>This shows the output of FindSendPropInfo and FindSendPropOffs for a SendPropArray prop, a SendPropArray3 prop, and a SendPropArray2 prop (and its separate inner prop manually looked up).</summary>

Code:

```sourcepawn
#include <sdktools>

public void OnPluginStart() {
    DumpPropInfo("CBasePlayer", "m_hViewModel"); // SendPropArray
    DumpPropInfo("CBasePlayer", "m_hMyWeapons"); // SendPropArray3
    DumpPropInfo("CTeam", "\"player_array\""); // SendPropArray2
    DumpPropInfo("CTeam", "player_array_element"); // SendPropArray2 inner element
}

void DumpPropInfo(const char[] classname, const char[] propname) {
    PropFieldType type;
    int num_bits;
    int local_offset;
    int array_size;
    int offset = FindSendPropInfo(classname, propname, type, num_bits, local_offset, array_size);
    PrintToServer("%s::%s, offset = %d, type = %d, bits = %d, local = %d, length = %d", classname, propname, offset, type, num_bits, local_offset, array_size);

    int legacy_offset = FindSendPropOffs(classname, propname);
    PrintToServer("%s::%s, legacy offset = %d", classname, propname, legacy_offset);
}
```

1.10:

```
CBasePlayer::m_hViewModel, offset = 3416, type = 1, bits = 21, local = 3416, length = 0
CBasePlayer::m_hViewModel, legacy offset = 3416
CBasePlayer::m_hMyWeapons, offset = 1860, type = 0, bits = 0, local = 1860, length = 0
CBasePlayer::m_hMyWeapons, legacy offset = 1860
CTeam::"player_array", offset = 0, type = 0, bits = 0, local = 0, length = 0
CTeam::"player_array", legacy offset = 0
CTeam::player_array_element, offset = 0, type = 1, bits = 10, local = 0, length = 0
CTeam::player_array_element, legacy offset = 0
```

1.11 pre-fix:

```
CBasePlayer::m_hViewModel, offset = 3416, type = 1, bits = 21, local = 3416, length = 2
CBasePlayer::m_hViewModel, legacy offset = 0
CBasePlayer::m_hMyWeapons, offset = 1860, type = 1, bits = 21, local = 1860, length = 48
CBasePlayer::m_hMyWeapons, legacy offset = 1860
CTeam::"player_array", offset = 0, type = 1, bits = 10, local = 0, length = 33
CTeam::"player_array", legacy offset = 0
CTeam::player_array_element, offset = -1, type = 0, bits = 0, local = 0, length = 0
CTeam::player_array_element, legacy offset = -1
```

1.11 post-fix:

```
CBasePlayer::m_hViewModel, offset = 3416, type = 1, bits = 21, local = 3416, length = 2
CBasePlayer::m_hViewModel, legacy offset = 3416
CBasePlayer::m_hMyWeapons, offset = 1860, type = 1, bits = 21, local = 1860, length = 48
CBasePlayer::m_hMyWeapons, legacy offset = 1860
CTeam::"player_array", offset = 0, type = 1, bits = 10, local = 0, length = 33
CTeam::"player_array", legacy offset = 0
CTeam::player_array_element, offset = -1, type = 0, bits = 0, local = 0, length = 0
CTeam::player_array_element, legacy offset = -1
```
</details>