### PR TITLE
Get sdktools and sdkhooks/dhooks to load on hl2sdk-mock

### DIFF
--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -375,6 +375,8 @@ void UTIL_ConsolePrint(const char *fmt, ...)
 #define GAMEFIX "2.pvkii"
 #elif SOURCE_ENGINE == SE_MCV
 #define GAMEFIX "2.mcv"
+#elif SOURCE_ENGINE == SE_MOCK
+#define GAMEFIX "2.mock"
 #else
 #define GAMEFIX "2.ep1"
 #endif

--- a/extensions/sdkhooks/AMBuilder
+++ b/extensions/sdkhooks/AMBuilder
@@ -12,8 +12,6 @@ project.sources += [
 
 for sdk_name in SM.sdks:
   sdk = SM.sdks[sdk_name]
-  if sdk.name == 'mock':
-    continue
 
   for cxx in builder.targets:
     if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -230,10 +230,15 @@ bool SDKHooks::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	if (!entListeners)
 	{
 		g_pSM->Format(error, maxlength, "Failed to setup entity listeners");
+#if SOURCE_ENGINE != SE_MOCK
 		return false;
+#endif
+	}
+	else
+	{
+		entListeners->AddToTail(this);
 	}
 
-	entListeners->AddToTail(this);
 
 	sharesys->AddDependency(myself, "bintools.ext", true, true);
 	sharesys->AddNatives(myself, g_Natives);
@@ -367,7 +372,10 @@ void SDKHooks::SDK_OnUnload()
 	sharesys->DropCapabilityProvider(myself, this, "SDKHook_LogicalEntSupport");
 
 	CUtlVector<IEntityListener *> *entListeners = EntListeners();
-	entListeners->FindAndRemove(this);
+	if (entListeners)
+	{
+		entListeners->FindAndRemove(this);
+	}
 
 	gameconfs->CloseGameConfigFile(g_pGameConf);
 }

--- a/extensions/sdktools/AMBuilder
+++ b/extensions/sdktools/AMBuilder
@@ -41,8 +41,6 @@ for sdk_name in SM.sdks:
   for cxx in builder.targets:
     if not cxx.target.arch in sdk.platformSpec[cxx.target.platform]:
       continue
-    if sdk_name == 'mock':
-      continue
 
     binary = SM.HL2ExtConfig(project, builder, cxx, 'sdktools.ext.' + sdk.ext, sdk)
     binary.compiler.cxxincludes += [

--- a/plugins/reservedslots.sp
+++ b/plugins/reservedslots.sp
@@ -66,7 +66,8 @@ enum KickType
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	if (GetEngineVersion() == Engine_Contagion)
+	sv_visiblemaxplayers = FindConVar("sv_visiblemaxplayers");
+	if (sv_visiblemaxplayers == null)
 	{
 		// sv_visiblemaxplayers doesn't exist
 		strcopy(error, err_max, "Reserved Slots is incompatible with this game");
@@ -82,7 +83,6 @@ public void OnPluginStart()
 	
 	sm_reserved_slots = CreateConVar("sm_reserved_slots", "0", "Number of reserved player slots", 0, true, 0.0);
 	sm_hide_slots = CreateConVar("sm_hide_slots", "0", "If set to 1, reserved slots will hidden (subtracted from the max slot count)", 0, true, 0.0, true, 1.0);
-	sv_visiblemaxplayers = FindConVar("sv_visiblemaxplayers");
 	sm_reserve_type = CreateConVar("sm_reserve_type", "0", "Method of reserving slots", 0, true, 0.0, true, 2.0);
 	sm_reserve_maxadmins = CreateConVar("sm_reserve_maxadmins", "1", "Maximum amount of admins to let in the server with reserve type 2", 0, true, 0.0);
 	sm_reserve_kicktype = CreateConVar("sm_reserve_kicktype", "0", "How to select a client to kick (if appropriate)", 0, true, 0.0, true, 2.0);

--- a/tools/buildbot/PackageScript
+++ b/tools/buildbot/PackageScript
@@ -67,7 +67,9 @@ for cxx_task in SM.spvm:
                              'sourcepawn.jit.x86' + os.path.splitext(cxx_task.binary.path)[1])
     builder.AddCopy(cxx_task.binary, dest_path)
   elif cxx_task.target.arch == 'x86_64':
-    builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/bin/x64'])
+    dest_path = os.path.join('addons/sourcemod/bin/x64',
+                             'sourcepawn.vm' + os.path.splitext(cxx_task.binary.path)[1])
+    builder.AddCopy(cxx_task.binary, dest_path)
 
 helpers.CopySpcomp('addons/sourcemod/scripting')
 


### PR DESCRIPTION
The necessary interfaces are stubbed out, so the extensions can load.

This is another step towards runtime tests in CI.