### PR TITLE
Handle `INVALID_FUNCTION` mismatches at plugin boundaries

### DIFF
--- a/core/logic/LegacyPluginCompat.h
+++ b/core/logic/LegacyPluginCompat.h
@@ -1,0 +1,39 @@
+// vim: set ts=4 sw=4 tw=99 noet :
+// =============================================================================
+// SourceMod
+// Copyright (C) 2004-2014 AlliedModders LLC.  All rights reserved.
+// =============================================================================
+//
+// This program is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License, version 3.0, as published by the
+// Free Software Foundation.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// As a special exception, AlliedModders LLC gives you permission to link the
+// code of this program (as well as its derivative works) to "Half-Life 2," the
+// "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+// by the Valve Corporation.  You must obey the GNU General Public License in
+// all respects for all other code used.  Additionally, AlliedModders LLC grants
+// this exception to all derivative works.  AlliedModders LLC defines further
+// exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+// or <http://www.sourcemod.net/license.php>.
+
+#ifndef _include_sourcemod_legacy_plugin_compat_h_
+#define _include_sourcemod_legacy_plugin_compat_h_
+
+/**
+ * Newer SourcePawn releases have changed the null function ID from -1 to 0.
+ * To accomodate this change, legacy plugins that send in a non-null function ID
+ * of 0 are stored as this value on new plugins and within SourceMod, then
+ * translated back to 0 when used in a legacy plugin context.
+ */
+#define LEGACY_FIRST_FUNCTION_ID -2
+
+#endif // _include_sourcemod_legacy_plugin_compat_h_

--- a/core/logic/smn_datapacks.cpp
+++ b/core/logic/smn_datapacks.cpp
@@ -244,7 +244,8 @@ static cell_t smn_WritePackFunction(IPluginContext *pContext, const cell_t *para
 		pDataPack->RemoveItem();
 	}
 
-	pDataPack->PackFunction(params[2]);
+	cell_t funcid = params[2];
+	pDataPack->PackFunction(pContext->IsNullFunctionId(funcid) ? 0 : funcid);
 
 	return 1;
 }
@@ -365,7 +366,8 @@ static cell_t smn_ReadPackFunction(IPluginContext *pContext, const cell_t *param
 		return pContext->ThrowNativeError("Invalid data pack type (got %d / expected %d).", pDataPack->GetCurrentType(), CDataPackType::Function);
 	}
 
-	return pDataPack->ReadFunction();
+	cell_t funcid = pDataPack->ReadFunction();
+	return funcid ? funcid : pContext->GetNullFunctionValue();
 }
 
 static cell_t smn_ReadPackCellArray(IPluginContext *pContext, const cell_t *params)

--- a/core/logic/smn_fakenatives.cpp
+++ b/core/logic/smn_fakenatives.cpp
@@ -36,6 +36,7 @@
 #include "ShareSys.h"
 #include "PluginSys.h"
 #include "sprintf.h"
+#include "LegacyPluginCompat.h"
 
 using namespace SourceHook;
 
@@ -385,6 +386,12 @@ static cell_t GetNativeFunction(IPluginContext *pContext, const cell_t *params)
 		// see alliedmodders/sourcepawn#912, alliedmodders/sourcemod#2068
 		// convert null function to receiver's expected value so equality checks against INVALID_FUNCTION pass
 		return pContext->GetNullFunctionValue();
+	}
+	else if (funcid == 0 && pContext->GetNullFunctionValue() == 0)
+	{
+		// convert 0th function on legacy plugin to a special value representation on newer plugins
+		// 0th function between legacy plugins are unchanged
+		return LEGACY_FIRST_FUNCTION_ID;
 	}
 	return funcid;
 }

--- a/core/logic/smn_fakenatives.cpp
+++ b/core/logic/smn_fakenatives.cpp
@@ -366,6 +366,29 @@ static cell_t SetNativeArray(IPluginContext *pContext, const cell_t *params)
 	return SP_ERROR_NONE;
 }
 
+static cell_t GetNativeFunction(IPluginContext *pContext, const cell_t *params)
+{
+	if (!s_curnative || (s_curnative->ctx != pContext))
+	{
+		return pContext->ThrowNativeError("Not called from inside a native function");
+	}
+
+	cell_t param = params[1];
+	if (param < 1 || param > s_curparams[0])
+	{
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAM, "Invalid parameter number: %d", param);
+	}
+	
+	cell_t funcid = s_curparams[param];
+	if (s_curcaller->IsNullFunctionId(funcid))
+	{
+		// see alliedmodders/sourcepawn#912, alliedmodders/sourcemod#2068
+		// convert null function to receiver's expected value so equality checks against INVALID_FUNCTION pass
+		return pContext->GetNullFunctionValue();
+	}
+	return funcid;
+}
+
 static cell_t FormatNativeString(IPluginContext *pContext, const cell_t *params)
 {
 	if (!s_curnative || (s_curnative->ctx != pContext))
@@ -483,7 +506,7 @@ REGISTER_NATIVES(nativeNatives)
 	{"GetNativeArray",			GetNativeArray},
 	{"GetNativeCell",			GetNativeCell},
 	{"GetNativeCellRef",		GetNativeCellRef},
-	{"GetNativeFunction",       GetNativeCell},
+	{"GetNativeFunction",       GetNativeFunction},
 	{"GetNativeString",			GetNativeString},
 	{"GetNativeStringLength",	GetNativeStringLength},
 	{"FormatNativeString",		FormatNativeString},

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -327,14 +327,11 @@ static cell_t sm_CallStartFunction(IPluginContext *pContext, const cell_t *param
 		}
 	}
 
-	IPluginContext *pTargetContext = pPlugin->GetBaseContext();
 	cell_t funcid = params[2];
 
-	if (pContext->IsNullFunctionId(funcid))
+	if (!pContext->IsNullFunctionId(funcid))
 	{
-		s_pFunction = pTargetContext->GetFunctionById(pTargetContext->GetNullFunctionValue());
-	} else {
-		s_pFunction = pTargetContext->GetFunctionById(funcid);
+		pPlugin->GetBaseContext()->GetFunctionByIdOrNull(funcid, &s_pFunction);
 	}
 
 	if (!s_pFunction)

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -36,6 +36,7 @@
 #include <IHandleSys.h>
 #include <IForwardSys.h>
 #include <ISourceMod.h>
+#include "LegacyPluginCompat.h"
 
 HandleType_t g_GlobalFwdType = 0;
 HandleType_t g_PrivateFwdType = 0;
@@ -331,7 +332,12 @@ static cell_t sm_CallStartFunction(IPluginContext *pContext, const cell_t *param
 
 	if (!pContext->IsNullFunctionId(funcid))
 	{
-		pPlugin->GetBaseContext()->GetFunctionByIdOrNull(funcid, &s_pFunction);
+		IPluginContext *pTargetContext = pPlugin->GetBaseContext();
+		if (funcid == LEGACY_FIRST_FUNCTION_ID && pTargetContext->GetNullFunctionValue() != 0)
+		{
+			funcid = 0;
+		}
+		pTargetContext->GetFunctionByIdOrNull(funcid, &s_pFunction);
 	}
 
 	if (!s_pFunction)

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -229,7 +229,17 @@ static cell_t sm_AddToForward(IPluginContext *pContext, const cell_t *params)
 		}
 	}
 
-	IPluginFunction *pFunction = pPlugin->GetBaseContext()->GetFunctionById(params[3]);
+	cell_t funcid = params[3];
+	IPluginFunction *pFunction;
+	if (!pContext->IsNullFunctionId(funcid))
+	{
+		IPluginContext *pTargetContext = pPlugin->GetBaseContext();
+		if (funcid == LEGACY_FIRST_FUNCTION_ID && pTargetContext->GetNullFunctionValue() != 0)
+		{
+			funcid = 0;
+		}
+		pPlugin->GetBaseContext()->GetFunctionByIdOrNull(funcid, &pFunction);
+	}
 
 	if (!pFunction)
 	{
@@ -266,7 +276,17 @@ static cell_t sm_RemoveFromForward(IPluginContext *pContext, const cell_t *param
 		}
 	}
 
-	IPluginFunction *pFunction = pPlugin->GetBaseContext()->GetFunctionById(params[3]);
+	cell_t funcid = params[3];
+	IPluginFunction *pFunction;
+	if (!pContext->IsNullFunctionId(funcid))
+	{
+		IPluginContext *pTargetContext = pPlugin->GetBaseContext();
+		if (funcid == LEGACY_FIRST_FUNCTION_ID && pTargetContext->GetNullFunctionValue() != 0)
+		{
+			funcid = 0;
+		}
+		pPlugin->GetBaseContext()->GetFunctionByIdOrNull(funcid, &pFunction);
+	}
 
 	if (!pFunction)
 	{

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -327,7 +327,15 @@ static cell_t sm_CallStartFunction(IPluginContext *pContext, const cell_t *param
 		}
 	}
 
-	s_pFunction = pPlugin->GetBaseContext()->GetFunctionById(params[2]);
+	IPluginContext *pTargetContext = pPlugin->GetBaseContext();
+	cell_t funcid = params[2];
+
+	if (pContext->IsNullFunctionId(funcid))
+	{
+		s_pFunction = pTargetContext->GetFunctionById(pTargetContext->GetNullFunctionValue());
+	} else {
+		s_pFunction = pTargetContext->GetFunctionById(funcid);
+	}
 
 	if (!s_pFunction)
 	{


### PR DESCRIPTION
Translates the following uses of `INVALID_FUNCTION` for compatibility between plugins compiled before and after the [upcoming] SourcePawn changes:

- `GetNativeFunction`
- `Call_StartFunction` (probably unnecessary since trying to call a null function shouldn't? work)
- `DataPack`s now store `INVALID_FUNCTION` as 0 internally and retrieved based on caller's context

This should make it so plugins can remain mostly compatible regardless of what value of `INVALID_FUNCTION` they are compiled with.  Function coercion to values was disallowed a while back so I'd imagine most plugins communicate their use of functions through these three avenues.

I confirmed the behavior is correct for `GetNativeFunction`; the other two are untested.