### PR TITLE
fix WeaponPrice offset on windows

### DIFF
--- a/gamedata/sm-cstrike.games/game.csgo.txt
+++ b/gamedata/sm-cstrike.games/game.csgo.txt
@@ -31,7 +31,7 @@
 			// -*(_DWORD *)(v34 + 8) in ida 7 -v34[52]
 			"WeaponPrice"
 			{
-				"windows"		"200"
+				"windows"		"208"
 				"linux"			"208"
 				"linux64"		"328"
 				"mac64"			"328"


### PR DESCRIPTION
seems like https://github.com/alliedmodders/sourcemod/commit/f7cd28cfd36e73652172fe81c93892dba6d87a94 pr a wrong gamedata for win