### PR TITLE
Fix rare crash with logs

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -266,7 +266,7 @@ class FileNatives :
 	public IPluginsListener
 {
 public:
-	FileNatives() : m_initialised(false)
+	FileNatives()
 	{
 	}
 	virtual void OnSourceModAllInitialized()
@@ -276,7 +276,6 @@ public:
 		g_ValveDirType = handlesys->CreateType("ValveDirectory", this, 0, NULL, NULL, g_pCoreIdent, NULL);
 		g_pLogHook = forwardsys->CreateForwardEx(NULL, ET_Hook, 1, NULL, Param_String);
 		pluginsys->AddPluginsListener(this);
-		m_initialised = true;
 	}
 	virtual void OnSourceModShutdown()
 	{
@@ -291,10 +290,6 @@ public:
 	}
 	virtual void OnHandleDestroy(HandleType_t type, void *object)
 	{
-		if (!m_initialised) {
-			return;
-		}
-
 		if (type == g_FileType)
 		{
 			FileObject *file = (FileObject *)object;
@@ -314,23 +309,15 @@ public:
 	}
 	virtual void AddLogHook(IPluginFunction *pFunc)
 	{
-		if (!m_initialised) {
-			return;
-		}
-		
 		g_pLogHook->AddFunction(pFunc);
 	}
 	virtual void RemoveLogHook(IPluginFunction *pFunc)
 	{
-		if (!m_initialised) {
-			return;
-		}
-
 		g_pLogHook->RemoveFunction(pFunc);
 	}
 	virtual bool LogPrint(const char *msg)
 	{
-		if (!m_initialised) {
+		if (!g_pLogHook) {
 			return false;
 		}
 

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -326,7 +326,6 @@ public:
 		g_pLogHook->Execute(&result);
 		return result >= Pl_Handled;
 	}
-	bool m_initialised;
 } s_FileNatives;
 
 bool OnLogPrint(const char *msg)

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -266,7 +266,7 @@ class FileNatives :
 	public IPluginsListener
 {
 public:
-	FileNatives()
+	FileNatives() : m_initialised(false)
 	{
 	}
 	virtual void OnSourceModAllInitialized()
@@ -276,6 +276,7 @@ public:
 		g_ValveDirType = handlesys->CreateType("ValveDirectory", this, 0, NULL, NULL, g_pCoreIdent, NULL);
 		g_pLogHook = forwardsys->CreateForwardEx(NULL, ET_Hook, 1, NULL, Param_String);
 		pluginsys->AddPluginsListener(this);
+		m_initialised = true;
 	}
 	virtual void OnSourceModShutdown()
 	{
@@ -290,6 +291,10 @@ public:
 	}
 	virtual void OnHandleDestroy(HandleType_t type, void *object)
 	{
+		if (!m_initialised) {
+			return;
+		}
+
 		if (type == g_FileType)
 		{
 			FileObject *file = (FileObject *)object;
@@ -309,19 +314,32 @@ public:
 	}
 	virtual void AddLogHook(IPluginFunction *pFunc)
 	{
+		if (!m_initialised) {
+			return;
+		}
+		
 		g_pLogHook->AddFunction(pFunc);
 	}
 	virtual void RemoveLogHook(IPluginFunction *pFunc)
 	{
+		if (!m_initialised) {
+			return;
+		}
+
 		g_pLogHook->RemoveFunction(pFunc);
 	}
 	virtual bool LogPrint(const char *msg)
 	{
+		if (!m_initialised) {
+			return false;
+		}
+
 		cell_t result = 0;
 		g_pLogHook->PushString(msg);
 		g_pLogHook->Execute(&result);
 		return result >= Pl_Handled;
 	}
+	bool m_initialised;
 } s_FileNatives;
 
 bool OnLogPrint(const char *msg)


### PR DESCRIPTION
Issue mentioned to Asherkin or Psychonic.

Long story short, if a metamod plugin happens to be detouring some game functions that SM unfortunately calls while initialising, and decides to have the console print something. It will trigger `FileFileNatives::LogPrint`, however by that point `g_pLogHook` has not yet been initialised, it's still a nullptr. This of course ends up with a nullpointer crash.

Let's ~~add a member property that tracks whether or not we've been initialised.~~ nullcheck `g_pLogHook`