### PR TITLE
Update SourcePawn.

### DIFF
--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -48,6 +48,8 @@
 #include <bridge/include/IVEngineServerBridge.h>
 #include <bridge/include/CoreProvider.h>
 
+#define SOURCEMOD_PLUGINAPI_VERSION     7
+
 CPluginManager g_PluginSys;
 HandleType_t g_PluginType = 0;
 IdentityType_t g_PluginIdent = 0;
@@ -314,7 +316,7 @@ bool CPlugin::ReadInfo()
 			base->LocalToString(info->time, (char **)&pTime);
 			ke::SafeSprintf(m_DateTime, sizeof(m_DateTime), "%s %s", pDate, pTime);
 		}
-		if (m_FileVersion > 6) {
+		if (m_FileVersion > SOURCEMOD_PLUGINAPI_VERSION) {
 			base->LocalToString(info->filevers, (char **)&pFileVers);
 			EvictWithError(Plugin_Failed, "Newer SourceMod required (%s or higher)", pFileVers);
 			return false;

--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -1787,10 +1787,10 @@ static cell_t SQL_ExecuteTransaction(IPluginContext *pContext, const cell_t *par
 
 	IPluginFunction *onSuccess = NULL;
 	IPluginFunction *onError = NULL;
-	if (params[3] != -1 && ((onSuccess = pContext->GetFunctionById(params[3])) == NULL))
-		return pContext->ThrowNativeError("Function id %x is invalid", params[3]);
-	if (params[4] != -1 && ((onError = pContext->GetFunctionById(params[4])) == NULL))
-		return pContext->ThrowNativeError("Function id %x is invalid", params[4]);
+	if (!pContext->GetFunctionByIdOrNull(params[3], &onSuccess))
+		return 0;
+	if (!pContext->GetFunctionByIdOrNull(params[4], &onError))
+		return 0;
 
 	cell_t data = params[5];
 	PrioQueueLevel priority = PrioQueue_Normal;

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -131,7 +131,7 @@ static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *param
 	if (pPlugin->GetBaseContext()->FindPublicByName(name, &idx) == SP_ERROR_NOT_FOUND)
 	{
 		/* Return INVALID_FUNCTION if not found */
-		return -1;
+		return pContext->GetNullFunctionValue();
 	}
 
 	/* Return function ID */

--- a/core/logic/smn_handles.cpp
+++ b/core/logic/smn_handles.cpp
@@ -119,5 +119,7 @@ REGISTER_NATIVES(handles)
 	{"CloseHandle",				sm_CloseHandle},
 	{"CloneHandle",				sm_CloneHandle},
 	{"GetMyHandle",				sm_GetMyHandle},
+	{"Handle.Close",			sm_CloseHandle},
+	{"Handle.~Handle",			sm_CloseHandle},
 	{NULL,						NULL},
 };

--- a/core/logic/smn_menus.cpp
+++ b/core/logic/smn_menus.cpp
@@ -1568,15 +1568,11 @@ static cell_t InternalShowMenu(IPluginContext *pContext, const cell_t *params)
 
 	IMenuHandler *pHandler;
 	CPanelHandler *pActualHandler = NULL;
-	if (params[5] != -1)
-	{
-		IPluginFunction *pFunction = pContext->GetFunctionById(params[5]);
-		if (pFunction == NULL)
-		{
-			return pContext->ThrowNativeError("Invalid function index %x", params[5]);
-		}
-		pActualHandler = g_MenuHelpers.GetPanelHandler(pFunction);
-	}
+	IPluginFunction* func;
+	if (!pContext->GetFunctionByIdOrNull(params[5], &func))
+		return 0;
+	if (func)
+		pActualHandler = g_MenuHelpers.GetPanelHandler(func);
 
 	if (pActualHandler == NULL)
 	{

--- a/extensions/clientprefs/natives.cpp
+++ b/extensions/clientprefs/natives.cpp
@@ -398,7 +398,7 @@ cell_t AddSettingsPrefabMenuItem(IPluginContext *pContext, const cell_t *params)
 
 
 	/* User passed a function id for a callback */
-	if (params[4] != -1)
+	if (!pContext->IsNullFunctionId(params[4]))
 	{
 		pItem->forward = forwards->CreateForwardEx(NULL, ET_Ignore, 5, NULL, Param_Cell, Param_Cell, Param_Cell, Param_String, Param_Cell); 
 		pItem->forward->AddFunction(pContext, static_cast<funcid_t>(params[4]));

--- a/plugins/include/core.inc
+++ b/plugins/include/core.inc
@@ -38,7 +38,7 @@
 #include <version>
 
 /** If this gets changed, you need to update Core's check. */
-#define SOURCEMOD_PLUGINAPI_VERSION     6
+#define SOURCEMOD_PLUGINAPI_VERSION     7
 
 struct PlVers
 {

--- a/plugins/include/handles.inc
+++ b/plugins/include/handles.inc
@@ -75,7 +75,11 @@ native void CloseHandle(Handle hndl);
  */
 native Handle CloneHandle(Handle hndl, Handle plugin=INVALID_HANDLE);
 
-using __intrinsics__.Handle;
+methodmap Handle __nullable__ {
+    public native ~Handle();
+
+    public native void Close();
+};
 
 /**
  * Do not use this function.  Returns if a Handle and its contents


### PR DESCRIPTION
This brings in a few breaking changes.

One, INVALID_FUNCTION is now 0 instead of -1. This is long overdue. Plugins should transparently work except in two cases:

  1. Third-party extensions that have a hardcoded test for -1 will no longer work. A new API has been provided for this, GetFunctionByIdOrNull.
  2. If a plugin "framework" uses INVALID_FUNCTION anywhere in its exported API, then all plugins using that framework need to be recompiled together, so they agree on the value of INVALID_FUNCTION.

Hopefully the damage here is minimal. The core plugin version has been bumped to 7 to try and limit conflicts.

Second, braceless functions are no longer supported. There wasn't really any way around this and it's better to bite the bullet now. This affects source compatibility, but not binary compatibility.

Third, the "using" keyword is no longer implemented. SourceMod now has a
Handle methodmap again. Plugins compiled against this new methodmap will
require a "Handle.~Handle" native, which 1.12 now provides.