### PR TITLE
.gitmodules: Make submodules shallow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "public/amtl"]
 	path = public/amtl
 	url = https://github.com/alliedmodders/amtl
+	shallow = true
 [submodule "sourcepawn"]
 	path = sourcepawn
 	url = https://github.com/alliedmodders/sourcepawn
+	shallow = true


### PR DESCRIPTION
If the full commit history isn't needed, this is probably free speed up for checkout.