### PR TITLE
Revert modtime==0 change due to new config issues

### DIFF
--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -1174,7 +1174,7 @@ bool GameConfigManager::LoadGameConfigFile(const char *file, IGameConfig **_pCon
 	{
 		bool ret = true;
 		time_t modtime = GetFileModTime(file);
-		if (pConfig->m_ModTime != modtime || pConfig->m_ModTime == 0)
+		if (pConfig->m_ModTime != modtime)
 		{
 			pConfig->m_ModTime = modtime;
 			ret = pConfig->Reparse(error, maxlength);


### PR DESCRIPTION
Spookmaster reported new issues on latest SM, alleged reparse invaliding a string. Just a quick revert while this gets handled