### PR TITLE
x32 Windows Gamedata Fixes for 4/18/2024 TF2 Update

### DIFF
--- a/gamedata/sdktools.games/game.tf.txt
+++ b/gamedata/sdktools.games/game.tf.txt
@@ -135,7 +135,7 @@
 			"FireOutput"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x81\xEC\x24\x01\x00\x00\x53\x8B\xC1"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x40\x01\x00\x00\x8B\xC1"
 				"linux"		"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
 				"linux64"	"@_ZN17CBaseEntityOutput10FireOutputE9variant_tP11CBaseEntityS2_f"
 			}

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -39,7 +39,7 @@
 			"Regenerate"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x24\x53\x56\x57\x8B\xF9\x8B\x07\xFF\x90"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x5C\x53\x56\x57\x8B\xF9\x8B\x07"
 				"linux"		"@_ZN9CTFPlayer10RegenerateEb"
 				"linux64"	"@_ZN9CTFPlayer10RegenerateEb"
 			}
@@ -60,28 +60,28 @@
 			"SetPowerplayEnabled"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x80\x7D\x08\x00\x56\x57\x8B\xF9"
+				"windows"	"\x55\x8B\xEC\x51\x80\x7D\x08\x00\x56\x57"
 				"linux"		"@_ZN9CTFPlayer19SetPowerplayEnabledEb"
 				"linux64"	"@_ZN9CTFPlayer19SetPowerplayEnabledEb"
 			}
 			"SetInWaitingForPlayers"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\xE8\x2A\x2A\x2A\x2A\x84\xC0\x0F\x85\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A"
+				"windows"	"\x55\x8B\xEC\x51\x56\x8B\xF1\xE8\x2A\x2A\x2A\x2A\x84\xC0\x0F\x85\x2A\x2A\x2A\x2A"
 				"linux"		"@_ZN24CTeamplayRoundBasedRules22SetInWaitingForPlayersEb"
 				"linux64"	"@_ZN24CTeamplayRoundBasedRules22SetInWaitingForPlayersEb"
 			}
 			"StunPlayer"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x20\x57\x8B\xF9\x8B\x87\xDC\x04\x00\x00"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x24\x57\x8B\xF9\x8B\x87\xDC\x04\x00\x00"
 				"linux"		"@_ZN15CTFPlayerShared10StunPlayerEffiP9CTFPlayer"
 				"linux64"	"@_ZN15CTFPlayerShared10StunPlayerEffiP9CTFPlayer"
 			}
 			"MakeBleed"
 			{
 				"library" 	"server"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x2C\x57\x8B\xF9\x89\x7D\xF0"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x10\x53\x8B\xD9\x89\x5D\xF8\x8B\x8B\x8C\x01\x00\x00"
 				"linux"		"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefibi"
 				"linux64"	"@_ZN15CTFPlayerShared9MakeBleedEP9CTFPlayerP13CTFWeaponBasefibi"
 			}
@@ -95,7 +95,7 @@
 			"CanPlayerTeleport"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x53\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x75\x2A\x5F\x32\xC0\x5B\x5D\xC2\x04\x00"
+				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A"
 				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
 				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
 			}


### PR DESCRIPTION
This fixes the following x32 Windows signatures that were changed in the recent TF2 update:
- SetInWaitingForPlayers
- Regenerate
- SetPowerplayEnabled
- StunPlayer
- MakeBleed
- FireOutput
- CanPlayerTeleport

I've tested all of them and can confirm that the gamedata is correct and the functions work as intended.