### PR TITLE
Ensure gameconfig file uniqueness when reading master.games

### DIFF
--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -814,7 +814,10 @@ public:
 				(!had_game && matched_engine) ||
 				(matched_engine && matched_game))
 			{
-				fileList->push_back(cur_file);
+				if (fileList->find(cur_file) == fileList->end())
+				{
+					fileList->push_back(cur_file);
+				}
 			}
 			state = MSTATE_MAIN;
 		}


### PR DESCRIPTION
The extended gameconfig format reads the master gameconf file twice, once each for the base engine and actual engine.  The file list isn't checked for duplicates, so 'common.games.txt' is loaded in twice, resulting in any 'common' file values potentially overriding values listed under '#default' in other files due to `bShouldBeReadingDefault`.  This happens in the case when matching game versions by CRC (such as public game branches).

This PR ensures each unique file is only traversed once.

Required for #1857.