### PR TITLE
Fix CommandListener ignoring Plugin_Handled

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -1214,7 +1214,7 @@ void PlayerManager::OnClientCommand(edict_t *pEntity)
 	if (g_ConsoleDetours.IsEnabled())
 	{
 		cell_t res2 = g_ConsoleDetours.InternalDispatch(client, &cargs);
-		if (res2 >= Pl_Stop)
+		if (res2 >= Pl_Handled)
 		{
 			RETURN_META(MRES_SUPERCEDE);
 		}


### PR DESCRIPTION
For issue #1363

I'm not entirely sure if this is the correct way to fix this.
But it works, and I couldn't find any other instances where `RETURN_META(MRES_SUPERCEDE);` or `RETURN_META_VALUE(MRES_SUPERCEDE, ...` were used that were using Pl_Stop instead of Pl_Handled

Tested with the same code as the issue:
```sourcepawn
#include <sourcemod>

public void OnPluginStart()
{
  AddCommandListener(CommandListener_Noclip, "sm_noclip");
}

Action CommandListener_Noclip(int client, const char[] command, int argc)
{
  if (IsPlayerAlive(client) && argc < 1) {
  	ReplyToCommand(client, "[SM] aaaa");
  	return Plugin_Handled;
  }
  return Plugin_Continue;
}
```
![fix](https://user-images.githubusercontent.com/13011795/184080542-fc47bc3d-56dd-4886-be7e-ff8feb9e351b.png)