### PR TITLE
Add more functions to ArrayStack

### DIFF
--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -240,9 +240,9 @@ static cell_t PopStackCell(IPluginContext *pContext, const cell_t *params)
 	}
 	else
 	{
-		if (idx >= array->blocksize() * 4)
+		if (idx >= array->blocksize() * sizeof(cell_t))
 		{
-			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * 4);
+			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * sizeof(cell_t));
 		}
 		*buffer = (cell_t)*((char *)blk + idx);
 	}
@@ -356,8 +356,8 @@ static cell_t ArrayStack_Pop(IPluginContext *pContext, const cell_t *params)
 			return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", idx, array->blocksize());
 		rval = blk[idx];
 	} else {
-		if (idx >= array->blocksize() * 4)
-			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * 4);
+		if (idx >= array->blocksize() * sizeof(cell_t))
+			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * sizeof(cell_t));
 		rval = (cell_t)*((char *)blk + idx);
 	}
 
@@ -383,8 +383,8 @@ static cell_t ArrayStack_Top(IPluginContext *pContext, const cell_t *params)
 			return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", idx, array->blocksize());
 		rval = blk[idx];
 	} else {
-		if (idx >= array->blocksize() * 4)
-			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * 4);
+		if (idx >= array->blocksize() * sizeof(cell_t))
+			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * sizeof(cell_t));
 		rval = (cell_t)*((char *)blk + idx);
 	}
 

--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -478,7 +478,6 @@ static cell_t ArrayStack_TopArray(IPluginContext *pContext, const cell_t *params
 		indexes = params[3];
 
 	memcpy(addr, blk, sizeof(cell_t) * indexes);
-	array->remove(idx);
 	return 0;
 }
 

--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -365,7 +365,7 @@ static cell_t ArrayStack_Pop(IPluginContext *pContext, const cell_t *params)
 	return rval;
 }
 
-static cell_t ArrayStack_Top(IPluginContext* pContext, const cell_t* params)
+static cell_t ArrayStack_Top(IPluginContext *pContext, const cell_t *params)
 {
 	OpenHandle<CellArray> array(pContext, params[1], htCellStack);
 	if (!array.Ok())
@@ -374,7 +374,7 @@ static cell_t ArrayStack_Top(IPluginContext* pContext, const cell_t* params)
 	if (array->size() == 0)
 		return pContext->ThrowNativeError("stack is empty");
 
-	cell_t* blk = array->at(array->size() - 1);
+	cell_t *blk = array->at(array->size() - 1);
 	size_t idx = (size_t)params[2];
 
 	cell_t rval;
@@ -382,11 +382,10 @@ static cell_t ArrayStack_Top(IPluginContext* pContext, const cell_t* params)
 		if (idx >= array->blocksize())
 			return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", idx, array->blocksize());
 		rval = blk[idx];
-	}
-	else {
+	} else {
 		if (idx >= array->blocksize() * 4)
 			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * 4);
-		rval = (cell_t) * ((char*)blk + idx);
+		rval = (cell_t)*((char *)blk + idx);
 	}
 
 	return rval;
@@ -426,7 +425,7 @@ static cell_t ArrayStack_TopString(IPluginContext *pContext, const cell_t *param
 	size_t idx = array->size() - 1;
 	cell_t *blk = array->at(idx);
 
-	cell_t* pWritten;
+	cell_t *pWritten;
 	pContext->LocalToPhysAddr(params[4], &pWritten);
 
 	size_t numWritten;
@@ -498,13 +497,13 @@ static cell_t GetStackBlockSize(IPluginContext *pContext, const cell_t *params)
 	return array->blocksize();
 }
 
-static cell_t GetStackSize(IPluginContext* pContext, const cell_t* params)
+static cell_t GetStackSize(IPluginContext *pContext, const cell_t *params)
 {
 	HandleError err;
-	CellArray* array;
+	CellArray *array;
 	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
 
-	if ((err = handlesys->ReadHandle(params[1], htCellStack, &sec, (void**)&array))
+	if ((err = handlesys->ReadHandle(params[1], htCellStack, &sec, (void **)&array))
 		!= HandleError_None)
 	{
 		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);

--- a/core/logic/smn_adt_stack.cpp
+++ b/core/logic/smn_adt_stack.cpp
@@ -365,6 +365,33 @@ static cell_t ArrayStack_Pop(IPluginContext *pContext, const cell_t *params)
 	return rval;
 }
 
+static cell_t ArrayStack_Top(IPluginContext* pContext, const cell_t* params)
+{
+	OpenHandle<CellArray> array(pContext, params[1], htCellStack);
+	if (!array.Ok())
+		return 0;
+
+	if (array->size() == 0)
+		return pContext->ThrowNativeError("stack is empty");
+
+	cell_t* blk = array->at(array->size() - 1);
+	size_t idx = (size_t)params[2];
+
+	cell_t rval;
+	if (params[3] == 0) {
+		if (idx >= array->blocksize())
+			return pContext->ThrowNativeError("Invalid block %d (blocksize: %d)", idx, array->blocksize());
+		rval = blk[idx];
+	}
+	else {
+		if (idx >= array->blocksize() * 4)
+			return pContext->ThrowNativeError("Invalid byte %d (blocksize: %d bytes)", idx, array->blocksize() * 4);
+		rval = (cell_t) * ((char*)blk + idx);
+	}
+
+	return rval;
+}
+
 static cell_t ArrayStack_PopString(IPluginContext *pContext, const cell_t *params)
 {
 	OpenHandle<CellArray> array(pContext, params[1], htCellStack); 
@@ -387,9 +414,54 @@ static cell_t ArrayStack_PopString(IPluginContext *pContext, const cell_t *param
 	return 1;
 }
 
+static cell_t ArrayStack_TopString(IPluginContext *pContext, const cell_t *params)
+{
+	OpenHandle<CellArray> array(pContext, params[1], htCellStack);
+	if (!array.Ok())
+		return 0;
+
+	if (array->size() == 0)
+		return pContext->ThrowNativeError("stack is empty");
+
+	size_t idx = array->size() - 1;
+	cell_t *blk = array->at(idx);
+
+	cell_t* pWritten;
+	pContext->LocalToPhysAddr(params[4], &pWritten);
+
+	size_t numWritten;
+	pContext->StringToLocalUTF8(params[2], params[3], (char *)blk, &numWritten);
+	*pWritten = (cell_t)numWritten;
+	return 1;
+}
+
 static cell_t ArrayStack_PopArray(IPluginContext *pContext, const cell_t *params)
 {
 	OpenHandle<CellArray> array(pContext, params[1], htCellStack); 
+	if (!array.Ok())
+		return 0;
+
+	if (array->size() == 0)
+		return pContext->ThrowNativeError("stack is empty");
+
+	cell_t *addr;
+	pContext->LocalToPhysAddr(params[2], &addr);
+
+	size_t idx = array->size() - 1;
+	cell_t *blk = array->at(idx);
+	size_t indexes = array->blocksize();
+
+	if (params[3] != -1 && (size_t)params[3] <= array->blocksize())
+		indexes = params[3];
+
+	memcpy(addr, blk, sizeof(cell_t) * indexes);
+	array->remove(idx);
+	return 0;
+}
+
+static cell_t ArrayStack_TopArray(IPluginContext *pContext, const cell_t *params)
+{
+	OpenHandle<CellArray> array(pContext, params[1], htCellStack);
 	if (!array.Ok())
 		return 0;
 
@@ -426,6 +498,21 @@ static cell_t GetStackBlockSize(IPluginContext *pContext, const cell_t *params)
 	return array->blocksize();
 }
 
+static cell_t GetStackSize(IPluginContext* pContext, const cell_t* params)
+{
+	HandleError err;
+	CellArray* array;
+	HandleSecurity sec(pContext->GetIdentity(), g_pCoreIdent);
+
+	if ((err = handlesys->ReadHandle(params[1], htCellStack, &sec, (void**)&array))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid Handle %x (error: %d)", params[1], err);
+	}
+
+	return array->size();
+}
+
 REGISTER_NATIVES(cellStackNatives)
 {
 	{"CreateStack",					CreateStack},
@@ -444,13 +531,17 @@ REGISTER_NATIVES(cellStackNatives)
 	{"ArrayStack.Clear",			ClearStack},
 	{"ArrayStack.Clone",			CloneStack},
 	{"ArrayStack.Pop",				ArrayStack_Pop},
+	{"ArrayStack.Top",				ArrayStack_Top},
 	{"ArrayStack.PopString",		ArrayStack_PopString},
+	{"ArrayStack.TopString",		ArrayStack_TopString},
 	{"ArrayStack.PopArray",			ArrayStack_PopArray},
+	{"ArrayStack.TopArray",			ArrayStack_TopArray},
 	{"ArrayStack.Push",				PushStackCell},
 	{"ArrayStack.PushString",		PushStackString},
 	{"ArrayStack.PushArray",		PushStackArray},
 	{"ArrayStack.Empty.get",		IsStackEmpty},
 	{"ArrayStack.BlockSize.get",	GetStackBlockSize},
+	{"ArrayStack.Length.get",		GetStackSize},
 
 	{NULL,							NULL},
 };

--- a/plugins/include/adt_stack.inc
+++ b/plugins/include/adt_stack.inc
@@ -99,6 +99,15 @@ methodmap ArrayStack < Handle
 	// @error              The stack is empty.
 	public native any Pop(int block=0, bool asChar=false);
 
+	// Reads a cell value from a stack without removing it.
+	//
+	// @param block        Optionally specify which block to read from
+	//                     (useful if the blocksize > 0).
+	// @param asChar       Optionally read as a byte instead of a cell.
+	// @return             Value read from the stack.
+	// @error              The stack is empty.
+	public native any Top(int block=0, bool asChar=false);
+
 	// Pops a string value from a stack.
 	//
 	// @param buffer       Buffer to store string.
@@ -108,6 +117,15 @@ methodmap ArrayStack < Handle
 	// @error              The stack is empty.
 	public native void PopString(char[] buffer, int maxlength, int &written = 0);
 
+	// Reads a string value from a stack without removing it.
+	//
+	// @param buffer       Buffer to store string.
+	// @param maxlength    Maximum size of the buffer.
+	// @param written      Number of characters written to buffer, not including
+	//                     the null terminator.
+	// @error              The stack is empty.
+	public native void TopString(char[] buffer, int maxlength, int &written = 0);
+
 	// Pops an array of cells from a stack.
 	//
 	// @param buffer       Buffer to store the array in.
@@ -116,6 +134,14 @@ methodmap ArrayStack < Handle
 	// @error              The stack is empty.
 	public native void PopArray(any[] buffer, int size=-1);
 
+	// Reads an array of cells from a stack without removing it.
+	//
+	// @param buffer       Buffer to store the array in.
+	// @param size         If not set, assumes the buffer size is equal to the
+	//                     blocksize.  Otherwise, the size passed is used.
+	// @error              The stack is empty.
+	public native void TopArray(any[] buffer, int size=-1);
+
 	// Returns true if the stack is empty, false otherwise.
 	property bool Empty {
 		public native get();
@@ -123,6 +149,10 @@ methodmap ArrayStack < Handle
 	
 	// Retrieve the blocksize the stack was created with.
 	property int BlockSize {
+		public native get();
+	}
+	
+	property int Length {
 		public native get();
 	}
 };


### PR DESCRIPTION
ArrayStack can be useful at times, but the lack of functions makes it pretty limiting. This PR adds new natives for peeking at the top value of the stack without actually removing it, as well as a property to fetch the amount of elements in the stack.

Adds the following natives:
`ArrayStack.Top`
`ArrayStack.TopString`
`ArrayStack.TopArray`

And a property:
`ArrayStack.Length`