### PR TITLE
Add gamedata for Pre-Fortress 2

### DIFF
--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -194,6 +194,7 @@
 			"game"					"vietnam"
 			"game"					"open_fortress"
 			"game"					"tf2classic"
+			"game"					"pf2"
 		}
 
 		"Keys"
@@ -248,6 +249,7 @@
 			"game"					"reactivedrop"
 			"game"					"open_fortress"
 			"game"					"tf2classic"
+			"game"					"pf2"
 		}
 		
 		"Keys"
@@ -311,6 +313,7 @@
 			"game"					"vietnam"
 			"game"					"open_fortress"
 			"game"					"tf2classic"
+			"game"					"pf2"
 		}
 		
 		"Keys"

--- a/gamedata/sdkhooks.games/game.pf2.txt
+++ b/gamedata/sdkhooks.games/game.pf2.txt
@@ -1,6 +1,6 @@
 "Games"
 {
-	"pf2"
+	"#default"
 	{
 		"Offsets"
 		{

--- a/gamedata/sdkhooks.games/game.pf2.txt
+++ b/gamedata/sdkhooks.games/game.pf2.txt
@@ -1,0 +1,160 @@
+"Games"
+{
+	"pf2"
+	{
+		"Offsets"
+		{
+			"CanBeAutobalanced"
+			{
+				"windows" 	"457"
+				"linux"		"458"
+				"mac"		"458"
+			}
+			"EndTouch"
+			{
+				"windows" 	"100"
+				"linux"		"101"
+				"mac"		"101"
+			}
+			// "RagdollImpact"
+			"FireBullets"
+			{
+				"windows" 	"112"
+				"linux"		"113"
+				"mac"		"113"
+			}
+			"GetMaxHealth"
+			{
+				"windows" 	"117"
+				"linux"		"118"
+				"mac"		"118"				
+			}
+			"GroundEntChanged"
+			{
+				"windows" 	"178"
+				"linux"		"178"
+				"mac"		"178"
+			}
+			"OnTakeDamage"
+			{
+				"windows" 	"62"
+				"linux"		"63"
+				"mac"		"63"
+			}
+			"OnTakeDamage_Alive"
+			{
+				"windows" 	"273"
+				"linux"		"274"
+				"mac"		"274"
+			}
+			"PreThink"
+			{
+				"windows" 	"333"
+				"linux"		"334"
+				"mac"		"334"
+			}
+			"PostThink"
+			{
+				"windows" 	"334"
+				"linux"		"335"
+				"mac"		"335"
+			}
+			"Reload"
+			{
+				"windows" 	"270"
+				"linux"		"271"
+				"mac"		"271"
+			}
+			"SetTransmit"
+			{
+				"windows" 	"20"
+				"linux"		"21"
+				"mac"		"21"
+			}
+			"ShouldCollide"
+			{
+				"windows" 	"16"
+				"linux"		"17"
+				"mac"		"17"
+			}
+			"Spawn"
+			{
+				"windows" 	"22"
+				"linux"		"23"
+				"mac"		"23"
+			}
+			"StartTouch"
+			{
+				"windows" 	"98"
+				"linux"		"99"
+				"mac"		"99"
+			}
+			"Think"
+			{
+				"windows" 	"47"
+				"linux"		"48"
+				"mac"		"48"
+			}
+			"Touch"
+			{
+				"windows" 	"99"
+				"linux"		"100"
+				"mac"		"100"
+			}
+			"TraceAttack"
+			{
+				"windows" 	"60"
+				"linux"		"61"
+				"mac"		"61"
+			}
+			"Use"
+			{
+				"windows" 	"97"
+				"linux"		"98"
+				"mac"		"98"
+			}
+			"VPhysicsUpdate"
+			{
+				"windows" 	"157"
+				"linux"		"158"
+				"mac"		"158"
+			}
+			"Blocked"
+			{
+				"windows" 	"102"
+				"linux"		"103"
+				"mac"		"103"
+			}
+			"Weapon_CanSwitchTo"
+			{
+				"windows"	"267"
+				"linux"		"268"
+				"mac"		"268"
+			}
+			"Weapon_CanUse"
+			{
+				"windows" 	"261"
+				"linux"		"262"
+				"mac"		"262"
+			}
+			"Weapon_Drop"
+			{
+				"windows" 	"264"
+				"linux"		"265"
+				"mac"		"265"
+			}
+			"Weapon_Equip"
+			{
+				"windows" 	"262"
+				"linux"		"263"
+				"mac"		"263"
+			}
+			"Weapon_Switch"
+			{
+				"windows" 	"265"
+				"linux"		"266"
+				"mac"		"266"
+			}
+		}
+	}
+}

--- a/gamedata/sdkhooks.games/master.games.txt
+++ b/gamedata/sdkhooks.games/master.games.txt
@@ -216,4 +216,8 @@
 	{
 		"game"		"tf2classic"
 	}
+	"game.pf2.txt"
+	{
+		"game"		"pf2"
+	}
 }

--- a/gamedata/sdktools.games/game.pf2.txt
+++ b/gamedata/sdktools.games/game.pf2.txt
@@ -1,6 +1,6 @@
 "Games"
 {
-	"pf2"
+	"#default"
 	{
 		"Offsets"
 		{

--- a/gamedata/sdktools.games/game.pf2.txt
+++ b/gamedata/sdktools.games/game.pf2.txt
@@ -1,0 +1,154 @@
+"Games"
+{
+	"pf2"
+	{
+		"Offsets"
+		{
+			"GetTEName"
+			{
+				"windows"	"4"
+				"linux"		"4"
+				"mac"		"4"
+			}
+			"GetTENext"
+			{
+				"windows"	"8"
+				"linux"		"8"
+				"mac"		"8"
+			}
+			"TE_GetServerClass"
+			{
+				"windows"	"0"
+				"linux"		"0"
+				"mac"		"0"
+			}
+			"GiveNamedItem"
+			{
+				"windows"	"401"
+				"linux"		"402"
+				"mac"		"402"
+			}
+			"RemovePlayerItem"
+			{
+				"windows"	"271"
+				"linux"		"272"
+				"mac"		"272"
+			}
+			"Weapon_GetSlot"
+			{
+				"windows"	"269"
+				"linux"		"270"
+				"mac"		"270"
+			}
+			"Ignite"
+			{
+				"windows"	"209"
+				"linux"		"210"
+				"mac"		"210"
+			}
+			"Extinguish"
+			{
+				"windows"	"213"
+				"linux"		"214"
+				"mac"		"214"
+			}
+			"Teleport"
+			{
+				"windows"	"108"
+				"linux"		"109"
+				"mac"		"109"
+			}
+			"CommitSuicide"
+			{
+				"windows"	"440"
+				"linux"		"440"
+				"mac"		"440"
+			}
+			"GetVelocity"
+			{
+				"windows"	"140"
+				"linux"		"141"
+				"mac"		"141"
+			}
+			"EyeAngles"
+			{
+				"windows"	"131"
+				"linux"		"132"
+				"mac"		"132"
+			}	
+			// CBaseEntity::SetModel(char const*)
+			"SetEntityModel"
+			{
+				"windows"	"24"
+				"linux"		"25"
+				"mac"		"25"
+			}
+			
+			"AcceptInput"
+			{
+				"windows"	"36"
+				"linux"		"37"
+				"mac"		"37"
+			}
+			"WeaponEquip"
+			{
+				"windows"	"262"
+				"linux"		"263"
+				"mac"		"263"
+			}
+			"Activate"
+			{
+				"windows"	"33"
+				"linux"		"34"
+				"mac"		"34"
+			}
+			"PlayerRunCmd"
+			{
+				"windows"	"419"
+				"linux"		"420"
+				"mac"		"420"
+			}
+			"GiveAmmo"
+			{
+				"windows"	"252"
+				"linux"		"253"
+				"mac"		"253"
+			}
+			// Found in engine.so of SDK13
+			"SetUserCvar"
+			{
+				"windows"	"18"
+				"linux"		"58"
+				"mac"		"58"
+			}
+			// Found in engine.so of SDK13
+			"SetClientName"
+			{
+				"windows"	"17"
+				"linux"		"57"
+				"mac"		"57"
+			}
+			"InfoChanged"
+			{
+				"windows"	"140"
+				"linux"		"140"
+				"mac"		"140"
+			}
+		}
+		"Keys"
+		{
+			"GameRulesProxy"	"CTFGameRulesProxy"
+			"GameRulesDataTable"	"tf_gamerules_data"
+		}
+		"Signatures"
+		{
+			"FireOutput"
+			{
+				"library"	"server"
+				"windows"	"@?FireOutput@CBaseEntityOutput@@QAEXVvariant_t@@PAVCBaseEntity@@1M@Z"
+				"linux"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
+				"mac"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
+			}
+		}
+	}
+}

--- a/gamedata/sdktools.games/master.games.txt
+++ b/gamedata/sdktools.games/master.games.txt
@@ -277,4 +277,8 @@
 	{
 		"game"		"tf2classic"
 	}
+	"game.pf2.txt"
+	{
+		"game"		"pf2"
+	}
 }


### PR DESCRIPTION
## Summary
- Updated `common.games.txt`
- Updated `master.games.txt`
- Added `sdkhooks.game/game.pf2.txt`
- Added `sdktools.games/game.pf2.txt`

## Notes
We intend to implement Datatables in the same way as TF2C.