### PR TITLE
Add new options to ArrayList FindString, FindValue

### DIFF
--- a/plugins/include/adt_array.inc
+++ b/plugins/include/adt_array.inc
@@ -207,19 +207,28 @@ methodmap ArrayList < Handle {
 	// Returns the index for the first occurrence of the provided string. If
 	// the string cannot be located, -1 will be returned.
 	//
-	// @param item          String to search for
-	// @param block         Optionally which block to search in
+	// @param item          String to search for.
+	// @param block         Optionally which block to search in.
+	// @param start         Index to start searching from (exclusive), or -1 for direction default.
+	//                      Valid numbers are in the interval [-1..Length].
+	// @param reverse       Whether the search direction should be reversed.
+	// @param caseSensitive If true (default), comparison is case sensitive.
+	//                      If false, comparison is case insensitive.
 	// @return              Array index, or -1 on failure
-	public native int FindString(const char[] item, int block=0);
+	// @error               Invalid block, or invalid start index.
+	public native int FindString(const char[] item, int block=0, int start=-1, bool reverse=false, bool caseSensitive=true);
 
 	// Returns the index for the first occurrence of the provided value. If the
 	// value cannot be located, -1 will be returned.
 	//
-	// @param item          Value to search for
-	// @param block         Optionally which block to search in
-	// @return              Array index, or -1 on failure
-	// @error               Invalid block index
-	public native int FindValue(any item, int block=0);
+	// @param item          Value to search for.
+	// @param block         Optionally which block to search in.
+	// @param start         Index to start searching from (exclusive), or -1 for direction default.
+	//                      Valid numbers are in the interval [-1..Length].
+	// @param reverse       Whether the search direction should be reversed.
+	// @return              Array index, or -1 on failure.
+	// @error               Invalid block, or invalid start index.
+	public native int FindValue(any item, int block=0, int start=-1, bool reverse=false);
 
 	// Sort an ADT Array. Specify the type as Integer, Float, or String.
 	//

--- a/plugins/testsuite/mock/test_arraylist_find.sp
+++ b/plugins/testsuite/mock/test_arraylist_find.sp
@@ -1,0 +1,141 @@
+#pragma semicolon 1
+#pragma newdecls required
+#include <testing>
+
+enum struct TestStruct
+{
+	int intval;
+	char strval[32];
+}
+
+public void OnPluginStart()
+{
+	ArrayList list = new ArrayList(sizeof(TestStruct));
+	
+	// --------------------------------------------------------------------------------
+
+	SetTestContext("EmptyArrayTest");
+
+	AssertEq("test_forward", list.FindString("index3", TestStruct::strval, -1, false), -1);
+	AssertEq("test_reverse", list.FindString("index3", TestStruct::strval, -1, true), -1);
+	AssertEq("test_forward", list.FindValue(3, TestStruct::intval, -1, false), -1);
+	AssertEq("test_reverse", list.FindValue(3, TestStruct::intval, -1, true), -1);
+
+	// --------------------------------------------------------------------------------
+
+	// Fill
+	TestStruct ts;
+	for (int i = 0; i < 10; i++)
+	{
+		ts.intval = i;
+		Format(ts.strval, sizeof(ts.strval), "index%d", i);
+		list.PushArray(ts);
+	}
+
+	// --------------------------------------------------------------------------------
+
+	SetTestContext("FindString");
+
+	AssertEq("test_defaults", list.FindString("index3", TestStruct::strval), 3);
+
+	AssertEq("test_forward", list.FindString("index3", TestStruct::strval, -1, false), 3);
+	AssertEq("test_forward", list.FindString("index3", TestStruct::strval, 0, false), 3);
+	AssertEq("test_forward", list.FindString("index3", TestStruct::strval, 2, false), 3);
+	AssertEq("test_forward", list.FindString("index3", TestStruct::strval, 3, false), -1);
+	AssertEq("test_forward", list.FindString("index3", TestStruct::strval, 10, false), -1);
+
+	AssertEq("test_reverse", list.FindString("index3", TestStruct::strval, -1, true), 3);
+	AssertEq("test_reverse", list.FindString("index3", TestStruct::strval, 0, true), -1);
+	AssertEq("test_reverse", list.FindString("index3", TestStruct::strval, 3, true), -1);
+	AssertEq("test_reverse", list.FindString("index3", TestStruct::strval, 4, true), 3);
+	AssertEq("test_reverse", list.FindString("index3", TestStruct::strval, 10, true), 3);
+
+	AssertEq("test_bottom", list.FindString("index0", TestStruct::strval, -1, false), 0);
+	AssertEq("test_bottom", list.FindString("index0", TestStruct::strval, -1, true), 0);
+	AssertEq("test_bottom", list.FindString("index0", TestStruct::strval, 1, true), 0);
+	AssertEq("test_bottom", list.FindString("index0", TestStruct::strval, 10, false), -1);
+	AssertEq("test_bottom", list.FindString("index0", TestStruct::strval, 10, true), 0);
+
+	AssertEq("test_top", list.FindString("index9", TestStruct::strval, -1, false), 9);
+	AssertEq("test_top", list.FindString("index9", TestStruct::strval, -1, true), 9);
+	AssertEq("test_top", list.FindString("index9", TestStruct::strval, 8, false), 9);
+	AssertEq("test_top", list.FindString("index9", TestStruct::strval, 10, false), -1);
+	AssertEq("test_top", list.FindString("index9", TestStruct::strval, 10, true), 9);
+	
+	AssertEq("test_case_sensitive", list.FindString("INDEX0", TestStruct::strval, .caseSensitive = true), -1);
+	AssertEq("test_case_sensitive", list.FindString("INDEX0", TestStruct::strval, .caseSensitive = false), 0);
+
+	// --------------------------------------------------------------------------------
+
+	SetTestContext("FindValue");
+
+	AssertEq("test_defaults", list.FindValue(3, TestStruct::intval), 3);
+
+	AssertEq("test_forward", list.FindValue(3, TestStruct::intval, -1, false), 3);
+	AssertEq("test_forward", list.FindValue(3, TestStruct::intval, 0, false), 3);
+	AssertEq("test_forward", list.FindValue(3, TestStruct::intval, 2, false), 3);
+	AssertEq("test_forward", list.FindValue(3, TestStruct::intval, 3, false), -1);
+	AssertEq("test_forward", list.FindValue(3, TestStruct::intval, 10, false), -1);
+
+	AssertEq("test_reverse", list.FindValue(3, TestStruct::intval, -1, true), 3);
+	AssertEq("test_reverse", list.FindValue(3, TestStruct::intval, 0, true), -1);
+	AssertEq("test_reverse", list.FindValue(3, TestStruct::intval, 3, true), -1);
+	AssertEq("test_reverse", list.FindValue(3, TestStruct::intval, 4, true), 3);
+	AssertEq("test_reverse", list.FindValue(3, TestStruct::intval, 10, true), 3);
+
+	AssertEq("test_bottom", list.FindValue(0, TestStruct::intval, -1, false), 0);
+	AssertEq("test_bottom", list.FindValue(0, TestStruct::intval, -1, true), 0);
+	AssertEq("test_bottom", list.FindValue(0, TestStruct::intval, 1, true), 0);
+	AssertEq("test_bottom", list.FindValue(0, TestStruct::intval, 10, false), -1);
+	AssertEq("test_bottom", list.FindValue(0, TestStruct::intval, 10, true), 0);
+
+	AssertEq("test_top", list.FindValue(9, TestStruct::intval, -1, false), 9);
+	AssertEq("test_top", list.FindValue(9, TestStruct::intval, -1, true), 9);
+	AssertEq("test_top", list.FindValue(9, TestStruct::intval, 8, false), 9);
+	AssertEq("test_top", list.FindValue(9, TestStruct::intval, 10, false), -1);
+	AssertEq("test_top", list.FindValue(9, TestStruct::intval, 10, true), 9);
+	
+	// --------------------------------------------------------------------------------
+
+	SetTestContext("IterateOverFindString");
+	int found, index;
+
+	// Duplicate last entry
+	list.PushArray(ts);
+
+	found = 0; index = -1;
+	while ((index = list.FindString("index9", TestStruct::strval, index, false)) != -1)
+	{
+		found++;
+	}
+	AssertEq("test_find_all_strings_forward", found, 2);
+
+	found = 0; index = -1;
+	while ((index = list.FindString("index9", TestStruct::strval, index, true)) != -1)
+	{
+		found++;
+	}
+	AssertEq("test_find_all_strings_reverse", found, 2);
+	
+	// --------------------------------------------------------------------------------
+	
+	SetTestContext("IterateOverFindValue");
+
+	found = 0, index = -1;
+	while ((index = list.FindValue(9, TestStruct::intval, index, false)) != -1)
+	{
+		found++;
+	}
+	AssertEq("test_find_all_values_forward", found, 2);
+
+	found = 0; index = -1;
+	while ((index = list.FindValue(9, TestStruct::intval, index, true)) != -1)
+	{
+		found++;
+	}
+	AssertEq("test_find_all_values_reverse", found, 2);
+
+	// --------------------------------------------------------------------------------
+
+	PrintToServer("OK");
+}


### PR DESCRIPTION
Adds new optional parameters to ArrayList find natives.

- FindString: start index, reverse search, case sensitivity
- FindValue: start index, reverse search

The intention is to cover most remaining use cases of easily and efficiently iterating over enum struct ArrayLists.
Test is included in PR, tested on linux, passed.

_I am still learning, so excuse any newbie mistakes. I'm open to suggestions._