### PR TITLE
Add support for SDKCall returning non-networked entity

### DIFF
--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -509,16 +509,7 @@ static cell_t SDKCall(IPluginContext *pContext, const cell_t *params)
 					|| vc->retinfo->vtype == Valve_CBasePlayer)
 		{
 			CBaseEntity *pEntity = *(CBaseEntity **)(vc->retbuf);
-			if (!pEntity)
-			{
-				return -1;
-			}
-			edict_t *pEdict = gameents->BaseEntityToEdict(pEntity);
-			if (!pEdict || pEdict->IsFree())
-			{
-				return -1;
-			}
-			return IndexOfEdict(pEdict);
+			return gamehelpers->EntityToBCompatRef(pEntity);
 		} else if (vc->retinfo->vtype == Valve_Edict) {
 			edict_t *pEdict = *(edict_t **)(vc->retbuf);
 			if (!pEdict || pEdict->IsFree())


### PR DESCRIPTION
Caught this from TF2 update where some serverside ents are no longer networked. This is supposedly missed when support for non-networked ents was added.
Quick-tested this in TF2 windows.