### PR TITLE
Allow using sm_nominate without args from console

### DIFF
--- a/plugins/nominations.sp
+++ b/plugins/nominations.sp
@@ -197,15 +197,7 @@ public Action Command_Nominate(int client, int args)
 	
 	if (args == 0)
 	{	
-		if (source == SM_REPLY_TO_CHAT)
-		{
-			OpenNominationMenu(client);
-		}
-		else
-		{
-			ReplyToCommand(client, "[SM] Usage: sm_nominate <mapname>");
-		}
-		
+		OpenNominationMenu(client);
 		return Plugin_Handled;
 	}
 	


### PR DESCRIPTION
This reverts a change introduced in https://github.com/alliedmodders/sourcemod/commit/b8fd7db58d34c9ee5c0b9f2a6cea844f9d978fdb where `sm_nominate` can no longer be used from console to bring up the map menu. I don't see a reason for this existing (correct me if I'm wrong) and it's a slight annoyance for people who use binds or console a lot