### PR TITLE
Update funcommands.games.txt

### DIFF
--- a/gamedata/funcommands.games.txt
+++ b/gamedata/funcommands.games.txt
@@ -75,6 +75,17 @@
 		}
 	}
 	
+	"nucleardawn"
+	{
+		"Keys"
+		{
+			"SpriteBeam"		"sprites/widestripe.vmt"
+			
+			"Team2BeaconColor"		"75,75,255,255"
+			"Team3BeaconColor"		"255,75,75,255"
+		}
+	}
+	
 	"#default"
 	{
 		"#supported"


### PR DESCRIPTION
Changes for Nuclear Dawn

*Correct beacon team colors (Consortium = blue / Empire = red) *Change beacon .vmt sprite to an existing one similar to the usual "laser.vmt" (white and 32x64 size)