### PR TITLE
Significantly improve performance of functions that check IsLANServer()

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -57,7 +57,6 @@ typedef ICommandLine *(*FakeGetCommandLine)();
 #define VSTDLIB_NAME		FORMAT_SOURCE_BIN_NAME("vstdlib")
 
 CHalfLife2 g_HL2;
-ConVar *sv_lan = NULL;
 
 static void *g_EntList = NULL;
 static void **g_pEntInfoList = NULL;
@@ -787,7 +786,7 @@ void CHalfLife2::ProcessFakeCliCmdQueue()
 
 bool CHalfLife2::IsLANServer()
 {
-	sv_lan = icvar->FindVar("sv_lan");
+	static ConVar *sv_lan = icvar->FindVar("sv_lan");
 
 	if (!sv_lan)
 	{


### PR DESCRIPTION
Affects `GetClientAuthId`, `BanClient`, `BanIdentity`, `RemoveBan`, generally any time an Auth ID is being validated.

This PR simply makes getting the "sv_lan" ConVar a 1 time static operation. Prior behavior could call FindVar() for every call of the affected functions. psychonic mentioned possibly using `ConVarRef` instead of `ConVar*`, but that it may not be available for ep1. That does indeed seem to be the case from my quick look through.

For those that enjoy seeing performance numbers, I'll summarize a couple of discord posts of using `GetClientAuthId()` and `GetClientName()` to compare profiled times at 1,000 loops on aging server hardware(Intel Xeon Gold 6242R).
Before:
```
GetClientName: 0.0219999998 ms, avg: 0.0000220000 ms
AuthId_Steam2: 40.1949996948 ms, avg: 0.0401949994 ms
AuthId_SteamID64: 83.3029937744 ms, avg: 0.0833029970 ms

GetClientName is 99.94%, 1827.04x faster than AuthId_Steam2
GetClientName is 99.97%, 3786.49x faster than AuthId_SteamID64
```
After:
```
GetClientName is 52.38%, 2.09x faster than AuthId_Steam2
GetClientName is 88.05%, 8.36x faster than AuthId_SteamID64
```
In my test environment, 1 player connection resulted in 19 calls to IsLANServer(). This would be ~0.79-1.58ms reduced to ~0.00087-0.0035ms. As a reference point, a standard server tick is every 15ms.