### PR TITLE
Update Half-Life 2: Deathmatch Gamedata

### DIFF
--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -203,147 +203,123 @@
 			}
 			"EndTouch"
 			{
-				"windows"	"100"
-				"linux"		"101"
-				"mac"		"101"
+				"windows"	"102"
+				"linux"		"103"
 			}
 			"FireBullets"
 			{
-				"windows"	"112"
-				"linux"		"113"
-				"mac"		"113"
+				"windows"	"114"
+				"linux"		"115"
 			}
 			"GetMaxHealth"
 			{
-				"windows"	"117"
-				"linux"		"118"
-				"mac"		"118"				
+				"windows"	"119"
+				"linux"		"120"			
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"177"
-				"linux"		"179"
-				"mac"		"179"
+				"windows"	"180"
+				"linux"		"182"
 			}
 			"OnTakeDamage"
 			{
-				"windows"	"62"
-				"linux"		"63"
-				"mac"		"63"
+				"windows"	"64"
+				"linux"		"65"
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"272"
-				"linux"		"273"
-				"mac"		"273"
+				"windows"	"278"
+				"linux"		"279"
 			}
 			"PreThink"
 			{
-				"windows"	"332"
-				"linux"		"333"
-				"mac"		"333"
+				"windows"	"338"
+				"linux"		"339"
 			}
 			"PostThink"
 			{
-				"windows"	"333"
-				"linux"		"334"
-				"mac"		"334"
+				"windows"	"339"
+				"linux"		"340"
 			}
 			"Reload"
 			{
-				"windows"	"270"
-				"linux"		"271"
-				"mac"		"271"
+				"windows"	"276"
+				"linux"		"277"
 			}
 			"SetTransmit"
 			{
 				"windows"	"20"
 				"linux"		"21"
-				"mac"		"21"
 			}
 			"ShouldCollide"
 			{
-				"windows"	"16"
-				"linux"		"17"
-				"mac"		"17"
+				"windows"	"17"
+				"linux"		"18"
 			}
 			"Spawn"
 			{
-				"windows"	"22"
-				"linux"		"23"
-				"mac"		"23"
+				"windows"	"24"
+				"linux"		"25"
 			}
 			"StartTouch"
 			{
-				"windows"	"98"
-				"linux"		"99"
-				"mac"		"99"
+				"windows"	"100"
+				"linux"		"101"
 			}
 			"Think"
 			{
-				"windows"	"47"
-				"linux"		"48"
-				"mac"		"48"
+				"windows"	"49"
+				"linux"		"50"
 			}
 			"Touch"
 			{
-				"windows"	"99"
-				"linux"		"100"
-				"mac"		"100"
+				"windows"	"101"
+				"linux"		"102"
 			}
 			"TraceAttack"
 			{
-				"windows"	"60"
-				"linux"		"61"
-				"mac"		"61"
+				"windows"	"62"
+				"linux"		"63"
 			}
 			"Use"
 			{
-				"windows"	"97"
-				"linux"		"98"
-				"mac"		"98"
+				"windows"	"99"
+				"linux"		"100"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"157"
-				"linux"		"158"
-				"mac"		"158"
+				"windows"	"160"
+				"linux"		"161"
 			}
 			"Blocked"
 			{
-				"windows"	"102"
-				"linux"		"103"
-				"mac"		"103"
+				"windows"	"104"
+				"linux"		"105"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"266"
-				"linux"		"267"
-				"mac"		"267"
+				"windows"	"272"
+				"linux"		"273"
 			}
 			"Weapon_CanUse"
 			{
-				"windows"	"260"
-				"linux"		"261"
-				"mac"		"261"
+				"windows"	"266"
+				"linux"		"267"
 			}
 			"Weapon_Drop"
 			{
-				"windows"	"263"
-				"linux"		"264"
-				"mac"		"264"
+				"windows"	"269"
+				"linux"		"270"
 			}
 			"Weapon_Equip"
 			{
-				"windows"	"261"
-				"linux"		"262"
-				"mac"		"262"
+				"windows"	"267"
+				"linux"		"268"
 			}
 			"Weapon_Switch"
 			{
-				"windows"	"264"
-				"linux"		"265"
-				"mac"		"265"
+				"windows"	"270"
+				"linux"		"271"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.hl2mp.txt
+++ b/gamedata/sdktools.games/game.hl2mp.txt
@@ -22,7 +22,6 @@
 				"library"	"server"
 				"windows"	"\x55\x8B\xEC\x56\x8B\xF1\x80\xBE\x31\x03\x00\x00\x00\x75\x2A\x83\xBE\x50\x04\x00\x00\x00\x75\x2A\xE8\x2A\x2A\x2A\x2A\x85\xC0\x74\x2A\x8B\xCE\xE8\x2A\x2A\x2A\x2A\x8B\x86\x50\x04\x00\x00\x85\xC0\x74\x2A\x83\x38\x00\x74\x2A\xFF\x75\x08\x50\xE8\x2A\x2A\x2A\x2A\x83\xC4\x08\x40"
 				"linux"		"@_ZN14CBaseAnimating16LookupAttachmentEPKc"
-				"mac"		"@_ZN14CBaseAnimating16LookupAttachmentEPKc"
 			}
 			"FireOutput"
 			{
@@ -39,105 +38,88 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"400"
-				"linux"		"401"
-				"mac"		"401"
+				"windows"	"407"
+				"linux"		"408"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"270"
-				"linux"		"271"
-				"mac"		"271"
+				"windows"	"276"
+				"linux"		"277"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"268"
-				"linux"		"269"
-				"mac"		"269"
+				"windows"	"274"
+				"linux"		"275"
 			}
 			"Ignite"
 			{
-				"windows"	"209"
-				"linux"		"210"
-				"mac"		"210"
+				"windows"	"215"
+				"linux"		"216"
 			}
 			"Extinguish"
 			{
-				"windows"	"213"
-				"linux"		"214"
-				"mac"		"214"
+				"windows"	"219"
+				"linux"		"220"
 			}
 			"Teleport"
 			{
-				"windows"	"108"
-				"linux"		"109"
-				"mac"		"109"
+				"windows"	"110"
+				"linux"		"111"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"439"
-				"linux"		"439"
-				"mac"		"439"
+				"windows"	"466"
+				"linux"		"466"
 			}
 			"GetVelocity"
 			{
-				"windows"	"140"
-				"linux"		"141"
-				"mac"		"141"
+				"windows"	"143"
+				"linux"		"144"
 			}
 			"EyeAngles"
 			{
-				"windows"	"131"
-				"linux"		"132"
-				"mac"		"132"
+				"windows"	"134"
+				"linux"		"135"
 			}
 			"AcceptInput"
 			{
-				"windows"	"36"
-				"linux"		"37"
-				"mac"		"37"
+				"windows"	"38"
+				"linux"		"39"
 			}
 			"SetEntityModel"
 			{
-				"windows"	"24"
-				"linux"		"25"
-				"mac"		"25"
+				"windows"	"26"
+				"linux"		"27"
 			}
 			"WeaponEquip"
 			{
-				"windows"	"261"
-				"linux"		"262"
-				"mac"		"262"
+				"windows"	"267"
+				"linux"		"268"
 			}
 			"Activate"
 			{
-				"windows"	"33"
-				"linux"		"34"
-				"mac"		"34"
+				"windows"	"35"
+				"linux"		"36"
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"418"
-				"linux"		"419"
-				"mac"		"419"
+				"windows"	"425"
+				"linux"		"426"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"252"
-				"linux"		"253"
-				"mac"		"253"
+				"windows"	"258"
+				"linux"		"259"
 			}
 			"SetOwnerEntity"
 			{
-				"windows"	"17"
-				"linux"		"18"
-				"mac"		"18"
+				"windows"	"18"
+				"linux"		"19"
 			}
 			"GetAttachment"
 			{
-				"windows"	"205"
-				"linux"		"206"
-				"mac"		"206"
+				"windows"	"211"
+				"linux"		"212"
 			}
 		}
 		


### PR DESCRIPTION
This PR updates the gamedata files of SDKTools and SDKHooks for Half-Life 2 Deathmatch.

Offsets obtained via Asherkin's vtable dumper using the Linux binary from the beta branch of the dedicated server.

I'm also removing the gamedata for mac since Sourcemod no longer supports it.

