### PR TITLE
DHooks: Remove function entry on a new matching section

### DIFF
--- a/extensions/dhooks/signatures.cpp
+++ b/extensions/dhooks/signatures.cpp
@@ -124,9 +124,11 @@ SMCResult SignatureGameConfig::ReadSMC_NewSection(const SMCStates *states, const
 	{
 		auto sig = signatures_.find(name);
 		if (sig.found())
-			g_CurrentSignature = sig->value;
-		else
-			g_CurrentSignature = new SignatureWrapper();
+		{
+			delete sig->value;
+			signatures_.remove(sig);
+		}
+		g_CurrentSignature = new SignatureWrapper();
 		g_CurrentFunctionName = name;
 		g_ParseState = PState_Function;
 		break;


### PR DESCRIPTION
Closes #1879.

This PR changes the behavior in DHooks so new matching functions replaces any previous declarations instead of attempting to apply changes to an existing one.  This does mean `DHookSetup.SetFromConf` needs to be called before other gamedata files are parsed to ensure the hook is initialized as expected.

Note that this does prevent merges of partially-defined functions via `#default` (failing the edge-case test in the linked issue).  I'd like to preserve that behavior, but I don't think there's any workable solution around that at this time without a change in the ~~`IGameConfigManager`~~ parsing interface, because as far as I'm aware there is no way for a custom gamedata section hook to detect when it's in a new file (default and game-specific sections both call into `ReadSMC_ParseStart`).

I considered making offset / signature / address a "variant" of sorts so only one can be provided at a time, but I believe the "arguments" section also has issues with merging.