### PR TITLE
Make KeyValues.Rewind traversal-stack clearing optional

### DIFF
--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -669,9 +669,21 @@ static cell_t smn_KvRewind(IPluginContext *pCtx, const cell_t *params)
 		return pCtx->ThrowNativeError("Invalid key value handle %x (error %d)", hndl, herr);
 	}
 
-	while (pStk->pCurRoot.size() > 1)
+	// Older plugins do not have the clearHistory param
+	if (params[0] < 2 || params[2])
 	{
-		pStk->pCurRoot.pop();
+		while (pStk->pCurRoot.size() > 1)
+		{
+			pStk->pCurRoot.pop();
+		}
+	}
+	else
+	{
+		auto root = pStk->pCurRoot.begin();
+		if (root != pStk->pCurRoot.end())
+		{
+			pStk->pCurRoot.push(*root);
+		}
 	}
 
 	return 1;

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -245,9 +245,9 @@ methodmap KeyValues < Handle
 	public native bool SavePosition();
 
 	// Jumps back to the previous position.  Returns false if there are no
-	// previous positions (i.e., at the root node).  This should be called
-	// once for each successful Jump call, in order to return to the top node.
-	// This function pops one node off the internal traversal stack.
+	// previous positions (i.e., at the root node with an empty traversal stack).
+	// This should be called once for each successful Jump call, in order to return
+	// to the top node.  This function pops one node off the internal traversal stack.
 	//
 	// @return              True on success, false if there is no higher node.
 	public native bool GoBack();
@@ -272,12 +272,14 @@ methodmap KeyValues < Handle
 	//                        thus the state is as if KvGoBack() was called.
 	public native int DeleteThis();
 
-	// Sets the position back to the top node, emptying the entire node
-	// traversal history.  This can be used instead of looping KvGoBack()
+	// Sets the position back to the top node, optionally emptying the entire
+	// node traversal history.  This can be used instead of looping KvGoBack()
 	// if recursive iteration is not important.
 	//
 	// @param kv            KeyValues Handle.
-	public native void Rewind();
+	// @param clearHistory  If true, the entire node traversal stack is cleared.
+	//                      If false, this will add to the traversal stack.
+	public native void Rewind(bool clearHistory=true);
 
 	// Retrieves the current section name.
 	//
@@ -306,7 +308,7 @@ methodmap KeyValues < Handle
 
 	// Returns the position in the jump stack; I.e. the number of calls
 	// required for KvGoBack to return to the root node.  If at the root node,
-	// 0 is returned.
+	// and the traversal stack is empty, 0 is returned.
 	//
 	// @return              Number of non-root nodes in the jump stack.
 	public native int NodesInStack();
@@ -558,9 +560,9 @@ native int KvDeleteThis(Handle kv);
 
 /**
  * Jumps back to the previous position.  Returns false if there are no
- * previous positions (i.e., at the root node).  This should be called
- * once for each successful Jump call, in order to return to the top node.
- * This function pops one node off the internal traversal stack.
+ * previous positions (i.e., at the root node with an empty traversal stack).
+ * This should be called once for each successful Jump call, in order to return
+ * to the top node.  This function pops one node off the internal traversal stack.
  *
  * @param kv            KeyValues Handle.
  * @return              True on success, false if there is no higher node.


### PR DESCRIPTION
As suggested by asherkin in the discord.
Hopefully implemented properly; not sure if there's other behaviour I'm not factoring in.
Tested with the following code:
```sourcepawn
char data[] = 
"\"TestRoot\""
... "{"
... "    \"node 1\""
... "    {"
... "        \"node 2\""
... "        {"
... "            \"somekey\" \"somevalue\""
... "        }"
... "    }"
... "}";

public void OnPluginStart()
{
    KeyValues kv = new KeyValues("blah");
    kv.ImportFromString(data);

    kv.JumpToKey("node 1");
    PrintToServer("1. nodes: %i", kv.NodesInStack());
    
    kv.JumpToKey("node 2");
    PrintToServer("2. nodes: %i", kv.NodesInStack());
    
    kv.JumpToKey("somekey");
    PrintToServer("3. nodes: %i", kv.NodesInStack());
    
    
    kv.Rewind();
    PrintToServer("rw1. nodes: %i", kv.NodesInStack());
    PrintToServer("goback: %i", kv.GoBack());
    

    kv.JumpToKey("node 1");
    PrintToServer("4. nodes: %i", kv.NodesInStack());
    
    kv.JumpToKey("node 2");
    PrintToServer("5. nodes: %i", kv.NodesInStack());
    
    kv.JumpToKey("somekey");
    PrintToServer("6. nodes: %i", kv.NodesInStack());
    
    
    kv.Rewind(false);
    PrintToServer("rw2. nodes: %i", kv.NodesInStack());
    PrintToServer("goback: %i", kv.GoBack());
}
```
![image](https://user-images.githubusercontent.com/13011795/232265048-62a0342a-c061-4092-80c9-7caad330a132.png)
