### PR TITLE
Fix DHooks jit code stack memory alignment

### DIFF
--- a/extensions/dhooks/DynamicHooks/hook.cpp
+++ b/extensions/dhooks/DynamicHooks/hook.cpp
@@ -355,13 +355,13 @@ void CHook::Write_CallHandler(sp::MacroAssembler& masm, HookType_t type)
 	Write_SaveRegisters(masm, type);
 
 	// Align the stack to 16 bytes.
-	masm.subl(esp, 8);
+	masm.subl(esp, 4);
 
 	// Call the global hook handler
 	masm.push(type);
 	masm.push(intptr_t(this));
 	masm.call(ExternalAddress((void *&)HookHandler));
-	masm.addl(esp, 16);
+	masm.addl(esp, 12);
 }
 
 void CHook::Write_SaveRegisters(sp::MacroAssembler& masm, HookType_t type)


### PR DESCRIPTION
This fixes wrong stack memory alignment, because stack already have 4 bytes of return address at this moment in both cases: pre and post calls of hook handler.

Cherry pick in 1.11 if it needed.

Found with crash after local recompiling of SM 1.11. After dhooks jit code stack was wrongly aligned and crashed on `movdqa` instruction. 
https://crash.limetech.org/inzoqhjqfcrl