### PR TITLE
DHooks: Error on argument passflags for detours

### DIFF
--- a/extensions/dhooks/natives.cpp
+++ b/extensions/dhooks/natives.cpp
@@ -256,6 +256,15 @@ cell_t Native_SetFromConf(IPluginContext *pContext, const cell_t *params)
 	setup->funcAddr = addr;
 	setup->offset = offset;
 
+	if (addr == nullptr)
+	{
+		setup->hookMethod = Virtual;
+	}
+	else
+	{
+		setup->hookMethod = Detour;
+	}
+
 	return 1;
 }
 
@@ -280,6 +289,13 @@ cell_t Native_AddParam(IPluginContext *pContext, const cell_t *params)
 	else
 	{
 		info.flags = PASSFLAG_BYVAL;
+	}
+
+	// DynamicDetours doesn't expose the passflags concept like SourceHook.
+	// See if we're trying to set some invalid flags on detour arguments.
+	if(setup->hookMethod == Detour && (info.flags & ~PASSFLAG_BYVAL) > 0)
+	{
+		return pContext->ThrowNativeError("Pass flags are only supported for virtual hooks.");
 	}
 
 	if (params[0] >= 5)

--- a/extensions/dhooks/vhook.h
+++ b/extensions/dhooks/vhook.h
@@ -225,6 +225,11 @@ public:
 	DHooksInfo *dg;
 };
 
+enum HookMethod {
+	Virtual,
+	Detour
+};
+
 class HookSetup
 {
 public:
@@ -238,6 +243,7 @@ public:
 		this->offset = offset;
 		this->funcAddr = nullptr;
 		this->callback = callback;
+		this->hookMethod = Virtual;
 	};
 	HookSetup(ReturnType returnType, unsigned int returnFlag, CallingConvention callConv, ThisPointerType thisType, void *funcAddr)
 	{
@@ -249,6 +255,7 @@ public:
 		this->offset = -1;
 		this->funcAddr = funcAddr;
 		this->callback = nullptr;
+		this->hookMethod = Detour;
 	};
 	~HookSetup(){};
 
@@ -266,6 +273,7 @@ public:
 	int offset;
 	void *funcAddr;
 	IPluginFunction *callback;
+	HookMethod hookMethod;
 };
 
 class DHooksManager


### PR DESCRIPTION
The passflags are only supported by SourceHook for virtual hooks and are ignored for detours with DynamicDetours. This caused confusion, so throw an error when trying to set e.g. the `DHookPass_ByRef` flag on detour arguments.