### PR TITLE
Fix incorrect offset for CommitSuicide

### DIFF
--- a/gamedata/sdktools.games/game.hl2mp.txt
+++ b/gamedata/sdktools.games/game.hl2mp.txt
@@ -68,8 +68,8 @@
 			}
 			"CommitSuicide"
 			{
-				"windows"	"466"
-				"linux"		"466"
+				"windows"	"446"
+				"linux"		"446"
 			}
 			"GetVelocity"
 			{


### PR DESCRIPTION
Tested working on latest HL2:DM Linux DS using SM 1.12.0.7169 via the following test code:
```
#include <sdktools>

Handle Call_CommitSuicide;

public void OnPluginStart()
{
    RegConsoleCmd("sm_suicide", Command_Suicide);
    StartPrepSDKCall(SDKCall_Player);
    PrepSDKCall_SetVirtual(446);
    PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_Plain);
    PrepSDKCall_AddParameter(SDKType_Bool, SDKPass_Plain);
    Call_CommitSuicide = EndPrepSDKCall();

    if(Call_CommitSuicide == INVALID_HANDLE)
    {
        SetFailState("Failed to setup CommitSuicide call");
    }
}

public Action Command_Suicide(int client, int args)
{
    if(IsClientInGame(client))
    {
        SDKCall(Call_CommitSuicide, client, false, false);
    }
    return Plugin_Handled;
}
```