### PR TITLE
[Linux x64] Fix variant_t usage by sdktools and bintools

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -725,7 +725,7 @@ inline void Write_PushObject(JitWriter *jit, const SourceHook::PassInfo *info, u
 		ObjectClass classes[MAX_CLASSES];
 		int numWords = ClassifyObject(smInfo, classes);
 
-		if (classes[0] == ObjectClass::Pointer)
+		if (classes[0] == ObjectClass::Pointer || classes[0] == ObjectClass::Memory)
 			goto push_byref;
 
 		int neededIntRegs = 0;

--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -48,7 +48,7 @@ class VariantFirstTimeInit
 public:
 	VariantFirstTimeInit()
 	{
-		*(uint32_t *)(&g_Variant_t[12 + VARIANT_T_PADDING]) = INVALID_EHANDLE_INDEX;
+		((CBaseHandle *)(&g_Variant_t[sizeof(int32_t)*3 + VARIANT_T_PADDING]))->Set(nullptr);
 	}
 } g_VariantFirstTimeInit;
 
@@ -159,13 +159,11 @@ static cell_t SetVariantEntity(IPluginContext *pContext, const cell_t *params)
 {
 	CBaseEntity *pEntity;
 	unsigned char *vptr = g_Variant_t;
-	CBaseHandle bHandle;
 
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
-	bHandle = reinterpret_cast<IHandleEntity *>(pEntity)->GetRefEHandle();
 
 	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING;
-	*(uint32_t *)vptr = (uint32_t)(bHandle.ToInt());
+	((CBaseHandle*)vptr)->Set(reinterpret_cast<IHandleEntity*>(pEntity));
 	vptr += sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_EHANDLE;
 

--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -164,9 +164,9 @@ static cell_t SetVariantEntity(IPluginContext *pContext, const cell_t *params)
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 	bHandle = reinterpret_cast<IHandleEntity *>(pEntity)->GetRefEHandle();
 
-	vptr += sizeof(int)*3;
-	*(size_t *)vptr = (size_t)(bHandle.ToInt());
-	vptr += sizeof(size_t);
+	vptr += sizeof(int)*2 + sizeof(size_t);
+	*(uint32_t *)vptr = (uint32_t)(bHandle.ToInt());
+	vptr += sizeof(uint32_t);
 	*(fieldtype_t *)vptr = FIELD_EHANDLE;
 
 	return 1;

--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -48,7 +48,7 @@ class VariantFirstTimeInit
 public:
 	VariantFirstTimeInit()
 	{
-		*(unsigned int *)(&g_Variant_t[12]) = INVALID_EHANDLE_INDEX;
+		*(uint32_t *)(&g_Variant_t[12 + VARIANT_T_PADDING]) = INVALID_EHANDLE_INDEX;
 	}
 } g_VariantFirstTimeInit;
 
@@ -57,7 +57,7 @@ static cell_t SetVariantBool(IPluginContext *pContext, const cell_t *params)
 	unsigned char *vptr = g_Variant_t;
 
 	*(bool *)vptr = (params[1]) ? true : false;
-	vptr += sizeof(int)*3 + sizeof(size_t);
+	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_BOOLEAN;
 
 	return 1;
@@ -71,7 +71,7 @@ static cell_t SetVariantString(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToString(params[1], &str);
 
 	*(string_t *)vptr = MAKE_STRING(str);
-	vptr += sizeof(int)*3 + sizeof(size_t);
+	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_STRING;
 
 	return 1;
@@ -82,7 +82,7 @@ static cell_t SetVariantInt(IPluginContext *pContext, const cell_t *params)
 	unsigned char *vptr = g_Variant_t;
 
 	*(int *)vptr = params[1];
-	vptr += sizeof(int)*3 + sizeof(size_t);
+	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_INTEGER;
 
 	return 1;
@@ -93,7 +93,7 @@ static cell_t SetVariantFloat(IPluginContext *pContext, const cell_t *params)
 	unsigned char *vptr = g_Variant_t;
 
 	*(float *)vptr = sp_ctof(params[1]);
-	vptr += sizeof(int)*3 + sizeof(size_t);
+	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_FLOAT;
 
 	return 1;
@@ -111,7 +111,7 @@ static cell_t SetVariantVector3D(IPluginContext *pContext, const cell_t *params)
 	*(float *)vptr = sp_ctof(val[1]);
 	vptr += sizeof(float);
 	*(float *)vptr = sp_ctof(val[2]);
-	vptr += sizeof(float) + sizeof(size_t);
+	vptr += sizeof(float) + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_VECTOR;
 
 	return 1;
@@ -129,7 +129,7 @@ static cell_t SetVariantPosVector3D(IPluginContext *pContext, const cell_t *para
 	*(float *)vptr = sp_ctof(val[1]);
 	vptr += sizeof(float);
 	*(float *)vptr = sp_ctof(val[2]);
-	vptr += sizeof(float) + sizeof(size_t);
+	vptr += sizeof(float) + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_POSITION_VECTOR;
 
 	return 1;
@@ -149,7 +149,7 @@ static cell_t SetVariantColor(IPluginContext *pContext, const cell_t *params)
 	*(unsigned char *)vptr = val[2];
 	vptr += sizeof(unsigned char);
 	*(unsigned char *)vptr = val[3];
-	vptr += sizeof(unsigned char) + sizeof(int)*2 + sizeof(size_t);
+	vptr += sizeof(unsigned char) + sizeof(int32_t)*2 + VARIANT_T_PADDING + sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_COLOR32;
 
 	return 1;
@@ -164,9 +164,9 @@ static cell_t SetVariantEntity(IPluginContext *pContext, const cell_t *params)
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 	bHandle = reinterpret_cast<IHandleEntity *>(pEntity)->GetRefEHandle();
 
-	vptr += sizeof(int)*2 + sizeof(size_t);
+	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING;
 	*(uint32_t *)vptr = (uint32_t)(bHandle.ToInt());
-	vptr += sizeof(uint32_t);
+	vptr += sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_EHANDLE;
 
 	return 1;

--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -57,7 +57,7 @@ static cell_t SetVariantBool(IPluginContext *pContext, const cell_t *params)
 	unsigned char *vptr = g_Variant_t;
 
 	*(bool *)vptr = (params[1]) ? true : false;
-	vptr += sizeof(int)*3 + sizeof(unsigned long);
+	vptr += sizeof(int)*3 + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_BOOLEAN;
 
 	return 1;
@@ -71,7 +71,7 @@ static cell_t SetVariantString(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToString(params[1], &str);
 
 	*(string_t *)vptr = MAKE_STRING(str);
-	vptr += sizeof(int)*3 + sizeof(unsigned long);
+	vptr += sizeof(int)*3 + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_STRING;
 
 	return 1;
@@ -82,7 +82,7 @@ static cell_t SetVariantInt(IPluginContext *pContext, const cell_t *params)
 	unsigned char *vptr = g_Variant_t;
 
 	*(int *)vptr = params[1];
-	vptr += sizeof(int)*3 + sizeof(unsigned long);
+	vptr += sizeof(int)*3 + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_INTEGER;
 
 	return 1;
@@ -93,7 +93,7 @@ static cell_t SetVariantFloat(IPluginContext *pContext, const cell_t *params)
 	unsigned char *vptr = g_Variant_t;
 
 	*(float *)vptr = sp_ctof(params[1]);
-	vptr += sizeof(int)*3 + sizeof(unsigned long);
+	vptr += sizeof(int)*3 + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_FLOAT;
 
 	return 1;
@@ -111,7 +111,7 @@ static cell_t SetVariantVector3D(IPluginContext *pContext, const cell_t *params)
 	*(float *)vptr = sp_ctof(val[1]);
 	vptr += sizeof(float);
 	*(float *)vptr = sp_ctof(val[2]);
-	vptr += sizeof(float) + sizeof(unsigned long);
+	vptr += sizeof(float) + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_VECTOR;
 
 	return 1;
@@ -129,7 +129,7 @@ static cell_t SetVariantPosVector3D(IPluginContext *pContext, const cell_t *para
 	*(float *)vptr = sp_ctof(val[1]);
 	vptr += sizeof(float);
 	*(float *)vptr = sp_ctof(val[2]);
-	vptr += sizeof(float) + sizeof(unsigned long);
+	vptr += sizeof(float) + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_POSITION_VECTOR;
 
 	return 1;
@@ -149,7 +149,7 @@ static cell_t SetVariantColor(IPluginContext *pContext, const cell_t *params)
 	*(unsigned char *)vptr = val[2];
 	vptr += sizeof(unsigned char);
 	*(unsigned char *)vptr = val[3];
-	vptr += sizeof(unsigned char) + sizeof(int)*2 + sizeof(unsigned long);
+	vptr += sizeof(unsigned char) + sizeof(int)*2 + sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_COLOR32;
 
 	return 1;
@@ -165,8 +165,8 @@ static cell_t SetVariantEntity(IPluginContext *pContext, const cell_t *params)
 	bHandle = reinterpret_cast<IHandleEntity *>(pEntity)->GetRefEHandle();
 
 	vptr += sizeof(int)*3;
-	*(unsigned long *)vptr = (unsigned long)(bHandle.ToInt());
-	vptr += sizeof(unsigned long);
+	*(size_t *)vptr = (size_t)(bHandle.ToInt());
+	vptr += sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_EHANDLE;
 
 	return 1;

--- a/extensions/sdktools/variant-t.h
+++ b/extensions/sdktools/variant-t.h
@@ -31,8 +31,11 @@
 
 #ifndef _INCLUDE_SOURCEMOD_EXTENSION_VARIANT_T_H_
 #define _INCLUDE_SOURCEMOD_EXTENSION_VARIANT_T_H_
-
+#if defined(_WIN64) || defined(__x86_64__)
+#define SIZEOF_VARIANT_T		24
+#else
 #define SIZEOF_VARIANT_T		20
+#endif
 
 /**
  * @file variant-t.h
@@ -47,10 +50,10 @@ inline void _init_variant_t()
 {
 	unsigned char *vptr = g_Variant_t;
 
-	*(int *)vptr = 0;
-	vptr += sizeof(int)*3;
-	*(unsigned long *)vptr = INVALID_EHANDLE_INDEX;
-	vptr += sizeof(unsigned long);
+	*(int32_t *)vptr = 0;
+	vptr += sizeof(int32_t)*3;
+	*(size_t *)vptr = INVALID_EHANDLE_INDEX;
+	vptr += sizeof(size_t);
 	*(fieldtype_t *)vptr = FIELD_VOID;
 }
 

--- a/extensions/sdktools/variant-t.h
+++ b/extensions/sdktools/variant-t.h
@@ -54,7 +54,7 @@ inline void _init_variant_t()
 
 	*(size_t *)vptr = 0;
 	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING;
-	*(uint32_t *)vptr = INVALID_EHANDLE_INDEX;
+	((CBaseHandle *)vptr)->Set(nullptr);
 	vptr += sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_VOID;
 }

--- a/extensions/sdktools/variant-t.h
+++ b/extensions/sdktools/variant-t.h
@@ -33,8 +33,10 @@
 #define _INCLUDE_SOURCEMOD_EXTENSION_VARIANT_T_H_
 #if defined(_WIN64) || defined(__x86_64__)
 #define SIZEOF_VARIANT_T		24
+#define VARIANT_T_PADDING 		4
 #else
 #define SIZEOF_VARIANT_T		20
+#define VARIANT_T_PADDING 		0
 #endif
 
 /**
@@ -51,9 +53,9 @@ inline void _init_variant_t()
 	unsigned char *vptr = g_Variant_t;
 
 	*(size_t *)vptr = 0;
-	vptr += sizeof(int)*2 + sizeof(size_t); //Variant_t's union is padded from 12 bytes to 16 on 64-bit
+	vptr += sizeof(int32_t)*3 + VARIANT_T_PADDING;
 	*(uint32_t *)vptr = INVALID_EHANDLE_INDEX;
-	vptr += sizeof(uint32_t);
+	vptr += sizeof(CBaseHandle);
 	*(fieldtype_t *)vptr = FIELD_VOID;
 }
 

--- a/extensions/sdktools/variant-t.h
+++ b/extensions/sdktools/variant-t.h
@@ -50,10 +50,10 @@ inline void _init_variant_t()
 {
 	unsigned char *vptr = g_Variant_t;
 
-	*(int32_t *)vptr = 0;
-	vptr += sizeof(int32_t)*3;
-	*(size_t *)vptr = INVALID_EHANDLE_INDEX;
-	vptr += sizeof(size_t);
+	*(size_t *)vptr = 0;
+	vptr += sizeof(int)*2 + sizeof(size_t); //Variant_t's union is padded from 12 bytes to 16 on 64-bit
+	*(uint32_t *)vptr = INVALID_EHANDLE_INDEX;
+	vptr += sizeof(uint32_t);
 	*(fieldtype_t *)vptr = FIELD_VOID;
 }
 


### PR DESCRIPTION
[Disclaimer: I'm not familiar with c++]
On TF2 64-bit Linux, a plugin calling AcceptEntityInput will lead to a null pointer segfault such as with the following:
```c++
SetVariantString(g_strItemModel[iItem]);
AcceptEntityInput(client, "SetCustomModel");
```
jit_call_x64 will classify g_Variant_t as ObjectClass::Memory, but later does not handle that case resulting in a default Assert(no --enable-optimize build) or a null pointer crash(--enable-optimize). I just placed it in the same if statement with ObjectClass::Pointer and that seemed to fix the crash issue, but AcceptEntityInput did not function.

g_Variant_t seems to be an array of bytes representation of the real variant_t object, but the size of variant_t changes between 32/64 bit due to memory alignment. x64 adds 4 bytes of padding after the union in variant_t which changes the total size to 24. I changed #define SIZEOF_VARIANT_T to 20/24 depending on architecture when compiling and accounted for the padding. I also heard longs are evil, so I replaced those as well.

This was only tested on Linux x64 with [alliedmodders/hl2sdk/pull/198](https://github.com/alliedmodders/hl2sdk/pull/198), I'm guessing Win64 would behave the same regarding alignment.