### PR TITLE
Fix sdktools gamedata

### DIFF
--- a/gamedata/sdktools.games/engine.ep2valve.txt
+++ b/gamedata/sdktools.games/engine.ep2valve.txt
@@ -20,13 +20,13 @@
 			{
 				"windows"	"4"
 				"linux"		"4"
-				"linux64"	"4"
+				"linux64"	"8"
 			}
 			"GetTENext"
 			{
 				"windows"	"8"
 				"linux"		"8"
-				"linux64"	"8"
+				"linux64"	"16"
 			}
 			"TE_GetServerClass"
 			{


### PR DESCRIPTION
Crash reported by @Malifox over discord, here's the updated gamedata. Once again a situation where the vtable size increase shifted everything, and ptr size increased.

Since this is the second time this happened, sorry about that, I've scanned other gamedata files for similar situation. And except for core's gamedata which was corrected, sdktools's gamedata should be the only other place we have gamedata offsets that aren't vtable offsets ? So hopefully this is the last time I've to make a PR like this.