### PR TITLE
AcceptEntityInput 64bit fix

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -725,7 +725,7 @@ inline void Write_PushObject(JitWriter *jit, const SourceHook::PassInfo *info, u
 		ObjectClass classes[MAX_CLASSES];
 		int numWords = ClassifyObject(smInfo, classes);
 
-		if (classes[0] == ObjectClass::Pointer)
+		if (classes[0] == ObjectClass::Pointer || classes[0] == ObjectClass::Memory)
 			goto push_byref;
 
 		int neededIntRegs = 0;

--- a/extensions/sdktools/AMBuilder
+++ b/extensions/sdktools/AMBuilder
@@ -48,7 +48,12 @@ for sdk_name in SM.sdks:
     binary.compiler.cxxincludes += [
       os.path.join(builder.sourcePath, 'public', 'jit'),
       os.path.join(builder.sourcePath, 'public', 'jit', 'x86'),
+      os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'server'),
+      os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'shared'),      
     ]
+
+    #binary.sources += [os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'server', 'variant_t.cpp')]
+
     binary.compiler.defines += ['HAVE_STRING_H']
 
     if sdk['name'] != 'episode1':

--- a/extensions/sdktools/AMBuilder
+++ b/extensions/sdktools/AMBuilder
@@ -48,9 +48,16 @@ for sdk_name in SM.sdks:
     binary.compiler.cxxincludes += [
       os.path.join(builder.sourcePath, 'public', 'jit'),
       os.path.join(builder.sourcePath, 'public', 'jit', 'x86'),
-      os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'server'),
-      os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'shared'),      
     ]
+
+    if sdk['name'] in ('episode1', 'darkm'):
+      binary.compiler.cxxincludes += [os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game_shared')]
+      binary.compiler.cxxincludes += [os.path.join(builder.options.hl2sdk_root, sdk['path'], 'dlls')]
+    else:
+      binary.compiler.cxxincludes += [
+        os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'shared'),
+        os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'server'),
+      ]
 
     #binary.sources += [os.path.join(builder.options.hl2sdk_root, sdk['path'], 'game', 'server', 'variant_t.cpp')]
 

--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -110,19 +110,6 @@ static cell_t SetVariantEntity(IPluginContext *pContext, const cell_t *params)
 	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
 	g_Variant_t.SetEntity(pEntity);
 
-	/*
-	unsigned char *vptr = g_Variant_t;
-	CBaseHandle bHandle;
-
-	ENTINDEX_TO_CBASEENTITY(params[1], pEntity);
-	bHandle = reinterpret_cast<IHandleEntity *>(pEntity)->GetRefEHandle();
-
-	vptr += sizeof(int)*3;
-	*(unsigned long *)vptr = (unsigned long)(bHandle.ToInt());
-	vptr += sizeof(unsigned long);
-	*(fieldtype_t *)vptr = FIELD_EHANDLE;
-	*/
-
 	return 1;
 }
 

--- a/extensions/sdktools/variant-t.h
+++ b/extensions/sdktools/variant-t.h
@@ -32,26 +32,22 @@
 #ifndef _INCLUDE_SOURCEMOD_EXTENSION_VARIANT_T_H_
 #define _INCLUDE_SOURCEMOD_EXTENSION_VARIANT_T_H_
 
-#define SIZEOF_VARIANT_T		20
+#include "variant_t.h"
+
+#define SIZEOF_VARIANT_T		sizeof(variant_t)
 
 /**
  * @file variant-t.h
  * @brief SDK Tools extension gamerules natives header.
  */
 
-extern unsigned char g_Variant_t[SIZEOF_VARIANT_T];
+extern variant_t g_Variant_t;
 
 extern sp_nativeinfo_t g_VariantTNatives[];
 
 inline void _init_variant_t()
 {
-	unsigned char *vptr = g_Variant_t;
-
-	*(int *)vptr = 0;
-	vptr += sizeof(int)*3;
-	*(unsigned long *)vptr = INVALID_EHANDLE_INDEX;
-	vptr += sizeof(unsigned long);
-	*(fieldtype_t *)vptr = FIELD_VOID;
+	memset(&g_Variant_t, 0, sizeof(g_Variant_t));
 }
 
 #endif //_INCLUDE_SOURCEMOD_EXTENSION_VARIANT_T_H_


### PR DESCRIPTION
Fixes AcceptEntityInput by using the struct definition instead of messy pointer math.

I could not add variant_t.cpp from the sdk because including cbase.h causes a large number of compile errors so I just pasted the 1 method into the sdktools file. If anyone wants to play around with making it work, you can uncomment the file include in the AMBuildScript file in the sdktools folder.

Includes a fix to bintools from malifox which is supposedly related, but I have no idea what it does to be honest.

https://github.com/alliedmodders/sourcemod/pull/2119

I only tested and confirmed this works on Linux and only on int and string variants.