### PR TITLE
Introduce MemoryPointer

### DIFF
--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -86,6 +86,7 @@ for cxx in builder.targets:
     'DatabaseConfBuilder.cpp',
     'LumpManager.cpp',
     'smn_entitylump.cpp',
+    'MemoryPointer.cpp'
   ]
 
   if binary.compiler.target.arch == 'x86_64':

--- a/core/logic/MemoryPointer.cpp
+++ b/core/logic/MemoryPointer.cpp
@@ -50,6 +50,11 @@ MemoryPointer::~MemoryPointer()
 	}
 }
 
+void MemoryPointer::Delete()
+{
+	delete this;
+}
+
 void* MemoryPointer::Get()
 {
 	return m_ptr;

--- a/core/logic/MemoryPointer.cpp
+++ b/core/logic/MemoryPointer.cpp
@@ -1,0 +1,61 @@
+/**
+ * vim: set ts=4 sw=4 tw=99 noet :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2024 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#include "MemoryPointer.h"
+#include <sourcehook.h>
+#include <sh_memory.h>
+#include <algorithm>
+
+MemoryPointer::MemoryPointer(cell_t size) : m_ptr(malloc(size)), m_owned(true), m_size(size)
+{
+}
+
+MemoryPointer::MemoryPointer(void* ptr, cell_t size) : m_ptr(ptr), m_owned(false), m_size(size)
+{
+}
+
+MemoryPointer::~MemoryPointer()
+{
+	if (m_owned)
+	{
+		free(m_ptr);
+	}
+}
+
+void* MemoryPointer::Get()
+{
+	return m_ptr;
+}
+
+cell_t MemoryPointer::GetSize()
+{
+	return m_size;
+}

--- a/core/logic/MemoryPointer.cpp
+++ b/core/logic/MemoryPointer.cpp
@@ -44,9 +44,10 @@ MemoryPointer::MemoryPointer(void* ptr, cell_t size) : m_ptr(ptr), m_owned(false
 
 MemoryPointer::~MemoryPointer()
 {
-	if (m_owned)
+	if (m_owned && m_ptr)
 	{
 		free(m_ptr);
+		m_ptr = nullptr;
 	}
 }
 

--- a/core/logic/MemoryPointer.h
+++ b/core/logic/MemoryPointer.h
@@ -44,6 +44,7 @@ public:
 
 // SourceMod::IMemoryPointer
 	virtual ~MemoryPointer();
+	virtual void Delete() override;
 	virtual void* Get() override;
 	virtual cell_t GetSize() override;
 protected:

--- a/core/logic/MemoryPointer.h
+++ b/core/logic/MemoryPointer.h
@@ -1,0 +1,53 @@
+/**
+ * vim: set ts=4 sw=4 tw=99 noet :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2024 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#pragma once
+
+#include <memory>
+#include <cstdint>
+#include <sp_vm_types.h>
+#include <IMemoryPointer.h>
+
+class MemoryPointer : public SourceMod::IMemoryPointer
+{
+public:
+	MemoryPointer(cell_t size);
+	MemoryPointer(void* ptr, cell_t size);
+
+// SourceMod::IMemoryPointer
+	virtual ~MemoryPointer();
+	virtual void* Get() override;
+	virtual cell_t GetSize() override;
+protected:
+	void* m_ptr;
+	bool m_owned;
+	cell_t m_size;
+};

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -88,11 +88,13 @@ public:
 		g_PlIter = handlesys->CreateType("PluginIterator", this, 0, NULL, NULL, g_pCoreIdent, NULL);
 		g_FrameIter = handlesys->CreateType("FrameIterator", this, 0, NULL, NULL, g_pCoreIdent, NULL);
 
-		HandleAccess security;
-		security.access[HandleAccess_Read] = 0;
-		security.access[HandleAccess_Delete] = HANDLE_RESTRICT_OWNER;
-		security.access[HandleAccess_Clone] = HANDLE_RESTRICT_IDENTITY | HANDLE_RESTRICT_OWNER;
-		g_MemoryPtr = handlesys->CreateType("MemoryPointer", this, 0, NULL, &security, g_pCoreIdent, NULL);
+		HandleAccess mp_hacc;
+		TypeAccess mp_tacc;
+		mp_hacc.access[HandleAccess_Read] = 0;
+		mp_hacc.access[HandleAccess_Delete] = HANDLE_RESTRICT_OWNER;
+		mp_hacc.access[HandleAccess_Clone] = HANDLE_RESTRICT_IDENTITY | HANDLE_RESTRICT_OWNER;
+		mp_tacc.access[HTypeAccess_Create] = true;
+		g_MemoryPtr = handlesys->CreateType("MemoryPointer", this, 0, &mp_tacc, &mp_hacc, g_pCoreIdent, NULL);
 
 		g_OnLogAction = forwardsys->CreateForward("OnLogAction", 
 			ET_Hook, 

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -1091,6 +1091,7 @@ static cell_t MemoryPointer_StoreMemoryPointer(IPluginContext *pContext, const c
 	}
 
 	ptr->StorePtr(store->Get(), params[3], params[4] != 0);
+	return 0;
 }
 
 static cell_t MemoryPointer_LoadMemoryPointer(IPluginContext *pContext, const cell_t *params)

--- a/core/logic/smn_gameconfigs.cpp
+++ b/core/logic/smn_gameconfigs.cpp
@@ -214,7 +214,7 @@ static cell_t smn_GameConfGetAddressEx(IPluginContext *pCtx, const cell_t *param
 	}
 
 	char *key;
-	void* val;
+	void* val = nullptr;
 	pCtx->LocalToString(params[2], &key);
 
 	if (!gc->GetAddress(key, &val) || val == nullptr)
@@ -248,7 +248,7 @@ static cell_t smn_GameConfGetMemSigEx(IPluginContext *pCtx, const cell_t *params
 	}
 
 	char *key;
-	void *val;
+	void *val = nullptr;
 	pCtx->LocalToString(params[2], &key);
 
 	if (!gc->GetMemSig(key, &val) || val == nullptr)

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -113,7 +113,7 @@ public:
 		// This should never fail
 		handlesys->FindHandleType("MemoryPointer", &g_MemoryPtr);
 	}
-} s_ConsoleHelpers;
+} s_EntitiesHelpers;
 
 enum PropType
 {

--- a/extensions/sdktools/extension.cpp
+++ b/extensions/sdktools/extension.cpp
@@ -92,6 +92,7 @@ SourceHook::CallClass<IVEngineServer> *enginePatch = NULL;
 SourceHook::CallClass<IEngineSound> *enginesoundPatch = NULL;
 HandleType_t g_CallHandle = 0;
 HandleType_t g_TraceHandle = 0;
+HandleType_t g_MemPtrHandle = 0;
 ISDKTools *g_pSDKTools;
 
 SMEXT_LINK(&g_SdkTools);
@@ -166,6 +167,12 @@ bool SDKTools::SDK_OnLoad(char *error, size_t maxlength, bool late)
 		handlesys->RemoveType(g_CallHandle, myself->GetIdentity());
 		g_CallHandle = 0;
 		ke::SafeSprintf(error, maxlength, "Could not create traceray handle type (err: %d)", err);
+		return false;
+	}
+
+	if (!handlesys->FindHandleType("MemoryPointer", &g_MemPtrHandle))
+	{
+		ke::SafeSprintf(error, maxlength, "Could not find MemoryPointer handle type");
 		return false;
 	}
 

--- a/extensions/sdktools/extension.h
+++ b/extensions/sdktools/extension.h
@@ -174,6 +174,7 @@ extern IGameHelpers *g_pGameHelpers;
 /* Handle types */
 extern HandleType_t g_CallHandle;
 extern HandleType_t g_TraceHandle;
+extern HandleType_t g_MemPtrHandle;
 /* Call Wrappers */
 extern ICallWrapper *g_pAcceptInput;
 /* Timers */

--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -183,6 +183,25 @@ static cell_t PrepSDKCall_SetAddress(IPluginContext *pContext, const cell_t *par
 	return (s_call_addr != NULL) ? 1 : 0;
 }
 
+static cell_t PrepSDKCall_SetAddressFromMemoryPointer(IPluginContext *pContext, const cell_t *params)
+{
+	IMemoryPointer* memPtr = nullptr;
+
+	HandleSecurity security;
+	security.pIdentity = myself->GetIdentity();
+	security.pOwner = pContext->GetIdentity();
+
+	HandleError err = HandleError_None;
+	Handle_t hndl = (Handle_t)params[1];
+	if ((err = handlesys->ReadHandle(hndl, g_MemPtrHandle, &security, (void **)&memPtr)) != HandleError_None)
+	{
+		return pContext->ThrowNativeError("Could not read MemoryPointer Handle %x (error %d)", hndl, err);
+	}
+
+	s_call_addr = memPtr->Get();
+	return (s_call_addr != NULL) ? 1 : 0;
+}
+
 // Must match same enum in sdktools.inc
 enum SDKFuncConfSource
 {
@@ -597,6 +616,7 @@ sp_nativeinfo_t g_CallNatives[] =
 	{"PrepSDKCall_SetVirtual",		PrepSDKCall_SetVirtual},
 	{"PrepSDKCall_SetSignature",	PrepSDKCall_SetSignature},
 	{"PrepSDKCall_SetAddress",		PrepSDKCall_SetAddress},
+	{"PrepSDKCall_SetAddressFromMemoryPointer",		PrepSDKCall_SetAddressFromMemoryPointer},
 	{"PrepSDKCall_SetFromConf",		PrepSDKCall_SetFromConf},
 	{"PrepSDKCall_SetReturnInfo",	PrepSDKCall_SetReturnInfo},
 	{"PrepSDKCall_AddParameter",	PrepSDKCall_AddParameter},

--- a/extensions/sdktools/vdecoder.cpp
+++ b/extensions/sdktools/vdecoder.cpp
@@ -660,7 +660,9 @@ DataStatus DecodeValveParam(IPluginContext *pContext,
 			security.pIdentity = myself->GetIdentity();
 			security.pOwner = pContext->GetIdentity();
 
-			Handle_t hndl = (Handle_t)param;
+			cell_t* addr;
+			pContext->LocalToPhysAddr(param, &addr);
+			Handle_t hndl = (Handle_t)*addr;
 
 			if (hndl == 0)
 			{

--- a/extensions/sdktools/vdecoder.cpp
+++ b/extensions/sdktools/vdecoder.cpp
@@ -46,6 +46,11 @@ public:
 	{
 	}
 
+	virtual void Delete() override
+	{
+		delete this;
+	}
+
 	virtual void* Get() override
 	{
 		return m_ptr;

--- a/extensions/sdktools/vdecoder.h
+++ b/extensions/sdktools/vdecoder.h
@@ -53,6 +53,7 @@ enum ValveType
 	Valve_Edict,			/**< Edict */
 	Valve_String,			/**< String */
 	Valve_Bool,				/**< Boolean */
+	Valve_MemoryPointer,    /**< Sourcemod's IMemoryPointer */
 	Valve_Object,			/**< Object, not matching one of the above types */
 };
 
@@ -84,6 +85,7 @@ enum ValveCallType
 	ValveCall_Raw, 		/**< Thiscall (address explicit first parameter) */
 	ValveCall_Server,       /**< Thiscall (CBaseServer implicit first parameter) */
 	ValveCall_Engine,       /**< Thiscall (CVEngineServer implicit first parameter) */
+	ValveCall_MemoryPointer /**< Thiscall (Sourcemod's IMemoryPointer handle implicit first parameter */
 };
 
 /**

--- a/plugins/include/entity.inc
+++ b/plugins/include/entity.inc
@@ -751,7 +751,17 @@ stock void SetEntDataArray(int entity, int offset, const any[] array, int arrayS
  * @return              Address of the entity.
  * @error               Invalid entity.
  */
+#pragma deprecated Use GetEntityMemoryPointer instead
 native Address GetEntityAddress(int entity);
+
+/**
+ * Gets the memory address of an entity and wraps into a new MemoryPointer handle.
+ *
+ * @param entity        Entity index.
+ * @return              New MemoryPointer handle.
+ * @error               Invalid entity.
+ */
+native MemoryPointer GetEntityMemoryPointer(int entity);
 
 /**
  * Retrieves the classname of an entity.
@@ -774,6 +784,7 @@ stock bool GetEntityClassname(int entity, char[] clsname, int maxlength)
  * @param addr          Address to a memory location.
  * @return              Entity index at the given location.  If there is no entity, or the stored entity is invalid, then -1 is returned.
  */
+#pragma deprecated Use MemoryPointer.LoadEntityFromHandle instead
 native int LoadEntityFromHandleAddress(Address addr);
 
 /**
@@ -782,4 +793,5 @@ native int LoadEntityFromHandleAddress(Address addr);
  * @param addr          Address to a memory location.
  * @param entity        Entity index to set, or -1 to clear.
  */
+#pragma deprecated Use MemoryPointer.StoreEntityToHandle instead
 native void StoreEntityToHandleAddress(Address addr, int entity);

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -140,7 +140,17 @@ native bool PrepSDKCall_SetSignature(SDKLibrary lib, const char[] signature, int
  * @param addr          Address of function to use.
  * @return              True on success, false on failure.
  */
+#pragma deprecated Use PrepSDKCall_SetAddressFromMemoryPointer instead
 native bool PrepSDKCall_SetAddress(Address addr);
+
+/**
+ * Uses the given pointer value as function address for the SDK call.
+ *
+ * @param handle        Handle to a MemoryPointer.
+ * @return              True on success, false on failure.
+ * @error               Invalid handle.
+ */
+native bool PrepSDKCall_SetAddressFromMemoryPointer(MemoryPointer handle);
 
 /**
  * Finds an address or virtual function index in a GameConfig file and sets it as

--- a/plugins/include/sdktools.inc
+++ b/plugins/include/sdktools.inc
@@ -62,7 +62,8 @@ enum SDKCallType
 	SDKCall_EntityList,     /**< CGlobalEntityList call */
 	SDKCall_Raw,            /**< |this| pointer with an arbitrary address */
 	SDKCall_Server,         /**< CBaseServer call */
-	SDKCall_Engine          /**< CVEngineServer call */
+	SDKCall_Engine,         /**< CVEngineServer call */
+	SDKCall_MemoryPointer   /**< |this| pointer retrieved from a MemoryPointer handle */
 };
 
 enum SDKLibrary
@@ -88,7 +89,8 @@ enum SDKType
 	SDKType_Float,          /**< Float (any) */
 	SDKType_Edict,          /**< edict_t (always as pointer) */
 	SDKType_String,         /**< NULL-terminated string (always as pointer) */
-	SDKType_Bool            /**< Boolean (any) */
+	SDKType_Bool,           /**< Boolean (any) */
+	SDKType_MemoryPointer   /**< Sourcemod MemoryPointer handle */
 };
 
 enum SDKPassMethod

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -113,13 +113,28 @@ methodmap GameData < Handle
 	//
 	// @param name          Name of the property to find.
 	// @return              An address calculated on success, or 0 on failure.
+	#pragma deprecated Use GameData.GetAddressEx instead
 	public native Address GetAddress(const char[] name);
+
+	// Finds an address calculation in a GameConfig file,
+	// performs LoadFromAddress on it as appropriate, then returns the final address as a new MemoryPointer handle.
+	//
+	// @param name          Name of the property to find.
+	// @return              New MemoryPointer handle containing the address calculated on success, or null on failure.
+	public native Address GetAddressEx(const char[] name);
 
 	// Returns a function address calculated from a signature.
 	//
 	// @param name          Name of the property to find.
 	// @return              An address calculated on success, or 0 on failure.
+	#pragma deprecated Use GameData.GetMemSigEx instead
 	public native Address GetMemSig(const char[] name);
+
+	// Returns a function address calculated from a signature as new MemoryPointer handle.
+	//
+	// @param name          Name of the property to find.
+	// @return              New MemoryPointer handle containing the address calculated on success, or null on failure.
+	public native Address GetMemSigEx(const char[] name);
 };
 
 /**
@@ -467,6 +482,7 @@ native bool GameConfGetKeyValue(Handle gc, const char[] key, char[] buffer, int 
  * @param name          Name of the property to find.
  * @return              An address calculated on success, or 0 on failure.
  */
+#pragma deprecated Use GameData.GetAddressEx instead
 native Address GameConfGetAddress(Handle gameconf, const char[] name);
 
 /**
@@ -739,6 +755,7 @@ enum Address
  * @return              The value that is stored at that address.
  * @error               Address is null or pointing to reserved memory.
  */
+#pragma deprecated Use MemoryPointer.Load instead
 native any LoadFromAddress(Address addr, NumberType size);
 
 /**
@@ -752,6 +769,7 @@ native any LoadFromAddress(Address addr, NumberType size);
  *                                 on the memory page being written to.
  * @error                          Address is null or pointing to reserved memory.
  */
+#pragma deprecated Use MemoryPointer.Store instead
 native void StoreToAddress(Address addr, any data, NumberType size, bool updateMemAccess = true);
 
 methodmap MemoryPointer < Handle {
@@ -761,9 +779,11 @@ methodmap MemoryPointer < Handle {
 	public native MemoryPointer(int size);
 	
 	// Stores the given data at the provided offset.
-	// @param data          The data to store.
-	// @param size          Size of the data to store.
-	// @param offset        Offset in bytes from the start.
+	// @param data            The data to store.
+	// @param size            Size of the data to store.
+	// @param offset          Offset in bytes from the start.
+	// @param updateMemAccess If true, SourceMod will set read / write / exec permissions
+    //                        on the memory page being written to.
 	public native void Store(any data, NumberType size, int offset = 0, bool updateMemAccess = true);
 
 	// Retrieves the data at the provided offset.
@@ -771,6 +791,33 @@ methodmap MemoryPointer < Handle {
 	// @param offset        Offset in bytes from the start.
 	// @return              The data that was stored.
 	public native any Load(NumberType size, int offset = 0);
+
+	// Stores the given entity index into a CHandle at the provided offset.
+	// @param entity          Entity index to store, -1 to clear.
+	// @param offset          Offset in bytes from the start.
+	public native void StoreEntityToHandle(int entity, int offset = 0);
+
+	// Retrieves the entity index from the CHandle at the provided offset.
+	// @param offset        Offset in bytes from the start.
+	// @return              Entity index at the given location.  If there is no entity, or the stored entity is invalid, then -1 is returned.
+	public native int LoadEntityFromHandle(int offset = 0);
+
+	// Stores a memory pointer at the provided offset.
+	// @param handle          Handle to the memory pointer to store.
+	// @param offset          Offset in bytes from the start.
+	// @param updateMemAccess If true, SourceMod will set read / write / exec permissions
+	//                        on the memory page being written to.
+	public native void StoreMemoryPointer(MemoryPointer handle, int offset = 0, bool updateMemAccess = true);
+
+	// Wraps the data loaded at the provided offset into a new MemoryPointer handle.
+	// @param offset          Offset in bytes from the start.
+	// @return                New Handle to a memory pointer.
+	public native MemoryPointer LoadMemoryPointer(int offset = 0);
+
+	// Creates a new MemoryPointer handle by offsetting the base pointer.
+	// @param size          Offset from base pointer in bytes.
+	// @return              New Handle to a memory pointer.
+	public native MemoryPointer Offset(int offset);
 };
 
 methodmap FrameIterator < Handle {

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -754,6 +754,25 @@ native any LoadFromAddress(Address addr, NumberType size);
  */
 native void StoreToAddress(Address addr, any data, NumberType size, bool updateMemAccess = true);
 
+methodmap MemoryPointer < Handle {
+	// Creates a memory block of the given bytes size.
+	// And wrap its pointer into a MemoryPointer handle.
+	// @return              New Handle to a memory pointer.
+	public native MemoryPointer(int size);
+	
+	// Stores the given data at the provided offset.
+	// @param data          The data to store.
+	// @param size          Size of the data to store.
+	// @param offset        Offset in bytes from the start.
+	public native void Store(any data, NumberType size, int offset = 0, bool updateMemAccess = true);
+
+	// Retrieves the data at the provided offset.
+	// @param size          Size of the data to store.
+	// @param offset        Offset in bytes from the start.
+	// @return              The data that was stored.
+	public native any Load(NumberType size, int offset = 0);
+};
+
 methodmap FrameIterator < Handle {
 	// Creates a stack frame iterator to build your own stack traces.
 	// @return              New handle to a FrameIterator.

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -121,7 +121,7 @@ methodmap GameData < Handle
 	//
 	// @param name          Name of the property to find.
 	// @return              New MemoryPointer handle containing the address calculated on success, or null on failure.
-	public native Address GetAddressEx(const char[] name);
+	public native MemoryPointer GetAddressEx(const char[] name);
 
 	// Returns a function address calculated from a signature.
 	//
@@ -134,7 +134,7 @@ methodmap GameData < Handle
 	//
 	// @param name          Name of the property to find.
 	// @return              New MemoryPointer handle containing the address calculated on success, or null on failure.
-	public native Address GetMemSigEx(const char[] name);
+	public native MemoryPointer GetMemSigEx(const char[] name);
 };
 
 /**

--- a/public/IMemoryPointer.h
+++ b/public/IMemoryPointer.h
@@ -44,6 +44,11 @@ namespace SourceMod
 		virtual ~IMemoryPointer() = default;
 
 		/**
+		 * @brief Deletes the Memory pointer.
+		 */
+		virtual void Delete() = 0;
+
+		/**
 		 * @brief Retrieves the underlying pointer.
 		 *
 		 * @return			The underlying pointer.
@@ -65,7 +70,7 @@ namespace SourceMod
 		 * @param offset                Offset in bytes to store the data at.
 		 * @param updateMemAccess       Whether or not to update the memory access before writing.
 		 */
-		virtual void Store(cell_t data, unsigned int byteSize, cell_t offset, bool updateMemAccess);
+		void Store(cell_t data, unsigned int byteSize, cell_t offset, bool updateMemAccess);
 
 		/**
 		 * @brief Loads data at the given offset.
@@ -74,8 +79,43 @@ namespace SourceMod
 		 * @param offset                Offset in bytes to read the data at.
 		 * @return                      The data stored at the given offset.
 		 */
-		virtual cell_t Load(unsigned int byteSize, cell_t offset);
+		cell_t Load(unsigned int byteSize, cell_t offset);
+
+		/**
+		 * @brief Stores a pointer at the given offset.
+		 *
+		 * @param data                  The pointer to store.
+		 * @param offset                Offset in bytes to store the data at.
+		 * @param updateMemAccess       Whether or not to update the memory access before writing.
+		 */
+		void StorePtr(void* data, cell_t offset, bool updateMemAccess);
+
+		/**
+		 * @brief Loads pointer at the given offset.
+		 *
+		 * @param offset                Offset in bytes to read the data at.
+		 * @return                      The pointer stored at the given offset.
+		 */
+		void* LoadPtr(cell_t offset);
 	};
+
+	inline void IMemoryPointer::StorePtr(void* data, cell_t offset, bool updateMemAccess)
+	{
+		auto ptr = &(((std::int8_t*)this->Get())[offset]);
+		if (updateMemAccess)
+		{
+			SourceHook::SetMemAccess(ptr, sizeof(void*), SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		}
+
+		*(void**)ptr = data;
+	}
+
+	inline void* IMemoryPointer::LoadPtr(cell_t offset)
+	{
+		auto ptr = &(((std::int8_t*)this->Get())[offset]);
+
+		return *(void**)ptr;
+	}
 
 	inline void IMemoryPointer::Store(cell_t data, unsigned int byteSize, cell_t offset, bool updateMemAccess)
 	{

--- a/public/IMemoryPointer.h
+++ b/public/IMemoryPointer.h
@@ -1,0 +1,107 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2024 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#pragma once
+
+#include <sourcehook.h>
+#include <sh_memory.h>
+#include <cstdint>
+#include <sp_vm_types.h>
+
+namespace SourceMod
+{
+	class IMemoryPointer
+	{
+	public:
+		virtual ~IMemoryPointer() = default;
+
+		/**
+		 * @brief Retrieves the underlying pointer.
+		 *
+		 * @return			The underlying pointer.
+		 */
+		virtual void* Get() = 0;
+
+		/**
+		 * @brief Approximate size in bytes of the memory block pointed by the pointer.
+		 *
+		 * @return			The pointed memory size in bytes, 0 if size is unknown.
+		 */
+		virtual cell_t GetSize() = 0;
+
+		/**
+		 * @brief Stores data at the given offset.
+		 *
+		 * @param data                  The data to store.
+		 * @param byteSize              Size of the data in bytes.
+		 * @param offset                Offset in bytes to store the data at.
+		 * @param updateMemAccess       Whether or not to update the memory access before writing.
+		 */
+		virtual void Store(cell_t data, unsigned int byteSize, cell_t offset, bool updateMemAccess);
+
+		/**
+		 * @brief Loads data at the given offset.
+		 *
+		 * @param byteSize              Size of the data in bytes.
+		 * @param offset                Offset in bytes to read the data at.
+		 * @return                      The data stored at the given offset.
+		 */
+		virtual cell_t Load(unsigned int byteSize, cell_t offset);
+	};
+
+	inline void IMemoryPointer::Store(cell_t data, unsigned int byteSize, cell_t offset, bool updateMemAccess)
+	{
+		auto ptr = &(((std::int8_t*)this->Get())[offset]);
+		if (updateMemAccess)
+		{
+			SourceHook::SetMemAccess(ptr, byteSize, SH_MEM_READ|SH_MEM_WRITE|SH_MEM_EXEC);
+		}
+
+		memcpy(ptr, &data, byteSize);
+	}
+
+	inline cell_t IMemoryPointer::Load(unsigned int byteSize, cell_t offset)
+	{
+		auto ptr = &(((std::int8_t*)this->Get())[offset]);
+
+		switch(byteSize)
+		{
+			case 1:
+				return *(std::int8_t*)(ptr);
+			case 2:
+				return *(std::int16_t*)(ptr);
+			case 4:
+				return *(std::int32_t*)(ptr);
+			default:
+				return 0;
+		}
+	}
+}


### PR DESCRIPTION
_This whole PR is still an heavy draft, nothing has been field tested._

## Introduction

As of today no immediate solution to `PseudoAddress` has been explored. Only third-party solutions like [NotnHeavy/SM-Address64](https://github.com/NotnHeavy/SM-Address64) & [skial-com/port64](https://github.com/skial-com/port64) have been made, but no major adoption so far. And while those solutions can work, I believe the friction for plugin authors is quite high. Now having to worry about the server architecture, and the confusing concept of treating ptrs as array of int/any.

## Explanation

Given that there's no timeline as for when enum struct natives will ever be a thing. I propose instead to expose a new handle type that shall act as an opaque pointer towards abitrary memory regions. The underlying C++ class `IMemoryPointer` contained by the handle type is exposed as a public header. Allowing third-party extensions to wrap their pointers into it, no longer having to rely and depend on `cell_t` capacity to store the pointer's value on 32 bits.

`IMemoryPointer` shall become the defacto standard to pass abitrary pointers around for plugins & extensions.

### List of natives

`MemoryPointer.MemoryPointer(int size)`
Allocates an abitrary amount of memory.

`MemoryPointer.Load`
Similar to `LoadFromAddress` native.

`MemoryPointer.Store`
Similar to `StoreToAddress` native.

`MemoryPointer.Offset`
Offsets the base pointer, and creates a new MemoryPointer handle.

`MemoryPointer.LoadMemoryPointer`
Interprets the loaded data as an address and wraps it into a new MemoryPointer handle.

`MemoryPointer.StoreMemoryPointer`
Retrieves the pointer's value wrapped inside the MemoryPointer handle, and stores it.

`MemoryPointer.LoadEntityFromHandle`
Similar to `LoadEntityFromHandleAddress` native.

`MemoryPointer.StoreEntityToHandle`
Similar to `StoreEntityToHandleAddress` native.

`GameData.GetMemSigEx`
Similar to `GameData.GetMemSig` but wraps the pointer into a `MemoryPointer` handle.

`GameData.GetAddressEx`
Similar to `GameData.GetAddress` but wraps the pointer into a `MemoryPointer` handle.

`GetEntityMemoryPointer`
Similar to `GetEntityAddress` but wraps the entity pointer into a `MemoryPointer` handle.

`SDKCall_MemoryPointer`
New sdkcall type to allow member function calls from the ptr contained by a MemoryPointer handle.

`SDKType_MemoryPointer`
New sdkparam type, to retrieve the abitrary ptr contained inside a `MemoryPointer` handle. `INVALID_HANDLE` / `null` are allowed values to represent nullptr, if allow null flag was passed.

`PrepSDKCall_SetAddressFromMemoryPointer`
Similar to `PrepSDKCall_SetAddress` native.

Ultimately this PR aims to supersede #2159 & #2112