### PR TITLE
Add support for radio menu and HUD message for Dystopia

### DIFF
--- a/gamedata/core.games/common.games.txt
+++ b/gamedata/core.games/common.games.txt
@@ -195,6 +195,7 @@
 			"game"					"open_fortress"
 			"game"					"tf2classic"
 			"game"					"pf2"
+			"game"					"dystopia"
 		}
 
 		"Keys"
@@ -250,6 +251,7 @@
 			"game"					"open_fortress"
 			"game"					"tf2classic"
 			"game"					"pf2"
+			"game"					"dystopia"
 		}
 		
 		"Keys"
@@ -314,6 +316,7 @@
 			"game"					"open_fortress"
 			"game"					"tf2classic"
 			"game"					"pf2"
+			"game"					"dystopia"
 		}
 		
 		"Keys"


### PR DESCRIPTION
Radio menus such as those created with `sm_vote` don't show up in the game, but the game seems to support them once the keys in `common.games.txt` are updated. Similarly HUD messages seem to work fine in maps with the `game_text` entity.

![radio_menu](https://github.com/user-attachments/assets/c5f9c004-0ffc-4328-a676-2d89ab543a87)


