### PR TITLE
- Fixes for OnPlayerTeleport hook for linux and linux64 systems

### DIFF
--- a/extensions/tf2/teleporter.cpp
+++ b/extensions/tf2/teleporter.cpp
@@ -37,7 +37,18 @@ IForward *g_teleportForward = NULL;
 
 class CTFPlayer;
 
+#if defined(__linux__) && defined(__i386__)
+class CanPlayerBeTeleportedClass
+{
+public:
+	__attribute__((regparm(2))) bool CanPlayerBeTeleported(CTFPlayer * pPlayer); 
+	static __attribute__((regparm(2))) bool (CanPlayerBeTeleportedClass::* CanPlayerBeTeleported_Actual)(CTFPlayer *);
+};
+__attribute__((regparm(2))) bool (CanPlayerBeTeleportedClass::* CanPlayerBeTeleportedClass::CanPlayerBeTeleported_Actual)(CTFPlayer *) = NULL;
+__attribute__((regparm(2))) bool CanPlayerBeTeleportedClass::CanPlayerBeTeleported(CTFPlayer* pPlayer)
+#else
 DETOUR_DECL_MEMBER1(CanPlayerBeTeleported, bool, CTFPlayer *, pPlayer)
+#endif
 {
 	bool origCanTeleport = DETOUR_MEMBER_CALL(CanPlayerBeTeleported)(pPlayer);
 

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -132,8 +132,8 @@
 				"library"	"server"
 				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A"
 				"windows64"	"\x48\x89\x5C\x24\x08\x48\x89\x74\x24\x10\x57\x48\x83\xEC\x20\x48\x8B\xFA\x48\x8B\xF1\x48\x85\xD2\x0F\x84\x2A\x2A\x2A\x2A\x45\x33\xC0"
-				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
-				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
+				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
+				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
 			}
 			
 			// Obsolete


### PR DESCRIPTION
  - Changed signature call of `CanPlayerTeleport` for linux/linux64 to current used name
  - Applied fix at detour class `CanPlayerBeTeleported` to use standard parameter proceedings for linux

Fixes issue #2140 

Fix tested on:
  - Linux Mint 21.3, built in Ubuntu 20.04, working properly
  - Windows 10, working properly