### PR TITLE
Add -m flag to checkout-deps to avoid downloading MySQL

### DIFF
--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -3,11 +3,17 @@
 
 trap "exit" INT
 
+download_mysql=1
+
 # List of HL2SDK branch names to download.
 # ./checkout-deps.sh -s tf2,css
-while getopts ":s:" opt; do
+# Disable downloading of mysql libraries.
+# ./checkout-deps.sh -m
+while getopts ":s:m" opt; do
   case $opt in
     s) IFS=', ' read -r -a sdks <<< "$OPTARG"
+    ;;
+    m) download_mysql=0
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;
@@ -66,7 +72,9 @@ else
   mysqlver=mysql-5.6.15-linux-glibc2.5-i686
   mysqlurl=https://cdn.mysql.com/archives/mysql-5.6/$mysqlver.$archive_ext
 fi
-getmysql
+if [ $download_mysql -eq 1 ]; then
+  getmysql
+fi
 
 # 64-bit MySQL
 mysqlfolder=mysql-5.5-x86_64
@@ -80,7 +88,9 @@ else
   mysqlver=mysql-5.6.15-linux-glibc2.5-x86_64
   mysqlurl=https://cdn.mysql.com/archives/mysql-5.6/$mysqlver.$archive_ext
 fi
-getmysql
+if [ $download_mysql -eq 1 ]; then
+  getmysql
+fi
 
 checkout ()
 {


### PR DESCRIPTION
If you just want to build an extension or SourceMod core and not the MySQL extension, don't download the large MySQL library archive.