### PR TITLE
Throw an error when attempting to remove worldspawn in RemoveEntity/RemoveEdict

### DIFF
--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -285,6 +285,11 @@ static cell_t RemoveEdict(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Edict %d (%d) is not a valid edict", g_HL2.ReferenceToIndex(params[1]), params[1]);
 	}
 
+	if (g_HL2.ReferenceToIndex(params[1]) == 0)
+	{
+		return pContext->ThrowNativeError("Cannot remove worldspawn");
+	}
+
 	engine->RemoveEdict(pEdict);
 
 	return 1;
@@ -296,6 +301,11 @@ static cell_t RemoveEntity(IPluginContext *pContext, const cell_t *params)
 	if (!pEntity)
 	{
 		return pContext->ThrowNativeError("Entity %d (%d) is not a valid entity", g_HL2.ReferenceToIndex(params[1]), params[1]);
+	}
+
+	if (g_HL2.ReferenceToIndex(params[1]) == 0)
+	{
+		return pContext->ThrowNativeError("Cannot remove worldspawn");
 	}
 
 	// Some games have UTIL_Remove exposed on IServerTools, but for consistence, we'll


### PR DESCRIPTION
It's probably common knowledge at this point that calling `RemoveEntity` on the worldspawn will instantly crash the server. Since it can be agreed that there is no real reason to ever do this, I've changed it so that it throws an error instead. This way, if a plugin ends up accidentally removing the worldspawn, it will be much easier for the plugin author to fix the issue.