### PR TITLE
Change FunCommands defaults

### DIFF
--- a/plugins/funcommands.sp
+++ b/plugins/funcommands.sp
@@ -130,21 +130,21 @@ void RegisterCvars()
 	g_Cvar_BeaconRadius = CreateConVar("sm_beacon_radius", "375", "Sets the radius for beacon's light rings.", 0, true, 50.0, true, 1500.0);
 
 	// timebomb
-	g_Cvar_TimeBombTicks = CreateConVar("sm_timebomb_ticks", "10.0", "Sets how long the timebomb fuse is.", 0, true, 5.0, true, 120.0);
+	g_Cvar_TimeBombTicks = CreateConVar("sm_timebomb_ticks", "5", "Sets how long the timebomb fuse is.", 0, true, 5.0, true, 120.0);
 	g_Cvar_TimeBombRadius = CreateConVar("sm_timebomb_radius", "600", "Sets the bomb blast radius.", 0, true, 50.0, true, 3000.0);
-	g_Cvar_TimeBombMode = CreateConVar("sm_timebomb_mode", "0", "Who is killed by the timebomb? 0 = Target only, 1 = Target's team, 2 = Everyone", 0, true, 0.0, true, 2.0);
+	g_Cvar_TimeBombMode = CreateConVar("sm_timebomb_mode", "2", "Who is killed by the timebomb? 0 = Target only, 1 = Target's team, 2 = Everyone", 0, true, 0.0, true, 2.0);
 	
 	// fire
-	g_Cvar_BurnDuration = CreateConVar("sm_burn_duration", "20.0", "Sets the default duration of sm_burn and firebomb victims.", 0, true, 0.5, true, 20.0);
-	g_Cvar_FireBombTicks = CreateConVar("sm_firebomb_ticks", "10.0", "Sets how long the FireBomb fuse is.", 0, true, 5.0, true, 120.0);
+	g_Cvar_BurnDuration = CreateConVar("sm_burn_duration", "30", "Sets the default duration of sm_burn and firebomb victims.", 0, true, 0.5, true, 30.0);
+	g_Cvar_FireBombTicks = CreateConVar("sm_firebomb_ticks", "5", "Sets how long the FireBomb fuse is.", 0, true, 5.0, true, 120.0);
 	g_Cvar_FireBombRadius = CreateConVar("sm_firebomb_radius", "600", "Sets the bomb blast radius.", 0, true, 50.0, true, 3000.0);
-	g_Cvar_FireBombMode = CreateConVar("sm_firebomb_mode", "0", "Who is targetted by the FireBomb? 0 = Target only, 1 = Target's team, 2 = Everyone", 0, true, 0.0, true, 2.0);
+	g_Cvar_FireBombMode = CreateConVar("sm_firebomb_mode", "2", "Who is targetted by the FireBomb? 0 = Target only, 1 = Target's team, 2 = Everyone", 0, true, 0.0, true, 2.0);
 	
 	// ice
-	g_Cvar_FreezeDuration = CreateConVar("sm_freeze_duration", "10.0", "Sets the default duration for sm_freeze and freezebomb victims", 0, true, 1.0, true, 120.0);	
-	g_Cvar_FreezeBombTicks = CreateConVar("sm_freezebomb_ticks", "10.0", "Sets how long the freezebomb fuse is.", 0, true, 5.0, true, 120.0);
+	g_Cvar_FreezeDuration = CreateConVar("sm_freeze_duration", "10", "Sets the default duration for sm_freeze and freezebomb victims", 0, true, 1.0, true, 120.0);	
+	g_Cvar_FreezeBombTicks = CreateConVar("sm_freezebomb_ticks", "5", "Sets how long the freezebomb fuse is.", 0, true, 5.0, true, 120.0);
 	g_Cvar_FreezeBombRadius = CreateConVar("sm_freezebomb_radius", "600", "Sets the freezebomb blast radius.", 0, true, 50.0, true, 3000.0);
-	g_Cvar_FreezeBombMode = CreateConVar("sm_freezebomb_mode", "0", "Who is targetted by the freezebomb? 0 = Target only, 1 = Target's team, 2 = Everyone", 0, true, 0.0, true, 2.0);
+	g_Cvar_FreezeBombMode = CreateConVar("sm_freezebomb_mode", "2", "Who is targetted by the freezebomb? 0 = Target only, 1 = Target's team, 2 = Everyone", 0, true, 0.0, true, 2.0);
 	
 	AutoExecConfig(true, "funcommands");
 }


### PR DESCRIPTION
I always thought it was funny that SourceMod had the ability to blow everyone up with the timebomb, so I think it would be cool if this was enabled by default.

I also changed the ticks down to 5 from 10, and increased burn duration to 30.