### PR TITLE
Implement File.Size

### DIFF
--- a/bridge/include/IFileSystemBridge.h
+++ b/bridge/include/IFileSystemBridge.h
@@ -44,6 +44,7 @@ public:
 	virtual char *ReadLine(char *pOutput, int maxChars, FileHandle_t file) = 0;
 	virtual bool EndOfFile(FileHandle_t file) = 0;
 	virtual bool FileExists(const char *pFileName, const char *pPathID = 0) = 0;
+	virtual unsigned int Size(FileHandle_t file) = 0;
 	virtual unsigned int Size(const char *pFileName, const char *pPathID = 0) = 0;
 	virtual int Read(void* pOutput, int size, FileHandle_t file) = 0;
 	virtual int Write(void const* pInput, int size, FileHandle_t file) = 0;

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -73,6 +73,7 @@ class FileObject
 public:
 	virtual ~FileObject()
 	{}
+	virtual size_t Size() = 0;
 	virtual size_t Read(void *pOut, int size) = 0;
 	virtual char *ReadLine(char *pOut, int size) = 0;
 	virtual size_t Write(const void *pData, int size) = 0;
@@ -117,6 +118,10 @@ public:
 			return false;
 
 		return true;
+	}
+
+	size_t Size() override {
+		return (size_t)bridge->filesystem->Size(handle_);
 	}
 
 	size_t Read(void *pOut, int size) override {
@@ -181,6 +186,19 @@ public:
 
 	static bool Delete(const char *path) {
 		return unlink(path) == 0;
+	}
+
+	size_t Size() override {
+		// Preserve current location
+		size_t curpos = ftell(fp_);
+
+		fseek(fp_, 0L, SEEK_END);
+		size_t size = ftell(fp_);
+
+		//Restore previous location
+		fseek(fp_, curpos, SEEK_SET);
+
+		return size;
 	}
 
 	size_t Read(void *pOut, int size) override {
@@ -1125,6 +1143,15 @@ static cell_t sm_RemoveGameLogHook(IPluginContext *pContext, const cell_t *param
 	return 1;
 }
 
+static cell_t File_Size(IPluginContext *pContext, const cell_t *params)
+{
+	OpenHandle<FileObject> file(pContext, params[1], g_FileType);
+	if (!file.Ok())
+		return -1;
+
+	return file->Size();
+}
+
 template <typename T>
 static cell_t File_ReadTyped(IPluginContext *pContext, const cell_t *params)
 {
@@ -1197,6 +1224,7 @@ REGISTER_NATIVES(filesystem)
 	{"File.Seek",				sm_FileSeek},
 	{"File.Flush",				sm_FlushFile},
 	{"File.Position.get",		sm_FilePosition},
+	{"File.Size",				File_Size},
 	{"File.ReadInt8",			File_ReadTyped<int8_t>},
 	{"File.ReadUint8",			File_ReadTyped<uint8_t>},
 	{"File.ReadInt16",			File_ReadTyped<int16_t>},

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -138,6 +138,10 @@ public:
 	{
 		return filesystem->FileExists(pFileName, pPathID);
 	}
+	unsigned int Size(FileHandle_t file) override
+	{
+		return filesystem->Size(file);
+	}
 	unsigned int Size(const char *pFileName, const char *pPathID = 0) override
 	{
 		return filesystem->Size(pFileName, pPathID);

--- a/plugins/include/files.inc
+++ b/plugins/include/files.inc
@@ -112,6 +112,11 @@ methodmap File < Handle
 		CloseHandle(this);
 	}
 
+	// Get the file size in bytes.
+	//
+	// @return                File size in bytes, -1 on error.
+	public native int Size();
+
 	// Reads a line of text from a file.
 	//
 	// @param buffer          String buffer to hold the line.


### PR DESCRIPTION
Addresses https://github.com/alliedmodders/sourcemod/issues/1578

Use the engine's method for valve files, and a simple seek/tell for system files.

Test plugin:
```sourcepawn
#include <sourcemod>

#pragma semicolon 1
#pragma newdecls required

public Plugin myinfo =
{
	name = "File Size Test",
	author = "Peak",
	description = "meow",
	version = SOURCEMOD_VERSION,
	url = "http://www.sourcemod.net/"
};

public void OnPluginStart()
{
    RegServerCmd("sm_fst", Command_FileSizeTest);
}

public Action Command_FileSizeTest(int args)
{
    //Test existing
    int existing = FileSize("addons/sourcemod/plugins/fsztest.smx");
    int existingGame = FileSize("addons/sourcemod/plugins/fsztest.smx", true);

    PrintToServer("Existing Native: %d, Existing Game: %d", existing, existingGame);

    //Test native
    File nf = OpenFile("addons/sourcemod/plugins/fsztest.smx", "r");
    int nv = nf.Size();
    nf.Close();

    //Test game
    File gf = OpenFile("addons/sourcemod/plugins/fsztest.smx", "r", true);
    int game = gf.Size();
    gf.Close();

    PrintToServer("Native: %d, Game: %d", nv, game);
    return Plugin_Handled;
}
```