### PR TITLE
DHooks: Fix changing of byref vector parameters

### DIFF
--- a/extensions/dhooks/natives.cpp
+++ b/extensions/dhooks/natives.cpp
@@ -884,7 +884,8 @@ cell_t Native_SetParamVector(IPluginContext *pContext, const cell_t *params)
 	int index = params[2] - 1;
 
 	size_t offset = GetParamOffset(paramStruct, index);
-	void *addr = (void **)((intptr_t)paramStruct->newParams + offset);
+	void **origAddr = (void **)((intptr_t)paramStruct->orgParams + offset);
+	void **newAddr = (void **)((intptr_t)paramStruct->newParams + offset);
 
 	switch(paramStruct->dg->params.at(index).type)
 	{
@@ -892,11 +893,23 @@ cell_t Native_SetParamVector(IPluginContext *pContext, const cell_t *params)
 		{
 			cell_t *buffer;
 			pContext->LocalToPhysAddr(params[3], &buffer);
+			SDKVector *origVec = *(SDKVector **)origAddr;
+			SDKVector **newVec = (SDKVector **)newAddr;
 
-			*(SDKVector **)addr = new SDKVector(sp_ctof(buffer[0]), sp_ctof(buffer[1]), sp_ctof(buffer[2]));
+			if(origVec == nullptr)
+			{
+				*newVec = new SDKVector(sp_ctof(buffer[0]), sp_ctof(buffer[1]), sp_ctof(buffer[2]));
+				// Free it later (cheaply) after the function returned.
+				smutils->AddFrameAction(FreeChangedVector, *newVec);
+			}
+			else
+			{
+				origVec->x = sp_ctof(buffer[0]);
+				origVec->y = sp_ctof(buffer[1]);
+				origVec->z = sp_ctof(buffer[2]);
+				*newVec = origVec;
+			}
 			paramStruct->isChanged[index] = true;
-			// Free it later (cheaply) after the function returned.
-			smutils->AddFrameAction(FreeChangedVector, *(SDKVector **)addr);
 			return 1;
 		}
 	}


### PR DESCRIPTION
We always created a new vector object instead of changing the passed in vector directly instead. This works for the function being called using our changed values - but the caller doesn't see the changed values if it's passing a vector by reference.

Only create a new vector if there isn't one being passed in and set the values directly in the passed in vector otherwise.