### PR TITLE
Add support for TF2's `vscript_test` branch

### DIFF
--- a/gamedata/sdkhooks.games/common.games.txt
+++ b/gamedata/sdkhooks.games/common.games.txt
@@ -23,31 +23,4 @@
 			}
 		}
 	}
-	
-	/**
-	 * Special handling for TF2's vscript_test branch.
-	 * There appears to be an issue where the #default value in this file
-	 * takes priority over the CRC-specific match in the engine-specific
-	 * one.
-	 */
-	"#default"
-	{
-		"CRC"
-		{
-			"server"
-			{
-				"windows"	"A801CADC"
-				"linux"		"DCB7584C"
-			}
-		}
-		"Offsets"
-		{
-			"EntityListeners"
-			{
-				"windows"	"131108"
-				"linux"		"131108"
-				"mac"		"131108"
-			}
-		}
-	}
 }

--- a/gamedata/sdkhooks.games/common.games.txt
+++ b/gamedata/sdkhooks.games/common.games.txt
@@ -23,4 +23,31 @@
 			}
 		}
 	}
+	
+	/**
+	 * Special handling for TF2's vscript_test branch.
+	 * There appears to be an issue where the #default value in this file
+	 * takes priority over the CRC-specific match in the engine-specific
+	 * one.
+	 */
+	"#default"
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"windows"	"A801CADC"
+				"linux"		"DCB7584C"
+			}
+		}
+		"Offsets"
+		{
+			"EntityListeners"
+			{
+				"windows"	"131108"
+				"linux"		"131108"
+				"mac"		"131108"
+			}
+		}
+	}
 }

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -466,8 +466,8 @@
 		{
 			"server"
 			{
-				"windows"	"961CE6F5"
-				"linux"		"76F8E7F1"
+				"windows"	"E0DB134E"
+				"linux"		"260B79CB"
 			}
 		}
 		"Offsets"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -474,6 +474,11 @@
 		{
 			"EntityListeners"
 			{
+				/**
+				 * FIXME: This is currently not being read from here, but from common.games.txt.
+				 * Other overrides below are read correctly, presumably because they aren't
+				 * being overridden via #default.
+				 */
 				"windows"	"131108"
 				"linux"		"131108"
 				"mac"		"131108"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -466,8 +466,8 @@
 		{
 			"server"
 			{
-				"windows"	"E0DB134E"
-				"linux"		"260B79CB"
+				"windows"	"0B67CA5E"
+				"linux"		"BD4C62D8"
 			}
 		}
 		"Offsets"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -474,11 +474,6 @@
 		{
 			"EntityListeners"
 			{
-				/**
-				 * FIXME: This is currently not being read from here, but from common.games.txt.
-				 * Other overrides below are read correctly, presumably because they aren't
-				 * being overridden via #default.
-				 */
 				"windows"	"131108"
 				"linux"		"131108"
 				"mac"		"131108"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -466,8 +466,8 @@
 		{
 			"server"
 			{
-				"linux"		"0448F204"
-				"windows"	"BFA098CF"
+				"windows"	"0448F204"
+				"linux"		"BFA098CF"
 			}
 		}
 		"Offsets"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -472,6 +472,12 @@
 		}
 		"Offsets"
 		{
+			"EntityListeners"
+			{
+				"windows"	"131108"
+				"linux"		"131108"
+				"mac"		"131108"
+			}
 			"CanBeAutobalanced"
 			{
 				"windows"	"473"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -466,8 +466,8 @@
 		{
 			"server"
 			{
-				"windows"	"FBCCF607"
-				"linux"		"B0EC9249"
+				"windows"	"961CE6F5"
+				"linux"		"76F8E7F1"
 			}
 		}
 		"Offsets"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -459,4 +459,169 @@
 			}
 		}
 	}
+	// special handling for TF2's vscript_test branch
+	"#default"
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"linux"		"0448F204"
+				"windows"	"BFA098CF"
+			}
+		}
+		"Offsets"
+		{
+			"CanBeAutobalanced"
+			{
+				"windows"	"473"
+				"linux"		"474"
+				"mac"		"474"
+			}
+			"EndTouch"
+			{
+				"windows"	"105"
+				"linux"		"106"
+				"mac"		"106"
+			}
+			"FireBullets"
+			{
+				"windows"	"117"
+				"linux"		"118"
+				"mac"		"118"
+			}
+			"GetMaxHealth"
+			{
+				"windows"	"122"
+				"linux"		"123"
+				"mac"		"123"
+			}
+			"GroundEntChanged"
+			{
+				"windows"	"183"
+				"linux"		"185"
+				"mac"		"185"
+			}
+			"OnTakeDamage"
+			{
+				"windows"	"64"
+				"linux"		"65"
+				"mac"		"65"
+			}
+			"OnTakeDamage_Alive"
+			{
+				"windows"	"282"
+				"linux"		"283"
+				"mac"		"283"
+			}
+			"PreThink"
+			{
+				"windows"	"343"
+				"linux"		"344"
+				"mac"		"344"
+			}
+			"PostThink"
+			{
+				"windows"	"344"
+				"linux"		"345"
+				"mac"		"345"
+			}
+			"Reload"
+			{
+				"windows"	"283"
+				"linux"		"289"
+				"mac"		"289"
+			}
+			"SetTransmit"
+			{
+				"windows"	"22"
+				"linux"		"23"
+				"mac"		"23"
+			}
+			"ShouldCollide"
+			{
+				"windows"	"17"
+				"linux"		"18"
+				"mac"		"18"
+			}
+			"Spawn"
+			{
+				"windows"	"24"
+				"linux"		"25"
+				"mac"		"25"
+			}
+			"StartTouch"
+			{
+				"windows"	"103"
+				"linux"		"104"
+				"mac"		"104"
+			}
+			"Think"
+			{
+				"windows"	"49"
+				"linux"		"50"
+				"mac"		"50"
+			}
+			"Touch"
+			{
+				"windows"	"104"
+				"linux"		"105"
+				"mac"		"105"
+			}
+			"TraceAttack"
+			{
+				"windows"	"62"
+				"linux"		"63"
+				"mac"		"63"
+			}
+			"Use"
+			{
+				"windows"	"102"
+				"linux"		"103"
+				"mac"		"103"
+			}
+			"VPhysicsUpdate"
+			{
+				"windows"	"163"
+				"linux"		"164"
+				"mac"		"164"
+			}
+			"Blocked"
+			{
+				"windows"	"107"
+				"linux"		"108"
+				"mac"		"108"
+			}
+			"Weapon_CanSwitchTo"
+			{
+				"windows"	"276"
+				"linux"		"277"
+				"mac"		"277"
+			}
+			"Weapon_CanUse"
+			{
+				"windows"	"270"
+				"linux"		"271"
+				"mac"		"271"
+			}
+			"Weapon_Drop"
+			{
+				"windows"	"273"
+				"linux"		"274"
+				"mac"		"274"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"271"
+				"linux"		"272"
+				"mac"		"272"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"274"
+				"linux"		"275"
+				"mac"		"275"
+			}
+		}
+	}
 }

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -466,8 +466,8 @@
 		{
 			"server"
 			{
-				"windows"	"0448F204"
-				"linux"		"BFA098CF"
+				"windows"	"A801CADC"
+				"linux"		"DCB7584C"
 			}
 		}
 		"Offsets"

--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -466,8 +466,8 @@
 		{
 			"server"
 			{
-				"windows"	"A801CADC"
-				"linux"		"DCB7584C"
+				"windows"	"FBCCF607"
+				"linux"		"B0EC9249"
 			}
 		}
 		"Offsets"

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -164,8 +164,8 @@
 		{
 			"server"
 			{
-				"linux"		"0448F204"
-				"windows"	"BFA098CF"
+				"windows"	"0448F204"
+				"linux"		"BFA098CF"
 			}
 		}
 		"Offsets"
@@ -288,8 +288,8 @@
 		{
 			"server"
 			{
-				"linux"		"0448F204"
-				"windows"	"BFA098CF"
+				"windows"	"0448F204"
+				"linux"		"BFA098CF"
 			}
 		}
 		"Signatures"
@@ -311,8 +311,8 @@
 		{
 			"server"
 			{
-				"linux"		"0448F204"
-				"windows"	"BFA098CF"
+				"windows"	"0448F204"
+				"linux"		"BFA098CF"
 			}
 		}
 		"Signatures"
@@ -326,5 +326,4 @@
 			}
 		}
 	}
-	
 }

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -164,8 +164,8 @@
 		{
 			"server"
 			{
-				"windows"	"961CE6F5"
-				"linux"		"76F8E7F1"
+				"windows"	"E0DB134E"
+				"linux"		"260B79CB"
 			}
 		}
 		"Offsets"
@@ -288,8 +288,8 @@
 		{
 			"server"
 			{
-				"windows"	"961CE6F5"
-				"linux"		"76F8E7F1"
+				"windows"	"E0DB134E"
+				"linux"		"260B79CB"
 			}
 		}
 		"Signatures"
@@ -311,8 +311,8 @@
 		{
 			"server"
 			{
-				"windows"	"961CE6F5"
-				"linux"		"76F8E7F1"
+				"windows"	"E0DB134E"
+				"linux"		"260B79CB"
 			}
 		}
 		"Signatures"

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -164,8 +164,8 @@
 		{
 			"server"
 			{
-				"windows"	"FBCCF607"
-				"linux"		"B0EC9249"
+				"windows"	"961CE6F5"
+				"linux"		"76F8E7F1"
 			}
 		}
 		"Offsets"
@@ -288,8 +288,8 @@
 		{
 			"server"
 			{
-				"windows"	"FBCCF607"
-				"linux"		"B0EC9249"
+				"windows"	"961CE6F5"
+				"linux"		"76F8E7F1"
 			}
 		}
 		"Signatures"
@@ -311,8 +311,8 @@
 		{
 			"server"
 			{
-				"windows"	"FBCCF607"
-				"linux"		"B0EC9249"
+				"windows"	"961CE6F5"
+				"linux"		"76F8E7F1"
 			}
 		}
 		"Signatures"

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -156,4 +156,175 @@
 			}
 		}
 	}
+	
+	/* Team Fortress 2 - vscript_test */
+	"#default"
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"linux"		"0448F204"
+				"windows"	"BFA098CF"
+			}
+		}
+		"Offsets"
+		{
+			"SetOwnerEntity"
+			{
+				"windows"	"18"
+				"linux"		"19"
+				"mac"		"19"
+			}
+			"GiveNamedItem"
+			{
+				"windows"	"412"
+				"linux"		"413"
+				"mac"		"413"
+			}
+			"RemovePlayerItem"
+			{
+				"windows"	"280"
+				"linux"		"281"
+				"mac"		"281"
+			}
+			"Weapon_GetSlot"
+			{
+				"windows"	"278"
+				"linux"		"279"
+				"mac"		"279"
+			}
+			"Ignite"
+			{
+				"windows"	"219"
+				"linux"		"220"
+				"mac"		"220"
+			}
+			"Extinguish"
+			{
+				"windows"	"223"
+				"linux"		"224"
+				"mac"		"224"
+			}
+			"Teleport"
+			{
+				"windows"	"113"
+				"linux"		"114"
+				"mac"		"114"
+			}
+			"CommitSuicide"
+			{
+				"windows"	"453"
+				"linux"		"453"
+				"mac"		"453"
+			}
+			"GetVelocity"
+			{
+				"windows"	"146"
+				"linux"		"147"
+				"mac"		"147"
+			}
+			"EyeAngles"
+			{
+				"windows"	"137"
+				"linux"		"138"
+				"mac"		"138"
+			}
+			"SetEntityModel"
+			{
+				"windows"	"26"
+				"linux"		"27"
+				"mac"		"27"
+			}
+			"AcceptInput"
+			{
+				"windows"	"38"
+				"linux"		"39"
+				"mac"		"39"
+			}
+			"WeaponEquip"
+			{
+				"windows"	"271"
+				"linux"		"272"
+				"mac"		"272"
+			}
+			"Activate"
+			{
+				"windows"	"35"
+				"linux"		"36"
+				"mac"		"36"
+			}
+			"PlayerRunCmd"
+			{
+				"windows"	"430"
+				"linux"		"431"
+				"mac"		"431"
+			}
+			"GiveAmmo"
+			{
+				"windows"	"262"
+				"linux"		"263"
+				"mac"		"263"
+			}
+			"GetAttachment"
+			{
+				"windows"	"215"
+				"linux"		"216"
+				"mac"		"216"
+			}
+		}
+		
+		"Keys"
+		{
+			"GameRulesProxy"	"CTFGameRulesProxy"
+			"GameRulesDataTable" "tf_gamerules_data"
+		}
+	}
+	
+	/* CBaseEntityOutput::FireOutput - vscript_test */
+	"#default"
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"linux"		"0448F204"
+				"windows"	"BFA098CF"
+			}
+		}
+		"Signatures"
+		{
+			"FireOutput"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x24\x01\x00\x00\x53\x8B\xC1"
+				"linux"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
+				"mac"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
+			}
+		}
+	}
+	
+	/* CBaseAnimating::LookupAttachment - vscript_test */
+	"#default"
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"linux"		"0448F204"
+				"windows"	"BFA098CF"
+			}
+		}
+		"Signatures"
+		{
+			"LookupAttachment"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\x80\xBE\x2A\x03\x00\x00\x00\x75\x2A\x83\xBE\x2A\x04\x00\x00\x00\x75\x2A\xE8\x2A\x2A\x2A\x2A\x85\xC0\x74\x2A\x8B\xCE\xE8\x2A\x2A\x2A\x2A\x8B\x86\x2A\x04\x00\x00\x85\xC0\x74\x2A\x83\x38\x00\x74\x2A\xFF\x75\x08\x50\xE8\x2A\x2A\x2A\x2A\x83\xC4\x08\x40"
+				"linux"		"@_ZN14CBaseAnimating16LookupAttachmentEPKc"
+				"mac"		"@_ZN14CBaseAnimating16LookupAttachmentEPKc"
+			}
+		}
+	}
+	
 }

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -164,8 +164,8 @@
 		{
 			"server"
 			{
-				"windows"	"0448F204"
-				"linux"		"BFA098CF"
+				"windows"	"A801CADC"
+				"linux"		"DCB7584C"
 			}
 		}
 		"Offsets"
@@ -288,8 +288,8 @@
 		{
 			"server"
 			{
-				"windows"	"0448F204"
-				"linux"		"BFA098CF"
+				"windows"	"A801CADC"
+				"linux"		"DCB7584C"
 			}
 		}
 		"Signatures"
@@ -311,8 +311,8 @@
 		{
 			"server"
 			{
-				"windows"	"0448F204"
-				"linux"		"BFA098CF"
+				"windows"	"A801CADC"
+				"linux"		"DCB7584C"
 			}
 		}
 		"Signatures"

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -164,8 +164,8 @@
 		{
 			"server"
 			{
-				"windows"	"E0DB134E"
-				"linux"		"260B79CB"
+				"windows"	"0B67CA5E"
+				"linux"		"BD4C62D8"
 			}
 		}
 		"Offsets"
@@ -288,8 +288,8 @@
 		{
 			"server"
 			{
-				"windows"	"E0DB134E"
-				"linux"		"260B79CB"
+				"windows"	"0B67CA5E"
+				"linux"		"BD4C62D8"
 			}
 		}
 		"Signatures"
@@ -311,8 +311,8 @@
 		{
 			"server"
 			{
-				"windows"	"E0DB134E"
-				"linux"		"260B79CB"
+				"windows"	"0B67CA5E"
+				"linux"		"BD4C62D8"
 			}
 		}
 		"Signatures"

--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -164,8 +164,8 @@
 		{
 			"server"
 			{
-				"windows"	"A801CADC"
-				"linux"		"DCB7584C"
+				"windows"	"FBCCF607"
+				"linux"		"B0EC9249"
 			}
 		}
 		"Offsets"
@@ -288,8 +288,8 @@
 		{
 			"server"
 			{
-				"windows"	"A801CADC"
-				"linux"		"DCB7584C"
+				"windows"	"FBCCF607"
+				"linux"		"B0EC9249"
 			}
 		}
 		"Signatures"
@@ -311,8 +311,8 @@
 		{
 			"server"
 			{
-				"windows"	"A801CADC"
-				"linux"		"DCB7584C"
+				"windows"	"FBCCF607"
+				"linux"		"B0EC9249"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -153,8 +153,8 @@
 		{
 			"server"
 			{
-				"windows"	"0448F204"
-				"linux"		"BFA098CF"
+				"windows"	"A801CADC"
+				"linux"		"DCB7584C"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -153,8 +153,8 @@
 		{
 			"server"
 			{
-				"windows"	"961CE6F5"
-				"linux"		"76F8E7F1"
+				"windows"	"E0DB134E"
+				"linux"		"260B79CB"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -153,8 +153,8 @@
 		{
 			"server"
 			{
-				"windows"	"FBCCF607"
-				"linux"		"B0EC9249"
+				"windows"	"961CE6F5"
+				"linux"		"76F8E7F1"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -153,8 +153,8 @@
 		{
 			"server"
 			{
-				"windows"	"A801CADC"
-				"linux"		"DCB7584C"
+				"windows"	"FBCCF607"
+				"linux"		"B0EC9249"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -153,8 +153,8 @@
 		{
 			"server"
 			{
-				"windows"	"E0DB134E"
-				"linux"		"260B79CB"
+				"windows"	"0B67CA5E"
+				"linux"		"BD4C62D8"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -153,8 +153,8 @@
 		{
 			"server"
 			{
-				"linux"		"0448F204"
-				"windows"	"BFA098CF"
+				"windows"	"0448F204"
+				"linux"		"BFA098CF"
 			}
 		}
 		"Signatures"

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -146,6 +146,150 @@
 			}
 		}
 	}
+	// special handling for TF2's vscript_test branch
+	"#default"
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"linux"		"0448F204"
+				"windows"	"BFA098CF"
+			}
+		}
+		"Signatures"
+		{
+			"Burn"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x56\x8B\xF1\x8B\x8E\x8C\x01\x00\x00\x8B\x01"
+				"linux"		"@_ZN15CTFPlayerShared4BurnEP9CTFPlayerP13CTFWeaponBasef"
+				"mac"		"@_ZN15CTFPlayerShared4BurnEP9CTFPlayerP13CTFWeaponBasef"
+			}
+			"RemoveDisguise"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x51\x56\x8B\xF1\x57\xF7\x86\xD0\x00\x00\x00\x00\x00\x02\x00"
+				"linux"		"@_ZN15CTFPlayerShared14RemoveDisguiseEv"
+				"mac"		"@_ZN15CTFPlayerShared14RemoveDisguiseEv"
+			}
+			"Disguise"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x24\x56\x57\x8B\xF9\x8B\x8F\x8C\x01\x00\x00"
+				"linux"		"@_ZN15CTFPlayerShared8DisguiseEiiP9CTFPlayerb"
+				"mac"		"@_ZN15CTFPlayerShared8DisguiseEiiP9CTFPlayerb"
+			}
+			"Regenerate"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x24\x53\x56\x57\x8B\xF9\x8B\x07\xFF\x90"
+				"linux"		"@_ZN9CTFPlayer10RegenerateEb"
+				"mac"		"@_ZN9CTFPlayer10RegenerateEb"
+			}
+			"AddCondition"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x56\x8B\xF1\x8B\x8E\x2A\x2A\x2A\x2A\x85\xC9\x0F\x84\x2A\x2A\x2A\x2A\x8B\x01\x8B"
+				"linux"		"@_ZN15CTFPlayerShared7AddCondE7ETFCondfP11CBaseEntity"
+				"mac"		"@_ZN15CTFPlayerShared7AddCondE7ETFCondfP11CBaseEntity"
+			}
+			"RemoveCondition"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x53\x8B\x5D\x08\x56\x53"
+				"linux"		"@_ZN15CTFPlayerShared10RemoveCondE7ETFCondb"
+				"mac"		"@_ZN15CTFPlayerShared10RemoveCondE7ETFCondb"
+			}
+			"SetPowerplayEnabled"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x80\x7D\x08\x00\x56\x57\x8B\xF9"
+				"linux"		"@_ZN9CTFPlayer19SetPowerplayEnabledEb"
+				"mac"		"@_ZN9CTFPlayer19SetPowerplayEnabledEb"
+			}
+			"SetInWaitingForPlayers"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\xE8\x2A\x2A\x2A\x2A\x84\xC0\x0F\x85\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A"
+				"linux"		"@_ZN24CTeamplayRoundBasedRules22SetInWaitingForPlayersEb"
+				"mac"		"@_ZN24CTeamplayRoundBasedRules22SetInWaitingForPlayersEb"
+			}
+			"StunPlayer"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x20\x57\x8B\xF9\x8B\x87\x54\x04\x00\x00"
+				"linux"		"@_ZN15CTFPlayerShared10StunPlayerEffiP9CTFPlayer"
+				"mac"		"@_ZN15CTFPlayerShared10StunPlayerEffiP9CTFPlayer"
+			}
+			"MakeBleed"
+			{
+				"library" 	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x2C\x57\x8B\xF9\x89\x7D\xF0"
+				"linux"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefibi"
+				"mac"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefibi"
+			}
+			"IsPlayerInDuel"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x81\x65\x2A\x2A\x2A\x2A\x2A\x8D\x45\xF8\x8B\x4D\x08\xC6\x45\xFF\x00\x81\x65\x2A\x2A\x2A\x2A\x2A\x50\xC7\x45\x2A\x2A\x2A\x2A\x2A\xE8\x2A\x2A\x2A\x2A\x84\xC0\x75\x04"
+				"linux"		"@_Z21DuelMiniGame_IsInDuelP9CTFPlayer"
+				"mac"		"@_Z21DuelMiniGame_IsInDuelP9CTFPlayer"
+			}
+			"CanPlayerTeleport"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x53\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x75\x2A\x5F\x32\xC0\x5B\x5D\xC2\x04\x00"
+				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
+				"mac"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
+			}
+			
+			// Obsolete
+			"IsHolidayActive"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x83\x78\x30\x00\x74\x04\x32\xC0"
+				"linux"		"@_Z18TF_IsHolidayActivei"
+				"mac"		"@_Z18TF_IsHolidayActivei"
+			}
+		}
+		"Offsets"
+		{
+			"ForceRespawn"
+			{
+				"windows"	"336"
+				"linux"		"337"
+				"mac"		"337"
+			}
+			"CalcIsAttackCriticalHelper"
+			{
+				"windows"	"397"
+				"linux"		"404"
+				"mac"		"404"
+			}
+			"CalcIsAttackCriticalHelperNoCrits"
+			{
+				"windows"	"398"
+				"linux"		"405"
+				"mac"		"405"
+			}
+			
+			// CTFGameRules::IsHolidayActive
+			"IsHolidayActive"
+			{
+				"windows"	"139"
+				"linux"		"140"
+				"mac"		"140"
+			}
+
+			"RemoveWearable"
+			{
+				"windows"	"439"
+				"linux"		"440"
+				"mac"		"440"
+			}
+		}
+	}
 	
 	/*
 	 * TF2 Holiday index values. Formerly SM TFHoliday enum.


### PR DESCRIPTION
> psychonic: If someone submits gamedata that still uses current build as default with overrides by crc for the branch, we could take it

This PR intends to add support for TF2's `vscript_test` staging branch.  This should be current for game version 7682888 (latest as of 2022-11-23).

Since VScripts are likely to be integrated into the game in the future, this also serves as preparation for that change regardless of whether or not the maintainers decide to add support for the branch.

~~Currently untested and unsure if the syntax is correct.  Will review when I'm more awake if nobody confirms this is working.~~

~~Do note that Linux servers are not usable at this time as the game itself is missing dependencies.  Even stock installations currently fail.~~

Summary of changes:

- Account for additions to entity vtables that have shifted entries by up to 4.
- `CTFPlayerShared::m_pOuter` was shifted down by 4 bytes, breaking Windows signatures in `sm-tf2.games` that relied on member offsets.  At the moment this is resolved by changing the bytes to match, but we could also wildcard them instead.
- Account for new location of `EntityListeners` for SDKHooks.