### PR TITLE
Add `KeyValues.Export()` method

### DIFF
--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -757,7 +757,6 @@ static cell_t smn_KeyValuesExport(IPluginContext *pCtx, const cell_t *params)
 	HandleError herr;
 	HandleSecurity sec;
 	KeyValueStack *pStk;
-	char *name;
 
 	sec.pOwner = NULL;
 	sec.pIdentity = g_pCoreIdent;
@@ -767,11 +766,10 @@ static cell_t smn_KeyValuesExport(IPluginContext *pCtx, const cell_t *params)
 	{
 		return pCtx->ThrowNativeError("Invalid key value handle %x (error %d)", hndl, herr);
 	}
-	pCtx->LocalToString(params[2], &name);
 
-	KeyValues *pNewKV = new KeyValues(name[0] == '\0' ? NULL : name); 
+	KeyValues *pNewKV = new KeyValues(NULL /* Will be initialized in KeyValues::operator=() */ ); 
 
-	*pNewKV = *(pStk->pCurRoot.front()); // KeyValues::operator= to recursive copy.
+	*pNewKV = *(pStk->pCurRoot.front()); // KeyValues::operator=() to recursive copy.
 
 	KeyValueStack *pExportStk = new KeyValueStack;
 

--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -751,6 +751,36 @@ static cell_t smn_KvGetDataType(IPluginContext *pCtx, const cell_t *params)
 	return pStk->pCurRoot.front()->GetDataType(name);
 }
 
+staitc cell_t smn_KeyValuesExport(IPluginContext *pCtx, const cell_t *params)
+{
+	Handle_t hndl = static_cast<Handle_t>(params[1]);
+	HandleError herr;
+	HandleSecurity sec;
+	KeyValueStack *pStk;
+	char *name;
+
+	sec.pOwner = NULL;
+	sec.pIdentity = g_pCoreIdent;
+
+	if ((herr=handlesys->ReadHandle(hndl, g_KeyValueType, &sec, (void **)&pStk))
+		!= HandleError_None)
+	{
+		return pCtx->ThrowNativeError("Invalid key value handle %x (error %d)", hndl, herr);
+	}
+	pCtx->LocalToString(params[2], &name);
+
+	KeyValues *pNewKV = new KeyValues(name[0] == '\0' ? NULL : name); 
+
+	*pNewKV = *pStk->pCurRoot; // KeyValues::operator= to recursive copy.
+
+	KeyValueStack *pExportStk = new KeyValueStack;
+
+	pExportStk->pBase = pNewKV;
+	pExportStk->pCurRoot.push(pNewKV);
+
+	return handlesys->CreateHandle(g_KeyValueType, pExportStk, pCtx->GetIdentity(), g_pCoreIdent, NULL);
+}
+
 static cell_t smn_KeyValuesToFile(IPluginContext *pCtx, const cell_t *params)
 {
 	Handle_t hndl = static_cast<Handle_t>(params[1]);
@@ -1241,6 +1271,7 @@ REGISTER_NATIVES(keyvaluenatives)
 	{"KeyValues.Import",				KeyValues_Import},
 	{"KeyValues.ImportFromFile",		smn_FileToKeyValues},
 	{"KeyValues.ImportFromString",		smn_StringToKeyValues},
+	{"KeyValues.Export",				smn_KeyValuesExport},
 	{"KeyValues.ExportToFile",			smn_KeyValuesToFile},
 	{"KeyValues.ExportToString",		smn_KeyValuesToString},
 	{"KeyValues.ExportLength.get",		smn_KeyValuesExportLength},

--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -751,7 +751,7 @@ static cell_t smn_KvGetDataType(IPluginContext *pCtx, const cell_t *params)
 	return pStk->pCurRoot.front()->GetDataType(name);
 }
 
-staitc cell_t smn_KeyValuesExport(IPluginContext *pCtx, const cell_t *params)
+static cell_t smn_KeyValuesExport(IPluginContext *pCtx, const cell_t *params)
 {
 	Handle_t hndl = static_cast<Handle_t>(params[1]);
 	HandleError herr;
@@ -771,7 +771,7 @@ staitc cell_t smn_KeyValuesExport(IPluginContext *pCtx, const cell_t *params)
 
 	KeyValues *pNewKV = new KeyValues(name[0] == '\0' ? NULL : name); 
 
-	*pNewKV = *pStk->pCurRoot; // KeyValues::operator= to recursive copy.
+	*pNewKV = *(pStk->pCurRoot.front()); // KeyValues::operator= to recursive copy.
 
 	KeyValueStack *pExportStk = new KeyValueStack;
 

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -65,10 +65,8 @@ methodmap KeyValues < Handle
 	// Exports a KeyValues tree to new descriptor. The tree is dumped from the current position.
 	// The Handle must be closed.
 	//
-	// @param name          Name of the root section where the export is placed.
-	//                      If NULL_STIRNG, export without a root section.
 	// @return              A Handle to a new KeyValues structure.
-	public native KeyValues Export(const char[] name = NULL_STRING);
+	public native KeyValues Export();
 
 	// Exports a KeyValues tree to a file. The tree is dumped from the current position.
 	//

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -62,6 +62,14 @@ methodmap KeyValues < Handle
 	// @param firstValue    If firstKey is non-empty, specifies the first key's value.
 	public native KeyValues(const char[] name, const char[] firstKey="", const char[] firstValue="");
 
+	// Exports a KeyValues tree to new descriptor. The tree is dumped from the current position.
+	// The Handle must be closed.
+	//
+	// @param name          Name of the root section where the export is placed.
+	//                      If NULL_STIRNG, export without a root section.
+	// @return              A Handle to a new KeyValues structure.
+	public native KeyValues Export(const char[] name = NULL_STRING);
+
 	// Exports a KeyValues tree to a file. The tree is dumped from the current position.
 	//
 	// @param file          File to dump write to.


### PR DESCRIPTION
I need this method to work safely among methodmaps that legacy `KeyValues` without high positions access.

For example,
```sourcepawn
methodmap X < KeyValues
{
	// ...

	public SubX GetSubX()
	{
		this.JumpToKey("sub");

		KeyValues hWorldValues = this.Export();

		this.GoBack();

		return view_as<SubX>(hWorldValues);
	}
};

methodmap SubX < KeyValues
{
	// ...
};
```

Would be correct for `SubX` not to be able jump to `X` with `this.GoBack()` and changed it. `KeyValues.Export()` solves this problem.