### PR TITLE
Clear gamerules pointer on level shutdown

### DIFF
--- a/extensions/sdktools/extension.cpp
+++ b/extensions/sdktools/extension.cpp
@@ -54,6 +54,7 @@
  */
 
 SH_DECL_HOOK6(IServerGameDLL, LevelInit, SH_NOATTRIB, false, bool, const char *, const char *, const char *, const char *, bool, bool);
+SH_DECL_HOOK0_void(IServerGameDLL, LevelShutdown, SH_NOATTRIB, false);
 #if SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_CSGO
 SH_DECL_HOOK1_void_vafmt(IVEngineServer, ClientCommand, SH_NOATTRIB, 0, edict_t *);
 #endif
@@ -174,6 +175,7 @@ bool SDKTools::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	CONVAR_REGISTER(this);
 
 	SH_ADD_HOOK(IServerGameDLL, LevelInit, gamedll, SH_MEMBER(this, &SDKTools::LevelInit), true);
+	SH_ADD_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SDKTools::LevelShutdown), true);
 
 	playerhelpers->RegisterCommandTargetProcessor(this);
 
@@ -274,6 +276,7 @@ void SDKTools::SDK_OnUnload()
 	plsys->RemovePluginsListener(&g_OutputManager);
 
 	SH_REMOVE_HOOK(IServerGameDLL, LevelInit, gamedll, SH_MEMBER(this, &SDKTools::LevelInit), true);
+	SH_REMOVE_HOOK(IServerGameDLL, LevelShutdown, gamedll, SH_MEMBER(this, &SDKTools::LevelShutdown), true);
 
 	if (enginePatch)
 	{
@@ -445,6 +448,11 @@ bool SDKTools::LevelInit(char const *pMapName, char const *pMapEntities, char co
 	}
 
 	RETURN_META_VALUE(MRES_IGNORED, true);
+}
+
+void SDKTools::LevelShutdown()
+{
+	ClearValveGlobals();
 }
 
 bool SDKTools::ProcessCommandTarget(cmd_target_info_t *info)

--- a/extensions/sdktools/extension.h
+++ b/extensions/sdktools/extension.h
@@ -131,8 +131,8 @@ public: //ICommandTargetProcessor
 	bool ProcessCommandTarget(cmd_target_info_t *info);
 public:
 	bool LevelInit(char const *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame, bool background);
-	void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax);
 	void LevelShutdown();
+	void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax);
 public:
 	bool HasAnyLevelInited() { return m_bAnyLevelInited; }
 #if SOURCE_ENGINE == SE_CSGO

--- a/extensions/sdktools/extension.h
+++ b/extensions/sdktools/extension.h
@@ -132,6 +132,7 @@ public: //ICommandTargetProcessor
 public:
 	bool LevelInit(char const *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame, bool background);
 	void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax);
+	void LevelShutdown();
 public:
 	bool HasAnyLevelInited() { return m_bAnyLevelInited; }
 #if SOURCE_ENGINE == SE_CSGO

--- a/extensions/sdktools/vglobals.cpp
+++ b/extensions/sdktools/vglobals.cpp
@@ -151,6 +151,11 @@ void UpdateValveGlobals()
 	}
 }
 
+void ClearValveGlobals()
+{
+	s_pGameRules = nullptr;
+}
+
 size_t UTIL_StringToSignature(const char *str, char buffer[], size_t maxlength)
 {
 	size_t real_bytes = 0;

--- a/extensions/sdktools/vglobals.h
+++ b/extensions/sdktools/vglobals.h
@@ -38,6 +38,7 @@ extern CBaseHandle g_ResourceEntity;
 
 void InitializeValveGlobals();
 void UpdateValveGlobals();
+void ClearValveGlobals();
 void GetIServer();
 void *GameRules();
 


### PR DESCRIPTION
As discussed in #1694, this PR fixes an issue where the gamerules pointer would not be cleared on level shutdown, leading to crashes when natives like `TF2_IsHolidayActive` try to access it before it's populated again.