### PR TITLE
Update Github Action workflow versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
       MYSQL_VERSION: '5.5'
       MMSOURCE_VERSION: '1.10'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
           path: sourcemod
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: hl2sdk-mysql-mmsource
         with:
@@ -53,7 +53,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-mysql${{ env.MYSQL_VERSION }}-
 
       # Setup Python for AMBuild
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Setup Python 3.8
         with:
           python-version: 3.8

--- a/.github/workflows/scripting.yml
+++ b/.github/workflows/scripting.yml
@@ -27,12 +27,12 @@ jobs:
     env:
       ARCH: x86,x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 
       # Setup Python for AMBuild
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Setup Python 3.8
         with:
           python-version: 3.8
@@ -73,7 +73,7 @@ jobs:
           echo "SM_VERSION=$(cat ../product.version)" >> $GITHUB_ENV
 
       - name: Archive tooling
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sourcemod-tooling-${{ env.SM_VERSION }}-${{ matrix.os_short }}
           path: build/package


### PR DESCRIPTION
The currently used versions use deprecated features and Node 12 which is EOL. Switch to newer versions as adviced.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/