### PR TITLE
Add natives to get chat trigger strings

### DIFF
--- a/core/ChatTriggers.cpp
+++ b/core/ChatTriggers.cpp
@@ -461,3 +461,23 @@ bool ChatTriggers::WasFloodedMessage()
 {
 	return m_bWasFloodedMessage;
 }
+
+const char *ChatTriggers::GetPublicChatTrigger()
+{
+	if (!m_PubTrigger.length())
+	{
+		return NULL;
+	}
+
+	return m_PubTrigger.c_str();
+}
+
+const char *ChatTriggers::GetPrivateChatTrigger()
+{
+	if (!m_PrivTrigger.length())
+	{
+		return NULL;
+	}
+
+	return m_PrivTrigger.c_str();
+}

--- a/core/ChatTriggers.h
+++ b/core/ChatTriggers.h
@@ -63,6 +63,8 @@ public:
 	unsigned int SetReplyTo(unsigned int reply);
 	bool IsChatTrigger();
 	bool WasFloodedMessage();
+	const char *GetPublicChatTrigger();
+	const char *GetPrivateChatTrigger();
 private:
 	enum ChatTriggerType {
 		ChatTrigger_Public,

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -1091,6 +1091,26 @@ static cell_t IsChatTrigger(IPluginContext *pContext, const cell_t *params)
 	return g_ChatTriggers.IsChatTrigger() ? 1 : 0;
 }
 
+static cell_t GetPublicChatTriggers(IPluginContext *pContext, const cell_t *params)
+{
+	size_t length;
+
+	const char *triggers = g_ChatTriggers.GetPublicChatTrigger();
+	pContext->StringToLocalUTF8(params[1], params[2], triggers ? triggers : "", &length);
+
+	return static_cast<cell_t>(length);
+}
+
+static cell_t GetSilentChatTriggers(IPluginContext *pContext, const cell_t *params)
+{
+	size_t length;
+
+	const char *triggers = g_ChatTriggers.GetPrivateChatTrigger();
+	pContext->StringToLocalUTF8(params[1], params[2], triggers ? triggers : "", &length);
+
+	return static_cast<cell_t>(length);
+}
+
 static cell_t SetCommandFlags(IPluginContext *pContext, const cell_t *params)
 {
 	char *name;
@@ -1514,6 +1534,8 @@ REGISTER_NATIVES(consoleNatives)
 	{"ReadCommandIterator",	ReadCommandIterator},
 	{"FakeClientCommandEx",	FakeClientCommandEx},
 	{"IsChatTrigger",		IsChatTrigger},
+	{"GetPublicChatTriggers", GetPublicChatTriggers},
+	{"GetSilentChatTriggers", GetSilentChatTriggers},
 	{"SetCommandFlags",		SetCommandFlags},
 	{"GetCommandFlags",		GetCommandFlags},
 	{"FindFirstConCommand",	FindFirstConCommand},

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -274,6 +274,24 @@ native ReplySource SetCmdReplySource(ReplySource source);
 native bool IsChatTrigger();
 
 /**
+ * Get the list of characters used for public chat triggers.
+ *
+ * @param buffer        Buffer to use for storing the string.
+ * @param maxlength     Maximum length of the buffer.
+ * @return              Length of string written to buffer.
+ */
+native int GetPublicChatTriggers(char[] buffer, int maxlength);
+
+/**
+ * Get the list of characters used for silent chat triggers.
+ *
+ * @param buffer        Buffer to use for storing the string.
+ * @param maxlength     Maximum length of the buffer.
+ * @return              Length of string written to buffer.
+ */
+native int GetSilentChatTriggers(char[] buffer, int maxlength);
+
+/**
  * Displays usage of an admin command to users depending on the 
  * setting of the sm_show_activity cvar.  All users receive a message 
  * in their chat text, except for the originating client, who receives 


### PR DESCRIPTION
The main utility of being able to know what the chat triggers are is if you want to display to clients how to type commands.
e.g. `Welcome to the server! Type !rules for the server rules.`

Or for chat processing, I guess.

Although I've never even encountered a server that has changed the chat triggers--so it's usually fine for plugins to just assume that `!` and `/` are correct--it's still allowed to be changed, and currently the only way to get the actual chat triggers is processing the `core.cfg` file manually.

Tested with the following code:
```sourcepawn
#include <sourcemod>

public void OnPluginStart()
{
    char buffer[32];
    int written;
    
    written = GetPublicChatTriggers(buffer, sizeof(buffer));
    PrintToServer("Public Triggers: '%s', written=%i", buffer, written);
    
    written = GetSilentChatTriggers(buffer, sizeof(buffer));
    PrintToServer("Silent Triggers: '%s', written=%i", buffer, written);
    
    // Outputs
    // Public Triggers: '!', written=1
    // Silent Triggers: '/', written=1

}
```