### PR TITLE
Always add `FCVAR_RELEASE` to `CreateConVar()`

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -429,7 +429,7 @@ Handle_t ConVarManager::CreateConVar(IPluginContext *pContext, const char *name,
 
 	/* Since an existing convar (or concmd with the same name) was not found , now we can finally create it */
 	pConVar = new ConVar(sm_strdup(name), sm_strdup(defaultVal), flags
-#if SOURCE_ENGINE >= SE_L4D2
+#if (SE_L4D <= SOURCE_ENGINE && SOURCE_ENGINE <= SE_L4D2) || SOURCE_ENGINE == SE_CSGO
 	 | FCVAR_RELEASE
 #endif
 	 , sm_strdup(description), hasMin, min, hasMax, max);

--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -428,7 +428,11 @@ Handle_t ConVarManager::CreateConVar(IPluginContext *pContext, const char *name,
 	pInfo->handle = hndl;
 
 	/* Since an existing convar (or concmd with the same name) was not found , now we can finally create it */
-	pConVar = new ConVar(sm_strdup(name), sm_strdup(defaultVal), flags, sm_strdup(description), hasMin, min, hasMax, max);
+	pConVar = new ConVar(sm_strdup(name), sm_strdup(defaultVal), flags
+#if SOURCE_ENGINE >= SE_L4D2
+	 | FCVAR_RELEASE
+#endif
+	 , sm_strdup(description), hasMin, min, hasMax, max);
 	pInfo->pVar = pConVar;
 
 	/* Add convar to plugin's list */


### PR DESCRIPTION
In my advanced HL2SDK (not AlliedModders), that is assembled from pieces of Valve games code, there was a problem in
https://github.com/Wend4r/hl2sdk/blob/29858017a1e7cd2216af4a31ef6f81d42f55e59a/tier1/convar.cpp#L1127-L1134 

If a convar is declared without flags, then it will be marked as `FCVAR_DEVELOPMENTONLY` by analogy with the games code.
`FCVAR_RELEASE` flag is added to `ConVarManager::CreateConVar()` to access from the console/usual command