### PR TITLE
Deprecate CreateInterface

### DIFF
--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -297,6 +297,12 @@ void SDKExtension::SDK_OnDependenciesDropped()
 
 #if defined SMEXT_CONF_METAMOD
 
+#if defined _MSC_VER
+	#define SMEXT_DLL_EXPORT				extern "C" __declspec(dllexport)
+#else
+	#define SMEXT_DLL_EXPORT				extern "C" __attribute__((visibility("default")))
+#endif
+
 PluginId g_PLID = 0;						/**< Metamod plugin ID */
 ISmmPlugin *g_PLAPI = NULL;					/**< Metamod plugin API */
 SourceHook::ISourceHook *g_SHPtr = NULL;	/**< SourceHook pointer */
@@ -308,27 +314,9 @@ IServerGameDLL *gamedll = NULL;				/**< IServerGameDLL pointer */
 #endif
 
 /** Exposes the extension to Metamod */
-SMM_API void *PL_EXPOSURE(const char *name, int *code)
+SMEXT_DLL_EXPORT METAMOD_PLUGIN *CreateInterface_MMS(const MetamodVersionInfo *mvi, const MetamodLoaderInfo *mli)
 {
-#if defined METAMOD_PLAPI_VERSION
-	if (name && !strcmp(name, METAMOD_PLAPI_NAME))
-#else
-	if (name && !strcmp(name, PLAPI_NAME))
-#endif
-	{
-		if (code)
-		{
-			*code = META_IFACE_OK;
-		}
-		return static_cast<void *>(g_pExtensionIface);
-	}
-
-	if (code)
-	{
-		*code = META_IFACE_FAILED;
-	}
-
-	return NULL;
+	return g_pExtensionIface;
 }
 
 bool SDKExtension::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool late)

--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -316,7 +316,7 @@ IServerGameDLL *gamedll = NULL;				/**< IServerGameDLL pointer */
 /** Exposes the extension to Metamod */
 SMEXT_DLL_EXPORT METAMOD_PLUGIN *CreateInterface_MMS(const MetamodVersionInfo *mvi, const MetamodLoaderInfo *mli)
 {
-	return g_pExtensionIface;
+	return g_pExtensionIface->SDK_OnMetamodCreateInterface(mvi, mli);
 }
 
 bool SDKExtension::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool late)
@@ -443,6 +443,11 @@ const char *SDKExtension::GetURL()
 const char *SDKExtension::GetVersion()
 {
 	return GetExtensionVerString();
+}
+
+METAMOD_PLUGIN *SDKExtension::SDK_OnMetamodCreateInterface(const MetamodVersionInfo *mvi, const MetamodLoaderInfo *mli)
+{
+	return this;
 }
 
 bool SDKExtension::SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlength, bool late)

--- a/public/smsdk_ext.cpp
+++ b/public/smsdk_ext.cpp
@@ -298,9 +298,9 @@ void SDKExtension::SDK_OnDependenciesDropped()
 #if defined SMEXT_CONF_METAMOD
 
 #if defined _MSC_VER
-	#define SMEXT_DLL_EXPORT				extern "C" __declspec(dllexport)
+#define SMEXT_DLL_EXPORT				extern "C" __declspec(dllexport)
 #else
-	#define SMEXT_DLL_EXPORT				extern "C" __attribute__((visibility("default")))
+#define SMEXT_DLL_EXPORT				extern "C" __attribute__((visibility("default")))
 #endif
 
 PluginId g_PLID = 0;						/**< Metamod plugin ID */

--- a/public/smsdk_ext.h
+++ b/public/smsdk_ext.h
@@ -153,6 +153,15 @@ public:
 
 #if defined SMEXT_CONF_METAMOD
 	/**
+	 * @brief Called when Metamod is requesting the extension (ISmmPlugin) interface.
+	 *
+	 * @param mvi			Struct that contains Metamod version, SourceHook version, Plugin version and Source Engine version.
+	 * @param mli			Struct that contains the library file name and path being loaded.
+	 * @return				The ISmmPlugin interface.
+	 */
+	virtual METAMOD_PLUGIN *SDK_OnMetamodCreateInterface(const MetamodVersionInfo *mvi, const MetamodLoaderInfo *mli);
+
+	/**
 	 * @brief Called when Metamod is attached, before the extension version is called.
 	 *
 	 * @param error			Error buffer.


### PR DESCRIPTION
# Why this change ?

`CreateInterface_MMS` was created 15 years ago. But `smsdk_ext.cpp` was never updated to have that change, and has continued to rely on the old function `CreateInterface` for 16 years.

On this aspect alone, I think this warrants an update.

However if this isn't enough to warrant the change. It should be noted that tier1 library the various SM extensions compile against, has its own definition of  `CreateInterface` which can clash with smsdkext's `CreateInterface` and cause linkage issues. So rather than cause headaches for sm extensions authors like myself lol, let's just axe this old function.

# New SDKExtension virtual

`METAMOD_PLUGIN *SDK_OnMetamodCreateInterface(const MetamodVersionInfo *mvi, const MetamodLoaderInfo *mli)`

Which exposes to the extension the two structs passed by metamod. As well as allowing greater control should extensions want, for whatever reason, return a different `ISmmPlugin` interface.