### PR TITLE
Update gamedata for Dystopia

### DIFF
--- a/gamedata/sdkhooks.games/game.dystopia.txt
+++ b/gamedata/sdkhooks.games/game.dystopia.txt
@@ -1,0 +1,19 @@
+"Games"
+{
+	"!Dystopia"
+	{
+		"Offsets"
+		{
+			"OnTakeDamage"
+			{
+				"windows"	"62"
+				"linux"		"63"
+			}
+			"OnTakeDamage_Alive"
+			{
+				"windows"	"275"
+				"linux"		"276"
+			}
+		}
+	}
+}

--- a/gamedata/sdkhooks.games/master.games.txt
+++ b/gamedata/sdkhooks.games/master.games.txt
@@ -208,4 +208,8 @@
 	{
 		"game"		"open_fortress"
 	}
+	"game.dystopia.txt"
+	{
+		"game"		"!Dystopia"
+	}
 }


### PR DESCRIPTION
Fix #2070 

Add the offsets for `OnTakeDamage` and `OnTakeDamage_Alive` for the game Dystopia, for Linux and Windows platforms. This change adds game support for the `SDKHook_OnTakeDamage`, and its variants.