### PR TITLE
Update checkout-deps files to install hl2sdk-mock

### DIFF
--- a/tools/checkout-deps.ps1
+++ b/tools/checkout-deps.ps1
@@ -92,6 +92,8 @@ $SDKS | ForEach-Object {
     Get-Repository -Name "hl2sdk-$_" -Branch $_ -Repo "hl2sdk-proxy-repo" "https://github.com/alliedmodders/hl2sdk.git"
 }
 
+Get-Repository -Name "hl2sdk-mock" -Branch "master" -Repo "https://github.com/alliedmodders/hl2sdk-mock.git"
+
 # Find a suitable installation of Python
 $PYTHON_CMD = Get-Command 'python3' -ErrorAction SilentlyContinue
 if ($NULL -eq $PYTHON_CMD)

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -153,6 +153,12 @@ do
   checkout
 done
 
+name=hl2sdk-mock
+branch=master
+repo="https://github.com/alliedmodders/hl2sdk-mock"
+origin=
+checkout
+
 python_cmd=`command -v python3`
 if [ -z "$python_cmd" ]; then
   python_cmd=`command -v python`


### PR DESCRIPTION
**Only tested on Windows (tools/checkout-deps.ps1).**

This just modifies both `tools/checkout-deps` files so that they both install the `alliedmodders/hl2sdk-mock` repository, so that SourceMod can compile successfully with AMBuild, considering the recent hl2sdk-manifests submodule addition.

This is from my (currently) extremely limited understanding of how SourceMod works internally (I just made a fork to modify a few things with the SourcePawn virtual machine out of plain interest), so if I misunderstood anything - apologies!