### PR TITLE
Allow void return type in timer callbacks

### DIFF
--- a/plugins/include/timers.inc
+++ b/plugins/include/timers.inc
@@ -54,8 +54,18 @@ typeset Timer
 	 * @param data          Handle or value passed to CreateTimer() when timer was created.
 	 * @return              Plugin_Stop to stop a repeating timer, any other value for
 	 *                      default behavior.
+	 *                      Ignored for non-repeating timers (use void return type).
 	 */
 	function Action(Handle timer, any data);
+
+	/**
+	 * Called when the timer interval has elapsed.
+	 * For repeating timers, use the callback with return value.
+	 *
+	 * @param timer         Handle to the timer object.
+	 * @param data          Handle or value passed to CreateTimer() when timer was created.
+	 */
+	function void(Handle timer, any data);
 
 	/**
 	 * Called when the timer interval has elapsed.
@@ -63,8 +73,17 @@ typeset Timer
 	 * @param timer         Handle to the timer object.
 	 * @return              Plugin_Stop to stop a repeating timer, any other value for
 	 *                      default behavior.
+	 *                      Ignored for non-repeating timers (use void return type).
 	 */
 	function Action(Handle timer);
+	
+	/**
+	 * Called when the timer interval has elapsed.
+	 * For repeating timers, use the callback with return value.
+	 *
+	 * @param timer         Handle to the timer object.
+	 */
+	function void(Handle timer);
 };
 
 /**


### PR DESCRIPTION
Why not allow void-return timers when majority of uses will be non repeating timers? 😉 
If used with repeating timer by accident, the timer just won't stop.

This imitates event hooks where both Action/void returns are allowed.