### PR TITLE
[DHooks] Fix `NaN` return when superceding pre-detour

### DIFF
--- a/extensions/dhooks/DynamicHooks/hook.cpp
+++ b/extensions/dhooks/DynamicHooks/hook.cpp
@@ -191,7 +191,7 @@ ReturnAction_t CHook::HookHandler(HookType_t eHookType)
 	if (eHookType == HOOKTYPE_PRE)
 	{
 		m_LastPreReturnAction.push_back(returnAction);
-		if (returnAction == ReturnAction_Override)
+		if (returnAction >= ReturnAction_Override)
 			m_pCallingConvention->SaveReturnValue(m_pRegisters);
 		if (returnAction < ReturnAction_Supercede)
 			m_pCallingConvention->SaveCallArguments(m_pRegisters);

--- a/extensions/dhooks/DynamicHooks/hook.cpp
+++ b/extensions/dhooks/DynamicHooks/hook.cpp
@@ -160,7 +160,7 @@ ReturnAction_t CHook::HookHandler(HookType_t eHookType)
 	{
 		ReturnAction_t lastPreReturnAction = m_LastPreReturnAction.back();
 		m_LastPreReturnAction.pop_back();
-		if (lastPreReturnAction == ReturnAction_Override)
+		if (lastPreReturnAction >= ReturnAction_Override)
 			m_pCallingConvention->RestoreReturnValue(m_pRegisters);
 		if (lastPreReturnAction < ReturnAction_Supercede)
 			m_pCallingConvention->RestoreCallArguments(m_pRegisters);


### PR DESCRIPTION
Fix #1959 
Pretty much everything is explained in the related issue.