### PR TITLE
Bump minimum MM:S version for build to 1.12

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -200,9 +200,7 @@ class SMConfig(object):
     if builder.options.mms_path:
       self.mms_root = builder.options.mms_path
     else:
-      self.mms_root = ResolveEnvPath('MMSOURCE111', 'mmsource-1.11')
-      if not self.mms_root:
-        self.mms_root = ResolveEnvPath('MMSOURCE110', 'mmsource-1.10')
+      self.mms_root = ResolveEnvPath('MMSOURCE112', 'mmsource-1.12')
       if not self.mms_root:
         self.mms_root = ResolveEnvPath('MMSOURCE_DEV', 'metamod-source')
       if not self.mms_root:


### PR DESCRIPTION
PVKII changes require at least MM:S 1.12 to build SM.