### PR TITLE
Allow ROOT flag to call public votes

### DIFF
--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -406,8 +406,13 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 
 bool TestVoteDelay(int client)
 {
+	if (CheckCommandAccess(client, "sm_vote_access", ADMFLAG_ROOT, true))
+	{
+		return true;
+	}
+	
  	int delay = CheckVoteDelay();
- 	
+	
  	if (delay > 0)
  	{
  		if (delay > 60)

--- a/plugins/basevotes.sp
+++ b/plugins/basevotes.sp
@@ -406,7 +406,7 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 
 bool TestVoteDelay(int client)
 {
-	if (CheckCommandAccess(client, "sm_vote_access", ADMFLAG_ROOT, true))
+	if (CheckCommandAccess(client, "sm_vote_delay_bypass", ADMFLAG_CONVARS, true))
 	{
 		return true;
 	}

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -308,8 +308,13 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 
 bool TestVoteDelay(int client)
 {
+	if (CheckCommandAccess(client, "sm_vote_access", ADMFLAG_ROOT, true))
+	{
+		return true;
+	}
+	
  	int delay = CheckVoteDelay();
- 	
+
  	if (delay > 0)
  	{
  		if (delay > 60)

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -308,7 +308,7 @@ void VoteSelect(Menu menu, int param1, int param2 = 0)
 
 bool TestVoteDelay(int client)
 {
-	if (CheckCommandAccess(client, "sm_vote_access", ADMFLAG_ROOT, true))
+	if (CheckCommandAccess(client, "sm_vote_delay_bypass", ADMFLAG_CONVARS, true))
 	{
 		return true;
 	}


### PR DESCRIPTION
This patch allow ROOT flag to call votes even if a delay is set. Its nice to have the possibility to set a delay betweens votes to limit public votes. Generally, we do this when we have lots of admins. But as a ROOT flag this limit shall no be set.