### PR TITLE
Fix sound flags enumeration

### DIFF
--- a/plugins/include/sdktools_sound.inc
+++ b/plugins/include/sdktools_sound.inc
@@ -72,18 +72,18 @@ enum
  */
 enum
 {
-	SND_NOFLAGS = 0,                                    /** Nothing */
-	SND_CHANGEVOL = 1,                                  /** Change sound volume */
-	SND_CHANGEPITCH = 2,                                /** Change sound pitch */
-	SND_STOP = 4,                                       /** Stop the sound */
-	SND_SPAWNING = 8,                                   /** Used in some cases for ambients */
-	SND_DELAY = 16,                                     /** Sound has an initial delay */
-	SND_STOPLOOPING = 32,                               /** Stop looping all sounds on the entity */
-	SND_SPEAKER = 64,                                   /** Being played by a mic through a speaker */
-	SND_SHOULDPAUSE = 128,                              /** Pause if game is paused */
-	SND_IGNORE_PHONEMES = 256,                          /** Prevents flex animation from being driven by this sound */
-	SND_IGNORE_NAME = 512,                              /** Changes all sounds emitted on the entity, regardless of actual name */
-	SND_DO_NOT_OVERWRITE_EXISTING_ON_CHANNEL = 1024     /** If an existing sound is found on the channel, the sound will not play instead of overwriting it */
+	SND_NOFLAGS = 0,                                         /** Nothing */
+	SND_CHANGEVOL = (1 << 0),                                /** Change sound volume */
+	SND_CHANGEPITCH = (1 << 1),                              /** Change sound pitch */
+	SND_STOP = (1 << 2),                                     /** Stop the sound */
+	SND_SPAWNING = (1 << 3),                                 /** Used in some cases for ambients */
+	SND_DELAY = (1 << 4),                                    /** Sound has an initial delay */
+	SND_STOPLOOPING = (1 << 5),                              /** Stop looping all sounds on the entity */
+	SND_SPEAKER = (1 << 6),                                  /** Being played by a mic through a speaker */
+	SND_SHOULDPAUSE = (1 << 7),                              /** Pause if game is paused */
+	SND_IGNORE_PHONEMES = (1 << 8),                          /** Prevents flex animation from being driven by this sound */
+	SND_IGNORE_NAME = (1 << 9),                              /** Changes all sounds emitted on the entity, regardless of actual name */
+	SND_DO_NOT_OVERWRITE_EXISTING_ON_CHANNEL = (1 << 10)     /** If an existing sound is found on the channel, the sound will not play instead of overwriting it */
 };
 
 /**

--- a/plugins/include/sdktools_sound.inc
+++ b/plugins/include/sdktools_sound.inc
@@ -72,15 +72,18 @@ enum
  */
 enum
 {
-	SND_NOFLAGS= 0,             /**< Nothing */
-	SND_CHANGEVOL = 1,          /**< Change sound volume */
-	SND_CHANGEPITCH = 2,        /**< Change sound pitch */
-	SND_STOP = 3,               /**< Stop the sound */
-	SND_SPAWNING = 4,           /**< Used in some cases for ambients */
-	SND_DELAY = 5,              /**< Sound has an initial delay */
-	SND_STOPLOOPING = 6,        /**< Stop looping all sounds on the entity */
-	SND_SPEAKER = 7,            /**< Being played by a mic through a speaker */
-	SND_SHOULDPAUSE = 8         /**< Pause if game is paused */
+	SND_NOFLAGS = 0,                                    /** Nothing */
+	SND_CHANGEVOL = 1,                                  /** Change sound volume */
+	SND_CHANGEPITCH = 2,                                /** Change sound pitch */
+	SND_STOP = 4,                                       /** Stop the sound */
+	SND_SPAWNING = 8,                                   /** Used in some cases for ambients */
+	SND_DELAY = 16,                                     /** Sound has an initial delay */
+	SND_STOPLOOPING = 32,                               /** Stop looping all sounds on the entity */
+	SND_SPEAKER = 64,                                   /** Being played by a mic through a speaker */
+	SND_SHOULDPAUSE = 128,                              /** Pause if game is paused */
+	SND_IGNORE_PHONEMES = 256,                          /** Prevents flex animation from being driven by this sound */
+	SND_IGNORE_NAME = 512,                              /** Changes all sounds emitted on the entity, regardless of actual name */
+	SND_DO_NOT_OVERWRITE_EXISTING_ON_CHANNEL = 1024     /** If an existing sound is found on the channel, the sound will not play instead of overwriting it */
 };
 
 /**


### PR DESCRIPTION
This fixes the values of sound flags since everything past SND_CHANGEPITCH was wrong. 

https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/public/soundflags.h#L115C18-L115C18

This also adds three other flags from SDK2013 which are SND_IGNORE_PHONEMES, SND_IGNORE_NAME, and SND_DO_NOT_OVERWRITE_EXISTING_ON_CHANNEL.