### PR TITLE
Expose ICellArray handle to extensions

### DIFF
--- a/core/logic/CellArray.h
+++ b/core/logic/CellArray.h
@@ -207,6 +207,16 @@ public:
 		return m_AllocSize * m_BlockSize * sizeof(cell_t);
 	}
 
+	size_t size_of()
+	{
+		return sizeof(CellArray);
+	}
+
+	void delete_this()
+	{
+		delete this;
+	}
+	
 private:
 	bool GrowIfNeeded(size_t count)
 	{

--- a/core/logic/smn_adt_array.cpp
+++ b/core/logic/smn_adt_array.cpp
@@ -53,13 +53,13 @@ public: //SMGlobalClass
 public: //IHandleTypeDispatch
 	void OnHandleDestroy(HandleType_t type, void *object)
 	{
-		CellArray *array = (CellArray *)object;
-		delete array;
+		ICellArray *array = (ICellArray *)object;
+		array->delete_this();
 	}
 	bool GetHandleApproxSize(HandleType_t type, void *object, unsigned int *pSize)
 	{
-		CellArray *pArray = (CellArray *)object;
-		*pSize = sizeof(CellArray) + pArray->mem_usage();
+		ICellArray *pArray = (ICellArray*)object;
+		*pSize = pArray->size_of() + pArray->mem_usage();
 		return true;
 	}
 } s_CellArrayHelpers;
@@ -77,7 +77,7 @@ static cell_t CreateArray(IPluginContext *pContext, const cell_t *params)
 	{
 		if (!array->resize(params[2]))
 		{
-			delete array;
+			array->delete_this();
 			return pContext->ThrowNativeError("Failed to resize array to startsize \"%u\".", params[2]);
 		}
 	}
@@ -85,7 +85,7 @@ static cell_t CreateArray(IPluginContext *pContext, const cell_t *params)
 	Handle_t hndl = handlesys->CreateHandle(htCellArray, array, pContext->GetIdentity(), g_pCoreIdent, NULL);
 	if (!hndl)
 	{
-		delete array;
+		array->delete_this();
 	}
 
 	return hndl;
@@ -569,7 +569,7 @@ static cell_t CloneArray(IPluginContext *pContext, const cell_t *params)
 	Handle_t hndl = handlesys->CreateHandle(htCellArray, array, pContext->GetIdentity(), g_pCoreIdent, NULL);
 	if (!hndl)
 	{
-		delete array;
+		array->delete_this();
 	}
 
 	return hndl;

--- a/core/sourcemod.h
+++ b/core/sourcemod.h
@@ -137,6 +137,8 @@ public: // ISourceMod
 	bool IsMapRunning();
 	void *FromPseudoAddress(uint32_t pseudoAddr);
 	uint32_t ToPseudoAddress(void *addr);
+	Handle_t CreateCellArrayHandle(IPluginContext *context, ICellArray* array, HandleError *err = nullptr);
+	ICellArray* ReadCellArrayHandle(IPluginContext *context, Handle_t hndl, HandleError *err = nullptr);
 private:
 	void ShutdownServices();
 private:

--- a/public/ICellArray.h
+++ b/public/ICellArray.h
@@ -140,6 +140,18 @@ namespace SourceMod
 		 * @return          Amount of memory used in bytes.
 		 */
 		virtual size_t mem_usage() = 0;
+
+		/**
+		 * @brief Retrieve the implementation size of this array in bytes.
+		 *
+		 * @return          Amount of memory used in bytes.
+		 */
+		virtual size_t size_of() = 0;
+
+		/**
+		 * @brief Delete the array object.
+		 */
+		virtual void delete_this() = 0;
 	};
 }
 

--- a/public/ISourceMod.h
+++ b/public/ISourceMod.h
@@ -38,6 +38,7 @@
  */
 
 #include <IHandleSys.h>
+#include <ICellArray.h>
 #include <sp_vm_api.h>
 #include <time.h>
 
@@ -331,6 +332,28 @@ namespace SourceMod
 		 * @return			Pseudo address, or 0 if memory address could not be converted.
 		 */
 		virtual uint32_t ToPseudoAddress(void *addr) = 0;
+
+		/**
+		 * @brief Wraps the given ICellArray object into an handle.
+		 *
+		 * @param context The plugin context that should own the handle.
+		 * @param array   The cell array object to wrap into the handle.
+		 * @param err     Optional address to store a possible handle error.
+		 *
+		 * @return        The Handle wrapping the ICellArray, or NULL otherwise.
+		 */
+		virtual Handle_t CreateCellArrayHandle(SourcePawn::IPluginContext *context, ICellArray* array, HandleError *err = nullptr) = 0;
+
+		/**
+		 * @brief Retrieves a ICellArray pointer from a handle.
+		 *
+		 * @param context   Plugin context owning the handle.
+		 * @param hndl      Handle from which to retrieve contents.
+		 * @param err       Optional address to store a possible handle error.
+		 *
+		 * @return          The ICellArray object pointer, or nullptr for any error encountered.
+		 */
+		virtual ICellArray* ReadCellArrayHandle(SourcePawn::IPluginContext *context, Handle_t hndl, HandleError *err = nullptr) = 0;
 	};
 }
 


### PR DESCRIPTION
Resolves #720 

Throughout my time using Sourcemod, I've come across multiple situations where being able to create a cell array handle and reading one would have been quite useful when designing natives for my extensions. Instead I've had to resort into creating a new handle type that mimics the behaviour of `ArrayList`, which is a source of many problems. It's extra work to put in place and unnecessary friction for plugin authors that need to read more documentation so they know how to loop through the pseudo-array like object. The current situation also adds an extra layer of complexity should the plugin author wants to make use of the `ArrayList` natives as they'd need to transpose the whole content from the extension's arraylike handle, to a new handle (arraylist) they created.

That feeling seems to have been echoed by other extensions authors in the past (see the linked issue), and still to this day I hear that desire from multiple places. I believe this is a justified addition to the extension API.