### PR TITLE
Add GetClientOriginalLanguage

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -2646,15 +2646,6 @@ void CPlayer::SetLanguageId(unsigned int id)
 	}
 }
 
-void CPlayer::ResetLanguageId()
-{
-	if(m_LangId != m_OriginalLangId)
-	{
-		m_LangId = m_OriginalLangId;
-		g_Players.OnClientLanguageChanged(m_iIndex, m_OriginalLangId);
-	}
-}
-
 int CPlayer::GetUserId()
 {
 	if (m_UserId == -1)

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -528,6 +528,7 @@ bool PlayerManager::OnClientConnect(edict_t *pEntity, const char *pszName, const
 			pPlayer->m_LangId = translator->GetServerLanguage();
 		}
 #endif
+		pPlayer->m_OriginalLangId = pPlayer->m_LangId;
 	}
 	
 	List<IClientListener *>::iterator iter;
@@ -2035,6 +2036,7 @@ bool PlayerManager::HandleConVarQuery(QueryCvarCookie_t cookie, int client, EQue
 			unsigned int langid;
 			unsigned int new_langid = (translator->GetLanguageByName(cvarValue, &langid)) ? langid : translator->GetServerLanguage();
 			m_Players[i].m_LangId = new_langid;
+			m_Players[i].m_OriginalLangId = new_langid;
 			OnClientLanguageChanged(i, new_langid);
 
 			return true;
@@ -2063,6 +2065,7 @@ void CPlayer::Initialize(const char *name, const char *ip, edict_t *pEntity)
 	m_pEdict = pEntity;
 	m_iIndex = IndexOfEdict(pEntity);
 	m_LangId = translator->GetServerLanguage();
+	m_OriginalLangId = m_LangId;
 
 	m_Serial.bits.index = m_iIndex;
 	m_Serial.bits.serial = g_PlayerSerialCount++;
@@ -2629,12 +2632,26 @@ unsigned int CPlayer::GetLanguageId()
 	return m_LangId;
 }
 
+unsigned int CPlayer::GetOriginalLanguageId()
+{
+	return m_OriginalLangId;
+}
+
 void CPlayer::SetLanguageId(unsigned int id)
 {
 	if(m_LangId != id)
 	{
 		m_LangId = id;
 		g_Players.OnClientLanguageChanged(m_iIndex, id);
+	}
+}
+
+void CPlayer::ResetLanguageId()
+{
+	if(m_LangId != m_OriginalLangId)
+	{
+		m_LangId = m_OriginalLangId;
+		g_Players.OnClientLanguageChanged(m_iIndex, m_OriginalLangId);
 	}
 }
 

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -96,7 +96,9 @@ public:
 	bool IsInKickQueue();
 	IPlayerInfo *GetPlayerInfo();
 	unsigned int GetLanguageId();
+	unsigned int GetOriginalLanguageId();
 	void SetLanguageId(unsigned int id);
+	void ResetLanguageId();
 	int GetUserId();
 	bool RunAdminCacheChecks();
 	void NotifyPostAdminChecks();
@@ -145,6 +147,7 @@ private:
 	bool m_bAdminCheckSignalled = false;
 	int m_iIndex;
 	unsigned int m_LangId = SOURCEMOD_LANGUAGE_ENGLISH;
+	unsigned int m_OriginalLangId = SOURCEMOD_LANGUAGE_ENGLISH;
 	int m_UserId = -1;
 	bool m_bFakeClient = false;
 	bool m_bIsSourceTV = false;

--- a/core/PlayerManager.h
+++ b/core/PlayerManager.h
@@ -98,7 +98,6 @@ public:
 	unsigned int GetLanguageId();
 	unsigned int GetOriginalLanguageId();
 	void SetLanguageId(unsigned int id);
-	void ResetLanguageId();
 	int GetUserId();
 	bool RunAdminCacheChecks();
 	void NotifyPostAdminChecks();

--- a/core/logic/smn_lang.cpp
+++ b/core/logic/smn_lang.cpp
@@ -144,7 +144,7 @@ static cell_t sm_SetClientLanguage(IPluginContext *pContext, const cell_t *param
 	return 1;
 }
 
-static cell_t sm_GetOriginalLanguage(IPluginContext *pContext, const cell_t *params)
+static cell_t sm_GetClientOriginalLanguage(IPluginContext *pContext, const cell_t *params)
 {
 	IGamePlayer *player = playerhelpers->GetGamePlayer(params[1]);
 
@@ -193,7 +193,7 @@ REGISTER_NATIVES(langNatives)
 	{"GetLanguageCount",			sm_GetLanguageCount},
 	{"GetLanguageInfo",				sm_GetLanguageInfo},
 	{"SetClientLanguage",			sm_SetClientLanguage},
-	{"GetOriginalLanguage",			sm_GetOriginalLanguage},
+	{"GetClientOriginalLanguage",	sm_GetClientOriginalLanguage},
 	{"GetLanguageByCode",			sm_GetLanguageByCode},
 	{"GetLanguageByName",			sm_GetLanguageByName},
 	{NULL,							NULL},

--- a/core/logic/smn_lang.cpp
+++ b/core/logic/smn_lang.cpp
@@ -144,7 +144,7 @@ static cell_t sm_SetClientLanguage(IPluginContext *pContext, const cell_t *param
 	return 1;
 }
 
-static cell_t sm_ResetClientLanguage(IPluginContext *pContext, const cell_t *params)
+static cell_t sm_GetOriginalLanguage(IPluginContext *pContext, const cell_t *params)
 {
 	IGamePlayer *player = playerhelpers->GetGamePlayer(params[1]);
 
@@ -153,9 +153,7 @@ static cell_t sm_ResetClientLanguage(IPluginContext *pContext, const cell_t *par
 		return pContext->ThrowNativeError("Invalid client index %d", params[1]);
 	}
 
-	player->ResetLanguageId();
-
-	return 1;
+	return player->GetOriginalLanguageId();
 }
 
 static cell_t sm_GetLanguageByCode(IPluginContext *pContext, const cell_t *params)
@@ -195,7 +193,7 @@ REGISTER_NATIVES(langNatives)
 	{"GetLanguageCount",			sm_GetLanguageCount},
 	{"GetLanguageInfo",				sm_GetLanguageInfo},
 	{"SetClientLanguage",			sm_SetClientLanguage},
-	{"ResetClientLanguage",			sm_ResetClientLanguage},
+	{"GetOriginalLanguage",			sm_GetOriginalLanguage},
 	{"GetLanguageByCode",			sm_GetLanguageByCode},
 	{"GetLanguageByName",			sm_GetLanguageByName},
 	{NULL,							NULL},

--- a/core/logic/smn_lang.cpp
+++ b/core/logic/smn_lang.cpp
@@ -144,6 +144,20 @@ static cell_t sm_SetClientLanguage(IPluginContext *pContext, const cell_t *param
 	return 1;
 }
 
+static cell_t sm_ResetClientLanguage(IPluginContext *pContext, const cell_t *params)
+{
+	IGamePlayer *player = playerhelpers->GetGamePlayer(params[1]);
+
+	if (!player || !player->IsConnected())
+	{
+		return pContext->ThrowNativeError("Invalid client index %d", params[1]);
+	}
+
+	player->ResetLanguageId();
+
+	return 1;
+}
+
 static cell_t sm_GetLanguageByCode(IPluginContext *pContext, const cell_t *params)
 {
 	char *code;
@@ -181,6 +195,7 @@ REGISTER_NATIVES(langNatives)
 	{"GetLanguageCount",			sm_GetLanguageCount},
 	{"GetLanguageInfo",				sm_GetLanguageInfo},
 	{"SetClientLanguage",			sm_SetClientLanguage},
+	{"ResetClientLanguage",			sm_ResetClientLanguage},
 	{"GetLanguageByCode",			sm_GetLanguageByCode},
 	{"GetLanguageByName",			sm_GetLanguageByName},
 	{NULL,							NULL},

--- a/plugins/include/lang.inc
+++ b/plugins/include/lang.inc
@@ -106,7 +106,7 @@ native void SetClientLanguage(int client, int language);
  * @return              Language number client originally had.
  * @error               Invalid client index or client not connected.
  */
-native int GetOriginalLanguage(int client);
+native int GetClientOriginalLanguage(int client);
 
 /**
  * Retrieves the language number from a language code.

--- a/plugins/include/lang.inc
+++ b/plugins/include/lang.inc
@@ -100,12 +100,13 @@ native void GetLanguageInfo(int language, char[] code="", int codeLen=0, char[] 
 native void SetClientLanguage(int client, int language);
 
 /**
- * Resets the language number of a client to its original value.
+ * Retrieves the language number a client had when they connected.
  *
  * @param client        Client index.
+ * @return              Language number client originally had.
  * @error               Invalid client index or client not connected.
  */
-native void ResetClientLanguage(int client);
+native int GetOriginalLanguage(int client);
 
 /**
  * Retrieves the language number from a language code.

--- a/plugins/include/lang.inc
+++ b/plugins/include/lang.inc
@@ -100,6 +100,14 @@ native void GetLanguageInfo(int language, char[] code="", int codeLen=0, char[] 
 native void SetClientLanguage(int client, int language);
 
 /**
+ * Resets the language number of a client to its original value.
+ *
+ * @param client        Client index.
+ * @error               Invalid client index or client not connected.
+ */
+native void ResetClientLanguage(int client);
+
+/**
  * Retrieves the language number from a language code.
  *
  * @param code          Language code (2-3 characters usually).

--- a/public/IPlayerHelpers.h
+++ b/public/IPlayerHelpers.h
@@ -41,7 +41,7 @@
 #include <IAdminSystem.h>
 
 #define SMINTERFACE_PLAYERMANAGER_NAME		"IPlayerManager"
-#define SMINTERFACE_PLAYERMANAGER_VERSION	21
+#define SMINTERFACE_PLAYERMANAGER_VERSION	22
 
 struct edict_t;
 class IPlayerInfo;
@@ -145,14 +145,6 @@ namespace SourceMod
 		virtual unsigned int GetLanguageId() =0;
 
 		/**
-		 * @brief Returns the original language id the client had when
-		 * they connected.
-		 *
-		 * @return		Language id.
-		 */
-		virtual unsigned int GetOriginalLanguageId() =0;
-
-		/**
 		 * @brief Returns a player's IPlayerInfo object, if any.
 		 *
 		 * @return		IPlayerInfo pointer, or NULL if none.
@@ -235,12 +227,6 @@ namespace SourceMod
 		virtual void SetLanguageId(unsigned int id) =0;
 
 		/**
-		 * @brief Sets the client's language id to the value they had when
-		 * they connected.
-		 */
-		virtual void ResetLanguageId() =0;
-
-		/**
 		 * @brief Returns whether the player is the SourceTV bot.
 		 *
 		 * @return		True if the SourceTV bot, false otherwise.
@@ -308,6 +294,14 @@ namespace SourceMod
 		 * @return			Steam3 Id on success or NULL if not available.
 		 */
 		virtual const char *GetSteam3Id(bool validated = true) =0;
+
+		/**
+		 * @brief Returns the original language id the client had when
+		 * they connected.
+		 *
+		 * @return		Language id.
+		 */
+		virtual unsigned int GetOriginalLanguageId() =0;
 	};
 
 	/**

--- a/public/IPlayerHelpers.h
+++ b/public/IPlayerHelpers.h
@@ -145,6 +145,14 @@ namespace SourceMod
 		virtual unsigned int GetLanguageId() =0;
 
 		/**
+		 * @brief Returns the original language id the client had when
+		 * they connected.
+		 *
+		 * @return		Language id.
+		 */
+		virtual unsigned int GetOriginalLanguageId() =0;
+
+		/**
 		 * @brief Returns a player's IPlayerInfo object, if any.
 		 *
 		 * @return		IPlayerInfo pointer, or NULL if none.
@@ -225,6 +233,12 @@ namespace SourceMod
 		virtual void MarkAsBeingKicked() =0;
 
 		virtual void SetLanguageId(unsigned int id) =0;
+
+		/**
+		 * @brief Sets the client's language id to the value they had when
+		 * they connected.
+		 */
+		virtual void ResetLanguageId() =0;
 
 		/**
 		 * @brief Returns whether the player is the SourceTV bot.


### PR DESCRIPTION
It seems reasonable that while there are functions to change a client's language, there should also be function to restore it back--both with the natives and also internally.

My use case for this is I was making a language selection menu and had to implement this logic manually.
In fact, every plugin that modifies the client's language would have to do so (particularly during OnPluginEnd) to be correctly written.

It makes sense then that a correct implementation is built in natively instead.

I'm not entirely sure that I'm supposed to set it inside PlayerManager::HandleConVarQuery(), but it looks like that's just an async way of getting the client's language for certain games, so I did.


Tested with the following code
```sourcepawn
public void OnPluginStart()
{
    LoadTranslations("common.phrases");

    RegConsoleCmd("lang_set", Lang_Set);
    RegConsoleCmd("lang_reset", Lang_Reset);
}

public Action Lang_Set(int client, int args)
{
    if (args < 1)
    {
        ReplyToCommand(client, "lang_set <code>");
        return Plugin_Handled;
    }
    char arg1[32];
    GetCmdArg(1, arg1, sizeof(arg1));
    
    int lang = GetLanguageByCode(arg1);
    if (lang == -1)
    {
        ReplyToCommand(client, "bad code");
        return Plugin_Handled;
    }

    SetClientLanguage(client, lang);
    ReplyToCommand(client, "Set lang to %s", arg1);
    ReplyToCommand(client, "%t", "No matching client");
    return Plugin_Handled;
}

public Action Lang_Reset(int client, int args)
{
    ResetClientLanguage(client);
    ReplyToCommand(client, "Reset lang to default");
    ReplyToCommand(client, "%t", "No matching client");
    return Plugin_Handled;
}
```