### PR TITLE
Ignore chat triggers for interactive ban reason

### DIFF
--- a/plugins/basebans.sp
+++ b/plugins/basebans.sp
@@ -384,7 +384,7 @@ public Action Command_AbortBan(int client, int args)
 
 public Action OnClientSayCommand(int client, const char[] command, const char[] sArgs)
 {
-	if(!IsChatTrigger() && playerinfo[client].isWaitingForChatReason)
+	if(playerinfo[client].isWaitingForChatReason && !IsChatTrigger())
 	{
 		playerinfo[client].isWaitingForChatReason = false;
 		PrepareBan(client, playerinfo[client].banTarget, playerinfo[client].banTime, sArgs);

--- a/plugins/basebans.sp
+++ b/plugins/basebans.sp
@@ -384,7 +384,7 @@ public Action Command_AbortBan(int client, int args)
 
 public Action OnClientSayCommand(int client, const char[] command, const char[] sArgs)
 {
-	if(playerinfo[client].isWaitingForChatReason)
+	if(!IsChatTrigger() && playerinfo[client].isWaitingForChatReason)
 	{
 		playerinfo[client].isWaitingForChatReason = false;
 		PrepareBan(client, playerinfo[client].banTarget, playerinfo[client].banTime, sArgs);


### PR DESCRIPTION
If the admin types a chat trigger for a command while BaseBans is waiting for them to type a ban reason, don't treat that message as the ban reason.

This change fixes a problem where an admin decides to cancel their ban with `sm_abortban`, by invoking it via a chat trigger (`!abortban`, `/abortban`, etc), but ends up accidentally banning the player with the ban reason `!abortban` (or by attempting to access any other command via a chat trigger while the basebans chat listener was expecting to receive the ban reason).

### Steps to reproduce

Admin decides to cancel the ban, point of view:
![abortban_example1](https://github.com/alliedmodders/sourcemod/assets/6595066/e7bbe4b0-d690-4fbf-9836-e046601d34a5)

It feels like substituting the "sm_command" with the "!command" chat trigger should work here. However:

The unfortunate player point of view (banned with reason "!abortban"):
![abortban_example2](https://github.com/alliedmodders/sourcemod/assets/6595066/4ee75485-f520-4407-9bb7-0498cdfb9621)

You can attempt to ban yourself to test this behaviour.

### After this change

After this commit, any chat trigger messages are ignored for the interactive ban reason, so things like `!abortban` will work.