### PR TITLE
Fix Int64ToString producing incorrect output

### DIFF
--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -170,7 +170,7 @@ static cell_t Int64ToString(IPluginContext *pCtx, const cell_t *params)
 	char *str;
 	pCtx->LocalToPhysAddr(params[1], &num);
 	pCtx->LocalToString(params[2], &str);
-	size_t res = ke::SafeSprintf(str, params[3], "%" KE_FMT_I64, (int64_t)num[1] << 32ll | (int64_t)num[0]);
+	size_t res = ke::SafeSprintf(str, params[3], "%" KE_FMT_I64, (uint64_t)num[1] << 32ll | (uint32_t)num[0]);
 
 	return static_cast<cell_t>(res);
 }


### PR DESCRIPTION
The `Int64ToString` method introduced in https://github.com/alliedmodders/sourcemod/commit/f603b7aec3219e0db56882447b35a57 does not currently operate as expected/produce the correct output for certain values. This PR adjusts the typecasts to ensure that the bitwise OR operation works as expected.

The following string inputs (fed through `StringToInt64` first) result in the following string outputs prior to this patch:

* in: -9999999999 / out: -1410065407
* in: 2286852952 / out: -2008114344
* in: 4294967295 / out: -1

While the second and third examples technically fit within 32 bits, because all ints in pawn are signed, the most significant bit is used for two's complement. This means that any value between the int32 max (2,147,483,647) and the uint32 max (4,294,967,295) must be stored within an int64 in pawn in order to get reliable string output.

Sample reproduction code:
```c
char[] input = "2286852952";

int value[2];
StringToInt64(input, value);

char output[32];
Int64ToString(value, output, sizeof(output));

PrintToServer("in: %s / out: %s", input, output);
```