### PR TITLE
entitylump: Fix append returning invalid indices

### DIFF
--- a/core/logic/LumpManager.cpp
+++ b/core/logic/LumpManager.cpp
@@ -122,10 +122,8 @@ void EntityLumpManager::Insert(size_t index) {
 }
 
 size_t EntityLumpManager::Append() {
-	return std::distance(
-			m_Entities.begin(),
-			m_Entities.emplace(m_Entities.end(), std::make_shared<EntityLumpEntry>())
-	);
+	auto it = m_Entities.emplace(m_Entities.end(), std::make_shared<EntityLumpEntry>());
+	return std::distance(m_Entities.begin(), it);
 }
 
 size_t EntityLumpManager::Length() {


### PR DESCRIPTION
This PR ensures that the iterator values used by `std::distance` are valid; currently the function may hold an invalidated reference to `m_Entities.begin()` if the append operation triggers a reallocation.

The issue can be reproduced once with the following code:

```sourcepawn
public void OnMapInit() {
	int length = EntityLump.Length();
	for (int n; n < 10000; n++) {
		int i = EntityLump.Append();
		if (length + n != i) {
			LogError("assertion failed: index = %d (n = %d)", i, n);
		}
	}
	while (EntityLump.Length() > length) {
		EntityLump.Erase(length);
	}
}
```