### PR TITLE
Prevent recursion in sm_ServerCommandEx (fixes #967)

### DIFF
--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -979,11 +979,15 @@ static cell_t sm_ServerCommandEx(IPluginContext *pContext, const cell_t *params)
 	}
 
 	engine->ServerExecute();
-
-	g_ShouldCatchSpew = true;
-	engine->ServerCommand("sm_conhook_start\n");
-	engine->ServerCommand(buffer);
-	engine->ServerCommand("sm_conhook_stop\n");
+	if (!g_ShouldCatchSpew) {
+		g_ShouldCatchSpew = true;
+		engine->ServerCommand("sm_conhook_start\n");
+		engine->ServerCommand(buffer);
+		engine->ServerCommand("sm_conhook_stop\n");
+	}
+	else {
+		engine->ServerCommand(buffer);
+	}
 
 	engine->ServerExecute();
 

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -984,8 +984,7 @@ static cell_t sm_ServerCommandEx(IPluginContext *pContext, const cell_t *params)
 		engine->ServerCommand("sm_conhook_start\n");
 		engine->ServerCommand(buffer);
 		engine->ServerCommand("sm_conhook_stop\n");
-	}
-	else {
+	} else {
 		engine->ServerCommand(buffer);
 	}
 


### PR DESCRIPTION
This fixes the issue with recursive `ServerCommandEx` in old engine (pre-Nuclear Dawn). The issue was that if `ServerCommandEx` is called recursively, `sm_conhook_start` and `sm_conhook_stop` will be added to the console buffer again. When that happens, it will set `g_OriginalSpewOutputFunc` to `SourcemodSpewOutputFunc` because the earlier call set the spew func to `SourcemodSpewOutputFunc`, and then when a line is printed, `SourcemodSpewOutputFunc` will call `SourcemodSpewOutputFunc` indefinitely until the stack overflows (in debug) or you get bored (in release). This patch fixes that by checking if we're already catching spew before adding `sm_conhook_start`/`stop` again.