### PR TITLE
Fix storing garbage strings

### DIFF
--- a/extensions/cstrike/util_cstrike.cpp
+++ b/extensions/cstrike/util_cstrike.cpp
@@ -240,15 +240,10 @@ void CreateHashMaps()
 	if (!pSchema)
 		return;
 
-	static const char *pPriceKey = NULL;
-
+	const char *pPriceKey = g_pGameConf->GetKeyValue("PriceKey");
 	if (!pPriceKey)
 	{
-		pPriceKey = g_pGameConf->GetKeyValue("PriceKey");
-		if (!pPriceKey)
-		{
-			return;
-		}
+		return;
 	}
 
 	static int iHashMapOffset = -1;

--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -33,11 +33,15 @@
 #include "gamerulesnatives.h"
 #include "vglobals.h"
 
-const char *g_szGameRulesProxy;
+char g_szGameRulesProxy[64];
 
 void GameRulesNativesInit()
 {
-	g_szGameRulesProxy = g_pGameConf->GetKeyValue("GameRulesProxy");
+	auto key = g_pGameConf->GetKeyValue("GameRulesProxy");
+	if (key)
+	{
+		strcpy(g_szGameRulesProxy, key);
+	}
 }
 
 static CBaseEntity *FindEntityByNetClass(int start, const char *classname)
@@ -202,7 +206,7 @@ static cell_t GameRules_GetProp(IPluginContext *pContext, const cell_t *params)
 
 	void *pGameRules = GameRules();
 
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -274,7 +278,7 @@ static cell_t GameRules_SetProp(IPluginContext *pContext, const cell_t *params)
 	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity");
 	
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed");
 
 	pContext->LocalToString(params[1], &prop);
@@ -335,7 +339,7 @@ static cell_t GameRules_GetPropFloat(IPluginContext *pContext, const cell_t *par
 
 	void *pGameRules = GameRules();
 
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -360,7 +364,7 @@ static cell_t GameRules_SetPropFloat(IPluginContext *pContext, const cell_t *par
 	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -394,7 +398,7 @@ static cell_t GameRules_GetPropEnt(IPluginContext *pContext, const cell_t *param
 
 	void *pGameRules = GameRules();
 
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -425,7 +429,7 @@ static cell_t GameRules_SetPropEnt(IPluginContext *pContext, const cell_t *param
 	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -475,7 +479,7 @@ static cell_t GameRules_GetPropVector(IPluginContext *pContext, const cell_t *pa
 
 	void *pGameRules = GameRules();
 
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -507,7 +511,7 @@ static cell_t GameRules_SetPropVector(IPluginContext *pContext, const cell_t *pa
 	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -551,7 +555,7 @@ static cell_t GameRules_GetPropString(IPluginContext *pContext, const cell_t *pa
 
 	void *pGameRules = GameRules();
 
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);
@@ -600,7 +604,7 @@ static cell_t GameRules_SetPropString(IPluginContext *pContext, const cell_t *pa
 	if ((pProxy = GetGameRulesProxyEnt()) == NULL)
 		return pContext->ThrowNativeError("Couldn't find gamerules proxy entity.");
 	
-	if (!pGameRules || !g_szGameRulesProxy || !strcmp(g_szGameRulesProxy, ""))
+	if (!pGameRules || !g_szGameRulesProxy[0])
 		return pContext->ThrowNativeError("Gamerules lookup failed.");
 
 	pContext->LocalToString(params[1], &prop);

--- a/extensions/sdktools/gamerulesnatives.cpp
+++ b/extensions/sdktools/gamerulesnatives.cpp
@@ -33,14 +33,15 @@
 #include "gamerulesnatives.h"
 #include "vglobals.h"
 
-char g_szGameRulesProxy[64];
+char g_szGameRulesProxy[64] = { 0 };
 
 void GameRulesNativesInit()
 {
 	auto key = g_pGameConf->GetKeyValue("GameRulesProxy");
 	if (key)
 	{
-		strcpy(g_szGameRulesProxy, key);
+		strncpy(g_szGameRulesProxy, key, sizeof(g_szGameRulesProxy));
+		g_szGameRulesProxy[sizeof(g_szGameRulesProxy) - 1] = '\0';
 	}
 }
 

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -39,7 +39,7 @@ struct TeamInfo
 	CBaseEntity *pEnt;
 };
 
-const char m_iScore[64] = { 0 };
+char m_iScore[64] = { 0 };
 
 SourceHook::CVector<TeamInfo> g_Teams;
 

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -39,7 +39,7 @@ struct TeamInfo
 	CBaseEntity *pEnt;
 };
 
-const char *m_iScore;
+const char m_iScore[64] = { 0 };
 
 SourceHook::CVector<TeamInfo> g_Teams;
 
@@ -137,13 +137,14 @@ static cell_t GetTeamScore(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Team index %d is invalid", teamindex);
 	}
 
-	if (!m_iScore)
+	if (!m_iScore[0])
 	{
-		m_iScore = g_pGameConf->GetKeyValue("m_iScore");
-		if (!m_iScore)
+		auto key = g_pGameConf->GetKeyValue("m_iScore");
+		if (!m_iScore[0])
 		{
 			return pContext->ThrowNativeError("Failed to get m_iScore key");
 		}
+		strcpy(m_iScore, key);
 	}
 
 	static int offset = -1;
@@ -175,13 +176,14 @@ static cell_t SetTeamScore(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Team index %d is invalid", teamindex);
 	}
 
-	if (m_iScore == NULL)
+	if (!m_iScore[0])
 	{
-		m_iScore = g_pGameConf->GetKeyValue("m_iScore");
-		if (m_iScore == NULL)
+		auto key = g_pGameConf->GetKeyValue("m_iScore");
+		if (!m_iScore[0])
 		{
 			return pContext->ThrowNativeError("Failed to get m_iScore key");
 		}
+		strcpy(m_iScore, key);
 	}
 
 	static int offset = -1;

--- a/extensions/sdktools/teamnatives.cpp
+++ b/extensions/sdktools/teamnatives.cpp
@@ -140,11 +140,12 @@ static cell_t GetTeamScore(IPluginContext *pContext, const cell_t *params)
 	if (!m_iScore[0])
 	{
 		auto key = g_pGameConf->GetKeyValue("m_iScore");
-		if (!m_iScore[0])
+		if (!key || !key[0])
 		{
 			return pContext->ThrowNativeError("Failed to get m_iScore key");
 		}
-		strcpy(m_iScore, key);
+		strncpy(m_iScore, key, sizeof(m_iScore));
+		m_iScore[sizeof(m_iScore) - 1] = '\0';
 	}
 
 	static int offset = -1;
@@ -179,11 +180,12 @@ static cell_t SetTeamScore(IPluginContext *pContext, const cell_t *params)
 	if (!m_iScore[0])
 	{
 		auto key = g_pGameConf->GetKeyValue("m_iScore");
-		if (!m_iScore[0])
+		if (!key || !key[0])
 		{
 			return pContext->ThrowNativeError("Failed to get m_iScore key");
 		}
-		strcpy(m_iScore, key);
+		strncpy(m_iScore, key, sizeof(m_iScore));
+		m_iScore[sizeof(m_iScore) - 1] = '\0';
 	}
 
 	static int offset = -1;

--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -34,6 +34,7 @@
 #include <datamap.h>
 
 variant_t g_Variant_t;
+char g_Variant_str_Value[128];
 
 // copy this definition as the original file includes cbase.h which explodes in a shower of compile errors
 void variant_t::SetEntity( CBaseEntity *val ) 
@@ -59,7 +60,9 @@ static cell_t SetVariantString(IPluginContext *pContext, const cell_t *params)
 {
 	char *str;
 	pContext->LocalToString(params[1], &str);
-	g_Variant_t.SetString(MAKE_STRING(str));
+	strncpy(g_Variant_str_Value, str, sizeof(g_Variant_str_Value));
+	g_Variant_str_Value[sizeof(g_Variant_str_Value) - 1] = '\0';
+	g_Variant_t.SetString(MAKE_STRING(g_Variant_str_Value));
 	return 1;
 }
 


### PR DESCRIPTION
As of #2253 plugins/extensions might reload sdktools gamedata, which turns all the strings globally stored into garbage.
For example :
https://github.com/alliedmodders/sourcemod/blob/f6737a4760e4bd6226f327f0e08ec5d8c7f6a4e4/extensions/sdktools/gamerulesnatives.cpp#L40

I've scoured the codebase for the usage of `GetKeyValue` and implemented a string copy of the returned value if it happens to be stored into a global variable. Verdict is that only sdktools and cstrike extension seem affected, hopefully that's all the instances of this issue.

Also closes #2193 