### PR TITLE
Fix Japanese translations

### DIFF
--- a/translations/jp/playercommands.phrases.txt
+++ b/translations/jp/playercommands.phrases.txt
@@ -17,12 +17,12 @@
 
 	"Slapped target"
 	{
-		"jp"		"{1} を叩きました。"
+		"jp"		"{1}を叩きました。"
 	}
 
 	"Slayed target"
 	{
-		"jp"		"{1} を殺害しました。"
+		"jp"		"{1}を殺害しました。"
 	}
 
 	"Name changed"
@@ -32,7 +32,7 @@
 
 	"Renamed target"
 	{
-		"jp"		"{1} をリネームしました"
+		"jp"		"{1}をリネームしました。"
 	}
 
 	"Rename player"

--- a/translations/jp/plugin.basecommands.txt
+++ b/translations/jp/plugin.basecommands.txt
@@ -7,7 +7,7 @@
 
 	"No access to cvar"
 	{
-		"jp"		"このCVarにアクセス出来ません。"
+		"jp"		"あなたはこのCVarにアクセス出来ません。"
 	}
 
 	"Value of cvar"
@@ -32,32 +32,32 @@
 
 	"Permabanned player"
 	{
-		"jp"		"プレイヤー \"{1}\" を永久禁止されました。"
+		"jp"		"プレイヤー \"{1}\" を永久BANしました。"
 	}
 
 	"Permabanned player reason"
 	{
-		"jp"		"プレイヤー \"{1}\" を永久禁止されました。(理由: {2})"
+		"jp"		"プレイヤー \"{1}\" を永久BANしました。(理由: {2})"
 	}
 
 	"Banned player"
 	{
-		"jp"		"プレイヤー \"{1}\" を{2}分間禁止されました。"
+		"jp"		"プレイヤー \"{1}\" を{2}分間BANしました。"
 	}
 
 	"Banned player reason"
 	{
-		"jp"		"プレイヤー \"{1}\" を{2}分間禁止されました。 (理由: {3})"
+		"jp"		"プレイヤー \"{1}\" を{2}分間BANしました。(理由: {3})"
 	}
 
 	"Removed bans matching"
 	{
-		"jp"		"フィルターにマッチする禁止を削除しました: {1}"
+		"jp"		"フィルターにマッチするBANを削除しました: {1}"
 	}
 
 	"Ban added"
 	{
-		"jp"		"禁止を追加しました。"
+		"jp"		"BANを追加しました。"
 	}
 
 	"Admin cache refreshed"
@@ -107,7 +107,7 @@
 
 	"Kicked target"
 	{
-		"jp"		"{1}を蹴れました。"
+		"jp"		"{1}をキックしました。"
 	}
 
 	"Admin access"
@@ -122,7 +122,7 @@
 
 	"Kicked target reason"
 	{
-		"jp"		"{1}を蹴れました。(理由: {2})"
+		"jp"		"{1}をキックしました。(理由: {2})"
 	}
 
 	"Please select a map"

--- a/translations/jp/rockthevote.phrases.txt
+++ b/translations/jp/rockthevote.phrases.txt
@@ -22,7 +22,7 @@
 
 	"Already Voted"
 	{
-		"jp"		"すでにRock the Voteに投票しています。（{1}投票、残り{2}必要）"
+		"jp"		"すでにRock the Voteに投票しています。({1}投票、残り{2}必要)"
 	}
 
 	"Minimal Players Not Met"
@@ -32,7 +32,7 @@
 
 	"RTV Requested"
 	{
-		"jp"		"{1} がRock the Voteを希望しています。({2}投票、残り{3}必要)"
+		"jp"		"{1}がRock the Voteを希望しています。({2}投票、残り{3}必要)"
 	}
 
 	"RTV Vote Ready"
@@ -47,7 +47,7 @@
 
 	"Selected Map"
 	{
-		"jp"		"{1} は {2} を選択しました。"
+		"jp"		"{1}は{2}を選択しました。"
 	}
 
 	"No Votes"


### PR DESCRIPTION
This fix is to revert most of #2042.

First of all, honorific expressions such as "禁止されました" are unnecessary in this case, and "蹴れました" is also a strange expression. Secondly, there is no need to replace "BAN" with "禁止" or "キック" with "蹴(れ)", for 99.9% of Japanese readers can understand "BAN" and "キック" as they are, because "BAN" and "キック" are already part of the Japanese language. (Citation: https://e-words.jp/w/BAN.html) Finally, the space between the name seems unnecessary unless it is wrapped in double quotation marks, which is also to make it consistent with other translations.