### PR TITLE
Neotokyo: Add "SetOwnerEntity" gamedata

### DIFF
--- a/gamedata/sdktools.games/game.neotokyo.txt
+++ b/gamedata/sdktools.games/game.neotokyo.txt
@@ -76,6 +76,10 @@
 			{
 				"windows"	"185"
 			}
+			"SetOwnerEntity"
+			{
+				"windows"	"18"
+			}
 		}
 		"Signatures"
 		{


### PR DESCRIPTION
Add "SetOwnerEntity" gamedata for the game Neotokyo.

This adds game support for natives `SetOwnerEntity`, and `SetEntityCollisionGroup`.