### PR TITLE
Remove incorrect note on DynamicHook.RemoveHook docs

### DIFF
--- a/plugins/include/dhooks.inc
+++ b/plugins/include/dhooks.inc
@@ -546,8 +546,7 @@ methodmap DynamicHook < DHookSetup
 	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
 	public native int HookRaw(HookMode mode, Address addr, DHookCallback callback);
 
-	// Remove hook by hook id:
-	// This will NOT fire the removal callback!
+	// Remove hook by hook id.
 	//
 	// @param hookid        Hook id to remove.
 	//
@@ -778,7 +777,6 @@ native int DHookRaw(Handle setup, bool post, Address addr, DHookRemovalCB remova
  * @param hookid            Hook id to remove
  *
  * @return                  true on success, false otherwise
- * @note                    This will not fire the removal callback!
  */
 native bool DHookRemoveHookID(int hookid);
 


### PR DESCRIPTION
`DynamicHook.RemoveHook` fires the removal callback despite its documentation saying otherwise.

This was briefly discussed in the AM guild:
> [4:38 AM] Mikusch: Am I going crazy or is the documentation for DynamicHook.RemoveHook lying to me
> [4:42 AM] Mikusch: @Peace-Maker Is the documentation or implementation wrong?
> [9:00 AM] Peace-Maker: Looks like the documentation, but I didn't write that code @Dr!fter
> [10:27 AM] Dr!fter: Indeed documentation. Not sure which should be fixed. Probably docs?
> [11:19 AM] Peace-Maker: I think so too. Was there a reason the callback shouldn't be called when a hook gets removed by that native? I don't see one
> [11:20 AM] Dr!fter: Not that I can think of.
> [11:21 AM] Dr!fter: In fact it would reduce duplicate code since if you do something in the callback you would have to do the same when removed