### PR TITLE
Fixup entinfo offset

### DIFF
--- a/gamedata/core.games/engine.ep2valve.txt
+++ b/gamedata/core.games/engine.ep2valve.txt
@@ -26,7 +26,7 @@
 			{
 				"windows"	"4"	
 				"linux"		"4"
-				"linux64"	"4"
+				"linux64"	"8"
 			}
 		}
 		


### PR DESCRIPTION
Did an oopsie, ofc the vtable size grew on 64bits. I unfortunately am not lucky enough to be doing `linux gaming` so I never joined my tf2 server instance, and therefore never tripped the code handling this. That could have been avoided by running a plugin that spawns entity however, my bad!