### PR TITLE
Add methods for clearing netprop cache

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -503,6 +503,26 @@ bool CHalfLife2::FindDataMapInfo(datamap_t *pMap, const char *offset, sm_datatab
 	return true;
 }
 
+void CHalfLife2::ClearDataTableCache()
+{
+	m_Maps.clear();
+}
+
+void CHalfLife2::ClearDataTableCache(datamap_t *pMap)
+{
+	m_Maps.removeIfExists(pMap);
+}
+
+void CHalfLife2::ClearSendPropCache()
+{
+	m_Classes.clear();
+}
+
+bool CHalfLife2::ClearSendPropCache(const char *classname)
+{
+	return m_Classes.remove(classname);
+}
+
 void CHalfLife2::SetEdictStateChanged(edict_t *pEdict, unsigned short offset)
 {
 #if SOURCE_ENGINE != SE_DARKMESSIAH

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -257,6 +257,11 @@ private:
 private:
 	void InitLogicalEntData();
 	void InitCommandLine();
+public:
+	void CHalfLife2::ClearDataTableCache();
+	void CHalfLife2::ClearDataTableCache(datamap_t *pMap);
+	void CHalfLife2::ClearSendPropCache();
+	bool CHalfLife2::ClearSendPropCache(const char *classname);
 private:
 	typedef ke::HashMap<datamap_t *, DataMapCache *, ke::PointerPolicy<datamap_t> > DataTableMap;
 


### PR DESCRIPTION
As mentioned in PR #1908, changing the behaviour of the datamap cache would break certain extensions.
[Kenzzer suggested adding functionality for extensions to clear the cache as a fix](https://github.com/alliedmodders/sourcemod/pull/1908#issuecomment-1399471595) (though don't ask me how that works).

I never got a response in the discord if this was a good solution or not, but here's a PR to at least keep track of things.



