### PR TITLE
Fix teleportation offsets for tf2classic

### DIFF
--- a/gamedata/sdktools.games/game.tf2classic.txt
+++ b/gamedata/sdktools.games/game.tf2classic.txt
@@ -66,7 +66,7 @@
 			/* CBaseEntity::Teleport(Vector const*, QAngle const*, Vector const*) */
 			"Teleport"
 			{
-				"linux"		"111"
+				"linux"		"110"
 				"windows"	"109"
 			}
 


### PR DESCRIPTION
In the sdktools tf2classic gamedata, the Linux offset for "CBaseEntity::Teleport" is off by 1, which causes teleports to not function properly (the `TeleportEntity()` function was seemingly doing nothing). Adjusting the value from "111" to the correct value of "110" fixes the issue.

Extra info:
- OS: Ubuntu Server 22.04.3 LTS
- Game: Team Fortress 2 Classic
- Metamod:Source Version: 1.11.0-dev+1153
- SourceMod Version: 1.11.0.6952