### PR TITLE
Enable math functions in sqlite

### DIFF
--- a/extensions/sqlite/AMBuilder
+++ b/extensions/sqlite/AMBuilder
@@ -16,6 +16,7 @@ for cxx in builder.targets:
     'SQLITE_THREADSAFE',
     'SQLITE_USE_URI',
     'SQLITE_ALLOW_URI_AUTHORITY',
+    'SQLITE_ENABLE_MATH_FUNCTIONS',
   ]
   if binary.compiler.target.platform == 'linux':
     binary.compiler.postlink += ['-ldl', '-lpthread']


### PR DESCRIPTION
I'd like to use `POW` in sqlite please... (and also have this in 1.11) (also I didn't test this but this this should:tm: work)