### PR TITLE
Add OnServerHibernationUpdate forward (closes #1483)

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -59,7 +59,8 @@ bool g_OnMapStarted = false;
 IForward *PreAdminCheck = NULL;
 IForward *PostAdminCheck = NULL;
 IForward *PostAdminFilter = NULL;
-IForward *ServerHibernationUpdate = NULL;
+IForward *ServerEnterHibernation = NULL;
+IForward *ServerExitHibernation = NULL;
 
 const unsigned int *g_NumPlayersToAuth = NULL;
 int lifestate_offset = -1;
@@ -204,7 +205,8 @@ void PlayerManager::OnSourceModAllInitialized()
 	PreAdminCheck = forwardsys->CreateForward("OnClientPreAdminCheck", ET_Event, 1, p1);
 	PostAdminCheck = forwardsys->CreateForward("OnClientPostAdminCheck", ET_Ignore, 1, p1);
 	PostAdminFilter = forwardsys->CreateForward("OnClientPostAdminFilter", ET_Ignore, 1, p1);
-	ServerHibernationUpdate = forwardsys->CreateForward("OnServerHibernationUpdate", ET_Ignore, 1, NULL, Param_Cell);
+	ServerEnterHibernation = forwardsys->CreateForward("OnServerEnterHibernation", ET_Ignore, 0, NULL);
+	ServerExitHibernation = forwardsys->CreateForward("OnServerExitHibernation", ET_Ignore, 0, NULL);
 
 	m_bIsListenServer = !engine->IsDedicatedServer();
 	m_ListenClient = 0;
@@ -256,7 +258,8 @@ void PlayerManager::OnSourceModShutdown()
 	forwardsys->ReleaseForward(PreAdminCheck);
 	forwardsys->ReleaseForward(PostAdminCheck);
 	forwardsys->ReleaseForward(PostAdminFilter);
-	forwardsys->ReleaseForward(ServerHibernationUpdate);
+	forwardsys->ReleaseForward(ServerEnterHibernation);
+	forwardsys->ReleaseForward(ServerExitHibernation);
 
 	delete [] m_Players;
 
@@ -782,9 +785,10 @@ void PlayerManager::OnSourceModLevelEnd()
 void PlayerManager::OnServerHibernationUpdate(bool bHibernating)
 {
 	cell_t res;
-	cell_t data = static_cast<cell_t>(bHibernating);
-	ServerHibernationUpdate->PushCell(data);
-	ServerHibernationUpdate->Execute(&res);
+	if (bHibernating)
+		ServerEnterHibernation->Execute(&res);
+	else
+		ServerExitHibernation->Execute(&res);
 	/* If bots were added at map start, but not fully inited before hibernation, there will
 	 * be no OnClientDisconnect for them, despite them getting booted right before this.
 	 */

--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -59,6 +59,7 @@ bool g_OnMapStarted = false;
 IForward *PreAdminCheck = NULL;
 IForward *PostAdminCheck = NULL;
 IForward *PostAdminFilter = NULL;
+IForward *ServerHibernationUpdate = NULL;
 
 const unsigned int *g_NumPlayersToAuth = NULL;
 int lifestate_offset = -1;
@@ -203,6 +204,7 @@ void PlayerManager::OnSourceModAllInitialized()
 	PreAdminCheck = forwardsys->CreateForward("OnClientPreAdminCheck", ET_Event, 1, p1);
 	PostAdminCheck = forwardsys->CreateForward("OnClientPostAdminCheck", ET_Ignore, 1, p1);
 	PostAdminFilter = forwardsys->CreateForward("OnClientPostAdminFilter", ET_Ignore, 1, p1);
+	ServerHibernationUpdate = forwardsys->CreateForward("OnServerHibernationUpdate", ET_Ignore, 1, NULL, Param_Cell);
 
 	m_bIsListenServer = !engine->IsDedicatedServer();
 	m_ListenClient = 0;
@@ -254,6 +256,7 @@ void PlayerManager::OnSourceModShutdown()
 	forwardsys->ReleaseForward(PreAdminCheck);
 	forwardsys->ReleaseForward(PostAdminCheck);
 	forwardsys->ReleaseForward(PostAdminFilter);
+	forwardsys->ReleaseForward(ServerHibernationUpdate);
 
 	delete [] m_Players;
 
@@ -778,6 +781,10 @@ void PlayerManager::OnSourceModLevelEnd()
 
 void PlayerManager::OnServerHibernationUpdate(bool bHibernating)
 {
+	cell_t res;
+	cell_t data = static_cast<cell_t>(bHibernating);
+	ServerHibernationUpdate->PushCell(data);
+	ServerHibernationUpdate->Execute(&res);
 	/* If bots were added at map start, but not fully inited before hibernation, there will
 	 * be no OnClientDisconnect for them, despite them getting booted right before this.
 	 */

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -216,6 +216,15 @@ forward Action OnClientPreAdminCheck(int client);
 forward void OnClientPostAdminFilter(int client);
 
 /**
+ * Called directly before the server hibernation state changes.
+ * This is your last chance to do anything in the plugin before
+ * hibernation occurs, as SV_Frame will no longer be called.
+ *
+ * @param state         The new hibernation state.
+ */
+forward void OnServerHibernationUpdate(bool state);
+
+/**
  * Called once a client is authorized and fully in-game, and 
  * after all post-connection authorizations have been performed.  
  *

--- a/plugins/include/clients.inc
+++ b/plugins/include/clients.inc
@@ -216,13 +216,16 @@ forward Action OnClientPreAdminCheck(int client);
 forward void OnClientPostAdminFilter(int client);
 
 /**
- * Called directly before the server hibernation state changes.
+ * Called directly before the server enters hibernation.
  * This is your last chance to do anything in the plugin before
  * hibernation occurs, as SV_Frame will no longer be called.
- *
- * @param state         The new hibernation state.
  */
-forward void OnServerHibernationUpdate(bool state);
+forward void OnServerEnterHibernation();
+
+/**
+ * Called directly before the server leaves hibernation.
+ */
+forward void OnServerExitHibernation();
 
 /**
  * Called once a client is authorized and fully in-game, and 


### PR DESCRIPTION
Adds the OnServerHibernationUpdate forward. OnServerHibernationUpdate_Post() isn't possible to implement because there would be no place for it to be called from after SV_Frame stops executing.
Link to Discord discussion:
https://discord.com/channels/335290997317697536/335290997317697536/1236880595448233995