### PR TITLE
Add a OnPlayerRunCmdPre forward

### DIFF
--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -298,7 +298,10 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 		RETURN_META(MRES_IGNORED);
 	}
 
-	if (m_usercmdsFwd->GetFunctionCount() == 0 && m_usercmdsPreFwd->GetFunctionCount() == 0)
+	bool hasUsercmdsPreFwds = (m_usercmdsPreFwd->GetFunctionCount() > 0);
+	bool hasUsercmdsFwds = (m_usercmdsFwd->GetFunctionCount() > 0);
+
+	if (!hasUsercmdsPreFwds && !hasUsercmdsFwds)
 	{
 		RETURN_META(MRES_IGNORED);
 	}
@@ -327,46 +330,52 @@ void CHookManager::PlayerRunCmd(CUserCmd *ucmd, IMoveHelper *moveHelper)
 	cell_t angles[3] = {sp_ftoc(ucmd->viewangles.x), sp_ftoc(ucmd->viewangles.y), sp_ftoc(ucmd->viewangles.z)};
 	cell_t mouse[2] = {ucmd->mousedx, ucmd->mousedy};
 	
-	m_usercmdsPreFwd->PushCell(client);
-	m_usercmdsPreFwd->PushCell(ucmd->buttons);
-	m_usercmdsPreFwd->PushCell(ucmd->impulse);
-	m_usercmdsPreFwd->PushArray(vel, 3);
-	m_usercmdsPreFwd->PushArray(angles, 3);
-	m_usercmdsPreFwd->PushCell(ucmd->weaponselect);
-	m_usercmdsPreFwd->PushCell(ucmd->weaponsubtype);
-	m_usercmdsPreFwd->PushCell(ucmd->command_number);
-	m_usercmdsPreFwd->PushCell(ucmd->tick_count);
-	m_usercmdsPreFwd->PushCell(ucmd->random_seed);
-	m_usercmdsPreFwd->PushArray(mouse, 2);
-	m_usercmdsPreFwd->Execute();
-
-	m_usercmdsFwd->PushCell(client);
-	m_usercmdsFwd->PushCellByRef(&ucmd->buttons);
-	m_usercmdsFwd->PushCellByRef(&impulse);
-	m_usercmdsFwd->PushArray(vel, 3, SM_PARAM_COPYBACK);
-	m_usercmdsFwd->PushArray(angles, 3, SM_PARAM_COPYBACK);
-	m_usercmdsFwd->PushCellByRef(&ucmd->weaponselect);
-	m_usercmdsFwd->PushCellByRef(&ucmd->weaponsubtype);
-	m_usercmdsFwd->PushCellByRef(&ucmd->command_number);
-	m_usercmdsFwd->PushCellByRef(&ucmd->tick_count);
-	m_usercmdsFwd->PushCellByRef(&ucmd->random_seed);
-	m_usercmdsFwd->PushArray(mouse, 2, SM_PARAM_COPYBACK);
-	m_usercmdsFwd->Execute(&result);
-
-	ucmd->impulse = impulse;
-	ucmd->forwardmove = sp_ctof(vel[0]);
-	ucmd->sidemove = sp_ctof(vel[1]);
-	ucmd->upmove = sp_ctof(vel[2]);
-	ucmd->viewangles.x = sp_ctof(angles[0]);
-	ucmd->viewangles.y = sp_ctof(angles[1]);
-	ucmd->viewangles.z = sp_ctof(angles[2]);
-	ucmd->mousedx = mouse[0];
-	ucmd->mousedy = mouse[1];
-
-
-	if (result == Pl_Handled)
+	if (hasUsercmdsPreFwds)
 	{
-		RETURN_META(MRES_SUPERCEDE);
+		m_usercmdsPreFwd->PushCell(client);
+		m_usercmdsPreFwd->PushCell(ucmd->buttons);
+		m_usercmdsPreFwd->PushCell(ucmd->impulse);
+		m_usercmdsPreFwd->PushArray(vel, 3);
+		m_usercmdsPreFwd->PushArray(angles, 3);
+		m_usercmdsPreFwd->PushCell(ucmd->weaponselect);
+		m_usercmdsPreFwd->PushCell(ucmd->weaponsubtype);
+		m_usercmdsPreFwd->PushCell(ucmd->command_number);
+		m_usercmdsPreFwd->PushCell(ucmd->tick_count);
+		m_usercmdsPreFwd->PushCell(ucmd->random_seed);
+		m_usercmdsPreFwd->PushArray(mouse, 2);
+		m_usercmdsPreFwd->Execute();
+	}
+
+	if (hasUsercmdsFwds)
+	{
+		m_usercmdsFwd->PushCell(client);
+		m_usercmdsFwd->PushCellByRef(&ucmd->buttons);
+		m_usercmdsFwd->PushCellByRef(&impulse);
+		m_usercmdsFwd->PushArray(vel, 3, SM_PARAM_COPYBACK);
+		m_usercmdsFwd->PushArray(angles, 3, SM_PARAM_COPYBACK);
+		m_usercmdsFwd->PushCellByRef(&ucmd->weaponselect);
+		m_usercmdsFwd->PushCellByRef(&ucmd->weaponsubtype);
+		m_usercmdsFwd->PushCellByRef(&ucmd->command_number);
+		m_usercmdsFwd->PushCellByRef(&ucmd->tick_count);
+		m_usercmdsFwd->PushCellByRef(&ucmd->random_seed);
+		m_usercmdsFwd->PushArray(mouse, 2, SM_PARAM_COPYBACK);
+		m_usercmdsFwd->Execute(&result);
+
+		ucmd->impulse = impulse;
+		ucmd->forwardmove = sp_ctof(vel[0]);
+		ucmd->sidemove = sp_ctof(vel[1]);
+		ucmd->upmove = sp_ctof(vel[2]);
+		ucmd->viewangles.x = sp_ctof(angles[0]);
+		ucmd->viewangles.y = sp_ctof(angles[1]);
+		ucmd->viewangles.z = sp_ctof(angles[2]);
+		ucmd->mousedx = mouse[0];
+		ucmd->mousedy = mouse[1];
+
+
+		if (result == Pl_Handled)
+		{
+			RETURN_META(MRES_SUPERCEDE);
+		}
 	}
 
 	RETURN_META(MRES_IGNORED);

--- a/extensions/sdktools/hooks.cpp
+++ b/extensions/sdktools/hooks.cpp
@@ -613,7 +613,7 @@ void CHookManager::OnPluginLoaded(IPlugin *plugin)
 	if (PRCH_enabled)
 	{
 		bool changed = false;
-		if (!PRCH_used && ((m_usercmdsFwd->GetFunctionCount() > 0) || m_usercmdsPreFwd->GetFunctionCount() > 0)))
+		if (!PRCH_used && ((m_usercmdsFwd->GetFunctionCount() > 0) || (m_usercmdsPreFwd->GetFunctionCount() > 0)))
 		{
 			PRCH_used = true;
 			changed = true;

--- a/extensions/sdktools/hooks.h
+++ b/extensions/sdktools/hooks.h
@@ -77,6 +77,7 @@ private:
 	void NetChannelHook(int client);
 
 private:
+	IForward *m_usercmdsPreFwd;
 	IForward *m_usercmdsFwd;
 	IForward *m_usercmdsPostFwd;
 	IForward *m_netFileSendFwd;

--- a/plugins/include/sdktools_hooks.inc
+++ b/plugins/include/sdktools_hooks.inc
@@ -51,8 +51,6 @@
  * @param tickcount     Tick count. A client's prediction based on the server's GetGameTickCount value.
  * @param seed          Random seed. Used to determine weapon recoil, spread, and other predicted elements.
  * @param mouse         Mouse direction (x, y).
- *
- * @note To see if all 11 params are available, use FeatureType_Capability and FEATURECAP_PLAYERRUNCMD_11PARAMS.
  */
 forward Action OnPlayerRunCmdPre(int client, int buttons, int impulse, float vel[3], float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, int mouse[2]);
 

--- a/plugins/include/sdktools_hooks.inc
+++ b/plugins/include/sdktools_hooks.inc
@@ -52,7 +52,7 @@
  * @param seed          Random seed. Used to determine weapon recoil, spread, and other predicted elements.
  * @param mouse         Mouse direction (x, y).
  */
-forward Action OnPlayerRunCmdPre(int client, int buttons, int impulse, float vel[3], float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, int mouse[2]);
+forward void OnPlayerRunCmdPre(int client, int buttons, int impulse, float vel[3], float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, int mouse[2]);
 
 /**
  * Called when a clients movement buttons are being processed

--- a/plugins/include/sdktools_hooks.inc
+++ b/plugins/include/sdktools_hooks.inc
@@ -52,7 +52,7 @@
  * @param seed          Random seed. Used to determine weapon recoil, spread, and other predicted elements.
  * @param mouse         Mouse direction (x, y).
  */
-forward void OnPlayerRunCmdPre(int client, int buttons, int impulse, float vel[3], float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, int mouse[2]);
+forward void OnPlayerRunCmdPre(int client, int buttons, int impulse, const float vel[3], const float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, const int mouse[2]);
 
 /**
  * Called when a clients movement buttons are being processed

--- a/plugins/include/sdktools_hooks.inc
+++ b/plugins/include/sdktools_hooks.inc
@@ -38,6 +38,25 @@
 #define FEATURECAP_PLAYERRUNCMD_11PARAMS    "SDKTools PlayerRunCmd 11Params"
 
 /**
+ * Called when a clients movement buttons are being processed (Read Only)
+ *
+ * @param client        Index of the client.
+ * @param buttons       Current commands (as bitflags - see entity_prop_stocks.inc).
+ * @param impulse       Current impulse command.
+ * @param vel           Players desired velocity.
+ * @param angles        Players desired view angles.
+ * @param weapon        Entity index of the new weapon if player switches weapon, 0 otherwise.
+ * @param subtype       Weapon subtype when selected from a menu.
+ * @param cmdnum        Command number. Increments from the first command sent.
+ * @param tickcount     Tick count. A client's prediction based on the server's GetGameTickCount value.
+ * @param seed          Random seed. Used to determine weapon recoil, spread, and other predicted elements.
+ * @param mouse         Mouse direction (x, y).
+ *
+ * @note To see if all 11 params are available, use FeatureType_Capability and FEATURECAP_PLAYERRUNCMD_11PARAMS.
+ */
+forward Action OnPlayerRunCmdPre(int client, int buttons, int impulse, float vel[3], float angles[3], int weapon, int subtype, int cmdnum, int tickcount, int seed, int mouse[2]);
+
+/**
  * Called when a clients movement buttons are being processed
  *
  * @param client        Index of the client.


### PR DESCRIPTION
As requested in this issue #1759, adds a OnPlayerRunCmdPre forward for use with certain plugins which want access to unmodified usercmds.

The name isn't ideal, but after a little discussion in the Discord, we've not been able to come up with anything better.

I'm also a little unsure if `hasUsercmdsPreFwds` and `hasUsercmdsFwds` are the correct formatting for the new varaibles.

I don't have an easy means to test this right now, so the changes are currently untested.

Closes #1759