### PR TITLE
make RenameFile() on Windows also replace the file

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -610,7 +610,7 @@ static cell_t sm_RenameFile(IPluginContext *pContext, const cell_t *params)
 	g_pSM->BuildPath(Path_Game, old_realpath, sizeof(old_realpath), "%s", oldpath);
 
 #ifdef PLATFORM_WINDOWS
-	return (MoveFileA(old_realpath, new_realpath)) ? 1 : 0;
+	return (MoveFileExA(old_realpath, new_realpath, MOVEFILE_REPLACE_EXISTING)) ? 1 : 0;
 #elif defined PLATFORM_POSIX
 	return (rename(old_realpath, new_realpath)) ? 0 : 1;
 #endif

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -610,7 +610,7 @@ static cell_t sm_RenameFile(IPluginContext *pContext, const cell_t *params)
 	g_pSM->BuildPath(Path_Game, old_realpath, sizeof(old_realpath), "%s", oldpath);
 
 #ifdef PLATFORM_WINDOWS
-	return (MoveFileExA(old_realpath, new_realpath, MOVEFILE_REPLACE_EXISTING)) ? 1 : 0;
+	return (MoveFileExA(old_realpath, new_realpath, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING)) ? 1 : 0;
 #elif defined PLATFORM_POSIX
 	return (rename(old_realpath, new_realpath)) ? 0 : 1;
 #endif


### PR DESCRIPTION
`RenameFile` on linux uses `rename()` which will replace the destination file if it exists. `MoveFileA` doesn't replace so this is swapping it with `MoveFileExA`+`MOVEFILE_REPLACE_EXISTING` which will replace the destination.