### PR TITLE
fix: Allow entity references for clients with L and N format specifiers

### DIFF
--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -106,7 +106,7 @@ public:
 	virtual bool IsMapLoading() = 0;
 	virtual bool IsMapRunning() = 0;
 	virtual int MaxClients() = 0;
-	virtual bool DescribePlayer(int index, const char **namep, const char **authp, int *useridp) = 0;
+	virtual bool DescribePlayer(int entRef, const char **namep, const char **authp, int *useridp) = 0;
 	virtual void LogToGame(const char *message) = 0;
 	virtual void ConPrint(const char *message) = 0;
 	virtual void ConsolePrint(const char *fmt, ...) = 0;

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -574,8 +574,9 @@ int CoreProviderImpl::MaxClients()
 	return g_Players.MaxClients();
 }
 
-bool CoreProviderImpl::DescribePlayer(int index, const char **namep, const char **authp, int *useridp)
+bool CoreProviderImpl::DescribePlayer(int entRef, const char **namep, const char **authp, int *useridp)
 {
+	int index = g_HL2.ReferenceToIndex(entRef);
 	CPlayer *player = g_Players.GetPlayerByIndex(index);
 	if (!player || !player->IsConnected())
 		return false;

--- a/core/provider.h
+++ b/core/provider.h
@@ -56,7 +56,7 @@ public:
 	bool IsMapLoading() override;
 	bool IsMapRunning() override;
 	int MaxClients() override;
-	bool DescribePlayer(int index, const char **namep, const char **authp, int *useridp) override;
+	bool DescribePlayer(int entRef, const char **namep, const char **authp, int *useridp) override;
 	void LogToGame(const char *message) override;
 	void ConPrint(const char *message) override;
 	void ConsolePrint(const char *fmt, ...) override;


### PR DESCRIPTION
Fixes #2243