### PR TITLE
Add SMCParser.ParseString

### DIFF
--- a/core/logic/smn_textparse.cpp
+++ b/core/logic/smn_textparse.cpp
@@ -29,6 +29,8 @@
  * Version: $Id$
  */
 
+#include <string.h>
+
 #include "common_logic.h"
 #include <ITextParsers.h>
 #include <ISourceMod.h>
@@ -264,6 +266,32 @@ static cell_t SMC_ParseFile(IPluginContext *pContext, const cell_t *params)
 	return (cell_t)p_err;
 }
 
+static cell_t SMC_ParseString(IPluginContext *pContext, const cell_t *params)
+{
+	OpenHandle<ParseInfo> parse(pContext, params[1], g_TypeSMC);
+	if (!parse.Ok())
+		return 0;
+
+	char *str;
+	pContext->LocalToString(params[2], &str);
+
+	SMCStates states;
+	SMCError p_err = textparsers->ParseSMCStream(str,
+												strlen(str),
+												parse,
+												&states,
+												NULL,
+												0);
+
+	cell_t *c_line, *c_col;
+	pContext->LocalToPhysAddr(params[3], &c_line);
+	pContext->LocalToPhysAddr(params[4], &c_col);
+
+	*c_line = states.line;
+	*c_col = states.col;
+	return (cell_t)p_err;
+}
+
 static cell_t SMC_GetErrorString(IPluginContext *pContext, const cell_t *params)
 {
 	const char *str = textparsers->GetSMCErrorString((SMCError)params[1]);
@@ -334,6 +362,7 @@ REGISTER_NATIVES(textNatives)
 	// Transitional syntax support.
 	{"SMCParser.SMCParser",				SMC_CreateParser},
 	{"SMCParser.ParseFile",				SMC_ParseFile},
+	{"SMCParser.ParseString",			SMC_ParseString},
 	{"SMCParser.OnStart.set",			SMC_SetParseStart},
 	{"SMCParser.OnEnd.set",				SMC_SetParseEnd},
 	{"SMCParser.OnEnterSection.set",	SMCParser_OnEnterSection_set},

--- a/plugins/include/textparse.inc
+++ b/plugins/include/textparse.inc
@@ -147,6 +147,14 @@ methodmap SMCParser < Handle
 	// @return              An SMCParseError result.
 	public native SMCError ParseFile(const char[] file, int &line = 0, int &col = 0);
 
+	// Parses raw UTF-8 text as an SMC file.
+	//
+	// @param string        A string containing an SMC file.
+	// @param line          An optional variable to store the last line number read.
+	// @param col           An optional variable to store the last column number read.
+	// @return              An SMCParseError result.
+	public native SMCError ParseString(const char[] string, int &line = 0, int &col = 0);
+
 	// Sets the callback for receiving SMC_ParseStart events.
 	property SMC_ParseStart OnStart {
 		public native set(SMC_ParseStart func);


### PR DESCRIPTION
Resolves #1686

Tested with the code below.
*(TL;DR - Exact same output as ParseFile)*

sourcemod/configs/parsetest.cfg
```keyvalues
"Root"
{
    "key1" "value1"
    "key2" "value2"

    "section1"
    {
        "key3" "value3"
        "section2"
        {
            "key4" "value4"
        }
    }
}
```

parsetest.sp
```sourcepawn
#include <sourcemod>

char NO_NEWLINES[] = ""
... "\"Root\""
... "{"
... "    \"key1\" \"value1\""
... "    \"key2\" \"value2\""
... ""
... "    \"section1\""
... "    {"
... "        \"key3\" \"value3\""
... "        \"section2\""
... "        {"
... "            \"key4\" \"value4\""
... "        }"
... "    }"
... "}";


char WITH_NEWLINES[] = ""
... "\"Root\"\n"
... "{\n"
... "    \"key1\" \"value1\"\n"
... "    \"key2\" \"value2\"\n"
... "\n"
... "    \"section1\"\n"
... "    {\n"
... "        \"key3\" \"value3\"\n"
... "        \"section2\"\n"
... "        {\n"
... "            \"key4\" \"value4\"\n"
... "        }\n"
... "    }\n"
... "}"; // Doesn't end in newline!


public void OnPluginStart()
{
    RegAdminCmd("sm_parsetest", Command_Test, ADMFLAG_ROOT);
}


public Action Command_Test(int client, int args)
{
    SMCParser smc = new SMCParser();
    
    smc.OnEnd = OnEndCB;
    smc.OnEnterSection = OnEnterSectionCB;
    smc.OnKeyValue = OnKeyValueCB;
    smc.OnLeaveSection = OnLeaveSectionCB;
    smc.OnRawLine = OnRawLineCB;
    smc.OnStart = OnStartCB;
    
    int line, col;
    
    PrintToServer("-------------------------------------------------");
    
    PrintToServer("ParseString (no newlines)");
    SMCError err = smc.ParseString(NO_NEWLINES, line, col);
    PrintToServer("Returned: err:%i, line:%i, col:%i", err, line, col);
    
    PrintToServer("-------------------------------------------------");
    
    PrintToServer("ParseString (with newlines)");
    err = smc.ParseString(WITH_NEWLINES, line, col);
    PrintToServer("Returned: err:%i, line:%i, col:%i", err, line, col);
    
    PrintToServer("-------------------------------------------------");
    
    char path[PLATFORM_MAX_PATH];
    BuildPath(Path_SM, path, sizeof(path), "configs/parsetest.cfg");
    PrintToServer("ParseFile");
    err = smc.ParseFile(path, line, col);
    PrintToServer("Returned: err:%i, line:%i, col:%i", err, line, col);
    
    PrintToServer("-------------------------------------------------");
    
    return Plugin_Handled;
}



void OnEndCB(SMCParser smc, bool halted, bool failed)
{
    PrintToServer("End: halted:%i, failed:%i", halted, failed);
}

SMCResult OnEnterSectionCB(SMCParser smc, const char[] name, bool opt_quotes)
{
    PrintToServer("EnterSection: name:'%s', opt_quotes:%i", name, opt_quotes);
    return SMCParse_Continue;
}

SMCResult OnKeyValueCB(SMCParser smc, const char[] key, const char[] value, bool key_quotes, bool value_quotes)
{
    PrintToServer("KeyValue: key:'%s', value:'%s', key_quotes:%i, value_quote:%i", key, value, key_quotes, value_quotes);
    return SMCParse_Continue;
}

SMCResult OnLeaveSectionCB(SMCParser smc)
{
    PrintToServer("LeaveSection");
    return SMCParse_Continue;
}

SMCResult OnRawLineCB(SMCParser smc, const char[] line, int lineno)
{
    PrintToServer("RawLine: line:'%s', lineno:%i", line, lineno);
    return SMCParse_Continue;
}

void OnStartCB(SMCParser smc)
{
    PrintToServer("Start");
}
```


Output (TL;DR - both the ParseString + newlines and ParseFile sections are identical as expected)
```
-------------------------------------------------
ParseString (no newlines)
Start
EnterSection: name:'Root', opt_quotes:1
End: halted:1, failed:0
Returned: err:9, line:1, col:35
-------------------------------------------------
ParseString (with newlines)
Start
RawLine: line:'"Root"', lineno:1
EnterSection: name:'Root', opt_quotes:1
RawLine: line:'{', lineno:2
RawLine: line:'    "key1" "value1"', lineno:3
KeyValue: key:'key1', value:'value1', key_quotes:1, value_quote:1
RawLine: line:'    "key2" "value2"', lineno:4
KeyValue: key:'key2', value:'value2', key_quotes:1, value_quote:1
RawLine: line:'', lineno:5
RawLine: line:'    "section1"', lineno:6
EnterSection: name:'section1', opt_quotes:1
RawLine: line:'    {', lineno:7
RawLine: line:'        "key3" "value3"', lineno:8
KeyValue: key:'key3', value:'value3', key_quotes:1, value_quote:1
RawLine: line:'        "section2"', lineno:9
EnterSection: name:'section2', opt_quotes:1
RawLine: line:'        {', lineno:10
RawLine: line:'            "key4" "value4"', lineno:11
KeyValue: key:'key4', value:'value4', key_quotes:1, value_quote:1
LeaveSection
RawLine: line:'        }', lineno:12
LeaveSection
RawLine: line:'    }', lineno:13
LeaveSection
End: halted:0, failed:0
Returned: err:0, line:14, col:2
-------------------------------------------------
ParseFile
Start
RawLine: line:'"Root"', lineno:1
EnterSection: name:'Root', opt_quotes:1
RawLine: line:'{', lineno:2
RawLine: line:'    "key1" "value1"', lineno:3
KeyValue: key:'key1', value:'value1', key_quotes:1, value_quote:1
RawLine: line:'    "key2" "value2"', lineno:4
KeyValue: key:'key2', value:'value2', key_quotes:1, value_quote:1
RawLine: line:'', lineno:5
RawLine: line:'    "section1"', lineno:6
EnterSection: name:'section1', opt_quotes:1
RawLine: line:'    {', lineno:7
RawLine: line:'        "key3" "value3"', lineno:8
KeyValue: key:'key3', value:'value3', key_quotes:1, value_quote:1
RawLine: line:'        "section2"', lineno:9
EnterSection: name:'section2', opt_quotes:1
RawLine: line:'        {', lineno:10
RawLine: line:'            "key4" "value4"', lineno:11
KeyValue: key:'key4', value:'value4', key_quotes:1, value_quote:1
LeaveSection
RawLine: line:'        }', lineno:12
LeaveSection
RawLine: line:'    }', lineno:13
LeaveSection
End: halted:0, failed:0
Returned: err:0, line:14, col:2
-------------------------------------------------
```