### PR TITLE
Change the method of compiling safetyhook

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -55,6 +55,7 @@ class SMConfig(object):
     self.target_archs = set()
     self.enable_asan = getattr(builder.options, 'enable_asan', False)
     self.asan_libs = {}
+    self.libsafetyhook = {}
 
     if builder.options.targets:
       target_archs = builder.options.targets.split(',')
@@ -522,14 +523,14 @@ class SMConfig(object):
 
   def AddCDetour(self, binary):
     public_path = os.path.join(builder.sourcePath, 'public')
-    binary.sources += [
-      os.path.join(public_path, 'CDetour', 'detours.cpp'),
-      os.path.join(public_path, 'safetyhook', 'amalgamated-dist', 'safetyhook.cpp'),
-      os.path.join(public_path, 'safetyhook', 'zydis', 'Zydis.c')
-    ]
+    binary.sources += [ os.path.join(public_path, 'CDetour', 'detours.cpp') ]
     binary.compiler.cxxincludes += [ os.path.join(public_path, 'safetyhook', 'include') ]
-    binary.compiler.includes += [ os.path.join(public_path, 'safetyhook', 'amalgamated-dist') ]
-    binary.compiler.includes += [ os.path.join(public_path, 'safetyhook', 'zydis') ]
+
+    for task in self.libsafetyhook:
+      if task.target.arch == binary.compiler.target.arch:
+        binary.compiler.linkflags += [task.binary]
+        return
+    raise Exception('No suitable build of safetyhook was found.')
 
   def HL2Library(self, context, compiler, name, sdk):
     binary = self.Library(context, compiler, name)
@@ -578,6 +579,16 @@ if SM.use_auto_versioning():
     'versionlib/AMBuilder',
     { 'SM': SM }
   )
+
+class SafetyHookShim(object):
+  def __init__(self):
+    self.all_targets = {}
+    self.libsafetyhook = {}
+
+SafetyHook = SafetyHookShim()
+SafetyHook.all_targets = SM.all_targets
+builder.Build('public/safetyhook/AMBuilder', {'SafetyHook': SafetyHook })
+SM.libsafetyhook = SafetyHook.libsafetyhook
 
 class SPRoot(object):
   def __init__(self):


### PR DESCRIPTION
Requires alliedmodders/safetyhook#2 to land (hopefully), in which case we need to also update the submodule. This supplement your PR#2163 @Headline it's not meant to replace it. (I'm targetting your safetyhook-mirror branch)