### PR TITLE
Move menu sound selection from core config to gamedata

### DIFF
--- a/configs/core.cfg
+++ b/configs/core.cfg
@@ -53,24 +53,6 @@
 	 * passwords to work, for security reasons.
 	 */
 	"PassInfoVar"			"_password"
-	
-	/**
-	 * Specifies the sound that gets played when an item is selected from a menu.
-	 */
-	"MenuItemSound"			"buttons/button14.wav"
-
-	/**
-	 * Specifies the sound that gets played when an "Exit" button is selected 
-	 * from a menu.
-	 */
-	"MenuExitSound"			"buttons/combine_button7.wav"
-	
-	/**
-	 * Specifies the sound that gets played when an "Exit Back" button is selected 
-	 * from a menu.  This is the special "Back" button that is intended to roll back
-	 * to a previous menu.
-	 */
-	"MenuExitBackSound"		"buttons/combine_button7.wav"
 
 	/**
 	 * Enables or disables whether SourceMod reads a client's cl_language cvar to set 

--- a/core/MenuManager.cpp
+++ b/core/MenuManager.cpp
@@ -38,6 +38,7 @@
 #include "sourcemm_api.h"
 #include "PlayerManager.h"
 #include "MenuStyle_Valve.h"
+#include <IGameConfigs.h>
 #include "sourcemm_api.h"
 #include "logic_bridge.h"
 
@@ -66,6 +67,29 @@ void MenuManager::OnSourceModAllInitialized()
 	/* Also deny deletion to styles */
 	access.access[HandleAccess_Delete] = HANDLE_RESTRICT_OWNER|HANDLE_RESTRICT_IDENTITY;
 	m_StyleType = handlesys->CreateType("IMenuStyle", this, 0, NULL, &access, g_pCoreIdent, NULL);
+}
+
+void MenuManager::OnSourceModAllInitialized_Post()
+{
+	const char* pTmp;
+	
+	pTmp = g_pGameConf->GetKeyValue("MenuItemSound");
+	if (nullptr != pTmp)
+	{
+		m_SelectSound = pTmp;
+	}
+
+	pTmp = g_pGameConf->GetKeyValue("MenuExitSound");
+	if (nullptr != pTmp)
+	{
+		m_ExitSound = pTmp;
+	}
+
+	pTmp = g_pGameConf->GetKeyValue("MenuExitBackSound");
+	if (nullptr != pTmp)
+	{
+		m_ExitBackSound = pTmp;
+	}
 }
 
 void MenuManager::OnSourceModAllShutdown()
@@ -699,30 +723,9 @@ bool MenuManager::MenuSoundsEnabled()
 	return (sm_menu_sounds.GetInt() != 0);
 }
 
-ConfigResult MenuManager::OnSourceModConfigChanged(const char *key,
-												   const char *value,
-												   ConfigSource source,
-												   char *error,
-												   size_t maxlength)
+std::string *MenuManager::GetMenuSound(ItemSelection sel)
 {
-	if (strcmp(key, "MenuItemSound") == 0)
-	{
-		m_SelectSound.assign(value);
-		return ConfigResult_Accept;
-	} else if (strcmp(key, "MenuExitBackSound") == 0) {
-		m_ExitBackSound.assign(value);
-		return ConfigResult_Accept;
-	} else if (strcmp(key, "MenuExitSound") == 0) {
-		m_ExitSound.assign(value);
-		return ConfigResult_Accept;
-	}
-
-	return ConfigResult_Ignore;
-}
-
-const char *MenuManager::GetMenuSound(ItemSelection sel)
-{
-	const char *sound = NULL;
+	std::string *sound = nullptr;
 
 	switch (sel)
 	{
@@ -732,7 +735,7 @@ const char *MenuManager::GetMenuSound(ItemSelection sel)
 		{
 			if (m_SelectSound.size() > 0)
 			{
-				sound = m_SelectSound.c_str();
+				sound = &m_SelectSound;
 			}
 			break;
 		}
@@ -740,7 +743,7 @@ const char *MenuManager::GetMenuSound(ItemSelection sel)
 		{
 			if (m_ExitBackSound.size() > 0)
 			{
-				sound = m_ExitBackSound.c_str();
+				sound = &m_ExitBackSound;
 			}
 			break;
 		}
@@ -748,7 +751,7 @@ const char *MenuManager::GetMenuSound(ItemSelection sel)
 		{
 			if (m_ExitSound.size() > 0)
 			{
-				sound = m_ExitSound.c_str();
+				sound = &m_ExitSound;
 			}
 			break;
 		}

--- a/core/MenuManager.h
+++ b/core/MenuManager.h
@@ -36,8 +36,8 @@
 #include <sh_vector.h>
 #include <sh_stack.h>
 #include <sh_list.h>
-#include <sh_string.h>
 #include "sm_globals.h"
+#include <string>
 
 using namespace SourceMod;
 using namespace SourceHook;
@@ -55,12 +55,8 @@ public:
 	MenuManager();
 public: //SMGlobalClass
 	void OnSourceModAllInitialized();
+	void OnSourceModAllInitialized_Post();
 	void OnSourceModAllShutdown();
-	ConfigResult OnSourceModConfigChanged(const char *key,
-		const char *value,
-		ConfigSource source,
-		char *error,
-		size_t maxlength);
 	void OnSourceModLevelChange(const char *mapName);
 public: //IMenuManager
 	virtual const char *GetInterfaceName()
@@ -99,7 +95,7 @@ public:
 	HandleError ReadStyleHandle(Handle_t handle, IMenuStyle **style);
 public:
 	bool MenuSoundsEnabled();
-	const char *GetMenuSound(ItemSelection sel);
+	std::string *GetMenuSound(ItemSelection sel);
 protected:
 	Handle_t CreateMenuHandle(IBaseMenu *menu, IdentityToken_t *pOwner);
 	Handle_t CreateStyleHandle(IMenuStyle *style);
@@ -109,9 +105,9 @@ private:
 	CVector<IMenuStyle *> m_Styles;
 	HandleType_t m_StyleType;
 	HandleType_t m_MenuType;
-	String m_SelectSound;
-	String m_ExitBackSound;
-	String m_ExitSound;
+	std::string m_SelectSound = "";
+	std::string m_ExitBackSound = "";
+	std::string m_ExitSound = "";
 };
 
 extern MenuManager g_Menus;

--- a/core/MenuStyle_Base.cpp
+++ b/core/MenuStyle_Base.cpp
@@ -311,9 +311,9 @@ void BaseMenuStyle::ClientPressedKey(int client, unsigned int key_press)
 			clients[0] = client;
 			filter.Initialize(clients, 1);
 
-			const char *sound = g_Menus.GetMenuSound(type);
+			std::string *sound = g_Menus.GetMenuSound(type);
 
-			if (sound != NULL)
+			if (nullptr != sound && !sound->empty())
 			{
 				edict_t *pEdict = PEntityOfEntIndex(client);
 				if (pEdict)
@@ -327,10 +327,10 @@ void BaseMenuStyle::ClientPressedKey(int client, unsigned int key_press)
 							client, 
 							CHAN_AUTO, 
 #if SOURCE_ENGINE >= SE_PORTAL2
-							sound, 
+							sound->c_str(),
 							-1, 
 #endif
-							sound, 
+							sound->c_str(),
 							VOL_NORM, 
 							ATTN_NORM, 
 #if SOURCE_ENGINE >= SE_PORTAL2

--- a/core/MenuStyle_Radio.h
+++ b/core/MenuStyle_Radio.h
@@ -40,6 +40,7 @@
 #include "UserMessages.h"
 #include "sm_fastlink.h"
 #include <sh_stack.h>
+#include <sh_string.h>
 #include <compat_wrappers.h>
 #include "logic/common_logic.h"
 #include "AutoHandleRooter.h"

--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -387,4 +387,32 @@
 			"RadioMenuClosesOnInvalidSlot"	"yes"
 		}
 	}
+
+
+	/**
+	 * Menu Sounds
+	 */
+	"#default"
+	{
+		"Keys"
+		{
+			/**
+	 		 * Specifies the sound that gets played when an item is selected from a menu.
+	 		 */
+			"MenuItemSound"			"buttons/button14.wav"
+
+			/**
+			 * Specifies the sound that gets played when an "Exit" button is selected 
+			 * from a menu.
+			 */
+			"MenuExitSound"			"buttons/combine_button7.wav"
+			
+			/**
+			 * Specifies the sound that gets played when an "Exit Back" button is selected 
+			 * from a menu.  This is the special "Back" button that is intended to roll back
+			 * to a previous menu.
+			 */
+			"MenuExitBackSound"		"buttons/combine_button7.wav"
+		}
+	}
 }


### PR DESCRIPTION
This change moves the specification of sound files for menu actions from core config to gamedata, allowing for different default sounds to be chosen per game, similar to what is done in funcommands for sounds and materials. This is necessary as more and more games ship without some of the stock HL2 resources.

In practice, I've never seen these changed in the core config, but utilizing the custom gamedata folder, it will still be possible to change the defaults.