### PR TITLE
Fix formatting nomination items

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -245,7 +245,11 @@ public Action Command_Nominate(int client, int args)
 		for (int i = 0; i < results.Length; i++)
 		{
 			g_MapList.GetString(results.Get(i), mapResult, sizeof(mapResult));
-			menu.AddItem(mapResult, mapResult);
+
+			char displayName[PLATFORM_MAX_PATH];
+			GetMapDisplayName(mapResult, displayName, sizeof(displayName));
+
+			menu.AddItem(mapResult, displayName);
 		}
 
 		menu.Display(client, 30);

--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -476,21 +476,24 @@ public int MenuHandler_MapSelect(Menu menu, MenuAction action, int param1, int p
 			
 			if ((status & MAPSTATUS_DISABLED) == MAPSTATUS_DISABLED)
 			{
+				char displayName[PLATFORM_MAX_PATH];
+				GetMapDisplayName(mapname, displayName, sizeof(displayName));
+
 				if ((status & MAPSTATUS_EXCLUDE_CURRENT) == MAPSTATUS_EXCLUDE_CURRENT)
 				{
-					Format(mapname, sizeof(mapname), "%s (%T)", mapname, "Current Map", param1);
+					Format(mapname, sizeof(mapname), "%s (%T)", displayName, "Current Map", param1);
 					return RedrawMenuItem(mapname);
 				}
 				
 				if ((status & MAPSTATUS_EXCLUDE_PREVIOUS) == MAPSTATUS_EXCLUDE_PREVIOUS)
 				{
-					Format(mapname, sizeof(mapname), "%s (%T)", mapname, "Recently Played", param1);
+					Format(mapname, sizeof(mapname), "%s (%T)", displayName, "Recently Played", param1);
 					return RedrawMenuItem(mapname);
 				}
 				
 				if ((status & MAPSTATUS_EXCLUDE_NOMINATED) == MAPSTATUS_EXCLUDE_NOMINATED)
 				{
-					Format(mapname, sizeof(mapname), "%s (%T)", mapname, "Nominated", param1);
+					Format(mapname, sizeof(mapname), "%s (%T)", displayName, "Nominated", param1);
 					return RedrawMenuItem(mapname);
 				}
 			}


### PR DESCRIPTION
This should fix nomination items appearing with workshop prefix in the results menu and when items are disabled.

Other solution to fix this is to **always** redraw the nomination items, lemme know if that's preferred.
This issue was found by @busheezy, thanks to him.