### PR TITLE
Allow gamedata to use vscript binary

### DIFF
--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -90,6 +90,7 @@ public:
 	void *          engineFactory;
 	void *          matchmakingDSFactory;
 	void *          soundemittersystemFactory;
+	void *          vscriptFactory;
 	SMGlobalClass *	listeners;
 
 	// ConVar functions.

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -612,6 +612,8 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 				addrInBase = bridge->matchmakingDSFactory;
 			} else if (strcmp(s_TempSig.library, "soundemittersystem") == 0) {
 				addrInBase = bridge->soundemittersystemFactory;
+			} else if (strcmp(s_TempSig.library, "vscript") == 0) {
+				addrInBase = bridge->vscriptFactory;
 			}
 			void *final_addr = NULL;
 			if (addrInBase == NULL)

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -637,6 +637,10 @@ void CoreProviderImpl::InitializeBridge()
 		this->soundemittersystemFactory = (void*)Sys_GetFactory(mmlib);
 	}
 
+	if (auto mmlib = ::filesystem->LoadModule("vscript" SOURCE_BIN_SUFFIX)) {
+		this->vscriptFactory = (void*)Sys_GetFactory(mmlib);
+	}
+
 	logic_init_(this, &logicore);
 
 	// Join logic's SMGlobalClass instances.


### PR DESCRIPTION
Similar to https://github.com/alliedmodders/sourcemod/pull/1787, as https://github.com/alliedmodders/sourcemod/pull/1626 seems to be frozen at the moment.

This is necessary for a plugin modifying some vscript VM behaviour.