### PR TITLE
Add MAX_CONSOLE_LENGTH define to console.inc

### DIFF
--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -37,6 +37,8 @@
 
 #define INVALID_FCVAR_FLAGS (-1)
 
+#define MAX_CONSOLE_LENGTH 1024
+
 /**
  * Console variable query helper values.
  */


### PR DESCRIPTION
This creates a define to match the underlying SourceMod buffer sizes for console related methods.