### PR TITLE
Correction for sourcemod use the new teleportation check gamedata registry from now on.

### DIFF
--- a/extensions/tf2/teleporter.cpp
+++ b/extensions/tf2/teleporter.cpp
@@ -31,7 +31,7 @@
 
 #include "teleporter.h"
 
-CDetour *canPlayerTeleportDetour = NULL;
+CDetour *canPlayerBeTeleportedDetour = NULL;
 
 IForward *g_teleportForward = NULL;
 
@@ -84,11 +84,11 @@ DETOUR_DECL_MEMBER1(CanPlayerBeTeleported, bool, CTFPlayer *, pPlayer)
 
 bool InitialiseTeleporterDetour()
 {
-	canPlayerTeleportDetour = DETOUR_CREATE_MEMBER(CanPlayerBeTeleported, "CanPlayerTeleport");
+	canPlayerBeTeleportedDetour = DETOUR_CREATE_MEMBER(CanPlayerBeTeleported, "CanPlayerBeTeleported");
 
-	if (canPlayerTeleportDetour != NULL)
+	if (canPlayerBeTeleportedDetour != NULL)
 	{
-		canPlayerTeleportDetour->EnableDetour();
+		canPlayerBeTeleportedDetour->EnableDetour();
 		return true;
 	}
 
@@ -99,9 +99,9 @@ bool InitialiseTeleporterDetour()
 
 void RemoveTeleporterDetour()
 {
-	if (canPlayerTeleportDetour != NULL)
+	if (canPlayerBeTeleportedDetour != NULL)
 	{
-		canPlayerTeleportDetour->Destroy();
-		canPlayerTeleportDetour = NULL;
+		canPlayerBeTeleportedDetour->Destroy();
+		canPlayerBeTeleportedDetour = NULL;
 	}
 }

--- a/extensions/tf2/teleporter.cpp
+++ b/extensions/tf2/teleporter.cpp
@@ -37,7 +37,18 @@ IForward *g_teleportForward = NULL;
 
 class CTFPlayer;
 
+#if defined(__linux__) && defined(__i386__)
+class CanPlayerBeTeleportedClass
+{
+public:
+	__attribute__((regparm(2))) bool CanPlayerBeTeleported(CTFPlayer * pPlayer); 
+	static __attribute__((regparm(2))) bool (CanPlayerBeTeleportedClass::* CanPlayerBeTeleported_Actual)(CTFPlayer *);
+};
+__attribute__((regparm(2))) bool (CanPlayerBeTeleportedClass::* CanPlayerBeTeleportedClass::CanPlayerBeTeleported_Actual)(CTFPlayer *) = NULL;
+__attribute__((regparm(2))) bool CanPlayerBeTeleportedClass::CanPlayerBeTeleported(CTFPlayer* pPlayer)
+#else
 DETOUR_DECL_MEMBER1(CanPlayerBeTeleported, bool, CTFPlayer *, pPlayer)
+#endif
 {
 	bool origCanTeleport = DETOUR_MEMBER_CALL(CanPlayerBeTeleported)(pPlayer);
 

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -126,14 +126,27 @@
 				"linux"		"@_Z21DuelMiniGame_IsInDuelP9CTFPlayer"
 				"linux64"	"@_Z21DuelMiniGame_IsInDuelP9CTFPlayer"
 			}
+			"CanPlayerBeTeleported"
+			{
+				/* String: "bidirectional_teleport" follow the xref, pick the function that doesn't involve another attribute, follow the graph view after 2 virtual function call, the first subroutine call is CanPlayerTeleport*/
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A"
+				"windows64"	"\x48\x89\x5C\x24\x08\x48\x89\x74\x24\x10\x57\x48\x83\xEC\x20\x48\x8B\xFA\x48\x8B\xF1\x48\x85\xD2\x0F\x84\x2A\x2A\x2A\x2A\x45\x33\xC0"
+				
+				// Recent updates altered where the teleport check was called in Linux systems.
+				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
+				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
+			}
+			
+			// Obsolete
 			"CanPlayerTeleport"
 			{
 				/* String: "bidirectional_teleport" follow the xref, pick the function that doesn't involve another attribute, follow the graph view after 2 virtual function call, the first subroutine call is CanPlayerTeleport*/
 				"library"	"server"
 				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A"
 				"windows64"	"\x48\x89\x5C\x24\x08\x48\x89\x74\x24\x10\x57\x48\x83\xEC\x20\x48\x8B\xFA\x48\x8B\xF1\x48\x85\xD2\x0F\x84\x2A\x2A\x2A\x2A\x45\x33\xC0"
-				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
-				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
+				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
+				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
 			}
 			
 			// Obsolete

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -132,8 +132,8 @@
 				"library"	"server"
 				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A"
 				"windows64"	"\x48\x89\x5C\x24\x08\x48\x89\x74\x24\x10\x57\x48\x83\xEC\x20\x48\x8B\xFA\x48\x8B\xF1\x48\x85\xD2\x0F\x84\x2A\x2A\x2A\x2A\x45\x33\xC0"
-				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
-				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer"
+				"linux"		"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
+				"linux64"	"@_ZN17CObjectTeleporter21PlayerCanBeTeleportedEP9CTFPlayer.part.0"
 			}
 			
 			// Obsolete


### PR DESCRIPTION
Followup of Pull Request #2234, I made a mistake and forgot to make Sourcemod start using the new registry for the teleportation check.

Already tested and it's working flawlessly.

Sorry :grimacing: This is the last pull request for the current issue, I swear.