### PR TITLE
missing translation added + fix

### DIFF
--- a/translations/lv/nominations.phrases.txt
+++ b/translations/lv/nominations.phrases.txt
@@ -42,7 +42,7 @@
 
 	"Can't Nominate Current Map"
 	{
-		"lv"		"Tevis izvēlētā karte ir patreizējā karte un nevar būt nominēta"
+		"lv"		"Tevis izvēlētā karte šobrīd tiek spēlēta un nevar būt nominēta"
 	}
 
 	"Map in Exclude List"
@@ -63,6 +63,12 @@
 	"Nominated"
 	{
 		"lv"		"Nominēja"
+	}
+	
+	"Map Not In Pool"
+	{
+		"#format"		"{1:s}"
+		"lv"			"Karte '{1}' nav pieejama nomināciju sarakstā."
 	}
 
 }


### PR DESCRIPTION
Added missing translation + Can't Nominate Current Map translation was changed because The sentence in Latvian doesn't sound good + the chosen word wasn't the best option in this sentence.