### PR TITLE
Update SDKCall return information

### DIFF
--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -194,6 +194,7 @@ native Handle EndPrepSDKCall();
  *  rules will result in crashes or wildly unexpected behavior!
  *
  * If the return value is a float or integer, the return value will be this value.
+ * If the return value is a string, then the number of bytes written will be this value.
  * If the return value is a CBaseEntity, CBasePlayer, or edict, the return value will
  *  always be the entity index, or -1 for NULL.
  *

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -194,7 +194,7 @@ native Handle EndPrepSDKCall();
  *  rules will result in crashes or wildly unexpected behavior!
  *
  * If the return value is a float or integer, the return value will be this value.
- * If the return value is a string, then the number of bytes written will be this value.
+ * If the return value is a string, the value returned by the function will be the number of bytes written.
  * If the return value is a CBaseEntity, CBasePlayer, or edict, the return value will
  *  always be the entity index, or -1 for NULL.
  *

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -194,7 +194,7 @@ native Handle EndPrepSDKCall();
  *  rules will result in crashes or wildly unexpected behavior!
  *
  * If the return value is a float or integer, the return value will be this value.
- * If the return value is a string, the value returned by the function will be the number of bytes written.
+ * If the return value is a string, the value returned by the function will be the number of bytes written, or -1 for NULL.
  * If the return value is a CBaseEntity, CBasePlayer, or edict, the return value will
  *  always be the entity index, or -1 for NULL.
  *


### PR DESCRIPTION
This adds the information that if the return value is a string then SDKCall will return the number of bytes written. See [here](https://github.com/alliedmodders/sourcemod/blob/master/extensions/sdktools/vcaller.cpp#L507)

I'm not entirely sure if the description given is clear enough or if it may cause confusion.
I'm open for suggestions.