### PR TITLE
Implement raw entity handle accessors

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -715,7 +715,7 @@ static cell_t LoadEntityFromHandleAddress(IPluginContext *pContext, const cell_t
 #ifdef PLATFORM_X86
 	void *addr = reinterpret_cast<void*>(params[1]);
 #else
-	void *addr = pseudoAddr.FromPseudoAddress(params[1]);
+	void *addr = g_SourceMod.FromPseudoAddress(params[1]);
 #endif
 
 	if (addr == NULL)
@@ -826,7 +826,7 @@ static cell_t StoreEntityToHandleAddress(IPluginContext *pContext, const cell_t 
 #ifdef PLATFORM_X86
 	void *addr = reinterpret_cast<void*>(params[1]);
 #else
-	void *addr = pseudoAddr.FromPseudoAddress(params[1]);
+	void *addr = g_SourceMod.FromPseudoAddress(params[1]);
 #endif
 
 	if (addr == NULL)

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -850,7 +850,7 @@ static cell_t StoreEntityToHandleAddress(IPluginContext *pContext, const cell_t 
 
 		if (!pOther)
 		{
-			return pContext->ThrowNativeError("Entity %d (%d) is invalid", g_HL2.ReferenceToIndex(params[3]), params[3]);
+			return pContext->ThrowNativeError("Entity %d (%d) is invalid", g_HL2.ReferenceToIndex(params[2]), params[2]);
 		}
 
 		IHandleEntity *pHandleEnt = (IHandleEntity *)pOther;

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -839,7 +839,6 @@ static cell_t StoreEntityToHandleAddress(IPluginContext *pContext, const cell_t 
 	}
 
 	CBaseHandle &hndl = *reinterpret_cast<CBaseHandle*>(addr);
-	CBaseEntity *pHandleEntity = g_HL2.ReferenceToEntity(hndl.GetEntryIndex());
 
 	if ((unsigned)params[2] == INVALID_EHANDLE_INDEX)
 	{

--- a/plugins/include/entity.inc
+++ b/plugins/include/entity.inc
@@ -767,3 +767,19 @@ stock bool GetEntityClassname(int entity, char[] clsname, int maxlength)
 {
 	return !!GetEntPropString(entity, Prop_Data, "m_iClassname", clsname, maxlength);
 }
+
+/**
+ * Interprets the address as an entity handle and returns the associated entity.
+ *
+ * @param addr          Address to a memory location.
+ * @return              Entity index at the given location.  If there is no entity, or the stored entity is invalid, then -1 is returned.
+ */
+native int LoadEntityFromHandleAddress(Address addr);
+
+/**
+ * Interprets the address as an entity handle and sets the entity.
+ *
+ * @param addr          Address to a memory location.
+ * @param entity        Entity index to set, or -1 to clear.
+ */
+native void StoreEntityToHandleAddress(Address addr, int entity);


### PR DESCRIPTION
Closes #1805.

Implements the ability to read / write handles located at arbitrary locations.

The native names `LoadEntityFromHandleAddress` and `StoreEntityToHandleAddress` are wordy.  Feel free to suggest alternatives.

Tested and confirmed working in TF2 with the following plugin (dumps the entity and item definition indices of each wearable on the player):

```
#include <sourcemod>

#pragma semicolon 1
#pragma newdecls required

public void OnPluginStart() {
    RegConsoleCmd("sm_wearables", ListWearables);
}

Action ListWearables(int client, int argc) {
    int offs_CTFPlayer_hMyWearables = FindSendPropInfo("CTFPlayer", "m_hMyWearables");
    
    // CTFPlayer::m_hMyWearables is a CUtlVector<CHandle>
    int count = GetEntData(client, offs_CTFPlayer_hMyWearables + 0x0C);
    Address pData = view_as<Address>(GetEntData(client, offs_CTFPlayer_hMyWearables));
    
    for (int i; i < count; i++) {
        // I don't think there's currently a way to write this in a 64-bit compatible way
        Address pHandle = pData + view_as<Address>(0x04 * i);
        int wearable = LoadEntityFromHandleAddress(pHandle);
        
        // testing - write and read data again to confirm that both operations work
        StoreEntityToHandleAddress(pHandle, wearable);
        wearable = LoadEntityFromHandleAddress(pHandle);
        
        if (!IsValidEntity(wearable)) {
            continue;
        }
        ReplyToCommand(client, "[%d] wearable %d (itemdef %d)", i, wearable,
                GetEntProp(wearable, Prop_Send, "m_iItemDefinitionIndex"));
    }
    return Plugin_Handled;
}
```