### PR TITLE
Fix mismatched memory release in regex clearmatch

### DIFF
--- a/extensions/regex/CRegEx.cpp
+++ b/extensions/regex/CRegEx.cpp
@@ -173,7 +173,7 @@ void RegEx::ClearMatch()
 	mErrorCode = 0;
 	mError = nullptr;
 	if (subject)
-		delete [] subject;
+		free(subject);
 	subject = nullptr;
 	mMatchCount = 0;
 }


### PR DESCRIPTION
subject is created with strdup which should be freed with C free and not C++ delete