### PR TITLE
Fix unused parameter warning in TF2_SetPlayerClass

### DIFF
--- a/plugins/include/tf2_stocks.inc
+++ b/plugins/include/tf2_stocks.inc
@@ -399,6 +399,7 @@ stock TFClassType TF2_GetPlayerClass(int client)
  */
 stock void TF2_SetPlayerClass(int client, TFClassType classType, bool weapons=true, bool persistent=true)
 {
+	#pragma unused weapons
 	SetEntProp(client, Prop_Send, "m_iClass", view_as<int>(classType));
 
 	if (persistent)


### PR DESCRIPTION
Latest sourcepawn submodule update brought in [#sourcepawn/938](https://github.com/alliedmodders/sourcepawn/pull/938), which now causes `TF2_SetPlayerClass` to throw a warning.