### PR TITLE
Add void function prototypes to NativeCall and MenuHandler

### DIFF
--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -448,6 +448,16 @@ typeset NativeCall
 	 * @return               Value for the native call to return.
 	 */
 	function any (Handle plugin, int numParams);
+
+	/**
+	 * Defines a native function.
+	 *
+	 * It is not necessary to validate the parameter count
+	 *
+	 * @param plugin         Handle of the calling plugin.
+	 * @param numParams      Number of parameters passed to the native.
+	 */
+	function void (Handle plugin, int numParams);
 }
 
 /**

--- a/plugins/include/menus.inc
+++ b/plugins/include/menus.inc
@@ -148,8 +148,15 @@ enum MenuSource
  * @param action            The action of the menu.
  * @param param1            First action parameter (usually the client).
  * @param param2            Second action parameter (usually the item).
+ *
+ * Use void-typed prototype if you don't plan to handle MenuAction_DrawItem
+ * and MenuAction_DisplayItem actions.
  */
-typedef MenuHandler = function int (Menu menu, MenuAction action, int param1, int param2);
+typeset MenuHandler
+{
+	function int (Menu menu, MenuAction action, int param1, int param2);
+	function void (Menu menu, MenuAction action, int param1, int param2);
+};
 
 // Panels are used for drawing raw menus without any extra helper functions.
 // Handles must be closed via delete or CloseHandle().


### PR DESCRIPTION
`void` NativeCall prototype can be used for simple natives which don't return any value.
`void` MenuHandler can be used for basic menu handlers that don't return modified item styles and don't redraw menu items.

This is done to silence compiler warnings 209 (`function has explicit 'int' tag but does not return a value`) and 242 (`function "FuncName" should return an explicit value`).