### PR TITLE
Fix passing variant_t parameters + fix codegen stack on Win64

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -787,7 +787,7 @@ inline void Write_PushObject(JitWriter *jit, const SourceHook::PassInfo *info, u
 		return;
 
 #elif defined PLATFORM_WINDOWS
-		if (info->size < 64 && (info->size & (info->size - 1)) == 0)
+		if (info->size > 8 || (info->size & (info->size - 1)) != 0)
 			goto push_byref;
 		else {
 			SourceHook::PassInfo podInfo;
@@ -1055,7 +1055,11 @@ void *JIT_CallCompile(CallWrapper *pWrapper, FuncAddrMethod method)
 	int numWords;
 #endif
 
+#ifdef PLATFORM_POSIX
 	g_StackUsage = 0;
+#elif defined PLATFORM_WINDOWS
+	g_StackUsage = 32;	// Shadow space
+#endif
 
 	writer.outbase = NULL;
 	writer.outptr = NULL;
@@ -1155,8 +1159,12 @@ skip_retbuffer:
 #endif
 
 	/* Clean up the calling stack */
+#ifdef PLATFORM_POSIX
 	if (hasParams && g_StackUsage)
+#endif
+	{
 		Write_RectifyStack(jit, g_StackAlign);
+	}
 
 	/* Copy the return type to the return buffer if the function is not void */
 	if (pRet && !Needs_Retbuf)

--- a/extensions/sdktools/output.cpp
+++ b/extensions/sdktools/output.cpp
@@ -73,7 +73,7 @@ bool EntityOutputManager::IsEnabled()
 	return enabled;
 }
 
-#ifdef PLATFORM_WINDOWS
+#if defined PLATFORM_WINDOWS && defined PLATFORM_X86
 DETOUR_DECL_MEMBER8(FireOutput, void, int, what, int, the, int, hell, int, msvc, void *, variant_t, CBaseEntity *, pActivator, CBaseEntity *, pCaller, float, fDelay)
 {
 	bool fireOutput = g_OutputManager.FireEventDetour((void *)this, pActivator, pCaller, fDelay);

--- a/extensions/sdktools/outputnatives.cpp
+++ b/extensions/sdktools/outputnatives.cpp
@@ -311,7 +311,7 @@ static cell_t FireEntityOutput(IPluginContext *pContext, const cell_t *params)
 		{
 			return pContext->ThrowNativeError("\"FireEntityOutput\" not supported by this mod");
 		}
-#ifdef PLATFORM_WINDOWS
+#if defined PLATFORM_WINDOWS && defined PLATFORM_X86
 		int iMaxParam = 8;
 		//Instead of being one param, MSVC broke variant_t param into 5 params..
 		PassInfo pass[8];


### PR DESCRIPTION
This fixes `AcceptEntityInput`, `FireEntityOutput`, and entity output hooks to work on Windows 64-bit. This also fixes a crash associated with using the `TF2_DisguisePlayer` native.

This was tested on a TF2 Windows 64-bit server with a custom build of SourceMod built using [this version of the SDK](https://github.com/TF2-DMB/hl2sdk-tf2/pull/3) (though alliedmodders/hl2sdk#198 might work too). I didn't test on other games running on 64-bit at this time but hopefully should follow the same rules.

## Explanation of fixes

- **Compared to x86, passing a structure by value is no longer separated across the stack.** Instead, [if a structure is not of size 1, 2, 4, or 8, it will be passed by reference](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170#parameter-passing). The `FireOutput` detour no longer has to manually spread out the `variant_t` struct parameter.
- **Fixed generated calls not allocating enough stack space for parameters pushed to the stack.**

TF2's Disguise function takes 5 parameters in total (including `this`) so the 5th parameter will be pushed onto the stack. However the initial code did not allocate enough stack space to store the 5th parameter, causing the code to overwrite part of the stack outside of the allocated stack space. Initially, the assembly for calling the function looked like this:

```asm
; Write_Execution_Prologue
push    rbp
mov     rbp, rsp
; arg stack
push    rbx
mov     rbx, rcx
push    r15
mov     r15, rsp
and     rsp, 0FFFFFFFFFFFFFFF0h
sub     rsp, 10h

; Write_PushThisPtr
mov     rcx, qword ptr [rbx]

; Write_PushPOD param_1
mov     edx, dword ptr [rbx+8]

; Write_PushPOD param_2
mov     r8d, dword ptr [rbx+0Ch]

; Write_PushPOD param_3
mov     r9, qword ptr [rbx+10h]

; Write_PushPOD param_4
movzx   rax, byte ptr [rbx+18h]
mov     qword ptr [rsp+20h], rax    ; <-- overran parameter space

; Write_CallFunction (direct)
mov     rax, 7FFF62C4EC20h
call    rax

; Write_RectifyStack
add     rsp, 10h

; Write_Function_Epilogue
mov     rsp, r15
pop     r15
pop     rbx
mov     rsp, rbp
pop     rbp
ret 
```

After forcing `g_StackUsage` to be 32 on `JIT_CallCompile`'s first pass, the generated code now allocates enough space:

```diff
; Write_Execution_Prologue
push    rbp
mov     rbp, rsp
; arg stack
push    rbx
mov     rbx, rcx
push    r15
mov     r15, rsp
and     rsp, 0FFFFFFFFFFFFFFF0h
-sub     rsp, 10h
+sub     rsp, 30h

; Write_PushThisPtr
mov     rcx, qword ptr [rbx]

; Write_PushPOD param_1
mov     edx, dword ptr [rbx+8]

; Write_PushPOD param_2
mov     r8d, dword ptr [rbx+0Ch]

; Write_PushPOD param_3
mov     r9, qword ptr [rbx+10h]

; Write_PushPOD param_4
movzx   rax, byte ptr [rbx+18h]
mov     qword ptr [rsp+20h], rax

; Write_CallFunction (direct)
mov     rax, 7FFF62C4EC20h
call    rax

; Write_RectifyStack
-add     rsp, 10h
+add     rsp, 30h

; Write_Function_Epilogue
mov     rsp, r15
pop     r15
pop     rbx
mov     rsp, rbp
pop     rbp
ret 
```

- **Fixed incorrect handling of objects passed by value.**

The x64 convention states that objects **not** of size 1, 2, 4, or 8 bytes must be passed by reference. Yet the check to pass an object by value or reference is incorrect.

https://github.com/alliedmodders/sourcemod/blob/e262064fd89f69216e317168a9f46bc99750d481/extensions/bintools/jit_call_x64.cpp#L790

I'm not sure why it was made this way (though an explanation would be welcome). This made it so that _only_ structures of 1, 2, 4, 8, 16, and 32 bytes to be passed by reference which makes no sense. The initial version caused the following codegen for calling `AcceptInput`:

```asm
; Write_Execution_Prologue
push    rbp
mov     rbp, rsp
; return buffer
push    r14
mov     r14, rdx
; arg stack
push    rbx
mov     rbx, rcx
push    r15
mov     r15, rsp
and     rsp, 0FFFFFFFFFFFFFFF0h
sub     rsp, 40h

; Write_PushThisPtr
mov     rcx, qword ptr [rbx]

; Write_PushPOD param_1
mov     rdx, qword ptr [rbx+8]

; Write_PushPOD param_2
mov     r8, qword ptr [rbx+10h]

; Write_PushPOD param_3
mov     r9, qword ptr [rbx+18h]

; Write_PushObject param_4
mov     qword ptr [rsp+20h], rax    ; <-- rax is undefined

; Write_PushPOD param_5
mov     r10d, dword ptr [rbx+34h]
mov     qword ptr [rsp+28h], r10

; Write_CallFunction (vtable)
mov     r10, qword ptr [rcx]
mov     r11, qword ptr [r10+130h]
call    r11

; Write_RectifyStack
add     rsp, 40h

; Write_MovRet2Buf
mov     byte ptr [r14], al

; Write_Function_Epilogue
mov     rsp, r15
pop     r15
pop     rbx
pop     r14
mov     rsp, rbp
pop     rbp
ret   
```

Correcting the check yields the following codegen:
```diff
; Write_Execution_Prologue
push    rbp
mov     rbp, rsp
; return buffer
push    r14
mov     r14, rdx
; arg stack
push    rbx
mov     rbx, rcx
push    r15
mov     r15, rsp
and     rsp, 0FFFFFFFFFFFFFFF0h
sub     rsp, 40h

; Write_PushThisPtr
mov     rcx, qword ptr [rbx]

; Write_PushPOD param_1
mov     rdx, qword ptr [rbx+8]

; Write_PushPOD param_2
mov     r8, qword ptr [rbx+10h]

; Write_PushPOD param_3
mov     r9, qword ptr [rbx+18h]

; Write_PushObject param_4
+lea     rax, [rbx+20h]
mov     qword ptr [rsp+20h], rax

; Write_PushPOD param_5
mov     r10d, dword ptr [rbx+34h]
mov     qword ptr [rsp+28h], r10

; Write_CallFunction (vtable)
mov     r10, qword ptr [rcx]
mov     r11, qword ptr [r10+130h]
call    r11

; Write_RectifyStack
add     rsp, 40h

; Write_MovRet2Buf
mov     byte ptr [r14], al

; Write_Function_Epilogue
mov     rsp, r15
pop     r15
pop     rbx
pop     r14
mov     rsp, rbp
pop     rbp
ret   
```