### PR TITLE
Improve HasEntProp performance

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -445,20 +445,25 @@ bool CHalfLife2::FindSendPropInfo(const char *classname, const char *offset, sm_
 		return false;
 	}
 
-	if (!pInfo->lookup.retrieve(offset, info))
-	{
-		sm_sendprop_info_t temp_info;
+	DataTableInfo::SendPropInfo temp;
 
-		if (!UTIL_FindInSendTable(pInfo->sc->m_pTable, offset, &temp_info, 0))
+	if (!pInfo->lookup.retrieve(offset, &temp))
+	{
+		bool found = UTIL_FindInSendTable(pInfo->sc->m_pTable, offset, &temp.info, 0);
+		temp.name = offset;
+
+		pInfo->lookup.insert(offset, temp);
+
+		if (found)
 		{
-			return false;
+			*info = temp.info;
 		}
 
-		pInfo->lookup.insert(offset, temp_info);
-		*info = temp_info;
+		return found;
 	}
-	
-	return true;
+
+	*info = temp.info;
+	return info->prop != nullptr;
 }
 
 SendProp *CHalfLife2::FindInSendTable(const char *classname, const char *offset)
@@ -492,15 +497,25 @@ bool CHalfLife2::FindDataMapInfo(datamap_t *pMap, const char *offset, sm_datatab
 		m_Maps.add(i, pMap, new DataMapCache());
 
 	DataMapCache *cache = i->value;
+	DataMapCacheInfo temp;
 
-	if (!cache->retrieve(offset, pDataTable))
+	if (!cache->retrieve(offset, &temp))
 	{
-		if (!UTIL_FindDataMapInfo(pMap, offset, pDataTable))
-			return false;
-		cache->insert(offset, *pDataTable);
+		bool found = UTIL_FindDataMapInfo(pMap, offset, &temp.info);
+		temp.name = offset;
+
+		cache->insert(offset, temp);
+
+		if (found)
+		{
+			*pDataTable = temp.info;
+		}
+
+		return found;
 	}
 
-	return true;
+	*pDataTable = temp.info;
+	return pDataTable->prop != nullptr;
 }
 
 void CHalfLife2::SetEdictStateChanged(edict_t *pEdict, unsigned short offset)

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -89,16 +89,24 @@ using namespace SourceMod;
 
 struct DataTableInfo
 {
-	struct SendPropPolicy
+	struct SendPropInfo
 	{
-		static inline bool matches(const char *name, const sm_sendprop_info_t &info)
+		static inline bool matches(const char *name, const SendPropInfo &info)
 		{
-			return strcmp(name, info.prop->GetName()) == 0;
+			return strcmp(name, info.name.c_str()) == 0;
 		}
 		static inline uint32_t hash(const detail::CharsAndLength &key)
 		{
 			return key.hash();
 		}
+
+		SendPropInfo()
+			: name(), info{nullptr, 0}
+		{
+		}
+
+		std::string name;
+		sm_sendprop_info_t info;
 	};
 
 	static inline bool matches(const char *name, const DataTableInfo *info)
@@ -116,22 +124,30 @@ struct DataTableInfo
 	}
 
 	ServerClass *sc;
-	NameHashSet<sm_sendprop_info_t, SendPropPolicy> lookup;
+	NameHashSet<SendPropInfo> lookup;
 };
 
-struct DataMapCachePolicy
+struct DataMapCacheInfo
 {
-	static inline bool matches(const char *name, const sm_datatable_info_t &info)
+	static inline bool matches(const char *name, const DataMapCacheInfo &info)
 	{
-		return strcmp(name, info.prop->fieldName) == 0;
+		return strcmp(name, info.name.c_str()) == 0;
 	}
 	static inline uint32_t hash(const detail::CharsAndLength &key)
 	{
 		return key.hash();
 	}
+
+	DataMapCacheInfo()
+		: name(), info{nullptr, 0}
+	{
+	}
+
+	std::string name;
+	sm_datatable_info_t info;
 };
 
-typedef NameHashSet<sm_datatable_info_t, DataMapCachePolicy> DataMapCache;
+typedef NameHashSet<DataMapCacheInfo> DataMapCache;
 
 struct DelayedFakeCliCmd
 {


### PR DESCRIPTION
Implements the `HasEntProp` optimization suggested by asherkin in the discord (caching missed lookups).
I tried to make any changes as non-disruptive as possible because I barely know what I'm doing, so it could probably be optimized further.

Testing shows it to be roughly 2-3x faster:
```
100 (* 6) iterations without fix:
[HasEntProp] Average Time:1.230063ms
[HasEntProp] Average Time:1.186231ms
[HasEntProp] Average Time:1.137192ms
Average = (3.553486ms / 3) = 1.18449533ms

100 (* 6) iterations with fix:
[HasEntProp] Average Time:0.383327ms
[HasEntProp] Average Time:0.375259ms
[HasEntProp] Average Time:0.443078ms
Average = (1.201664ms / 3) = 0.4005546ms
```

Using the following code, specifically `sm_hasentprop2` (which is probably not a good test):
The props used are either common, less common, or invalid for each of Prop_Send and Prop_Data.
```sourcepawn
#include <sourcemod>
#include <profiler>

#pragma semicolon 1
#pragma newdecls required

public Plugin myinfo = {
    name        = "",
    author      = "",
    description = "",
    version     = "0.0.0",
    url         = ""
};

public void OnPluginStart()
{
    PrintToServer("Ready to test HasEntProp!");
    
    RegConsoleCmd("sm_hasentprop", Cmd_HasEntProp);
    RegConsoleCmd("sm_hasentprop2", Cmd_HasEntProp2);
}


Action Cmd_HasEntProp(int client, int args)
{
    int maxEnts = GetMaxEntities();

    Profiler p = new Profiler();
    for (int i = 1; i <= 4; ++i)
    {
        int ents;
        int name;
        int silencer;
        int speed;
        int attack;
        
        p.Start();
    
        for (int j = MaxClients + 1; j <= maxEnts; ++j)
        {
            if (!IsValidEntity(j))
                continue;
                
            ++ents;
 
            if (HasEntProp(j, Prop_Send, "m_iName"))
                ++name;

            if (HasEntProp(j, Prop_Send, "m_bSilencerOn"))
                ++silencer;
            
            if (HasEntProp(j, Prop_Send, "invalid prop"))
                PrintToChatAll("%i INVALID?! (Prop_Send)", j);
                
            if (HasEntProp(j, Prop_Data, "m_flSpeed"))
                ++speed;

            if (HasEntProp(j, Prop_Data, "m_flNextPrimaryAttack"))
                ++attack;

            if (HasEntProp(j, Prop_Data, "invalid prop"))
                PrintToChatAll("%i INVALID?! (Prop_Data)", j);
        }
        
        p.Stop();
        
        PrintToChatAll("[HasEntProp %i] Time:%f | Ents:%i, Name:%i, Silencer:%i, Speed:%i, Attack:%i", i, p.Time, ents, name, silencer, speed, attack);
    }
    
    delete p;

    return Plugin_Handled;
}

Action Cmd_HasEntProp2(int client, int args)
{
    int maxEnts = GetMaxEntities();
    float totalTime;
    Profiler p = new Profiler();
    
    const int ITERS = 100;

    for (int i = 1; i <= ITERS; ++i)
    {
        int dummy;
        
        p.Start();
    
        for (int j = MaxClients + 1; j <= maxEnts; ++j)
        {
            if (!IsValidEntity(j))
                continue;
    
            if (HasEntProp(j, Prop_Send, "m_iName"))
                ++dummy;
            
            if (HasEntProp(j, Prop_Send, "m_bSilencerOn"))
                ++dummy;
            
            if (HasEntProp(j, Prop_Send, "invalid prop"))
                ++dummy;
                
            
            if (HasEntProp(j, Prop_Data, "m_flSpeed"))
                ++dummy;

            if (HasEntProp(j, Prop_Data, "m_flNextPrimaryAttack"))
                ++dummy;
            
            if (HasEntProp(j, Prop_Data, "invalid prop"))
                ++dummy;
        }
        
        p.Stop();
        
        totalTime += p.Time;
    }
    
    PrintToChatAll("[HasEntProp] Average Time:%fms", (totalTime / ITERS) * 1000);
    delete p;

    return Plugin_Handled;
}
```