### PR TITLE
Update SourcePawn

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -773,6 +773,8 @@ if SM.use_auto_versioning():
   )
 
 class SPRoot(object):
+  def __init__(self):
+    self.generated_headers = SM.generated_headers
   # SourcePawn's build scripts are always one-offs, and attach the current target
   # to the builder, so we have to provide a shim to our StaticLibrary() method.
   def StaticLibrary(self, builder, name):

--- a/plugins/include/float.inc
+++ b/plugins/include/float.inc
@@ -275,7 +275,6 @@ stock int RoundFloat(float value)
  * User defined operators.
  */
 #if !defined __sourcepawn2__
-#pragma rational Float
 
 // Internal aliases for backwards compatibility.
 native float __FLOAT_MUL__(float a, float b) = FloatMul;


### PR DESCRIPTION
Bring in the latest changes (again) and fix the tooling Actions artifact on macOS.