### PR TITLE
Add function to find a TopMenu Item

### DIFF
--- a/extensions/topmenus/TopMenu.cpp
+++ b/extensions/topmenus/TopMenu.cpp
@@ -1239,6 +1239,18 @@ unsigned int TopMenu::FindCategory(const char *name)
 	return obj->object_id;
 }
 
+unsigned int TopMenu::FindItem(const char *name)
+{
+	topmenu_object_t *obj;
+	if (!m_ObjLookup.retrieve(name, &obj))
+		return 0;
+
+	if (obj->type != TopMenuObject_Item)
+		return 0;
+
+	return obj->object_id;
+}
+
 void TopMenu::OnMaxPlayersChanged( int newvalue )
 {
 	m_max_clients = newvalue;

--- a/extensions/topmenus/TopMenu.h
+++ b/extensions/topmenus/TopMenu.h
@@ -142,6 +142,7 @@ public: //ITopMenu
 		TopMenuPosition position);
 	virtual bool LoadConfiguration(const char *file, char *error, size_t maxlength);
 	virtual unsigned int FindCategory(const char *name);
+	virtual unsigned int FindItem(const char *name);
 	const char *GetObjectInfoString(unsigned int object_id);
 	const char *GetObjectName(unsigned int object_id);
 public: //IMenuHandler

--- a/extensions/topmenus/smn_topmenus.cpp
+++ b/extensions/topmenus/smn_topmenus.cpp
@@ -300,6 +300,24 @@ static cell_t FindTopMenuCategory(IPluginContext *pContext, const cell_t *params
 	return pMenu->FindCategory(name);
 }
 
+static cell_t FindTopMenuItem(IPluginContext *pContext, const cell_t *params)
+{
+	HandleError err;
+	ITopMenu *pMenu;
+	HandleSecurity sec(pContext->GetIdentity(), myself->GetIdentity());
+
+	if ((err = handlesys->ReadHandle(params[1], hTopMenuType, &sec, (void **)&pMenu))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
+	}
+
+	char *name;
+	pContext->LocalToString(params[2], &name);
+
+	return pMenu->FindItem(name);
+}
+
 static cell_t DisplayTopMenu(IPluginContext *pContext, const cell_t *params)
 {
 	HandleError err;
@@ -486,6 +504,7 @@ sp_nativeinfo_t g_TopMenuNatives[] =
 	{"TopMenu.LoadConfig",		LoadTopMenuConfig},
 	{"TopMenu.Remove",			RemoveFromTopMenu},
 	{"TopMenu.FindCategory",	FindTopMenuCategory},
+	{"TopMenu.FindItem",		FindTopMenuItem},
 	{"TopMenu.GetInfoString",	GetTopMenuInfoString},
 	{"TopMenu.GetObjName",		GetTopMenuName},
 	{"TopMenu.CacheTitles.set",	SetTopMenuTitleCaching},

--- a/plugins/include/topmenus.inc
+++ b/plugins/include/topmenus.inc
@@ -244,7 +244,14 @@ methodmap TopMenu < Handle
 	// @return              TopMenuObject ID on success, or
 	//                     INVALID_TOPMENUOBJECT on failure.
 	public native TopMenuObject FindCategory(const char[] name);
-
+	
+	// Finds an item's topobj ID in a TopMenu.
+	//
+	// @param name         Object's unique name.
+	// @return              TopMenuObject ID on success, or
+	//                     INVALID_TOPMENUOBJECT on failure.
+	public native TopMenuObject FindItem(const char[] name);
+	
 	// Set the menu title caching behavior of the TopMenu. By default titles
 	// are cached to reduce overhead. If you need dynamic menu titles which
 	// change each time the menu is displayed to a user, set this to false.
@@ -441,6 +448,7 @@ public void __ext_topmenus_SetNTVOptional()
 	MarkNativeAsOptional("TopMenu.Display");
 	MarkNativeAsOptional("TopMenu.DisplayCategory");
 	MarkNativeAsOptional("TopMenu.FindCategory");
+	MarkNativeAsOptional("TopMenu.FindItem");
 	MarkNativeAsOptional("TopMenu.CacheTitles.set");
 }
 #endif


### PR DESCRIPTION
This can be used to change the logic of TopMenu items (find item -> remove -> create again) registered by base plugins (basecommands for example). I will use this to change the logic for sm_who (instead of flags, I will display their groups) so I don't have to modify basecommands whenever its updated.