### PR TITLE
Add KeyValues.Merge

### DIFF
--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -1113,6 +1113,34 @@ static cell_t smn_KvGetSectionSymbol(IPluginContext *pCtx, const cell_t *params)
 	return 1;
 }
 
+static cell_t KeyValues_Merge(IPluginContext *pContext, const cell_t *params)
+{
+	Handle_t hndl_this = static_cast<Handle_t>(params[1]);
+	Handle_t hndl_other = static_cast<Handle_t>(params[2]);
+	HandleError herr;
+	HandleSecurity sec;
+	KeyValueStack *pStk_this, *pStk_other;
+
+	sec.pOwner = NULL;
+	sec.pIdentity = g_pCoreIdent;
+
+	if ((herr=handlesys->ReadHandle(hndl_this, g_KeyValueType, &sec, (void **)&pStk_this))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid key value handle %x (error %d)", hndl_this, herr);
+	}
+	if ((herr=handlesys->ReadHandle(hndl_other, g_KeyValueType, &sec, (void **)&pStk_other))
+		!= HandleError_None)
+	{
+		return pContext->ThrowNativeError("Invalid key value handle %x (error %d)", hndl_other, herr);
+	}
+
+	pStk_this->pCurRoot.front()->RecursiveMergeKeyValues(pStk_other->pCurRoot.front());
+
+	return 1;
+
+}
+
 static cell_t KeyValues_Import(IPluginContext *pContext, const cell_t *params)
 {
 	// This version takes (dest, src). The original is (src, dest).
@@ -1256,6 +1284,7 @@ REGISTER_NATIVES(keyvaluenatives)
 	{"KeyValues.ExportToFile",			smn_KeyValuesToFile},
 	{"KeyValues.ExportToString",		smn_KeyValuesToString},
 	{"KeyValues.ExportLength.get",		smn_KeyValuesExportLength},
+	{"KeyValues.Merge",					KeyValues_Merge},
 
 	{NULL,						NULL}
 };

--- a/core/smn_keyvalues.cpp
+++ b/core/smn_keyvalues.cpp
@@ -1115,6 +1115,9 @@ static cell_t smn_KvGetSectionSymbol(IPluginContext *pCtx, const cell_t *params)
 
 static cell_t KeyValues_Merge(IPluginContext *pContext, const cell_t *params)
 {
+#if SOURCE_ENGINE == SE_EPISODEONE
+	return pContext->ThrowNativeError("KeyValues.Merge is not supported on this engine version");
+#else
 	Handle_t hndl_this = static_cast<Handle_t>(params[1]);
 	Handle_t hndl_other = static_cast<Handle_t>(params[2]);
 	HandleError herr;
@@ -1138,7 +1141,7 @@ static cell_t KeyValues_Merge(IPluginContext *pContext, const cell_t *params)
 	pStk_this->pCurRoot.front()->RecursiveMergeKeyValues(pStk_other->pCurRoot.front());
 
 	return 1;
-
+#endif
 }
 
 static cell_t KeyValues_Import(IPluginContext *pContext, const cell_t *params)

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -334,6 +334,12 @@ methodmap KeyValues < Handle
 	// @param id            Id of the current section.
 	// @return              True on success, false on failure.
 	public native bool GetSectionSymbol(int &id);
+
+	// Merge from the current position of another KeyValues into the current
+	// position of this one.
+	//
+	// @param other         KeyValues Handle to merge from.
+	public native void Merge(KeyValues other);
 };
 
 /**

--- a/plugins/include/keyvalues.inc
+++ b/plugins/include/keyvalues.inc
@@ -339,6 +339,7 @@ methodmap KeyValues < Handle
 	// position of this one.
 	//
 	// @param other         KeyValues Handle to merge from.
+	// @error               Invalid Handle or unsupported engine version.
 	public native void Merge(KeyValues other);
 };
 


### PR DESCRIPTION
AI in Discord brought up that `Import`/`CopySubkeys` doesn't do what you want if you want to merge together KVs.  Although it does copy the foreign data in, it also replaces the existing data when it does so.  To get around this, his workaround was to manually iterate, create, and import:

```sourcepawn
if (!hKVSource.GotoFirstSubKey(false)) {
    return;
}

char sSectionName[256];
do {
    hKVSource.GetSectionName(sSectionName, sizeof(sSectionName));
    hKVDestination.JumpToKey(sSectionName, true);
    hKVDestination.Import(hKVSource);
    hKVDestination.GoBack();
} while (hKVSource.GotoNextKey(false));
```

With this PR, you should be able to just do `hKVDestination.Merge(hKVSource)`.
