### PR TITLE
Update clang-8 CI run to Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-latest, windows-latest]
         include:
           - os: windows-latest
             os_short: win
@@ -21,7 +21,7 @@ jobs:
             os_short: linux
             compiler_cc: clang
             compiler_cxx: clang++
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             os_short: linux
             compiler_cc: clang-8
             compiler_cxx: clang++-8


### PR DESCRIPTION
The Ubuntu 18.04 runner image is deprecated and will be unsupported on 2023/04/01. It appears Ubuntu 20.04 has a package for clang-8, so just do the switch.

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/