### PR TITLE
Fix IsClientSourceTV in L4D2

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -646,7 +646,7 @@ void PlayerManager::OnClientPutInServer(edict_t *pEntity, const char *playername
 
 		int userId = engine->GetPlayerUserId(pEntity);
 #if (SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_SDK2013 \
-	|| SOURCE_ENGINE == SE_BMS || SOURCE_ENGINE == SE_NUCLEARDAWN  || SOURCE_ENGINE == SE_LEFT4DEAD2 || SOURCE_ENGINE == SE_PVKII)
+	|| SOURCE_ENGINE == SE_BMS || SOURCE_ENGINE == SE_NUCLEARDAWN || SOURCE_ENGINE == SE_PVKII)
 		static ConVar *tv_name = icvar->FindVar("tv_name");
 #endif
 #if SOURCE_ENGINE == SE_TF2
@@ -675,7 +675,7 @@ void PlayerManager::OnClientPutInServer(edict_t *pEntity, const char *playername
 #elif SOURCE_ENGINE == SE_BLADE
 				|| strcmp(playername, "BBTV") == 0
 #elif (SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_SDK2013 \
-	|| SOURCE_ENGINE == SE_BMS || SOURCE_ENGINE == SE_NUCLEARDAWN  || SOURCE_ENGINE == SE_LEFT4DEAD2 || SOURCE_ENGINE == SE_PVKII)
+	|| SOURCE_ENGINE == SE_BMS || SOURCE_ENGINE == SE_NUCLEARDAWN || SOURCE_ENGINE == SE_PVKII)
 				|| (tv_name && strcmp(playername, tv_name->GetString()) == 0) || (tv_name && tv_name->GetString()[0] == 0 && strcmp(playername, "unnamed") == 0)
 #else
 				|| strcmp(playername, "SourceTV") == 0


### PR DESCRIPTION
References https://github.com/alliedmodders/sourcemod/commit/8a10f4b7a20d4cff1268ea5130a01bf9b81ab854
References https://github.com/alliedmodders/sourcemod/commit/90ca9d7a47e053c06e48d0bc90afb58cc4ebd28b

This PR fixes `IsClientSourceTV` in L4D2 when a custom `tv_name` is used. Specifically a non `SourceTV` `tv_name` was incorrectly resulting in the bot not being considered the SourceTV bot.

The first commit makes this specific distinction for L4D2 - that the bot is spawned as `SourceTV` even if `tv_name` has a different value. The second commit makes L4D2 also compare the bot name with `tv_name` even though this is not applicable.

Credit for finding the cause of this issue goes to @asherkin . Tested with [SourceTV Support](https://github.com/shqke/sourcetvsupport) and [hide_sourcetv](https://github.com/shqke/sp_public/tree/master/hide_sourcetv) (which seemed to be broken with a custom `tv_name`, but the problem was in SM).