### PR TITLE
Fix `SetEntityHealth` to support 'any' entities

### DIFF
--- a/plugins/include/entity_prop_stocks.inc
+++ b/plugins/include/entity_prop_stocks.inc
@@ -534,19 +534,10 @@ stock void SetEntityHealth(int entity, int amount)
 		gotconfig = true;
 	}
 
-	char cls[64];
 	PropFieldType type;
 	int offset;
 
-	if (!GetEntityNetClass(entity, cls, sizeof(cls)))
-	{
-		ThrowError("SetEntityHealth not supported by this mod: Could not get serverclass name");
-		return;
-	}
-
-	offset = FindSendPropInfo(cls, prop, type);
-
-	if (offset <= 0)
+	if ((offset = FindDataMapInfo(entity, prop, type)) == -1)
 	{
 		ThrowError("SetEntityHealth not supported by this mod");
 		return;
@@ -559,7 +550,12 @@ stock void SetEntityHealth(int entity, int amount)
 	}
 	else
 	{
-		SetEntProp(entity, Prop_Send, prop, amount);
+		SetEntData(entity, offset, amount);
+	}
+
+	if (IsValidEdict(entity))
+	{
+		ChangeEdictState(entity);
 	}
 }
 


### PR DESCRIPTION
This PR closes #1770 

### What changed ?

Instead of assuming the prop name given in core gamedata is a networked property. We will instead assume it's the datamap equivalent, and is on the same offset, plus visible on every single entity as it is a CBaseEntity datamap, unlike the netprop which is only visible if the deriving class decided to have it networked.
To maintain the behaviour the old native had (mainly firing a network update, since it used `Prop_Send`) we notify the game the entity changed in order to fire a network update. And if the entity isn't networked we do nothing.

### Benefits

This will allow for a wider range of entity support. Granted plugins could just do `SetEntProp(entity, Prop_Data, "m_iHealth", amount)`. But Sourcemod aims at being strongly backwards compatible, therefore it is safe to say this native isn't going to be removed anytime soon. So since we already keep track of the property name in the core gamedata might as well just make a native that works on any source games (not that I'm aware of any that changed this property name but still).