### PR TITLE
Allow ROOT flag to call public votes

### DIFF
--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -406,14 +406,12 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 
 bool TestVoteDelay(int client)
 {
- 	int delay = CheckVoteDelay();
- 	
-	int client_flags = client == 0 ? ADMFLAG_ROOT : GetUserFlagBits(client);
-	
-	if (client_flags & ADMFLAG_ROOT)
+	if (CheckCommandAccess(client, "sm_vote_access", ADMFLAG_ROOT, true))
 	{
 		return true;
 	}
+	
+ 	int delay = CheckVoteDelay();
 	
  	if (delay > 0)
  	{

--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -408,6 +408,13 @@ bool TestVoteDelay(int client)
 {
  	int delay = CheckVoteDelay();
  	
+	int client_flags = client == 0 ? ADMFLAG_ROOT : GetUserFlagBits(client);
+	
+	if (client_flags & ADMFLAG_ROOT)
+	{
+		return true;
+	}
+	
  	if (delay > 0)
  	{
  		if (delay > 60)

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -309,7 +309,14 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 bool TestVoteDelay(int client)
 {
  	int delay = CheckVoteDelay();
- 	
+	
+ 	int client_flags = client == 0 ? ADMFLAG_ROOT : GetUserFlagBits(client);
+	
+	if (client_flags & ADMFLAG_ROOT)
+	{
+		return true;
+	}
+
  	if (delay > 0)
  	{
  		if (delay > 60)

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -308,14 +308,12 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 
 bool TestVoteDelay(int client)
 {
- 	int delay = CheckVoteDelay();
-	
- 	int client_flags = client == 0 ? ADMFLAG_ROOT : GetUserFlagBits(client);
-	
-	if (client_flags & ADMFLAG_ROOT)
+	if (CheckCommandAccess(client, "sm_vote_access", ADMFLAG_ROOT, true))
 	{
 		return true;
 	}
+	
+ 	int delay = CheckVoteDelay();
 
  	if (delay > 0)
  	{


### PR DESCRIPTION
This patch allow ROOT flag to call votes even if a delay is set. Its nice to have the possibility to set a delay betweens votes to limit public votes. Generally, we do this when we have lots of admins. But as a ROOT flag this limit shall no be set.