### PR TITLE
Fix invalid client index in Basebans menu

### DIFF
--- a/plugins/basebans.sp
+++ b/plugins/basebans.sp
@@ -51,7 +51,6 @@ public Plugin myinfo =
 TopMenu hTopMenu;
 
 enum struct PlayerInfo {
-	int banTarget;
 	int banTargetUserId;
 	int banTime;
 	int isWaitingForChatReason;
@@ -387,7 +386,7 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 	if(playerinfo[client].isWaitingForChatReason)
 	{
 		playerinfo[client].isWaitingForChatReason = false;
-		PrepareBan(client, playerinfo[client].banTarget, playerinfo[client].banTime, sArgs);
+		PrepareBan(client, playerinfo[client].banTargetUserId, playerinfo[client].banTime, sArgs);
 		return Plugin_Stop;
 	}
 


### PR DESCRIPTION
Fix #1768

The `sm_admin`-triggered Menu flow for banning players is caching client indices inside the basebans.sp `PlayerInfo` struct, and can then incorrectly use them in the menu callback without checking for the related client's UserId validity. This leads to bug #1768 occurring when the ban target player disconnects from the server before the banning admin could complete the banmenu UI flow.

Since the related menu callbacks can't rely on the cached client index, I have removed the basebans.sp `PlayerInfo.banTarget` member entirely, in favor of the `PlayerInfo.banTarget`, and instead call `GetClientOfUserId(...)` to get & validate the target client index where necessary. The `PrepareBan(...)` function has been refactored to take a ban target UserId (instead of the target client index) accordingly.

---

To reproduce this bug, follow these steps:

* Admin joins server
* "Cheater"/undesired player joins server
* Admin opens the `sm_admin -> "Player Commmands" -> "Ban Player"` menu
* Admin selects the cheater
* Cheater disconnects
* Admin selects the ban duration, and/or reason for ban
* Server throws the error as described by #1768

