### PR TITLE
Fix asm.c compiler warnings on Windows

### DIFF
--- a/public/asm/asm.c
+++ b/public/asm/asm.c
@@ -1,10 +1,10 @@
 #include "asm.h"
 #include "libudis86/udis86.h"
+#include <string.h>
 
 #ifndef WIN32
 #define _GNU_SOURCE
 #include <dlfcn.h>
-#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -89,7 +89,7 @@ void check_thunks(unsigned char *dest, unsigned char *pc)
 #endif
 }
 
-int copy_bytes(unsigned char *func, unsigned char *dest, int required_len)
+int copy_bytes(unsigned char *func, unsigned char *dest, unsigned int required_len)
 {
 	ud_t ud_obj;
 	ud_init(&ud_obj);

--- a/public/asm/asm.h
+++ b/public/asm/asm.h
@@ -1,5 +1,4 @@
-#ifndef __ASM_H__
-#define __ASM_H__
+#pragma once
 
 #define OP_JMP				0xE9
 #define OP_JMP_SIZE			5
@@ -23,7 +22,7 @@ void check_thunks(unsigned char *dest, unsigned char *pc);
 //if dest is NULL, returns minimum number of bytes needed to be copied
 //if dest is not NULL, it will copy the bytes to dest as well as fix CALLs and JMPs
 //http://www.devmaster.net/forums/showthread.php?t=2311
-int copy_bytes(unsigned char *func, unsigned char* dest, int required_len);
+int copy_bytes(unsigned char *func, unsigned char* dest, unsigned int required_len);
 
 //insert a specific JMP instruction at the given location
 void inject_jmp(void* src, void* dest);
@@ -37,5 +36,3 @@ void* eval_jump(void* src);
 #ifdef __cplusplus
 }
 #endif
-
-#endif //__ASM_H__


### PR DESCRIPTION
Fixes:

* `G:\sm\sourcemod\public\asm\asm.c(133): warning C4013: 'memcpy' undefined; assuming extern returning int`
* `G:\sm\sourcemod\public\asm\asm.c(106): warning C4018: '<': signed/unsigned mismatch`