### PR TITLE
Add custom sdktools trace types

### DIFF
--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -489,7 +489,7 @@ static cell_t smn_TRTraceRayFilter(IPluginContext *pContext, const cell_t *param
 
 	if (params[0] >= 7)
 	{
-		traceType = params[7];
+		traceType = (TraceType_t)params[7];
 	}
 	else
 	{
@@ -549,7 +549,7 @@ static cell_t smn_TRTraceHullFilter(IPluginContext *pContext, const cell_t *para
 
 	if (params[0] >= 8)
 	{
-		traceType = params[8];
+		traceType = (TraceType_t)params[8];
 	}
 	else
 	{
@@ -811,7 +811,7 @@ static cell_t smn_TRTraceRayFilterEx(IPluginContext *pContext, const cell_t *par
 	
 	if (params[0] >= 7)
 	{
-		traceType = params[7];
+		traceType = (TraceType_t)params[7];
 	}
 	else
 	{
@@ -886,7 +886,7 @@ static cell_t smn_TRTraceHullFilterEx(IPluginContext *pContext, const cell_t *pa
 	
 	if (params[0] >= 8)
 	{
-		traceType = params[8];
+		traceType = (TraceType_t)params[8];
 	}
 	else
 	{

--- a/extensions/sdktools/trnatives.cpp
+++ b/extensions/sdktools/trnatives.cpp
@@ -51,7 +51,7 @@ private:
 	cell_t m_EntRef = INVALID_EHANDLE_INDEX;
 };
 
-class CSMTraceFilter : public CTraceFilter
+class CSMTraceFilter : public ITraceFilter
 {
 public:
 	bool ShouldHitEntity(IHandleEntity *pEntity, int contentsMask)
@@ -74,10 +74,19 @@ public:
 		m_pFunc = pFunc;
 		m_Data = data;
 	}
+	virtual TraceType_t GetTraceType() const
+	{
+		return m_TraceType;
+	}
+	void SetTraceType(TraceType_t traceType)
+	{
+		m_TraceType = traceType;
+	}
 private:
 	ExceptionHandler *m_pEh;
 	IPluginFunction *m_pFunc;
 	cell_t m_Data;
+	TraceType_t m_TraceType;
 };
 
 class CSMTraceEnumerator : public IPartitionEnumerator
@@ -458,6 +467,7 @@ static cell_t smn_TRTraceRayFilter(IPluginContext *pContext, const cell_t *param
 	cell_t *startaddr, *endaddr;
 	IPluginFunction *pFunc;
 	cell_t data;
+	TraceType_t traceType;
 
 	pFunc = pContext->GetFunctionById(params[5]);
 	if (!pFunc)
@@ -476,6 +486,17 @@ static cell_t smn_TRTraceRayFilter(IPluginContext *pContext, const cell_t *param
 
 	DetectExceptions eh(pContext);
 	g_SMTraceFilter.SetFunctionPtr(&eh, pFunc, data);
+
+	if (params[0] >= 7)
+	{
+		traceType = params[7];
+	}
+	else
+	{
+		traceType = TRACE_EVERYTHING;
+	}
+
+	g_SMTraceFilter.SetTraceType(traceType);
 
 	pContext->LocalToPhysAddr(params[1], &startaddr);
 	pContext->LocalToPhysAddr(params[2], &endaddr);
@@ -513,6 +534,7 @@ static cell_t smn_TRTraceHullFilter(IPluginContext *pContext, const cell_t *para
 	cell_t data;
 	IPluginFunction *pFunc;
 	cell_t *startaddr, *endaddr, *mins, *maxs;
+	TraceType_t traceType;
 
 	pFunc = pContext->GetFunctionById(params[6]);
 	if (!pFunc)
@@ -524,6 +546,17 @@ static cell_t smn_TRTraceHullFilter(IPluginContext *pContext, const cell_t *para
 
 	DetectExceptions eh(pContext);
 	g_SMTraceFilter.SetFunctionPtr(&eh, pFunc, data);
+
+	if (params[0] >= 8)
+	{
+		traceType = params[8];
+	}
+	else
+	{
+		traceType = TRACE_EVERYTHING;
+	}
+
+	g_SMTraceFilter.SetTraceType(traceType);
 
 	pContext->LocalToPhysAddr(params[1], &startaddr);
 	pContext->LocalToPhysAddr(params[2], &endaddr);
@@ -750,6 +783,7 @@ static cell_t smn_TRTraceRayFilterEx(IPluginContext *pContext, const cell_t *par
 	IPluginFunction *pFunc;
 	cell_t *startaddr, *endaddr;
 	cell_t data;
+	TraceType_t traceType;
 
 	pFunc = pContext->GetFunctionById(params[5]);
 	if (!pFunc)
@@ -774,6 +808,17 @@ static cell_t smn_TRTraceRayFilterEx(IPluginContext *pContext, const cell_t *par
 
 	DetectExceptions eh(pContext);
 	smfilter.SetFunctionPtr(&eh, pFunc, data);
+	
+	if (params[0] >= 7)
+	{
+		traceType = params[7];
+	}
+	else
+	{
+		traceType = TRACE_EVERYTHING;
+	}
+
+	smfilter.SetTraceType(traceType);
 
 	StartVec.Init(sp_ctof(startaddr[0]), sp_ctof(startaddr[1]), sp_ctof(startaddr[2]));
 
@@ -818,6 +863,7 @@ static cell_t smn_TRTraceHullFilterEx(IPluginContext *pContext, const cell_t *pa
 	IPluginFunction *pFunc;
 	cell_t *startaddr, *endaddr, *mins, *maxs;
 	cell_t data;
+	TraceType_t traceType;
 
 	pFunc = pContext->GetFunctionById(params[6]);
 	if (!pFunc)
@@ -837,6 +883,17 @@ static cell_t smn_TRTraceHullFilterEx(IPluginContext *pContext, const cell_t *pa
 
 	DetectExceptions eh(pContext);
 	smfilter.SetFunctionPtr(&eh, pFunc, data);
+	
+	if (params[0] >= 8)
+	{
+		traceType = params[8];
+	}
+	else
+	{
+		traceType = TRACE_EVERYTHING;
+	}
+
+	smfilter.SetTraceType(traceType);
 
 	StartVec.Init(sp_ctof(startaddr[0]), sp_ctof(startaddr[1]), sp_ctof(startaddr[2]));
 	vmins.Init(sp_ctof(mins[0]), sp_ctof(mins[1]), sp_ctof(mins[2]));

--- a/plugins/include/sdktools_trace.inc
+++ b/plugins/include/sdktools_trace.inc
@@ -164,6 +164,14 @@ enum RayType
 	RayType_Infinite    /**< The trace ray will go from the start position to infinity using a direction vector. */
 };
 
+enum TraceType
+{
+	TRACE_EVERYTHING = 0,
+	TRACE_WORLD_ONLY,               /**< NOTE: This does *not* test static props!!! */
+	TRACE_ENTITIES_ONLY,            /**< NOTE: This version will *not* test static props */
+	TRACE_EVERYTHING_FILTER_PROPS   /**< NOTE: This version will pass the IHandleEntity for props through the filter, unlike all other filters */
+};
+
 typeset TraceEntityFilter
 {
 	/**
@@ -357,13 +365,15 @@ native void TR_EnumerateEntitiesPoint(const float pos[3],
  * @param filter        Function to use as a filter.
  * @param data          Arbitrary data value to pass through to the filter
  *                      function.
+ * @param traceType     Trace type.
  */
 native void TR_TraceRayFilter(const float pos[3],
                               const float vec[3],
                               int flags,
                               RayType rtype,
                               TraceEntityFilter filter,
-                              any data=0);
+                              any data=0,
+			      TraceType traceType=TRACE_EVERYTHING);
 
 /**
  * Starts up a new trace hull using a global trace result and a customized
@@ -380,6 +390,7 @@ native void TR_TraceRayFilter(const float pos[3],
  * @param filter        Function to use as a filter.
  * @param data          Arbitrary data value to pass through to the filter
  *                      function.
+ * @param traceType     Trace type.
  */
 native void TR_TraceHullFilter(const float pos[3],
                                const float vec[3],
@@ -387,7 +398,8 @@ native void TR_TraceHullFilter(const float pos[3],
                                const float maxs[3],
                                int flags,
                                TraceEntityFilter filter,
-                               any data=0);
+                               any data=0,
+			       TraceType traceType=TRACE_EVERYTHING);
 
 /**
  * Clips a ray to a particular entity.
@@ -478,6 +490,7 @@ native Handle TR_TraceHullEx(const float pos[3],
  * @param rtype         Method to calculate the ray direction.
  * @param filter        Function to use as a filter.
  * @param data          Arbitrary data value to pass through to the filter function.
+ * @param traceType     Trace type.
  * @return              Ray trace handle, which must be closed via CloseHandle().
  */
 native Handle TR_TraceRayFilterEx(const float pos[3],
@@ -485,7 +498,8 @@ native Handle TR_TraceRayFilterEx(const float pos[3],
                                   int flags,
                                   RayType rtype,
                                   TraceEntityFilter filter,
-                                  any data=0);
+                                  any data=0,
+				  TraceType traceType=TRACE_EVERYTHING);
 
 /**
  * Starts up a new trace hull using a new trace result and a customized
@@ -501,6 +515,7 @@ native Handle TR_TraceRayFilterEx(const float pos[3],
  * @param flags         Trace flags.
  * @param filter        Function to use as a filter.
  * @param data          Arbitrary data value to pass through to the filter function.
+ * @param traceType     Trace type.
  * @return              Ray trace handle, which must be closed via CloseHandle().
  */
 native Handle TR_TraceHullFilterEx(const float pos[3],
@@ -509,7 +524,8 @@ native Handle TR_TraceHullFilterEx(const float pos[3],
                                    const float maxs[3],
                                    int flags,
                                    TraceEntityFilter filter,
-                                   any data=0);
+                                   any data=0,
+				   TraceType traceType=TRACE_EVERYTHING);
 
 /**
  * Clips a ray to a particular entity.


### PR DESCRIPTION
This is a pretty useful introduction that allows to use trace types such as TRACE_WORLD_ONLY, which allows to ignore the SpatialPartition algorithm, thereby reducing the call time of trace functions in some cases up to ~2 times.