### PR TITLE
Add TE_WriteEnt and TE_ReadEnt natives to SDKTools

### DIFF
--- a/extensions/sdktools/tempents.cpp
+++ b/extensions/sdktools/tempents.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "tempents.h"
+#include <basehandle.h>
 
 TempEntityManager g_TEManager;
 ICallWrapper *g_GetServerClass = NULL;
@@ -179,6 +180,43 @@ bool TempEntityInfo::TE_GetEntData(const char *name, int *value)
 	} else {
 		return false;
 	}
+
+	return true;
+}
+
+bool TempEntityInfo::TE_SetEntDataEnt(const char *name, IHandleEntity *value)
+{
+	/* Search for our offset */
+	int offset = _FindOffset(name);
+
+	if (offset < 0)
+	{
+		return false;
+	}
+
+	auto *pHndl = (CBaseHandle *)((uint8_t *)m_Me + offset);
+	pHndl->Set(value);
+
+	return true;
+}
+
+
+bool TempEntityInfo::TE_GetEntDataEnt(const char *name, IHandleEntity **value)
+{
+	/* Search for our offset */
+	int offset = _FindOffset(name);
+
+	if (offset < 0)
+	{
+		return false;
+	}
+
+	auto *pHndl = (CBaseHandle *)((uint8_t *)m_Me + offset);
+	auto *pEnt = reinterpret_cast<IHandleEntity *>(gamehelpers->ReferenceToEntity(pHndl->GetEntryIndex()));
+	if (!pEnt || *pHndl != pEnt->GetRefEHandle())
+		return false;
+
+	*value = pEnt;
 
 	return true;
 }

--- a/extensions/sdktools/tempents.h
+++ b/extensions/sdktools/tempents.h
@@ -47,10 +47,12 @@ public:
 	ServerClass *GetServerClass();
 	bool IsValidProp(const char *name);
 	bool TE_SetEntData(const char *name, int value);
+	bool TE_SetEntDataEnt(const char *name, IHandleEntity *value);
 	bool TE_SetEntDataFloat(const char *name, float value);
 	bool TE_SetEntDataVector(const char *name, float vector[3]);
 	bool TE_SetEntDataFloatArray(const char *name, cell_t *array, int size);
 	bool TE_GetEntData(const char *name, int *value);
+	bool TE_GetEntDataEnt(const char *name, IHandleEntity **value);
 	bool TE_GetEntDataFloat(const char *name, float *value);
 	bool TE_GetEntDataVector(const char *name, float vector[3]);
 	void Send(IRecipientFilter &filter, float delay);

--- a/extensions/sdktools/tenatives.cpp
+++ b/extensions/sdktools/tenatives.cpp
@@ -307,6 +307,57 @@ static cell_t smn_TEReadNum(IPluginContext *pContext, const cell_t *params)
 	return val;
 }
 
+static cell_t smn_TEWriteEnt(IPluginContext *pContext, const cell_t *params)
+{
+	if (!g_TEManager.IsAvailable())
+	{
+		return pContext->ThrowNativeError("TempEntity System unsupported or not available, file a bug report");
+	}
+	if (!g_CurrentTE)
+	{
+		return pContext->ThrowNativeError("No TempEntity call is in progress");
+	}
+
+	char *prop;
+	pContext->LocalToString(params[1], &prop);
+
+	CBaseEntity *pEntity = gamehelpers->ReferenceToEntity(params[2]);
+	if (!pEntity && params[2] != -1)
+	{
+		return pContext->ThrowNativeError("Entity %d (%d) is invalid", gamehelpers->ReferenceToIndex(params[2]));
+	}
+
+	if (!g_CurrentTE->TE_SetEntDataEnt(prop, reinterpret_cast<IHandleEntity *>(pEntity)))
+	{
+		return pContext->ThrowNativeError("Temp entity property \"%s\" not found", prop);
+	}
+
+	return 1;
+}
+
+static cell_t smn_TEReadEnt(IPluginContext *pContext, const cell_t *params)
+{
+	if (!g_TEManager.IsAvailable())
+	{
+		return pContext->ThrowNativeError("TempEntity System unsupported or not available, file a bug report");
+	}
+	if (!g_CurrentTE)
+	{
+		return pContext->ThrowNativeError("No TempEntity call is in progress");
+	}
+
+	char *prop;
+	IHandleEntity *val;
+	pContext->LocalToString(params[1], &prop);
+
+	if (!g_CurrentTE->TE_GetEntDataEnt(prop, &val))
+	{
+		return pContext->ThrowNativeError("Temp entity property \"%s\" not found", prop);
+	}
+
+	return gamehelpers->EntityToBCompatRef(reinterpret_cast<CBaseEntity *>(val));
+}
+
 static cell_t smn_TE_WriteFloat(IPluginContext *pContext, const cell_t *params)
 {
 	if (!g_TEManager.IsAvailable())
@@ -547,6 +598,8 @@ sp_nativeinfo_t g_TENatives[] =
 	{"TE_Start",				smn_TEStart},
 	{"TE_WriteNum",				smn_TEWriteNum},
 	{"TE_ReadNum",				smn_TEReadNum},
+	{"TE_WriteEnt",				smn_TEWriteEnt},
+	{"TE_ReadEnt",				smn_TEReadEnt},
 	{"TE_WriteFloat",			smn_TE_WriteFloat},
 	{"TE_ReadFloat",			smn_TE_ReadFloat},
 	{"TE_WriteVector",			smn_TEWriteVector},

--- a/plugins/include/sdktools_tempents.inc
+++ b/plugins/include/sdktools_tempents.inc
@@ -99,6 +99,24 @@ native void TE_WriteNum(const char[] prop, int value);
 native int TE_ReadNum(const char[] prop);
 
 /**
+ * Sets an entity value in the current temp entity.
+ *
+ * @param prop          Property to use.
+ * @param value         Entity reference or index value to set.
+ * @error               Property not found.
+ */
+native void TE_WriteEnt(const char[] prop, int value);
+
+/**
+ * Reads an entity value in the current temp entity.
+ *
+ * @param prop          Property to use.
+ * @return              Property value as backwards compatible entity reference.
+ * @error               Property not found.
+ */
+native int TE_ReadEnt(const char[] prop);
+
+/**
  * Sets a floating point number in the current temp entity.
  *
  * @param prop          Property to use.


### PR DESCRIPTION
TF2 now has at least one tempent property that utilizes entity handles. It's possible that some other games already did as well. These new natives function similarly to both the GetEntPropEnt/SetEntPropEnt natives and the other TE_Read*/TE_Write* natives.