### PR TITLE
Correct missed team offsets in CheckRestartRound

### DIFF
--- a/gamedata/sm-cstrike.games/game.csgo.txt
+++ b/gamedata/sm-cstrike.games/game.csgo.txt
@@ -39,16 +39,16 @@
 			//Offset into CheckRestartRound
 			"CTTeamScoreOffset"
 			{
-				"windows"	"98"
-				"linux"		"115"
+				"windows"	"174"
+				"linux"		"107"
 				"linux64"	"143"
 				"mac64"		"148"
 			}
 			//Offset into CheckRestartRound
 			"TTeamScoreOffset"
 			{
-				"windows"	"125"
-				"linux"		"148"
+				"windows"	"201"
+				"linux"		"140"
 				"linux64"	"174"
 				"mac64"		"177"
 			}


### PR DESCRIPTION
Fixes `CS_GetTeamScore` crashing, untested on Windows.

Missed them in #1842 due to the CheckRestartRound/CheckWinLimit naming shenanigans.