### PR TITLE
Change sort optional parameters from Handle to any

### DIFF
--- a/plugins/include/sorting.inc
+++ b/plugins/include/sorting.inc
@@ -90,12 +90,12 @@ native void SortStrings(char[][] array, int array_size, SortOrder order = Sort_A
  * @param elem1         First element to compare.
  * @param elem2         Second element to compare.
  * @param array         Array that is being sorted (order is undefined).
- * @param hndl          Handle optionally passed in while sorting.
+ * @param data          Handle or value optionally passed in while sorting.
  * @return              -1 if first should go before second
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
-typedef SortFunc1D = function int (int elem1, int elem2, const int[] array, Handle hndl);
+typedef SortFunc1D = function int (int elem1, int elem2, const int[] array, any data);
 
 /**
  * Sorts a custom 1D array.  You must pass in a comparison function.
@@ -103,9 +103,9 @@ typedef SortFunc1D = function int (int elem1, int elem2, const int[] array, Hand
  * @param array         Array to sort.
  * @param array_size    Size of the array to sort.
  * @param sortfunc      Sort function.
- * @param hndl          Optional Handle to pass through the comparison calls.
+ * @param data          Optional Handle or value to pass through the comparison calls.
  */
-native void SortCustom1D(int[] array, int array_size, SortFunc1D sortfunc, Handle hndl=INVALID_HANDLE);
+native void SortCustom1D(int[] array, int array_size, SortFunc1D sortfunc, any data=0);
 
 /**
  * Sort comparison function for 2D array elements (sub-arrays).
@@ -114,15 +114,15 @@ native void SortCustom1D(int[] array, int array_size, SortFunc1D sortfunc, Handl
  * @param elem1         First array to compare.
  * @param elem2         Second array to compare.
  * @param array         Array that is being sorted (order is undefined).
- * @param hndl          Handle optionally passed in while sorting.
+ * @param data          Handle or value optionally passed in while sorting.
  * @return              -1 if first should go before second
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
 typeset SortFunc2D
 {
-	function int (int[] elem1, int[] elem2, const int[][] array, Handle hndl);
-	function int (char[] elem1, char[] elem2, const char[][] array, Handle hndl);
+	function int (int[] elem1, int[] elem2, const int[][] array, any data);
+	function int (char[] elem1, char[] elem2, const char[][] array, any data);
 };
 
 /**
@@ -133,7 +133,7 @@ typeset SortFunc2D
  * @param sortfunc      Sort comparison function to use.
  * @param hndl          Optional Handle to pass through the comparison calls.
  */
-native void SortCustom2D(any[][] array, int array_size, SortFunc2D sortfunc, Handle hndl=INVALID_HANDLE);
+native void SortCustom2D(any[][] array, int array_size, SortFunc2D sortfunc, any data=0);
 
 /**
  * Sort an ADT Array. Specify the type as Integer, Float, or String.
@@ -152,18 +152,18 @@ native void SortADTArray(Handle array, SortOrder order, SortType type);
  * @param index1        First index to compare.
  * @param index2        Second index to compare.
  * @param array         Array that is being sorted (order is undefined).
- * @param hndl          Handle optionally passed in while sorting.
+ * @param data          Handle or value optionally passed in while sorting.
  * @return              -1 if first should go before second
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
-typedef SortFuncADTArray = function int (int index1, int index2, Handle array, Handle hndl);
+typedef SortFuncADTArray = function int (int index1, int index2, Handle array, any data);
 
 /**
  * Custom sorts an ADT Array. You must pass in a comparison function.
  *
  * @param array         Array Handle to sort
  * @param sortfunc      Sort comparison function to use
- * @param hndl          Optional Handle to pass through the comparison calls.
+ * @param data          Optional Handle or data to pass through the comparison calls.
  */
-native void SortADTArrayCustom(Handle array, SortFuncADTArray sortfunc, Handle hndl=INVALID_HANDLE);
+native void SortADTArrayCustom(Handle array, SortFuncADTArray sortfunc, any data=0);


### PR DESCRIPTION
Not seeing any particular reason why the optional parameter needs to exclusively be a handle.

This change shouldn't break any API.