### PR TITLE
Block Hidden Commands from Help Command

### DIFF
--- a/plugins/adminhelp.sp
+++ b/plugins/adminhelp.sp
@@ -98,7 +98,7 @@ public Action HelpCmd(int client, int args)
 			cmdIter.GetName(name, sizeof(name));
 			cmdIter.GetDescription(desc, sizeof(desc));
 
-			if ((StrContains(name, arg, false) != -1) && CheckCommandAccess(client, name, cmdIter.Flags))
+			if ((StrContains(name, arg, false) != -1) && ((FindConVar(name).Flags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
 			{
 				PrintToConsole(client, "[%03d] %s - %s", i++, name, (desc[0] == '\0') ? noDesc : desc);
 			}
@@ -120,7 +120,7 @@ public Action HelpCmd(int client, int args)
 			{
 				cmdIter.GetName(name, sizeof(name));
 
-				if (CheckCommandAccess(client, name, cmdIter.Flags))
+				if (((FindConVar(name).Flags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
 				{
 					i++;
 				}
@@ -142,7 +142,7 @@ public Action HelpCmd(int client, int args)
 			cmdIter.GetName(name, sizeof(name));
 			cmdIter.GetDescription(desc, sizeof(desc));
 			
-			if (CheckCommandAccess(client, name, cmdIter.Flags))
+			if (((FindConVar(name).Flags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
 			{
 				i++;
 				PrintToConsole(client, "[%03d] %s - %s", i+StartCmd, name, (desc[0] == '\0') ? noDesc : desc);


### PR DESCRIPTION
Allows using `FCVAR_HIDDEN` to block commands from appearing in `sm_help` and `sm_searchcmd` which helps with creating alias to commands without filling up the list with those aliases.

For example:
```sourcepawn
RegAdminCmd("sm_setmyperk", MyCommand, ADMFLAG_CHEATS);
RegAdminCmd("sm_setmyperks", MyCommand, ADMFLAG_CHEATS, _, FCVAR_HIDDEN);

RegConsoleCmd("ff2_boss", MyCommand);
RegConsoleCmd("ff2boss", MyCommand, _, FCVAR_HIDDEN);
```