### PR TITLE
Add UTC option to FormatTime

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -260,7 +260,8 @@ static cell_t FormatTime(IPluginContext *pContext, const cell_t *params)
 #ifdef PLATFORM_WINDOWS
 		InvalidParameterHandler p;
 #endif
-		if (params[5])
+		// Older plugins dont have param[5]
+		if (params[0] < 5 || params[5])
 		{
 			t = (params[4] == -1) ? g_pSM->GetAdjustedTime() : (time_t)params[4];
 			written = strftime(buffer, params[2], format, localtime(&t));

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -260,8 +260,16 @@ static cell_t FormatTime(IPluginContext *pContext, const cell_t *params)
 #ifdef PLATFORM_WINDOWS
 		InvalidParameterHandler p;
 #endif
-		t = (params[4] == -1) ? g_pSM->GetAdjustedTime() : (time_t)params[4];
-		written = strftime(buffer, params[2], format, localtime(&t));
+		if (params[5])
+		{
+			t = (params[4] == -1) ? g_pSM->GetAdjustedTime() : (time_t)params[4];
+			written = strftime(buffer, params[2], format, localtime(&t));
+		}
+		else
+		{
+			t = (params[4] == -1) ? time(NULL) : (time_t)params[4];
+			written = strftime(buffer, params[2], format, gmtime(&t));
+		}
 	}
 
 	if (params[2] && format[0] != '\0' && !written)

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -407,9 +407,11 @@ native int GetTime(int bigStamp[2]={0,0});
  * @param maxlength     Maximum length of output string buffer.
  * @param format        Formatting rules (passing NULL_STRING will use the rules defined in sm_datetime_format).
  * @param stamp         Optional time stamp.
+ * @param adjust        If true, formatting will adjust for the local timezone and sm_time_adjustment value.
+ *                      If false, the time will be formatted for UTC/GMT.
  * @error               Buffer too small or invalid time format.
  */
-native void FormatTime(char[] buffer, int maxlength, const char[] format, int stamp=-1);
+native void FormatTime(char[] buffer, int maxlength, const char[] format, int stamp=-1, bool adjust=true);
 
 /**
  * Loads a game config file.


### PR DESCRIPTION
Resolves #875

Tested with the following code and https://www.epochconverter.com/
```sourcepawn
#include <sourcemod>

public void OnPluginStart()
{
    char time[32];
    
    PrintToServer("Now: %i", GetTime());
    
    FormatTime(time, sizeof(time), "%Y-%m-%d %H:%M:%S", 0);
    PrintToServer("Local time 0: %s", time);
    
    FormatTime(time, sizeof(time), "%Y-%m-%d %H:%M:%S", 0, false); 
    PrintToServer("UTC time 0: %s", time);
    
    FormatTime(time, sizeof(time), "%Y-%m-%d %H:%M:%S");
    PrintToServer("Local time now: %s", time);
    
    FormatTime(time, sizeof(time), "%Y-%m-%d %H:%M:%S", -1, false);
    PrintToServer("UTC time now: %s", time);

    // OUTPUTS:
    // Now: 1660197444
    // Local time 0: 1970-01-01 11:00:00
    // UTC time 0: 1970-01-01 00:00:00
    // Local time now: 2022-08-11 15:57:24
    // UTC time now: 2022-08-11 05:57:24
}
```