### PR TITLE
Add sdktools gamerules support for NMRiH

### DIFF
--- a/gamedata/sdktools.games/game.nmrih.txt
+++ b/gamedata/sdktools.games/game.nmrih.txt
@@ -185,5 +185,11 @@
 				"mac"		"211"
 			}
 		}
+		
+		"Keys"
+		{
+			"GameRulesProxy"		"CNMRiH_GameRulesProxy"
+			"GameRulesDataTable"	"nmrih_gamerules_data"
+		}
 	}
 }


### PR DESCRIPTION
Adds support for `GameRules_` natives. Tested working in-game