### PR TITLE
Add "EnableLineDebugging" core.cfg option

### DIFF
--- a/configs/core.cfg
+++ b/configs/core.cfg
@@ -138,4 +138,11 @@
 	 * "jitdump" - Generate extended perf metadata (Linux only - function names, bytecode, and source information)
 	 */
 	"JITMetadata"	"default"
+
+	/**
+	 * Setup the SourcePawn VM to enable extensions to use a debugging API to step through
+	 * plugins line by line. This heavily decreases server performance and should NEVER be
+	 * used on a production server, but ONLY during plugin development.
+	 */
+	"EnableLineDebugging"	"no"
 }

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -365,6 +365,12 @@ void SourceModBase::StartSourceMod(bool late)
 		g_pSourcePawn2->InstallWatchdogTimer(atoi(timeout) * 1000);
 	}
 
+	const char *linedebugger = GetCoreConfigValue("EnableLineDebugging");
+	if (linedebugger != NULL && strcasecmp(linedebugger, "yes") == 0)
+	{
+		g_pPawnEnv->EnableDebugBreak();
+	}
+
 	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
 }
 


### PR DESCRIPTION
Allow extensions to register a debug break handler in the SourcePawn VM using `smutils->GetScriptingEngine()->SetDebugBreakHandler(callback)`.

Enable line debugging support in the VM before any plugin is loaded through a core.cfg option. This is required for potential debuggers to work.