### PR TITLE
TF2: Add TFCond_ImmuneToPushback condition

### DIFF
--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -208,7 +208,8 @@ enum TFCond
 	TFCond_LostFooting, //126: Less ground friction
 	TFCond_AirCurrent, //127: Reduced air control and friction
 	TFCond_HalloweenHellHeal, // 128: Used when a player gets teleported to hell
-	TFCond_PowerupModeDominant // 129: Reduces effects of certain powerups
+	TFCond_PowerupModeDominant, // 129: Reduces effects of certain powerups
+	TFCond_ImmuneToPushback // 130: Player is immune to pushback effects
 };
 
 const float TFCondDuration_Infinite = -1.0;


### PR DESCRIPTION
A new condition 130 was added with the 2023-07-26 Team Fortress 2 update. Internally named `TF_COND_IMMUNE_TO_PUSHBACK` and can be found via string search in the latest game binary. Used in `CTFBotMainAction::Update`.