### PR TITLE
Fix TF2_OnIsHolidayActive forward not getting called after map change

### DIFF
--- a/extensions/tf2/holiday.cpp
+++ b/extensions/tf2/holiday.cpp
@@ -118,10 +118,6 @@ void HolidayManager::UnhookIfNecessary()
 	if (!m_iHookID)
 		return;
 
-	// We're still wanted
-	if (m_isHolidayForward->GetFunctionCount() > 0)
-		return;
-
 	SH_REMOVE_HOOK_ID(m_iHookID);
 	m_iHookID = 0;
 }
@@ -165,6 +161,10 @@ void HolidayManager::OnPluginLoaded(IPlugin *plugin)
 
 void HolidayManager::OnPluginUnloaded(IPlugin *plugin)
 {
+	// We're still wanted
+	if (m_isHolidayForward->GetFunctionCount() > 0)
+		return;
+
 	UnhookIfNecessary();
 }
 

--- a/extensions/tf2/holiday.cpp
+++ b/extensions/tf2/holiday.cpp
@@ -55,7 +55,7 @@ void HolidayManager::OnSDKLoad(bool bLate)
 
 void HolidayManager::OnSDKUnload()
 {
-	UnhookIfNecessary();
+	Unhook();
 	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &HolidayManager::Hook_LevelShutdown), false);
 
 	plsys->RemovePluginsListener(this);
@@ -72,7 +72,7 @@ void HolidayManager::OnServerActivated()
 void HolidayManager::Hook_LevelShutdown()
 {
 	// GameRules is going away momentarily. Unhook before it does.
-	UnhookIfNecessary();
+	Unhook();
 
 	m_bInMap = false;
 }
@@ -112,7 +112,7 @@ void HolidayManager::HookIfNecessary()
 	m_iHookID = SH_ADD_MANUALHOOK(IsHolidayActive, pGameRules, SH_MEMBER(this, &HolidayManager::Hook_IsHolidayActive), false);
 }
 
-void HolidayManager::UnhookIfNecessary()
+void HolidayManager::Unhook()
 {
 	// Not hooked
 	if (!m_iHookID)
@@ -165,7 +165,7 @@ void HolidayManager::OnPluginUnloaded(IPlugin *plugin)
 	if (m_isHolidayForward->GetFunctionCount() > 0)
 		return;
 
-	UnhookIfNecessary();
+	Unhook();
 }
 
 bool HolidayManager::Hook_IsHolidayActive(int holiday)

--- a/extensions/tf2/holiday.h
+++ b/extensions/tf2/holiday.h
@@ -57,7 +57,7 @@ private:
 	bool IsHookEnabled() const { return m_iHookID != 0; }
 	void *GetGameRules();
 	void HookIfNecessary();
-	void UnhookIfNecessary();
+	void Unhook();
 
 private:
 	int m_iHookID;


### PR DESCRIPTION
Fixes #1747

After a map change, the virtual hook on `IsHolidayActive` will be invalid due to the gamerules object being destroyed, but current code does not attempt to hook it again if a plugin using the `TF2_OnIsHolidayActive` forward is still loaded.

Always unhook on level change, and check for plugins using the forward only in `HolidayManager::OnPluginUnloaded`.