### PR TITLE
Stop EntIndexToEntRef throwing

### DIFF
--- a/core/smn_halflife.cpp
+++ b/core/smn_halflife.cpp
@@ -546,11 +546,6 @@ static cell_t GetEngineVersion(IPluginContext *pContext, const cell_t *params)
 
 static cell_t IndexToReference(IPluginContext *pContext, const cell_t *params)
 {
-	if (params[1] >= NUM_ENT_ENTRIES || params[1] < 0)
-	{
-		return pContext->ThrowNativeError("Invalid entity index %i", params[1]);
-	}
-
 	return g_HL2.IndexToReference(params[1]);
 }
 

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -662,7 +662,6 @@ stock void DisplayAskConnectBox(int client, float time, const char[] ip, const c
  *
  * @param entity        Entity index.
  * @return              Entity reference or -1 on invalid entity.
- * @error               Entity index >= GetMaxEntities() or < 0
  */
 native int EntIndexToEntRef(int entity);
 


### PR DESCRIPTION
Some forwards such as `OnEntityCreated` provide either an entref or an index, which is a bit of gotcha.
A simple fix, in most cases, could be to always force the value to either an index or an entref with the `EntIndexToEntRef` or `EntRefToEntIndex` natives depending on what you're doing.

However, mixing entrefs and indexes with `EntIndexToEntRef` will currently throw an error because entrefs are always an out-of-bounds index.

To me it *seems like* the throw was added because `CHalfLife2::IndexToReference` would call `CHalfLife2::LookupEntity`, which at the time of writing wouldn't validate index bounds.
However a later commit added this bounds checking to `CHalfLife2::LookupEntity`, making the check in the `EntIndexToEntRef` native redundant.

Additionally, `CHalfLife2::IndexToReference` seems to accept both indexes and references so no other checks should be needed.

Unless I'm missing something important, there is no benefit to having `EntIndexToEntRef` throw an error, and no breakage to old plugins by removing it.
