### PR TITLE
Add native IsClientAdminChecked to expose m_bAdminCheckSignalled

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -2393,6 +2393,11 @@ bool CPlayer::IsAuthorized()
 	return m_IsAuthorized;
 }
 
+bool CPlayer::IsAdminChecked()
+{
+	return m_bAdminCheckSignalled;
+}
+
 bool CPlayer::IsAuthStringValidated()
 {     
 #if SOURCE_ENGINE >= SE_ORANGEBOX

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -87,6 +87,7 @@ public:
 	bool WasCountedAsInGame();
 	bool IsConnected();
 	bool IsAuthorized();
+	bool IsAdminChecked();
 	bool IsFakeClient();
 	bool IsSourceTV() const;
 	bool IsReplay() const;

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -486,6 +486,17 @@ static cell_t sm_IsClientAuthorized(IPluginContext *pCtx, const cell_t *params)
 	return (playerhelpers->GetGamePlayer(index)->IsAuthorized()) ? 1 : 0;
 }
 
+static cell_t sm_IsClientAdminChecked(IPluginContext *pCtx, const cell_t *params)
+{
+	int index = params[1];
+	if ((index < 1) || (index > playerhelpers->GetMaxClients()))
+	{
+		return pCtx->ThrowNativeError("Client index %d is invalid", index);
+	}
+
+	return (playerhelpers->GetGamePlayer(index)->IsAdminChecked()) ? 1 : 0;
+}
+
 static cell_t sm_IsClientFakeClient(IPluginContext *pCtx, const cell_t *params)
 {
 	int index = params[1];
@@ -1630,6 +1641,7 @@ REGISTER_NATIVES(playernatives)
 	{ "GetUserAdmin", GetUserAdmin },
 	{ "GetUserFlagBits", GetUserFlagBits },
 	{ "IsClientAuthorized", sm_IsClientAuthorized },
+	{ "IsClientAdminChecked", sm_IsClientAdminChecked },
 	{ "IsClientConnected", sm_IsClientConnected },
 	{ "IsFakeClient", sm_IsClientFakeClient },
 	{ "IsClientSourceTV", sm_IsClientSourceTV },

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -402,6 +402,8 @@ native bool IsClientAuthorized(int client);
  * Returns if all post-connection authorizations have been performed for a client.
  *
  * Note: See OnClientPostAdminCheck
+ *
+ * @return              True if post-connection authorizations performed, false otherwise
  */
 native bool IsClientAdminChecked(int client);
 

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -399,6 +399,13 @@ stock bool IsPlayerInGame(int client)
 native bool IsClientAuthorized(int client);
 
 /**
+ * Returns if all post-connection authorizations have been performed for a client.
+ *
+ * Note: See OnClientPostAdminCheck
+ */
+native bool IsClientAdminChecked(int client);
+
+/**
  * Returns if a certain player is a fake client.
  *
  * @param client        Player index.

--- a/public/IPlayerHelpers.h
+++ b/public/IPlayerHelpers.h
@@ -41,7 +41,7 @@
 #include <IAdminSystem.h>
 
 #define SMINTERFACE_PLAYERMANAGER_NAME		"IPlayerManager"
-#define SMINTERFACE_PLAYERMANAGER_VERSION	21
+#define SMINTERFACE_PLAYERMANAGER_VERSION	22
 
 struct edict_t;
 class IPlayerInfo;

--- a/public/IPlayerHelpers.h
+++ b/public/IPlayerHelpers.h
@@ -202,6 +202,13 @@ namespace SourceMod
 		virtual bool IsAuthorized() =0;
 		
 		/**
+		 * @brief Returns if all post-connection authorizations have been performed for a client.
+		 *
+		 * @return		True if post-connection authorizations performed, else false
+		 */
+		virtual bool IsAdminChecked() =0;
+		
+		/**
 		 * @brief Kicks the client with a message
 		 *
 		 * @param message   The message shown to the client when kicked

--- a/public/IPlayerHelpers.h
+++ b/public/IPlayerHelpers.h
@@ -204,7 +204,7 @@ namespace SourceMod
 		/**
 		 * @brief Returns if all post-connection authorizations have been performed for a client.
 		 *
-		 * @return		True if post-connection authorizations performed, else false
+		 * @return		True if post-connection authorizations performed, false otherwise
 		 */
 		virtual bool IsAdminChecked() =0;
 		


### PR DESCRIPTION
As title mentions, this adds a native to return the value of m_bAdminCheckSignalled for a player.

Although unlikely, it can be incorrect to assume that an authorized player has had their admin stuff processed.
```sourcepawn
native bool IsClientAdminChecked(int client);
```

```sourcepawn
bool g_Late;

public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max) {
    g_Late = late;
}

public void OnPluginStart() {
    if (g_Late) {
        for (int i = 1; i <= MaxClients; ++i) {
            if (!IsClientConnected(i)) { continue; }

            OnClientConnected(i);

            if (IsClientInGame(i)) { OnClientPutInServer(i); }
           
            if (IsClientAuthorized(i)) {
                char auth[32];
                GetClientAuthId(i, AuthId_Steam2, auth, sizeof(auth), false);
                OnClientAuthorized(i, auth);

                if (IsClientAdminChecked(i)) { OnClientPostAdminCheck(i); }
            }
        }
    }
}

public void OnClientConnected(int client) { /* do stuff */ }

public void OnClientPutInServer(int client) { /* do stuff */ }

public void OnClientAuthorized(int client, const char[] auth) { /* do stuff */ }

public void OnClientPostAdminCheck(int client) { /* do stuff */ }
```