### PR TITLE
Bump MySQL to 5.7.44 on Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       ARCH: x86,x86_64
       DEPENDENCIES_FOLDER: dependencies
       DEPENDENCIES_ROOT: ${{ github.workspace }}/dependencies
-      MYSQL_VERSION: '5.5'
+      MYSQL_VERSION: '5.7'
       MMSOURCE_VERSION: '1.12'
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
 
           # Satisfy checkout-deps requirement for a "sourcemod" folder.
           mkdir -p sourcemod
-          ../sourcemod/tools/checkout-deps.sh -s ${{ join(fromJSON(env.SDKS)) }}
+          ../sourcemod/tools/checkout-deps.sh -s ${{ join(fromJSON(env.SDKS)) }} -d
 
       - name: Install Linux dependencies
         if: startsWith(runner.os, 'Linux')

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -146,7 +146,7 @@ class SMConfig(object):
           self.mysql_root['x86'] = builder.options.mysql_path
         else:
           for i in range(10):
-            self.mysql_root['x86'] = ResolveEnvPath('MYSQL55', 'mysql-5.' + str(i))
+            self.mysql_root['x86'] = ResolveEnvPath('MYSQL57', 'mysql-5.' + str(i))
             if self.mysql_root['x86']:
               break
         if not self.mysql_root['x86'] or not os.path.isdir(self.mysql_root['x86']):
@@ -158,7 +158,7 @@ class SMConfig(object):
           self.mysql_root['x86_64'] = builder.options.mysql64_path
         else:
           for i in range(10):
-            self.mysql_root['x86_64'] = ResolveEnvPath('MYSQL55_64', 'mysql-5.' + str(i) + '-x86_64')
+            self.mysql_root['x86_64'] = ResolveEnvPath('MYSQL57_64', 'mysql-5.' + str(i) + '-x86_64')
             if self.mysql_root['x86_64']:
               break
         if not self.mysql_root['x86_64'] or not os.path.isdir(self.mysql_root['x86_64']):

--- a/extensions/mysql/AMBuilder
+++ b/extensions/mysql/AMBuilder
@@ -13,6 +13,10 @@ if SM.mysql_root:
       binary.compiler.cxxflags += ['-fno-rtti']
     elif binary.compiler.family == 'msvc':
       binary.compiler.cxxflags += ['/GR-']
+      if builder.options.debug == '1':
+        binary.compiler.cflags += ['/MDd']
+      else:
+        binary.compiler.cflags += ['/MD']
 
     if binary.compiler.target.platform == 'linux' or binary.compiler.target.platform == 'mac':
       binary.compiler.postlink += [
@@ -25,8 +29,17 @@ if SM.mysql_root:
       binary.compiler.postlink += ['-lrt']
     elif binary.compiler.target.platform == 'windows':
       binary.compiler.defines += ['WIN32_LEAN_AND_MEAN']
+      if builder.options.debug == '1':
+        binary.compiler.defines += ['_ITERATOR_DEBUG_LEVEL=2']
+        binary.compiler.postlink += [
+          os.path.join(SM.mysql_root[arch], 'lib', 'debug', 'mysqlclient.lib'),
+        ]
+      else:
+        binary.compiler.postlink += [
+          os.path.join(SM.mysql_root[arch], 'lib', 'mysqlclient.lib'),
+        ]
       binary.compiler.postlink += [
-        os.path.join(SM.mysql_root[arch], 'lib', 'mysqlclient.lib'),
+        'crypt32.lib',
         'wsock32.lib'
       ]
 

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -4,16 +4,21 @@
 trap "exit" INT
 
 download_mysql=1
+download_mysql_debug=1
 
 # List of HL2SDK branch names to download.
 # ./checkout-deps.sh -s tf2,css
 # Disable downloading of mysql libraries.
 # ./checkout-deps.sh -m
+# Disable downloading of mysql debug libraries on Windows.
+# ./checkout-deps.sh -d
 while getopts ":s:m" opt; do
   case $opt in
     s) IFS=', ' read -r -a sdks <<< "$OPTARG"
     ;;
     m) download_mysql=0
+    ;;
+    d) download_mysql_debug=0
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;
@@ -59,13 +64,14 @@ getmysql ()
 }
 
 # 32-bit MySQL
-mysqlfolder=mysql-5.5
+mysqlfolder=mysql-5.7
 if [ $ismac -eq 1 ]; then
+  mysqlfolder=mysql-5.5
   mysqlver=mysql-5.5.28-osx10.5-x86
   mysqlurl=https://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
 elif [ $iswin -eq 1 ]; then
-  mysqlver=mysql-5.5.62-win32
-  mysqlurl=https://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
+  mysqlver=mysql-5.7.44-win32
+  mysqlurl=https://cdn.mysql.com/archives/mysql-5.7/$mysqlver.$archive_ext
   # The folder in the zip archive does not contain the substring "-noinstall", so strip it
   mysqlver=${mysqlver/-noinstall}
 else
@@ -77,19 +83,36 @@ if [ $download_mysql -eq 1 ]; then
 fi
 
 # 64-bit MySQL
-mysqlfolder=mysql-5.5-x86_64
+mysqlfolder=mysql-5.7-x86_64
 if [ $ismac -eq 1 ]; then
+  mysqlfolder=mysql-5.5-x86_64
   mysqlver=mysql-5.5.28-osx10.5-x86_64
   mysqlurl=https://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
 elif [ $iswin -eq 1 ]; then
-  mysqlver=mysql-5.5.62-winx64
-  mysqlurl=https://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
+  mysqlver=mysql-5.7.44-winx64
+  mysqlurl=https://cdn.mysql.com/archives/mysql-5.7/$mysqlver.$archive_ext
 else
   mysqlver=mysql-5.7.44-linux-glibc2.12-x86_64
   mysqlurl=https://cdn.mysql.com/archives/mysql-5.7/$mysqlver.$archive_ext
 fi
 if [ $download_mysql -eq 1 ]; then
   getmysql
+fi
+
+if [ $iswin -eq 1 && $download_mysql_debug -eq 1 ]; then
+  mysqlfolder=mysql-5.7-debug
+  mysqlver=mysql-5.7.44-win32
+  mysqlurl=https://cdn.mysql.com/archives/mysql-5.7/$mysqlver-debug-test.$archive_ext
+  getmysql
+  cp -r $mysqlfolder/lib/* mysql-5.7/lib
+  rm -rf $mysqlfolder
+
+  mysqlfolder=mysql-5.7-debug-x86_64
+  mysqlver=mysql-5.7.44-winx64
+  mysqlurl=https://cdn.mysql.com/archives/mysql-5.7/$mysqlver-debug-test.$archive_ext
+  getmysql
+  cp -r $mysqlfolder/lib/* mysql-5.7-x86_64/lib
+  rm -rf $mysqlfolder
 fi
 
 checkout ()


### PR DESCRIPTION
Dynamically link the CRT for the MySQL extension to be able to use libmysqlclient builds past the 5.5.54 release. This requires the [VC runtime](https://www.microsoft.com/en-us/download/details.aspx?id=48145) to be installed now while we previously linked them statically.

This allows to use the new `caching_sha2_password` default password encryption scheme from MySQL 8+ from Windows SRCDS too.

The build slaves need updating too if we want this.

Fixes #2231

## Old dll dependencies
```
dumpbin /dependents dbi.mysql.ext.dll
Microsoft (R) COFF/PE Dumper Version 14.37.32824.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file dbi.mysql.ext.dll

File Type: DLL

  Image has the following dependencies:

    WSOCK32.dll
    Secur32.dll
    WS2_32.dll
    KERNEL32.dll
    ADVAPI32.dll

  Summary

      2BB000 .data
       1D000 .rdata
        7000 .reloc
        1000 .rsrc
       74000 .text
```

## New dll dependencies
```
dumpbin /dependents dbi.mysql.ext.dll
Microsoft (R) COFF/PE Dumper Version 14.37.32824.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file dbi.mysql.ext.dll

File Type: DLL

  Image has the following dependencies:

    CRYPT32.dll
    WSOCK32.dll
    MSVCP140.dll
    Secur32.dll
    WS2_32.dll
    bcrypt.dll
    VCRUNTIME140.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-time-l1-1-0.dll
    api-ms-win-crt-utility-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    KERNEL32.dll
    USER32.dll
    ADVAPI32.dll

  Summary

       B1000 .data
      33C000 .rdata
       1A000 .reloc
        1000 .rsrc
      1FD000 .text
```