### PR TITLE
Add missing null pointer check to protobuf messages

### DIFF
--- a/core/MenuStyle_Radio.cpp
+++ b/core/MenuStyle_Radio.cpp
@@ -503,6 +503,10 @@ void CRadioMenuPlayer::Radio_Refresh()
 #if SOURCE_ENGINE == SE_CSGO || SOURCE_ENGINE == SE_BLADE
 	// TODO: find what happens past 240 on CS:GO
 	CCSUsrMsg_ShowMenu *msg = (CCSUsrMsg_ShowMenu *)g_UserMsgs.StartProtobufMessage(g_ShowMenuId, players, 1, USERMSG_BLOCKHOOKS);
+	if (!msg)
+	{
+		return;
+	}
 	msg->set_bits_valid_slots(display_keys);
 	msg->set_display_time(time);
 	msg->set_menu_string(ptr);

--- a/core/smn_hudtext.cpp
+++ b/core/smn_hudtext.cpp
@@ -320,6 +320,10 @@ void UTIL_SendHudText(int client, const hud_text_parms &textparms, const char *p
 
 #if SOURCE_ENGINE == SE_CSGO || SOURCE_ENGINE == SE_BLADE
 	CCSUsrMsg_HudMsg *msg = (CCSUsrMsg_HudMsg *)g_UserMsgs.StartProtobufMessage(g_HudMsgNum, players, 1, 0);
+	if (!msg)
+	{
+		return;
+	}
 	msg->set_channel(textparms.channel & 0xFF);
 
 	CMsgVector2D *pos = msg->mutable_pos();


### PR DESCRIPTION
`StartProtobufMessage` can sometimes return a null pointer but the check for null pointer is only implemented in 7 out of 9 occurences in the repository, causing the crashes below.

https://crash.limetech.org/lf4n2nhxysdr
https://crash.limetech.org/k5iw7z2mfxe7

I am not sure how the function can return null pointer in these crashes though, I am fairly certain there was no hook that happened there.