### PR TITLE
Reconcile the concept of Edict & Networkable across the codebase

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -413,6 +413,17 @@ ServerClass *CHalfLife2::FindServerClass(const char *classname)
 	return pInfo->sc;
 }
 
+ServerClass *CHalfLife2::FindServerClass(CBaseEntity *pEntity)
+{
+	IServerNetworkable* pNetwork = ((IServerUnknown *)pEntity)->GetNetworkable();
+	if (pNetwork == nullptr)
+	{
+		return nullptr;
+	}
+
+	return pNetwork->GetServerClass();
+}
+
 DataTableInfo *CHalfLife2::_FindServerClass(const char *classname)
 {
 	DataTableInfo *pInfo = NULL;

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -413,7 +413,7 @@ ServerClass *CHalfLife2::FindServerClass(const char *classname)
 	return pInfo->sc;
 }
 
-ServerClass *CHalfLife2::FindServerClass(CBaseEntity *pEntity)
+ServerClass *CHalfLife2::FindEntityServerClass(CBaseEntity *pEntity)
 {
 	IServerNetworkable* pNetwork = ((IServerUnknown *)pEntity)->GetNetworkable();
 	if (pNetwork == nullptr)

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -205,6 +205,7 @@ public: //IGameHelpers
 	bool FindSendPropInfo(const char *classname, const char *offset, sm_sendprop_info_t *info);
 	datamap_t *GetDataMap(CBaseEntity *pEntity);
 	ServerClass *FindServerClass(const char *classname);
+	ServerClass *FindServerClass(CBaseEntity *pEntity);
 	typedescription_t *FindInDataMap(datamap_t *pMap, const char *offset);
 	bool FindDataMapInfo(datamap_t *pMap, const char *offset, sm_datatable_info_t *pDataTable);
 	void SetEdictStateChanged(edict_t *pEdict, unsigned short offset);

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -205,7 +205,7 @@ public: //IGameHelpers
 	bool FindSendPropInfo(const char *classname, const char *offset, sm_sendprop_info_t *info);
 	datamap_t *GetDataMap(CBaseEntity *pEntity);
 	ServerClass *FindServerClass(const char *classname);
-	ServerClass *FindServerClass(CBaseEntity *pEntity);
+	ServerClass *FindEntityServerClass(CBaseEntity *pEntity);
 	typedescription_t *FindInDataMap(datamap_t *pMap, const char *offset);
 	bool FindDataMapInfo(datamap_t *pMap, const char *offset, sm_datatable_info_t *pDataTable);
 	void SetEdictStateChanged(edict_t *pEdict, unsigned short offset);

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -1252,10 +1252,6 @@ static cell_t SetEntDataString(IPluginContext *pContext, const cell_t *params)
 	SendProp *pProp; \
 	IServerUnknown *pUnk = (IServerUnknown *)pEntity; \
 	IServerNetworkable *pNet = pUnk->GetNetworkable(); \
-	if (!pNet->GetEdict() || pNet->GetEdict()->IsFree()) \
-	{ \
-		return pContext->ThrowNativeError("Entity %d (%d) is not networkable", g_HL2.ReferenceToIndex(params[1]), params[1]); \
-	} \
 	if (!g_HL2.FindSendPropInfo(pNet->GetServerClass()->GetName(), prop, &info)) \
 	{ \
 		const char *class_name = g_HL2.GetEntityClassname(pEntity); \
@@ -1416,10 +1412,6 @@ static cell_t GetEntPropArraySize(IPluginContext *pContext, const cell_t *params
 			
 			IServerUnknown *pUnk = (IServerUnknown *)pEntity;
 			IServerNetworkable *pNet = pUnk->GetNetworkable();
-			if (!pNet->GetEdict() || pNet->GetEdict()->IsFree())
-			{
-				return pContext->ThrowNativeError("Entity %d (%d) is not networkable", g_HL2.ReferenceToIndex(params[1]), params[1]);
-			}
 			if (!g_HL2.FindSendPropInfo(pNet->GetServerClass()->GetName(), prop, &info))
 			{
 				const char *class_name = g_HL2.GetEntityClassname(pEntity);

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -430,13 +430,7 @@ static cell_t GetEntityNetClass(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid entity (%d - %d)", g_HL2.ReferenceToIndex(params[1]), params[1]);
 	}
 
-	IServerNetworkable *pNet = pUnk->GetNetworkable();
-	if (!pNet)
-	{
-		return 0;
-	}
-
-	ServerClass *pClass = pNet->GetServerClass();
+	ServerClass *pClass = g_HL2.FindServerClass(pEntity);
 	if (!pClass)
 	{
 		return 0;
@@ -1268,12 +1262,7 @@ static cell_t SetEntDataString(IPluginContext *pContext, const cell_t *params)
 #define FIND_PROP_SEND(type, type_name) \
 	sm_sendprop_info_t info;\
 	SendProp *pProp; \
-	IServerUnknown *pUnk = (IServerUnknown *)pEntity; \
-	IServerNetworkable *pNet = pUnk->GetNetworkable(); \
-	if (pNet == nullptr) { \
-		pContext->ThrowNativeError("Enity (%d - %d) is missing a networkable interface. No mod support.", g_HL2.ReferenceToIndex(params[1]), params[1]); \
-	} \
-	ServerClass *pServerClass = pNet->GetServerClass(); \
+	ServerClass *pServerClass = g_HL2.FindServerClass(pEntity); \
 	if (pServerClass == nullptr) { \
 		pContext->ThrowNativeError("Enity (%d - %d) has no server class!", g_HL2.ReferenceToIndex(params[1]), params[1]); \
 	} \
@@ -1435,14 +1424,7 @@ static cell_t GetEntPropArraySize(IPluginContext *pContext, const cell_t *params
 		{
 			sm_sendprop_info_t info;
 			
-			IServerUnknown *pUnk = (IServerUnknown *)pEntity;
-			IServerNetworkable *pNet = pUnk->GetNetworkable();
-			if (pNet == nullptr)
-			{
-				return pContext->ThrowNativeError("Enity (%d - %d) is missing a networkable interface. No mod support.", g_HL2.ReferenceToIndex(params[1]), params[1]);
-			}
-
-			ServerClass *pServerClass = pNet->GetServerClass();
+			ServerClass *pServerClass = g_HL2.FindServerClass(pEntity);
 			if (pServerClass == nullptr)
 			{
 				return pContext->ThrowNativeError("Enity (%d - %d) has no server class!", g_HL2.ReferenceToIndex(params[1]), params[1]);

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -433,13 +433,13 @@ static cell_t GetEntityNetClass(IPluginContext *pContext, const cell_t *params)
 	IServerNetworkable *pNet = pUnk->GetNetworkable();
 	if (!pNet)
 	{
-		return pContext->ThrowNativeError("Entity (%d - %d) is missing a networkable interface. No mod support.", g_HL2.ReferenceToIndex(params[1]), params[1]);
+		return 0;
 	}
 
 	ServerClass *pClass = pNet->GetServerClass();
 	if (!pClass)
 	{
-		return pContext->ThrowNativeError("Entity (%d - %d) has no server class!", g_HL2.ReferenceToIndex(params[1]), params[1]);
+		return 0;
 	}
 
 	pContext->StringToLocal(params[2], params[3], pClass->GetName());

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -134,13 +134,6 @@ inline edict_t *BaseEntityToEdict(CBaseEntity *pEntity)
 {
 	IServerUnknown *pUnk = (IServerUnknown *)pEntity;
 	IServerNetworkable *pNet = pUnk->GetNetworkable();
-	edict_t *edict = pNet->GetEdict();
-
-	if (edict->IsFree())
-	{
-		return nullptr;
-	}
-
 	return pNet->GetEdict();
 }
 

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -1264,7 +1264,7 @@ static cell_t SetEntDataString(IPluginContext *pContext, const cell_t *params)
 	SendProp *pProp; \
 	ServerClass *pServerClass = g_HL2.FindServerClass(pEntity); \
 	if (pServerClass == nullptr) { \
-		pContext->ThrowNativeError("Enity (%d - %d) has no server class!", g_HL2.ReferenceToIndex(params[1]), params[1]); \
+		pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", g_HL2.ReferenceToIndex(params[1]), params[1]); \
 	} \
 	if (!g_HL2.FindSendPropInfo(pServerClass->GetName(), prop, &info)) \
 	{ \
@@ -1427,7 +1427,7 @@ static cell_t GetEntPropArraySize(IPluginContext *pContext, const cell_t *params
 			ServerClass *pServerClass = g_HL2.FindServerClass(pEntity);
 			if (pServerClass == nullptr)
 			{
-				return pContext->ThrowNativeError("Enity (%d - %d) has no server class!", g_HL2.ReferenceToIndex(params[1]), params[1]);
+				return pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", g_HL2.ReferenceToIndex(params[1]), params[1]);
 			}
 
 			if (!g_HL2.FindSendPropInfo(pServerClass->GetName(), prop, &info))

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -430,7 +430,7 @@ static cell_t GetEntityNetClass(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid entity (%d - %d)", g_HL2.ReferenceToIndex(params[1]), params[1]);
 	}
 
-	ServerClass *pClass = g_HL2.FindServerClass(pEntity);
+	ServerClass *pClass = g_HL2.FindEntityServerClass(pEntity);
 	if (!pClass)
 	{
 		return 0;
@@ -1262,7 +1262,7 @@ static cell_t SetEntDataString(IPluginContext *pContext, const cell_t *params)
 #define FIND_PROP_SEND(type, type_name) \
 	sm_sendprop_info_t info;\
 	SendProp *pProp; \
-	ServerClass *pServerClass = g_HL2.FindServerClass(pEntity); \
+	ServerClass *pServerClass = g_HL2.FindEntityServerClass(pEntity); \
 	if (pServerClass == nullptr) { \
 		pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", g_HL2.ReferenceToIndex(params[1]), params[1]); \
 	} \
@@ -1424,7 +1424,7 @@ static cell_t GetEntPropArraySize(IPluginContext *pContext, const cell_t *params
 		{
 			sm_sendprop_info_t info;
 			
-			ServerClass *pServerClass = g_HL2.FindServerClass(pEntity);
+			ServerClass *pServerClass = g_HL2.FindEntityServerClass(pEntity);
 			if (pServerClass == nullptr)
 			{
 				return pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", g_HL2.ReferenceToIndex(params[1]), params[1]);

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -254,14 +254,7 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 
 	//Psychonic is awesome for this
 	sm_sendprop_info_t spi;
-	IServerUnknown *pUnk = (IServerUnknown *)pWeapon;
-	IServerNetworkable *pNet = pUnk->GetNetworkable();
-	if (pNet == nullptr)
-	{
-		return pContext->ThrowNativeError("Entity %d has no networkable interface. No mod support.", params[2]);
-	}
-
-	ServerClass *pServerClass = pNet->GetServerClass();
+	ServerClass *pServerClass = gamehelpers->FindServerClass(pWeapon);
 	if (pServerClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Entity %d has no server class!", params[2]);

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -256,8 +256,18 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	sm_sendprop_info_t spi;
 	IServerUnknown *pUnk = (IServerUnknown *)pWeapon;
 	IServerNetworkable *pNet = pUnk->GetNetworkable();
+	if (pNet == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity %d has no networkable interface. No mod support.", params[2]);
+	}
 
-	if (!UTIL_FindDataTable(pNet->GetServerClass()->m_pTable, "DT_WeaponCSBase", &spi, 0))
+	ServerClass *pServerClass = pNet->GetServerClass();
+	if (pServerClass == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity %d has no server class!", params[2]);
+	}
+
+	if (!UTIL_FindDataTable(pServerClass->m_pTable, "DT_WeaponCSBase", &spi, 0))
 		return pContext->ThrowNativeError("Entity index %d is not a weapon", params[2]);
 
 	if (!gamehelpers->FindSendPropInfo("CBaseCombatWeapon", "m_hOwnerEntity", &spi))

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -257,7 +257,7 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	ServerClass *pServerClass = gamehelpers->FindServerClass(pWeapon);
 	if (pServerClass == nullptr)
 	{
-		return pContext->ThrowNativeError("Entity %d has no server class!", params[2]);
+		return pContext->ThrowNativeError("Failed to retrieve entity %d server class!", params[2]);
 	}
 
 	if (!UTIL_FindDataTable(pServerClass->m_pTable, "DT_WeaponCSBase", &spi, 0))

--- a/extensions/cstrike/natives.cpp
+++ b/extensions/cstrike/natives.cpp
@@ -254,7 +254,7 @@ static cell_t CS_DropWeapon(IPluginContext *pContext, const cell_t *params)
 
 	//Psychonic is awesome for this
 	sm_sendprop_info_t spi;
-	ServerClass *pServerClass = gamehelpers->FindServerClass(pWeapon);
+	ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pWeapon);
 	if (pServerClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Failed to retrieve entity %d server class!", params[2]);

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -594,8 +594,21 @@ HookReturn SDKHooks::Hook(int entity, SDKHookType type, IPluginFunction *callbac
 		IServerUnknown *pUnk = (IServerUnknown *)pEnt;
 
 		IServerNetworkable *pNet = pUnk->GetNetworkable();
-		if (!UTIL_ContainsDataTable(pNet->GetServerClass()->m_pTable, g_HookTypes[type].dtReq))
+		if (pNet == nullptr)
+		{
 			return HookRet_BadEntForHookType;
+		}
+
+		ServerClass *pServerClass = pNet->GetServerClass();
+		if (pServerClass == nullptr)
+		{
+			return HookRet_BadEntForHookType;
+		}
+
+		if (!UTIL_ContainsDataTable(pServerClass->m_pTable, g_HookTypes[type].dtReq))
+		{
+			return HookRet_BadEntForHookType;
+		}
 	}
 
 	size_t entry;

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -591,15 +591,7 @@ HookReturn SDKHooks::Hook(int entity, SDKHookType type, IPluginFunction *callbac
 
 	if (!!strcmp(g_HookTypes[type].dtReq, ""))
 	{
-		IServerUnknown *pUnk = (IServerUnknown *)pEnt;
-
-		IServerNetworkable *pNet = pUnk->GetNetworkable();
-		if (pNet == nullptr)
-		{
-			return HookRet_BadEntForHookType;
-		}
-
-		ServerClass *pServerClass = pNet->GetServerClass();
+		ServerClass *pServerClass = gamehelpers->FindServerClass(pEnt);
 		if (pServerClass == nullptr)
 		{
 			return HookRet_BadEntForHookType;

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -591,7 +591,7 @@ HookReturn SDKHooks::Hook(int entity, SDKHookType type, IPluginFunction *callbac
 
 	if (!!strcmp(g_HookTypes[type].dtReq, ""))
 	{
-		ServerClass *pServerClass = gamehelpers->FindServerClass(pEnt);
+		ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pEnt);
 		if (pServerClass == nullptr)
 		{
 			return HookRet_BadEntForHookType;

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -594,7 +594,7 @@ HookReturn SDKHooks::Hook(int entity, SDKHookType type, IPluginFunction *callbac
 		IServerUnknown *pUnk = (IServerUnknown *)pEnt;
 
 		IServerNetworkable *pNet = pUnk->GetNetworkable();
-		if (pNet && !UTIL_ContainsDataTable(pNet->GetServerClass()->m_pTable, g_HookTypes[type].dtReq))
+		if (!UTIL_ContainsDataTable(pNet->GetServerClass()->m_pTable, g_HookTypes[type].dtReq))
 			return HookRet_BadEntForHookType;
 	}
 

--- a/extensions/sdkhooks/natives.cpp
+++ b/extensions/sdkhooks/natives.cpp
@@ -233,7 +233,7 @@ cell_t Native_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	ServerClass *pClass = gamehelpers->FindServerClass(pWeapon);
 	if (pClass == nullptr)
 	{
-		return pContext->ThrowNativeError("Entity index %d has no server class!", params[2]);
+		return pContext->ThrowNativeError("Failed to retrieve entity %d server class!", params[2]);
 	}
 
 	if (!UTIL_ContainsDataTable(pClass->m_pTable, "DT_BaseCombatWeapon"))

--- a/extensions/sdkhooks/natives.cpp
+++ b/extensions/sdkhooks/natives.cpp
@@ -232,8 +232,18 @@ cell_t Native_DropWeapon(IPluginContext *pContext, const cell_t *params)
 
 	IServerUnknown *pUnk = (IServerUnknown *)pWeapon;
 	IServerNetworkable *pNet = pUnk->GetNetworkable();
+	if (pNet == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity index %d has no networkable interface. No mod support.", params[2]);
+	}
 
-	if (!UTIL_ContainsDataTable(pNet->GetServerClass()->m_pTable, "DT_BaseCombatWeapon"))
+	ServerClass *pClass = pNet->GetServerClass();
+	if (pClass == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity index %d has no server class!", params[2]);
+	}
+
+	if (!UTIL_ContainsDataTable(pClass->m_pTable, "DT_BaseCombatWeapon"))
 		return pContext->ThrowNativeError("Entity index %d is not a weapon", params[2]);
 
 	sm_sendprop_info_t spi;

--- a/extensions/sdkhooks/natives.cpp
+++ b/extensions/sdkhooks/natives.cpp
@@ -230,14 +230,7 @@ cell_t Native_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	if (!pWeapon)
 		return pContext->ThrowNativeError("Invalid entity index %d for weapon", params[2]);
 
-	IServerUnknown *pUnk = (IServerUnknown *)pWeapon;
-	IServerNetworkable *pNet = pUnk->GetNetworkable();
-	if (pNet == nullptr)
-	{
-		return pContext->ThrowNativeError("Entity index %d has no networkable interface. No mod support.", params[2]);
-	}
-
-	ServerClass *pClass = pNet->GetServerClass();
+	ServerClass *pClass = gamehelpers->FindServerClass(pWeapon);
 	if (pClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Entity index %d has no server class!", params[2]);

--- a/extensions/sdkhooks/natives.cpp
+++ b/extensions/sdkhooks/natives.cpp
@@ -230,7 +230,7 @@ cell_t Native_DropWeapon(IPluginContext *pContext, const cell_t *params)
 	if (!pWeapon)
 		return pContext->ThrowNativeError("Invalid entity index %d for weapon", params[2]);
 
-	ServerClass *pClass = gamehelpers->FindServerClass(pWeapon);
+	ServerClass *pClass = gamehelpers->FindEntityServerClass(pWeapon);
 	if (pClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Failed to retrieve entity %d server class!", params[2]);

--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -45,23 +45,18 @@ static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
 	int maxEntities = gpGlobals->maxEntities;
 	for (int i = start; i < maxEntities; i++)
 	{
-		edict_t *current = gamehelpers->EdictOfIndex(i);
-		if (current == NULL || current->IsFree())
+		IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
+		if (pUnknown == nullptr)
+		{
 			continue;
+		}
 
-		IServerNetworkable *network = current->GetNetworkable();
-		if (network == NULL)
-			continue;
-
-		IHandleEntity *pHandleEnt = network->GetEntityHandle();
-		if (pHandleEnt == NULL)
-			continue;
-
+		IServerNetworkable *network = pUnknown->GetNetworkable();
 		ServerClass *sClass = network->GetServerClass();
 		const char *name = sClass->GetName();
 
 		if (!strcmp(name, classname))
-			return gamehelpers->ReferenceToEntity(gamehelpers->IndexOfEdict(current));		
+			return pUnknown->GetBaseEntity();		
 	}
 
 	return NULL;

--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -51,7 +51,7 @@ static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
 			continue;
 		}
 
-		ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
+		ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pEntity);
 		if (pServerClass == nullptr)
 		{
 			continue;

--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -51,15 +51,27 @@ static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
 			continue;
 		}
 
-		IServerNetworkable *network = pUnknown->GetNetworkable();
-		ServerClass *sClass = network->GetServerClass();
-		const char *name = sClass->GetName();
+		IServerNetworkable *pNetwork = pUnknown->GetNetworkable();
+		if (pNetwork == nullptr)
+		{
+			continue;
+		}
 
+		ServerClass *pServerClass = pNetwork->GetServerClass();
+		if (pServerClass == nullptr)
+		{
+			continue;
+		}
+		
+
+		const char *name = pServerClass->GetName();
 		if (!strcmp(name, classname))
-			return pUnknown->GetBaseEntity();		
+		{
+			return (CBaseEntity*)pUnknown;
+		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 static CBaseEntity* GetGameRulesProxyEnt()

--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -45,19 +45,13 @@ static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
 	int maxEntities = gpGlobals->maxEntities;
 	for (int i = start; i < maxEntities; i++)
 	{
-		IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
-		if (pUnknown == nullptr)
+		CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(i);
+		if (pEntity == nullptr)
 		{
 			continue;
 		}
 
-		IServerNetworkable *pNetwork = pUnknown->GetNetworkable();
-		if (pNetwork == nullptr)
-		{
-			continue;
-		}
-
-		ServerClass *pServerClass = pNetwork->GetServerClass();
+		ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
 		if (pServerClass == nullptr)
 		{
 			continue;
@@ -67,7 +61,7 @@ static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
 		const char *name = pServerClass->GetName();
 		if (!strcmp(name, classname))
 		{
-			return (CBaseEntity*)pUnknown;
+			return pEntity;
 		}
 	}
 

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -58,7 +58,7 @@ void InitTeamNatives()
 			continue;
 		}
 
-		ServerClass *pClass = gamehelpers->FindServerClass(pEntity);
+		ServerClass *pClass = gamehelpers->FindEntityServerClass(pEntity);
 		if (pClass == nullptr)
 		{
 			continue;

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -52,19 +52,13 @@ void InitTeamNatives()
 
 	for (int i = 0; i < edictCount; i++)
 	{
-		IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
-		if (pUnknown == nullptr)
+		CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(i);
+		if (pEntity == nullptr)
 		{
 			continue;
 		}
 
-		IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-		if (pNetworkable == nullptr)
-		{
-			continue;
-		}
-
-		ServerClass *pClass = pNetworkable->GetServerClass();
+		ServerClass *pClass = gamehelpers->FindServerClass(pEntity);
 		if (pClass == nullptr)
 		{
 			continue;
@@ -77,15 +71,14 @@ void InitTeamNatives()
 			if (pTeamNumProp != NULL)
 			{
 				int offset = pTeamNumProp->GetOffset();
-				CBaseEntity *pEnt = pUnknown->GetBaseEntity();
-				int TeamIndex = *(int *)((unsigned char *)pEnt + offset);
+				int TeamIndex = *(int *)((unsigned char *)pEntity + offset);
 
 				if (TeamIndex >= (int)g_Teams.size())
 				{
 					g_Teams.resize(TeamIndex+1);
 				}
 				g_Teams[TeamIndex].ClassName = pClass->GetName();
-				g_Teams[TeamIndex].pEnt = pEnt;
+				g_Teams[TeamIndex].pEnt = pEntity;
 			}
 		}
 	}

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -59,7 +59,17 @@ void InitTeamNatives()
 		}
 
 		IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
+		if (pNetworkable == nullptr)
+		{
+			continue;
+		}
+
 		ServerClass *pClass = pNetworkable->GetServerClass();
+		if (pClass == nullptr)
+		{
+			continue;
+		}
+		
 		if (FindNestedDataTable(pClass->m_pTable, "DT_Team"))
 		{
 			SendProp *pTeamNumProp = g_pGameHelpers->FindInSendTable(pClass->GetName(), "m_iTeamNum");

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -50,19 +50,16 @@ void InitTeamNatives()
 
 	int edictCount = gpGlobals->maxEntities;
 
-	for (int i=0; i<edictCount; i++)
+	for (int i = 0; i < edictCount; i++)
 	{
-		edict_t *pEdict = PEntityOfEntIndex(i);
-		if (!pEdict || pEdict->IsFree())
-		{
-			continue;
-		}
-		if (!pEdict->GetNetworkable())
+		IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
+		if (pUnknown == nullptr)
 		{
 			continue;
 		}
 
-		ServerClass *pClass = pEdict->GetNetworkable()->GetServerClass();
+		IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
+		ServerClass *pClass = pNetworkable->GetServerClass();
 		if (FindNestedDataTable(pClass->m_pTable, "DT_Team"))
 		{
 			SendProp *pTeamNumProp = g_pGameHelpers->FindInSendTable(pClass->GetName(), "m_iTeamNum");
@@ -70,7 +67,7 @@ void InitTeamNatives()
 			if (pTeamNumProp != NULL)
 			{
 				int offset = pTeamNumProp->GetOffset();
-				CBaseEntity *pEnt = pEdict->GetUnknown()->GetBaseEntity();
+				CBaseEntity *pEnt = pUnknown->GetBaseEntity();
 				int TeamIndex = *(int *)((unsigned char *)pEnt + offset);
 
 				if (TeamIndex >= (int)g_Teams.size())

--- a/extensions/sdktools/vglobals.cpp
+++ b/extensions/sdktools/vglobals.cpp
@@ -330,7 +330,17 @@ void GetResourceEntity()
 			}
 
 			IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
+			if (pNetworkable == nullptr)
+			{
+				continue;
+			}
+
 			ServerClass *pClass = pNetworkable->GetServerClass();
+			if (pClass == nullptr)
+			{
+				continue;
+			}
+			
 			if (FindNestedDataTable(pClass->m_pTable, "DT_PlayerResource"))
 			{
 				g_ResourceEntity = pNetworkable->GetEntityHandle()->GetRefEHandle();

--- a/extensions/sdktools/vglobals.cpp
+++ b/extensions/sdktools/vglobals.cpp
@@ -323,19 +323,13 @@ void GetResourceEntity()
 
 		for (int i = 0; i < edictCount; i++)
 		{
-			IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
-			if (pUnknown == nullptr)
+			CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(i);
+			if (pEntity == nullptr)
 			{
 				continue;
 			}
 
-			IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-			if (pNetworkable == nullptr)
-			{
-				continue;
-			}
-
-			ServerClass *pClass = pNetworkable->GetServerClass();
+			ServerClass *pClass = gamehelpers->FindServerClass(pEntity);
 			if (pClass == nullptr)
 			{
 				continue;
@@ -343,7 +337,7 @@ void GetResourceEntity()
 			
 			if (FindNestedDataTable(pClass->m_pTable, "DT_PlayerResource"))
 			{
-				g_ResourceEntity = pNetworkable->GetEntityHandle()->GetRefEHandle();
+				g_ResourceEntity = ((IHandleEntity *)pEntity)->GetRefEHandle();
 				break;
 			}
 		}

--- a/extensions/sdktools/vglobals.cpp
+++ b/extensions/sdktools/vglobals.cpp
@@ -329,7 +329,7 @@ void GetResourceEntity()
 				continue;
 			}
 
-			ServerClass *pClass = gamehelpers->FindServerClass(pEntity);
+			ServerClass *pClass = gamehelpers->FindEntityServerClass(pEntity);
 			if (pClass == nullptr)
 			{
 				continue;

--- a/extensions/sdktools/vglobals.cpp
+++ b/extensions/sdktools/vglobals.cpp
@@ -321,28 +321,19 @@ void GetResourceEntity()
 	{
 		int edictCount = gpGlobals->maxEntities;
 
-		for (int i=0; i<edictCount; i++)
+		for (int i = 0; i < edictCount; i++)
 		{
-			edict_t *pEdict = PEntityOfEntIndex(i);
-			if (!pEdict || pEdict->IsFree())
-			{
-				continue;
-			}
-			if (!pEdict->GetNetworkable())
+			IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
+			if (pUnknown == nullptr)
 			{
 				continue;
 			}
 
-			IHandleEntity *pHandleEnt = pEdict->GetNetworkable()->GetEntityHandle();
-			if (!pHandleEnt)
-			{
-				continue;
-			}
-
-			ServerClass *pClass = pEdict->GetNetworkable()->GetServerClass();
+			IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
+			ServerClass *pClass = pNetworkable->GetServerClass();
 			if (FindNestedDataTable(pClass->m_pTable, "DT_PlayerResource"))
 			{
-				g_ResourceEntity = pHandleEnt->GetRefEHandle();
+				g_ResourceEntity = pNetworkable->GetEntityHandle()->GetRefEHandle();
 				break;
 			}
 		}

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -1672,7 +1672,18 @@ static cell_t LookupEntityAttachment(IPluginContext* pContext, const cell_t* par
 	CBaseEntity* pEntity;
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 
-	ServerClass* pClass = ((IServerUnknown*)pEntity)->GetNetworkable()->GetServerClass();
+	IServerNetworkable *pNetwork = ((IServerUnknown*)pEntity)->GetNetworkable();
+	if (pNetwork == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity %d (%d) has no networkable interface. No mod support.", gamehelpers->ReferenceToIndex(params[1]), params[1]);
+	}
+
+	ServerClass* pClass = pNetwork->GetServerClass();
+	if (pClass == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity %d (%d) has no server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
+	}
+
 	if (!FindNestedDataTable(pClass->m_pTable, "DT_BaseAnimating"))
 	{
 		return pContext->ThrowNativeError("Entity %d (%d) is not a CBaseAnimating", gamehelpers->ReferenceToIndex(params[1]), params[1]);
@@ -1718,7 +1729,18 @@ static cell_t GetEntityAttachment(IPluginContext* pContext, const cell_t* params
 	CBaseEntity* pEntity;
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 
-	ServerClass* pClass = ((IServerUnknown*)pEntity)->GetNetworkable()->GetServerClass();
+	IServerNetworkable *pNetwork = ((IServerUnknown*)pEntity)->GetNetworkable();
+	if (pNetwork == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity %d (%d) has no networkable interface. No mod support.", gamehelpers->ReferenceToIndex(params[1]), params[1]);
+	}
+
+	ServerClass* pClass = pNetwork->GetServerClass();
+	if (pClass == nullptr)
+	{
+		return pContext->ThrowNativeError("Entity %d (%d) has no server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
+	}
+	
 	if (!FindNestedDataTable(pClass->m_pTable, "DT_BaseAnimating"))
 	{
 		return pContext->ThrowNativeError("Entity %d (%d) is not a CBaseAnimating", gamehelpers->ReferenceToIndex(params[1]), params[1]);

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -1672,7 +1672,7 @@ static cell_t LookupEntityAttachment(IPluginContext* pContext, const cell_t* par
 	CBaseEntity* pEntity;
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 
-	ServerClass* pClass = gamehelpers->FindServerClass(pEntity);
+	ServerClass* pClass = gamehelpers->FindEntityServerClass(pEntity);
 	if (pClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
@@ -1723,7 +1723,7 @@ static cell_t GetEntityAttachment(IPluginContext* pContext, const cell_t* params
 	CBaseEntity* pEntity;
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 
-	ServerClass* pClass = gamehelpers->FindServerClass(pEntity);
+	ServerClass* pClass = gamehelpers->FindEntityServerClass(pEntity);
 	if (pClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -1675,7 +1675,7 @@ static cell_t LookupEntityAttachment(IPluginContext* pContext, const cell_t* par
 	ServerClass* pClass = gamehelpers->FindServerClass(pEntity);
 	if (pClass == nullptr)
 	{
-		return pContext->ThrowNativeError("Entity %d (%d) has no server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
+		return pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
 	}
 
 	if (!FindNestedDataTable(pClass->m_pTable, "DT_BaseAnimating"))
@@ -1726,7 +1726,7 @@ static cell_t GetEntityAttachment(IPluginContext* pContext, const cell_t* params
 	ServerClass* pClass = gamehelpers->FindServerClass(pEntity);
 	if (pClass == nullptr)
 	{
-		return pContext->ThrowNativeError("Entity %d (%d) has no server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
+		return pContext->ThrowNativeError("Failed to retrieve entity %d (%d) server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
 	}
 	
 	if (!FindNestedDataTable(pClass->m_pTable, "DT_BaseAnimating"))

--- a/extensions/sdktools/vnatives.cpp
+++ b/extensions/sdktools/vnatives.cpp
@@ -1672,13 +1672,7 @@ static cell_t LookupEntityAttachment(IPluginContext* pContext, const cell_t* par
 	CBaseEntity* pEntity;
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 
-	IServerNetworkable *pNetwork = ((IServerUnknown*)pEntity)->GetNetworkable();
-	if (pNetwork == nullptr)
-	{
-		return pContext->ThrowNativeError("Entity %d (%d) has no networkable interface. No mod support.", gamehelpers->ReferenceToIndex(params[1]), params[1]);
-	}
-
-	ServerClass* pClass = pNetwork->GetServerClass();
+	ServerClass* pClass = gamehelpers->FindServerClass(pEntity);
 	if (pClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Entity %d (%d) has no server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);
@@ -1729,13 +1723,7 @@ static cell_t GetEntityAttachment(IPluginContext* pContext, const cell_t* params
 	CBaseEntity* pEntity;
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 
-	IServerNetworkable *pNetwork = ((IServerUnknown*)pEntity)->GetNetworkable();
-	if (pNetwork == nullptr)
-	{
-		return pContext->ThrowNativeError("Entity %d (%d) has no networkable interface. No mod support.", gamehelpers->ReferenceToIndex(params[1]), params[1]);
-	}
-
-	ServerClass* pClass = pNetwork->GetServerClass();
+	ServerClass* pClass = gamehelpers->FindServerClass(pEntity);
 	if (pClass == nullptr)
 	{
 		return pContext->ThrowNativeError("Entity %d (%d) has no server class!", gamehelpers->ReferenceToIndex(params[1]), params[1]);

--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -81,14 +81,7 @@ bool CritManager::TryEnable()
 			continue;
 		}
 
-		IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
-		IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-		if (pNetworkable == nullptr)
-		{
-			continue;
-		}
-
-		ServerClass *pServerClass = pNetworkable->GetServerClass();
+		ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
 		if (pServerClass == nullptr)
 		{
 			continue;
@@ -132,14 +125,7 @@ void CritManager::OnEntityCreated(CBaseEntity *pEntity, const char *classname)
 		return;
 	}
 
-	IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
-	IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-	if (pNetworkable == nullptr)
-	{
-		return;
-	}
-
-	ServerClass *pServerClass = pNetworkable->GetServerClass();
+	ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
 	if (pServerClass == nullptr)
 	{
 		return;
@@ -189,14 +175,7 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 	CBaseEntity *pWeapon = META_IFACEPTR(CBaseEntity);
 	
 	// If there's an invalid ent or invalid networkable here, we've got issues elsewhere.
-
-	IServerNetworkable *pNetWeapon = ((IServerUnknown *)pWeapon)->GetNetworkable();
-	if (pNetWeapon == nullptr)
-	{
-		RETURN_META_VALUE(MRES_IGNORED, false);
-	}
-
-	ServerClass *pServerClass = pNetWeapon->GetServerClass();
+	ServerClass *pServerClass = gamehelpers->FindServerClass(pWeapon);
 	if (pServerClass == nullptr)
 	{
 		g_pSM->LogError(myself, "Invalid server class on weapon.");

--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -76,13 +76,28 @@ bool CritManager::TryEnable()
 	for (size_t i = playerhelpers->GetMaxClients() + 1; i < MAX_EDICTS; ++i)
 	{
 		CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(i);
-		if (pEntity == NULL)
+		if (pEntity == nullptr)
+		{
 			continue;
+		}
 
 		IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
 		IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-		if (!UTIL_ContainsDataTable(pNetworkable->GetServerClass()->m_pTable, TF_WEAPON_DATATABLE))
+		if (pNetworkable == nullptr)
+		{
 			continue;
+		}
+
+		ServerClass *pServerClass = pNetworkable->GetServerClass();
+		if (pServerClass == nullptr)
+		{
+			continue;
+		}
+
+		if (!UTIL_ContainsDataTable(pServerClass->m_pTable, TF_WEAPON_DATATABLE))
+		{
+			continue;
+		}
 
 		SH_ADD_MANUALHOOK(CalcIsAttackCriticalHelper, pEntity, SH_MEMBER(&g_CritManager, &CritManager::Hook_CalcIsAttackCriticalHelper), false);
 		SH_ADD_MANUALHOOK(CalcIsAttackCriticalHelperNoCrits, pEntity, SH_MEMBER(&g_CritManager, &CritManager::Hook_CalcIsAttackCriticalHelperNoCrits), false);
@@ -113,12 +128,27 @@ void CritManager::Disable()
 void CritManager::OnEntityCreated(CBaseEntity *pEntity, const char *classname)
 {
 	if (!m_enabled)
+	{
 		return;
+	}
 
 	IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
 	IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-	if (!UTIL_ContainsDataTable(pNetworkable->GetServerClass()->m_pTable, TF_WEAPON_DATATABLE))
+	if (pNetworkable == nullptr)
+	{
 		return;
+	}
+
+	ServerClass *pServerClass = pNetworkable->GetServerClass();
+	if (pServerClass == nullptr)
+	{
+		return;
+	}
+
+	if (!UTIL_ContainsDataTable(pServerClass->m_pTable, TF_WEAPON_DATATABLE))
+	{
+		return;
+	}
 
 	SH_ADD_MANUALHOOK(CalcIsAttackCriticalHelper, pEntity, SH_MEMBER(&g_CritManager, &CritManager::Hook_CalcIsAttackCriticalHelper), false);
 	SH_ADD_MANUALHOOK(CalcIsAttackCriticalHelperNoCrits, pEntity, SH_MEMBER(&g_CritManager, &CritManager::Hook_CalcIsAttackCriticalHelperNoCrits), false);
@@ -161,8 +191,13 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 	// If there's an invalid ent or invalid networkable here, we've got issues elsewhere.
 
 	IServerNetworkable *pNetWeapon = ((IServerUnknown *)pWeapon)->GetNetworkable();
+	if (pNetWeapon == nullptr)
+	{
+		RETURN_META_VALUE(MRES_IGNORED, false);
+	}
+
 	ServerClass *pServerClass = pNetWeapon->GetServerClass();
-	if (!pServerClass)
+	if (pServerClass == nullptr)
 	{
 		g_pSM->LogError(myself, "Invalid server class on weapon.");
 		RETURN_META_VALUE(MRES_IGNORED, false);

--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -81,9 +81,6 @@ bool CritManager::TryEnable()
 
 		IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
 		IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-		if (!pNetworkable)
-			continue;
-
 		if (!UTIL_ContainsDataTable(pNetworkable->GetServerClass()->m_pTable, TF_WEAPON_DATATABLE))
 			continue;
 
@@ -120,9 +117,6 @@ void CritManager::OnEntityCreated(CBaseEntity *pEntity, const char *classname)
 
 	IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
 	IServerNetworkable *pNetworkable = pUnknown->GetNetworkable();
-	if (!pNetworkable)
-		return;
-
 	if (!UTIL_ContainsDataTable(pNetworkable->GetServerClass()->m_pTable, TF_WEAPON_DATATABLE))
 		return;
 

--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -81,7 +81,7 @@ bool CritManager::TryEnable()
 			continue;
 		}
 
-		ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
+		ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pEntity);
 		if (pServerClass == nullptr)
 		{
 			continue;
@@ -125,7 +125,7 @@ void CritManager::OnEntityCreated(CBaseEntity *pEntity, const char *classname)
 		return;
 	}
 
-	ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
+	ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pEntity);
 	if (pServerClass == nullptr)
 	{
 		return;
@@ -175,7 +175,7 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 	CBaseEntity *pWeapon = META_IFACEPTR(CBaseEntity);
 	
 	// If there's an invalid ent or invalid server class here, we've got issues elsewhere.
-	ServerClass *pServerClass = gamehelpers->FindServerClass(pWeapon);
+	ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pWeapon);
 	if (pServerClass == nullptr)
 	{
 		g_pSM->LogError(myself, "Invalid server class on weapon.");

--- a/extensions/tf2/criticals.cpp
+++ b/extensions/tf2/criticals.cpp
@@ -174,7 +174,7 @@ bool CritManager::Hook_CalcIsAttackCriticalHelpers(bool noCrits)
 {
 	CBaseEntity *pWeapon = META_IFACEPTR(CBaseEntity);
 	
-	// If there's an invalid ent or invalid networkable here, we've got issues elsewhere.
+	// If there's an invalid ent or invalid server class here, we've got issues elsewhere.
 	ServerClass *pServerClass = gamehelpers->FindServerClass(pWeapon);
 	if (pServerClass == nullptr)
 	{

--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -441,7 +441,7 @@ int FindEntityByNetClass(int start, const char *classname)
 			continue;
 		}
 
-		ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
+		ServerClass *pServerClass = gamehelpers->FindEntityServerClass(pEntity);
 		if (pServerClass == nullptr)
 		{
 			continue;

--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -435,23 +435,16 @@ int FindEntityByNetClass(int start, const char *classname)
 
 	for (int i = ((start != -1) ? start : 0); i < gpGlobals->maxEntities; i++)
 	{
-		current = engine->PEntityOfEntIndex(i);
-		if (current == NULL || current->IsFree())
+		IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
+		if (pUnknown == nullptr)
 		{
 			continue;
 		}
 
-		IServerNetworkable *network = current->GetNetworkable();
-
-		if (network == NULL)
-		{
-			continue;
-		}
-
+		IServerNetworkable *network = pUnknown->GetNetworkable();
 		ServerClass *sClass = network->GetServerClass();
 		const char *name = sClass->GetName();
 		
-
 		if (strcmp(name, classname) == 0)
 		{
 			return i;

--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -435,19 +435,13 @@ int FindEntityByNetClass(int start, const char *classname)
 
 	for (int i = ((start != -1) ? start : 0); i < gpGlobals->maxEntities; i++)
 	{
-		IServerUnknown *pUnknown = (IServerUnknown *)gamehelpers->ReferenceToEntity(i);
-		if (pUnknown == nullptr)
+		CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(i);
+		if (pEntity == nullptr)
 		{
 			continue;
 		}
 
-		IServerNetworkable *pNetwork = pUnknown->GetNetworkable();
-		if (pNetwork == nullptr)
-		{
-			continue;
-		}
-
-		ServerClass *pServerClass = pNetwork->GetServerClass();
+		ServerClass *pServerClass = gamehelpers->FindServerClass(pEntity);
 		if (pServerClass == nullptr)
 		{
 			continue;

--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -441,10 +441,19 @@ int FindEntityByNetClass(int start, const char *classname)
 			continue;
 		}
 
-		IServerNetworkable *network = pUnknown->GetNetworkable();
-		ServerClass *sClass = network->GetServerClass();
-		const char *name = sClass->GetName();
+		IServerNetworkable *pNetwork = pUnknown->GetNetworkable();
+		if (pNetwork == nullptr)
+		{
+			continue;
+		}
+
+		ServerClass *pServerClass = pNetwork->GetServerClass();
+		if (pServerClass == nullptr)
+		{
+			continue;
+		}
 		
+		const char *name = pServerClass->GetName();
 		if (strcmp(name, classname) == 0)
 		{
 			return i;

--- a/public/IGameHelpers.h
+++ b/public/IGameHelpers.h
@@ -357,7 +357,7 @@ namespace SourceMod
 		 *
 		 * @return				ServerClass pointer on success, nullptr on failure.
 		 */
-		virtual ServerClass *FindServerClass(CBaseEntity *pEntity) = 0;
+		virtual ServerClass *FindEntityServerClass(CBaseEntity *pEntity) = 0;
 	};
 }
 

--- a/public/IGameHelpers.h
+++ b/public/IGameHelpers.h
@@ -40,7 +40,7 @@
  */
 
 #define SMINTERFACE_GAMEHELPERS_NAME		"IGameHelpers"
-#define SMINTERFACE_GAMEHELPERS_VERSION		11
+#define SMINTERFACE_GAMEHELPERS_VERSION		12
 
 class CBaseEntity;
 class CBaseHandle;
@@ -351,6 +351,13 @@ namespace SourceMod
 		 * @return				64-bit server Steam id.
 		 */
 		virtual uint64_t GetServerSteamId64() const =0;
+
+		/**
+		 * @brief Finds a given entity's server class.
+		 *
+		 * @return				ServerClass pointer on success, nullptr on failure.
+		 */
+		virtual ServerClass *FindServerClass(CBaseEntity *pEntity) = 0;
 	};
 }
 


### PR DESCRIPTION
This fixes #1902 and potential crash in other natives.

# What is this all about ?

Well, the scope of this PR mainly boils down to
`CBaseEdict::GetNetworkable` & `IServerUnknown::GetNetworkable` (CBaseEntity::GetNetworkable)

The former, is the edict that gives a pointer (that might or might not be valid) of the attached entity's networkable
The latter, is the entity/unknown that gives a pointer (that is always valid) of the attached entity's networkable

# What are the benefits ?

The PR is mostly a speculative a fix for PR #1902 but everything points towards an unproperly setup Networkable's vtable. Which is strange, because Sourcemod retrives the networkable interface of any entity in a lot of places.
https://github.com/alliedmodders/sourcemod/search?q=GetNetworkable
But the key difference with all of them, and the gamerules native (as well tf2's objective ressource native, and another function). Is that they use the edict_t ptr, to retrieve the networkable interface. While everywhere else in the codebase, we go from edict ptr to unknown ptr (the cbaseentity) to the networkable interface.

This leads me to believe, the engine doesn't properly clean up the networkable ptr on its edict_t(s) which is assigned by the srcds.

# Why is a core file modified ?

The goal is to keep the retrieval of the networkable interface consistent across all the codebase. That includes core files.
Furthermore, this also fixes a non logical message of the Set/GetEntProp natives
`Edict %d (%d) is not networkable`
Edicts are networkable by definition. We should have never gotten that far to begin with, if we started from an edict. But we don't, we start from a `IServerUnknown`. So we remove this useless check, whose error message never ever showed in sourcemode entire lifetime, I browsed the forums & google never found a post where a plugin maker asks about the error message.

~~# Why is there some null check removed on networkable ?~~

> `IServerUnknown` is only ever implemented by `CBaseEntity`
> `IServerUnknown::GetNetworkable` is implemented like so by `CBaseEntity`
> 
> ```
> inline IServerNetworkable *CBaseEntity::GetNetworkable()
> {
> 	return &m_Network;
> }
> ```
> The ptr can never ever be invalid. Its memory is allocated along with `CBaseEntity (IServerUnknown)`
> 
> And it is always initialised.
> ```cpp
> CBaseEntity::CBaseEntity( bool bServerOnly )
> {
> 	NetworkProp()->Init( this );
> ```
> This statement is true, all the way back to the 2007 release of the source engine. I haven't/couldn't check older versions. But I'm confident.
> 
> Sourcemod itself is "guilty" of not null checking the networkable interface, when retrieving it from `IServerUnknown`
> https://github.com/alliedmodders/sourcemod/blob/57a38636fcb1bccfed0f69705b237e8f028c0d1a/extensions/tf2/criticals.cpp#L169-L170
> https://github.com/alliedmodders/sourcemod/blob/51bba0b8942faef8366b426057f64d10c798a62b/extensions/sdkhooks/natives.cpp#L234-L237
> 
> https://github.com/alliedmodders/sourcemod/blob/775d4f04f25edc10531d615ccd9e977cd82d467a/extensions/sdktools/vnatives.cpp#L1675-L1676
> https://github.com/alliedmodders/sourcemod/blob/775d4f04f25edc10531d615ccd9e977cd82d467a/extensions/sdktools/vnatives.cpp#L1721-L1722
> A no check, that I myself justified using the same arguments used in this PR
> https://github.com/alliedmodders/sourcemod/pull/1653#discussion_r760973885
> 
> https://github.com/alliedmodders/sourcemod/blob/536750b428ebf0ae82fb2b274765b990d0f9c742/extensions/cstrike/natives.cpp#L255-L260

Edited : After discussion, it has been decided null checks should not be removed. Instead null checks have been added where they had been missing.

# This should be field tested

I haven't had the chance to try the changes myself. This is all speculative, but I'm confident in the research I've performed.
Attached to this post is a zip file containing the sourcemod installation compiled with the changes of this PR (linux), minus the pgsql extension + spcomp, which gave me troubles to be compiled because of zlib.
~~[sourcemod.zip](https://github.com/alliedmodders/sourcemod/files/10375229/sourcemod.zip)~~ OUTDATED
~~[sourcemod.zip](https://github.com/alliedmodders/sourcemod/files/10375813/sourcemod.zip)~~ OUTDATED
[sourcemod.zip](https://github.com/alliedmodders/sourcemod/files/10377543/sourcemod.zip) - Latest