### PR TITLE
Update gamedata engine.ep2v.txt for 64 bits

### DIFF
--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -37,7 +37,7 @@
 			"GetMaxHealth"
 			{
 				"windows"	"122"
-				"windows64"	"123"
+				"windows64"	"122"
 				"linux"		"123"
 				"linux64"	"123"
 			}


### PR DESCRIPTION
GetMaxHealth in this file has the Windows 64 bit signature wrong using the Linux 32 bit/64 bit signature resulting in crashes.