### PR TITLE
Fix ReadMapList ignoring file's last modified time

### DIFF
--- a/core/logic/smn_maplists.cpp
+++ b/core/logic/smn_maplists.cpp
@@ -592,7 +592,10 @@ private:
 			}
 		}
 
-		if (!libsys->FileTime(pMapList->path, FileTime_LastChange, &last_time)
+		char realpath[PLATFORM_MAX_PATH];
+		g_pSM->BuildPath(Path_Game, realpath, sizeof(realpath), "%s", pMapList->path);
+
+		if (!libsys->FileTime(realpath, FileTime_LastChange, &last_time)
 			|| last_time > pMapList->last_modified_time)
 		{
 			/* Reparse */


### PR DESCRIPTION
```
if (!libsys->FileTime(pMapList->path, FileTime_LastChange, &last_time)
	|| last_time > pMapList->last_modified_time)
{
	/* Reparse */
	FileHandle_t fp;
```
Here the `pMapList->path` is not a real path, so `libsys->FileTime` will always return false so that the map file will be always reparsed.