### PR TITLE
Enable CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
      - master
+     - '[0-9]+.[0-9]+-dev'
   pull_request:
     branches:
      - master
+     - '[0-9]+.[0-9]+-dev'
 jobs:
   test:
     strategy:

--- a/.github/workflows/scripting.yml
+++ b/.github/workflows/scripting.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - '[0-9]+.[0-9]+-dev'
     paths:
       - 'plugins/include/*'
       - 'sourcepawn/**'


### PR DESCRIPTION
While we don't commonly have PRs against release branches, it seems like we should have CI runs when we do. It also seems useful to have the scripting archive for them.

I'm not 100% this syntax is correct but there isn't a super easy way to test it without just doing it.