### PR TITLE
Expand ShowHudText message buffer for CS:GO

### DIFF
--- a/core/smn_hudtext.cpp
+++ b/core/smn_hudtext.cpp
@@ -373,7 +373,11 @@ static cell_t ShowSyncHudText(IPluginContext *pContext, const cell_t *params)
 	Handle_t err;
 	CPlayer *pPlayer;
 	hud_syncobj_t *obj;
+#if SOURCE_ENGINE == SE_CSGO
+	char message_buffer[512];
+#else
 	char message_buffer[255-36];
+#endif
 
 	if (!s_HudMsgHelpers.IsSupported())
 	{
@@ -453,7 +457,11 @@ static cell_t ShowHudText(IPluginContext *pContext, const cell_t *params)
 {
 	int client;
 	CPlayer *pPlayer;
+#if SOURCE_ENGINE == SE_CSGO
+	char message_buffer[512];
+#else
 	char message_buffer[255-36];
+#endif
 
 	if (!s_HudMsgHelpers.IsSupported())
 	{


### PR DESCRIPTION
This allows for ShowHudText to use the full message size available in CS:GO, rather than getting cut off compared to an ingame game_text as seen in https://cdn.discordapp.com/attachments/335290997317697536/983095891802066984/2022-06-05_15-50-19.mp4