### PR TITLE
Add note about automatic unhook

### DIFF
--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -378,6 +378,8 @@ forward Action OnLevelInit(const char[] mapName, char mapEntities[2097152]);
 /**
  * Hooks an entity
  *
+ * Unhooked automatically upon destruction/removal of the entity
+ *
  * @param entity        Entity index
  * @param type          Type of function to hook
  * @param callback      Function to call when hook is called
@@ -386,6 +388,8 @@ native void SDKHook(int entity, SDKHookType type, SDKHookCB callback);
 
 /**
  * Hooks an entity
+ *
+ * Unhooked automatically upon destruction/removal of the entity
  *
  * @param entity        Entity index
  * @param type          Type of function to hook


### PR DESCRIPTION
Adds a little note to `SDKHook` and `SDKHookEx` hinting at the automatic unhook behavior here
https://github.com/alliedmodders/sourcemod/blob/d5a26adc493d2dfe1919ab1ff619bfb0d404ee84/extensions/sdkhooks/extension.cpp#L1847