### PR TITLE
entitylump: Output separator as spaces instead of tabs

### DIFF
--- a/core/logic/LumpManager.cpp
+++ b/core/logic/LumpManager.cpp
@@ -102,7 +102,7 @@ std::string EntityLumpManager::Dump() {
 		}
 		stream << "{\n";
 		for (const auto& pair : *entry) {
-			stream << '"' << pair.first << "\"	\"" << pair.second << '"' << '\n';
+			stream << '"' << pair.first << "\" \"" << pair.second << '"' << '\n';
 		}
 		stream << "}\n";
 	}


### PR DESCRIPTION
On NMRiH and possibly other games that use the Maphack system, entries that are modified using that system are rendered with tab characters stripped out - see `CNMRiHMapHackManager::GetEntDataString`.

That results in there being no separators at all between keys and values, as Maphack receives the serialized string from Entity Lump Manager, which uses tabs as its key / value separator.

This crash only occurs if `GetMapHackManager()->HasEntData()` is set to true, so to my understanding it would not crash on removals of entire entities, and it would not crash on maps that do not use Maphack at all.

This commit changes the key / value separator character to use spaces instead.

Fixes #1833.