### PR TITLE
ZPS: Add missing offsets

### DIFF
--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -516,25 +516,19 @@ static cell_t ForcePlayerSuicide(IPluginContext *pContext, const cell_t *params)
 			return pContext->ThrowNativeError("\"CommitSuicide\" wrapper failed to initialize");
 		}
 	}
-#if SOURCE_ENGINE == SE_SDK2013
+	bool bForce = false;
 	if (!strcmp(g_pSM->GetGameFolderName(), "zps"))
 	{
-		START_CALL();
-		DECODE_VALVE_PARAM(1, thisinfo, 0);
-		*(bool *)(vptr + pCall->vparams[0].offset) = false;
-		*(bool *)(vptr + pCall->vparams[1].offset) = true;
-		FINISH_CALL_SIMPLE(NULL);
+		// ZPS requires force to be set as true otherwise the action itself is delayed.
+		// Which affects Slay and Timebomb.
+		bForce = true;
 	}
-	else
-	{
-		START_CALL();
-		DECODE_VALVE_PARAM(1, thisinfo, 0);
-		*(bool *)(vptr + pCall->vparams[0].offset) = false;
-		*(bool *)(vptr + pCall->vparams[1].offset) = false;
-		FINISH_CALL_SIMPLE(NULL);
-	}
-#endif // SDK2013
 
+	START_CALL();
+	DECODE_VALVE_PARAM(1, thisinfo, 0);
+	*(bool *)(vptr + pCall->vparams[0].offset) = false;
+	*(bool *)(vptr + pCall->vparams[1].offset) = bForce;
+	FINISH_CALL_SIMPLE(NULL);
 	return 1;
 }
 #else

--- a/gamedata/sdkhooks.games/game.zpanic.txt
+++ b/gamedata/sdkhooks.games/game.zpanic.txt
@@ -6,28 +6,28 @@
 		{
 			"EndTouch"
 			{
-				"windows"	"110"
-				"linux"		"111"
+				"windows"	"107"
+				"linux"		"108"
 			}
 			"FireBullets"
 			{
-				"windows"	"124"
-				"linux"		"124"
+				"windows"	"121"
+				"linux"		"121"
 			}
 			"OnTakeDamage"
 			{
-				"windows"	"72"
-				"linux"		"73"
+				"windows"	"69"
+				"linux"		"70"
 			}
 			"PreThink"
 			{
-				"windows"	"351"
-				"linux"		"352"
+				"windows"	"348"
+				"linux"		"349"
 			}
 			"PostThink"
 			{
-				"windows"	"352"
-				"linux"		"353"
+				"windows"	"349"
+				"linux"		"350"
 			}
 			"SetTransmit"
 			{
@@ -46,8 +46,8 @@
 			}
 			"StartTouch"
 			{
-				"windows"	"108"
-				"linux"		"109"
+				"windows"	"105"
+				"linux"		"106"
 			}
 			"Think"
 			{
@@ -56,48 +56,48 @@
 			}
 			"Touch"
 			{
-				"windows"	"109"
-				"linux"		"110"
+				"windows"	"106"
+				"linux"		"107"
 			}
 			"TraceAttack"
 			{
-				"windows"	"70"
-				"linux"		"71"
+				"windows"	"67"
+				"linux"		"68"
 			}
 			"Use"
 			{
-				"windows"	"107"
-				"linux"		"108"
+				"windows"	"104"
+				"linux"		"105"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"171"
-				"linux"		"172"
+				"windows"	"168"
+				"linux"		"169"
 			}
 			"Weapon_CanSwitchTo"
-			{
-				"windows"	"281"
-				"linux"		"282"
-			}
-			"Weapon_CanUse"
-			{
-				"windows"	"275"
-				"linux"		"276"
-			}
-			"Weapon_Drop"
 			{
 				"windows"	"278"
 				"linux"		"279"
 			}
+			"Weapon_CanUse"
+			{
+				"windows"	"272"
+				"linux"		"273"
+			}
+			"Weapon_Drop"
+			{
+				"windows"	"275"
+				"linux"		"276"
+			}
 			"Weapon_Equip"
 			{
-				"windows"	"276"
-				"linux"		"277"
+				"windows"	"273"
+				"linux"		"274"
 			}
 			"Weapon_Switch"
 			{
-				"windows"	"279"
-				"linux"		"280"
+				"windows"	"276"
+				"linux"		"277"
 			}
 		}
 	}

--- a/gamedata/sdkhooks.games/game.zpanic.txt
+++ b/gamedata/sdkhooks.games/game.zpanic.txt
@@ -4,6 +4,31 @@
 	{
 		"Offsets"
 		{
+			"GroundEntChanged"
+			{
+				"windows"	"188"
+				"linux"		"190"
+			}
+			"OnTakeDamage_Alive"
+			{
+				"windows"	"287"
+				"linux"		"288"
+			}
+			"GetMaxHealth"
+			{
+				"windows"	"126"
+				"linux"		"127"
+			}
+			"Blocked"
+			{
+				"windows"	"109"
+				"linux"		"110"
+			}
+			"Reload"
+			{
+				"windows"	"287"
+				"linux"		"288"
+			}
 			"EndTouch"
 			{
 				"windows"	"107"

--- a/gamedata/sdktools.games/game.zpanic.txt
+++ b/gamedata/sdktools.games/game.zpanic.txt
@@ -18,48 +18,48 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"420"
-				"linux"		"421"
+				"windows"	"417"
+				"linux"		"418"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"288"
-				"linux"		"289"
+				"windows"	"285"
+				"linux"		"286"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"283"
-				"linux"		"284"
+				"windows"	"280"
+				"linux"		"281"
 			}
 			"Ignite"
 			{
-				"windows"	"223"
-				"linux"		"224"
+				"windows"	"220"
+				"linux"		"221"
 			}
 			"Extinguish"
 			{
-				"windows"	"227"
-				"linux"		"228"
+				"windows"	"224"
+				"linux"		"225"
 			}
 			"Teleport"
 			{
-				"windows"	"118"
-				"linux"		"119"
+				"windows"	"115"
+				"linux"		"116"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"461"
-				"linux"		"461"
+				"windows"	"453"
+				"linux"		"453"
 			}
 			"GetVelocity"
 			{
-				"windows"	"154"
-				"linux"		"155"
+				"windows"	"151"
+				"linux"		"152"
 			}
 			"EyeAngles"
 			{
-				"windows"	"145"
-				"linux"		"146"
+				"windows"	"142"
+				"linux"		"143"
 			}
 			"AcceptInput"
 			{
@@ -73,8 +73,8 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"276"
-				"linux"		"277"
+				"windows"	"273"
+				"linux"		"274"
 			}
 			"Activate"
 			{
@@ -83,13 +83,13 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"440"
-				"linux"		"441"
+				"windows"	"433"
+				"linux"		"434"
 			}
 			"GetAttachment"
 			{
-				"windows"	"219"
-				"linux"		"220"
+				"windows"	"216"
+				"linux"		"217"
 			}
 			"SetOwnerEntity"
 			{
@@ -102,7 +102,7 @@
 			"FireOutput"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x81\xEC\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\xC5\x89\x2A\x2A\x53\x8B\x5D\x2A\x8B\xC1\x8B\x2A\x2A\x56\x57"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x30\x01\x00\x00\xA1\x2A\x2A\x2A\x2A\x33\xC5\x89\x45\xFC\x53\x8B\x5D\x20"
 				"linux"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
 			}
 			"LookupAttachment"

--- a/gamedata/sdktools.games/game.zpanic.txt
+++ b/gamedata/sdktools.games/game.zpanic.txt
@@ -96,6 +96,11 @@
 				"windows"	"25"
 				"linux"		"26"
 			}
+			"GiveAmmo"
+			{
+				"windows"	"264"
+				"linux"		"265"
+			}
 		}
 		"Signatures"
 		{

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -71,6 +71,7 @@ enum AuthIdType
 
 #define MAXPLAYERS      65  /**< Maximum number of players SourceMod supports */
 #define MAX_NAME_LENGTH 128 /**< Maximum buffer required to store a client name */
+#define MAX_AUTHID_LENGTH 64 /**< Maximum buffer required to store any AuthID type */
 
 public const int MaxClients;   /**< Maximum number of players the server supports (dynamic) */
 


### PR DESCRIPTION
Adds support for the SDKHook Types: OnTakeDamage_Alive, GroundEntChanged, GetMaxHealth, Blocked and Reload.
Adds support for GivePlayerAmmo native.

I would have added them earlier but wasn't aware they were missing entirely.