### PR TITLE
Add CommandIterator.ConVarFlags property

### DIFF
--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -1574,6 +1574,7 @@ REGISTER_NATIVES(consoleNatives)
 	{"CommandIterator.GetDescription",	sm_CommandIteratorGetDesc},
 	{"CommandIterator.GetName",		sm_CommandIteratorGetName},
 	{"CommandIterator.Flags.get",		sm_CommandIteratorAdminFlags},
+	{"CommandIterator.AdminFlags.get",		sm_CommandIteratorAdminFlags},
 	{"CommandIterator.ConVarFlags.get",		sm_CommandIteratorConVarFlags},
 	{"CommandIterator.Plugin.get",		sm_CommandIteratorPlugin},
 

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -1393,7 +1393,7 @@ static cell_t sm_CommandIteratorNext(IPluginContext *pContext, const cell_t *par
 	return iter->iter != cmds.end();
 }
 
-static cell_t sm_CommandIteratorFlags(IPluginContext *pContext, const cell_t *params)
+static cell_t sm_CommandIteratorAdminFlags(IPluginContext *pContext, const cell_t *params)
 {
 	GlobCmdIter *iter;
 	HandleError err;
@@ -1412,6 +1412,27 @@ static cell_t sm_CommandIteratorFlags(IPluginContext *pContext, const cell_t *pa
 	
 	ConCmdInfo *pInfo = (*(iter->iter));
 	return pInfo->eflags;
+}
+
+static cell_t sm_CommandIteratorConVarFlags(IPluginContext *pContext, const cell_t *params)
+{
+	GlobCmdIter *iter;
+	HandleError err;
+	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
+
+	if ((err = handlesys->ReadHandle(params[1], hCmdIterType, &sec, (void **)&iter))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid CommandIterator Handle %x", params[1]);
+	}
+	const List<ConCmdInfo *> &cmds = g_ConCmds.GetCommandList();
+	if (!iter->started || iter->iter == cmds.end())
+	{
+		return pContext->ThrowNativeError("Invalid CommandIterator position");
+	}
+	
+	ConCmdInfo *pInfo = (*(iter->iter));
+	return pInfo->pCmd->m_nFlags;
 }
 
 static cell_t sm_CommandIteratorGetDesc(IPluginContext *pContext, const cell_t *params)
@@ -1552,7 +1573,8 @@ REGISTER_NATIVES(consoleNatives)
 	{"CommandIterator.Next",		sm_CommandIteratorNext},
 	{"CommandIterator.GetDescription",	sm_CommandIteratorGetDesc},
 	{"CommandIterator.GetName",		sm_CommandIteratorGetName},
-	{"CommandIterator.Flags.get",		sm_CommandIteratorFlags},
+	{"CommandIterator.Flags.get",		sm_CommandIteratorAdminFlags},
+	{"CommandIterator.ConVarFlags.get",		sm_CommandIteratorConVarFlags},
 	{"CommandIterator.Plugin.get",		sm_CommandIteratorPlugin},
 
 	{NULL,					NULL}

--- a/plugins/adminhelp.sp
+++ b/plugins/adminhelp.sp
@@ -98,7 +98,7 @@ public Action HelpCmd(int client, int args)
 			cmdIter.GetName(name, sizeof(name));
 			cmdIter.GetDescription(desc, sizeof(desc));
 
-			if ((StrContains(name, arg, false) != -1) && ((FindConVar(name).Flags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
+			if ((StrContains(name, arg, false) != -1) && ((cmdIter.ConVarFlags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
 			{
 				PrintToConsole(client, "[%03d] %s - %s", i++, name, (desc[0] == '\0') ? noDesc : desc);
 			}
@@ -120,7 +120,7 @@ public Action HelpCmd(int client, int args)
 			{
 				cmdIter.GetName(name, sizeof(name));
 
-				if (((FindConVar(name).Flags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
+				if (((cmdIter.ConVarFlags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
 				{
 					i++;
 				}
@@ -142,7 +142,7 @@ public Action HelpCmd(int client, int args)
 			cmdIter.GetName(name, sizeof(name));
 			cmdIter.GetDescription(desc, sizeof(desc));
 			
-			if (((FindConVar(name).Flags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
+			if (((cmdIter.ConVarFlags & FCVAR_HIDDEN) == 0) && CheckCommandAccess(client, name, cmdIter.Flags))
 			{
 				i++;
 				PrintToConsole(client, "[%03d] %s - %s", i+StartCmd, name, (desc[0] == '\0') ? noDesc : desc);

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -537,10 +537,20 @@ methodmap CommandIterator < Handle {
 		public native get();
 	}
 
+	// This property is deprecated. Use .AdminFlags instead.
 	// Retrieves the command's effective admin flags.
 	//
 	// @error                Invalid iterator position.
+	// @deprecated           Use .AdminFlags instead.
+	#pragma deprecated Use .AdminFlags instead.
 	property int Flags {
+		public native get();
+	}
+
+	// Retrieves the command's effective admin flags.
+	//
+	// @error                Invalid iterator position.
+	property int AdminFlags {
 		public native get();
 	}
 

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -537,10 +537,17 @@ methodmap CommandIterator < Handle {
 		public native get();
 	}
 
-	// Retrieves the command's default flags
+	// Retrieves the command's effective admin flags.
 	//
 	// @error                Invalid iterator position.
 	property int Flags {
+		public native get();
+	}
+
+	// Retrieves the command's convar flags.
+	//
+	// @error                Invalid iterator position.
+	property int ConVarFlags {
 		public native get();
 	}
 }


### PR DESCRIPTION
Allow to access the convar flags `FCVAR_*` value from the iterator using a `ConVarFlags` property.
The `CommandIterator.Flags` property should have been called `AdminFlags`, but it's too late to change that now.

This was brought up in #1831.