### PR TITLE
fix: Print full map name in Log instead of args

### DIFF
--- a/plugins/basecommands/map.sp
+++ b/plugins/basecommands/map.sp
@@ -112,7 +112,7 @@ public Action Command_Map(int client, int args)
 	GetMapDisplayName(displayName, displayName, sizeof(displayName));
 
 	ShowActivity2(client, "[SM] ", "%t", "Changing map", displayName);
-	LogAction(client, -1, "\"%L\" changed map to \"%s\"", client, map);
+	LogAction(client, -1, "\"%L\" changed map to \"%s\"", client, displayName);
 
 	DataPack dp;
 	CreateDataTimer(3.0, Timer_ChangeMap, dp);

--- a/plugins/basecommands/map.sp
+++ b/plugins/basecommands/map.sp
@@ -112,7 +112,7 @@ public Action Command_Map(int client, int args)
 	GetMapDisplayName(displayName, displayName, sizeof(displayName));
 
 	ShowActivity2(client, "[SM] ", "%t", "Changing map", displayName);
-	LogAction(client, -1, "\"%L\" changed map to \"%s\"", client, displayName);
+	LogAction(client, -1, "\"%L\" changed map to \"%s\" (input \"%s\")", client, displayName, map);
 
 	DataPack dp;
 	CreateDataTimer(3.0, Timer_ChangeMap, dp);


### PR DESCRIPTION
Print the full map name in LogAction instead of the args.
Exemple : !map de_
**Before:** 
`.Rushaway<150><[U:1:44340774]><> changed map to de_`

**After:**
`.Rushaway<150><[U:1:44340774]><> changed map to de_dust2`