### PR TITLE
SDKTools: Add parameters to ForcePlayerSuicide native

### DIFF
--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -516,19 +516,22 @@ static cell_t ForcePlayerSuicide(IPluginContext *pContext, const cell_t *params)
 			return pContext->ThrowNativeError("\"CommitSuicide\" wrapper failed to initialize");
 		}
 	}
-	bool bForce = false;
+
+	START_CALL();
+	DECODE_VALVE_PARAM(1, thisinfo, 0);
+	DECODE_VALVE_PARAM(2, vparams, 0);
 	if (!strcmp(g_pSM->GetGameFolderName(), "zps"))
 	{
 		// ZPS requires force to be set as true otherwise the action itself is delayed.
 		// Which affects Slay and Timebomb.
-		bForce = true;
+		*(bool*)(vptr + pCall->vparams[1].offset) = true;
 	}
-
-	START_CALL();
-	DECODE_VALVE_PARAM(1, thisinfo, 0);
-	*(bool *)(vptr + pCall->vparams[0].offset) = false;
-	*(bool *)(vptr + pCall->vparams[1].offset) = bForce;
+	else
+	{
+		DECODE_VALVE_PARAM(3, vparams, 1);
+	}
 	FINISH_CALL_SIMPLE(NULL);
+
 	return 1;
 }
 #else

--- a/plugins/include/sdktools_functions.inc
+++ b/plugins/include/sdktools_functions.inc
@@ -102,9 +102,11 @@ native void TeleportEntity(int entity, const float origin[3] = NULL_VECTOR, cons
  * Forces a player to commit suicide.
  *
  * @param client        Client index.
+ * @param explode       If true, explode the player.
+ * @param force         If true, ignore the suicide cooldown.
  * @error               Invalid client or client not in game, or lack of mod support.
  */
-native void ForcePlayerSuicide(int client);
+native void ForcePlayerSuicide(int client, bool explode = false, bool force = false);
 
 /**
  * Slaps a player in a random direction.


### PR DESCRIPTION
The function `CBasePlayer::CommitSuicide` has two additional parameters which SourceMod silently passes `false` for when calling the `ForcePlayerSuicide` native. There are situations where you want to force the player to gib (explode) or want to bypass the 5 second suicide cooldown.
This PR allows users to pass the parameters to the underlying call.

```sourcepawn
native void ForcePlayerSuicide(int client, bool explode = false, bool force = false);
```

Tested on TF2 Windows.