### PR TITLE
Fix regression in DescribePlayer (%N / %L) for players not yet having entities

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -978,7 +978,7 @@ cell_t CHalfLife2::EntityToReference(CBaseEntity *pEntity)
 {
 	IServerUnknown *pUnknown = (IServerUnknown *)pEntity;
 	CBaseHandle hndl = pUnknown->GetRefEHandle();
-	return (hndl.ToInt() | (1<<31));
+	return (hndl.ToInt() | ENTREF_MASK);
 }
 
 CBaseEntity *CHalfLife2::ReferenceToEntity(cell_t entRef)
@@ -990,10 +990,10 @@ CBaseEntity *CHalfLife2::ReferenceToEntity(cell_t entRef)
 
 	CEntInfo *pInfo = NULL;
 
-	if (entRef & (1<<31))
+	if (entRef & ENTREF_MASK)
 	{
 		/* Proper ent reference */
-		int hndlValue = entRef & ~(1<<31);
+		int hndlValue = entRef & ~ENTREF_MASK;
 		CBaseHandle hndl(hndlValue);
 
 		pInfo = LookupEntity(hndl.GetEntryIndex());
@@ -1094,10 +1094,10 @@ int CHalfLife2::ReferenceToIndex(cell_t entRef)
 		return INVALID_EHANDLE_INDEX;
 	}
 
-	if (entRef & (1<<31))
+	if (entRef & ENTREF_MASK)
 	{
 		/* Proper ent reference */
-		int hndlValue = entRef & ~(1<<31);
+		int hndlValue = entRef & ~ENTREF_MASK;
 		CBaseHandle hndl(hndlValue);
 
 		CEntInfo *pInfo = LookupEntity(hndl.GetEntryIndex());
@@ -1148,7 +1148,7 @@ cell_t CHalfLife2::EntityToBCompatRef(CBaseEntity *pEntity)
 	
 	if (hndl.GetEntryIndex() >= MAX_EDICTS)
 	{
-		return (hndl.ToInt() | (1<<31));
+		return (hndl.ToInt() | ENTREF_MASK);
 	}
 	else
 	{
@@ -1163,7 +1163,7 @@ cell_t CHalfLife2::ReferenceToBCompatRef(cell_t entRef)
 		return INVALID_EHANDLE_INDEX;
 	}
 
-	int hndlValue = entRef & ~(1<<31);
+	int hndlValue = entRef & ~ENTREF_MASK;
 	CBaseHandle hndl(hndlValue);
 
 	if (hndl.GetEntryIndex() < MAX_EDICTS)

--- a/core/HalfLife2.h
+++ b/core/HalfLife2.h
@@ -57,6 +57,8 @@ class ICommandArgs;
 using namespace SourceHook;
 using namespace SourceMod;
 
+static const int ENTREF_MASK = (1 << 31);
+
 #define HUD_PRINTTALK		3
 #define HUD_PRINTCENTER		4
 

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -576,7 +576,14 @@ int CoreProviderImpl::MaxClients()
 
 bool CoreProviderImpl::DescribePlayer(int entRef, const char **namep, const char **authp, int *useridp)
 {
-	int index = g_HL2.ReferenceToIndex(entRef);
+	int index = entRef;
+	if (entRef & ENTREF_MASK)
+	{
+		// Unless this is an explicit entity reference, we don't know nor care if the player has an entity yet,
+		// as long as they are currently connected. (But if it *is* an explicit ref, validate it)
+		index = g_HL2.ReferenceToIndex(entRef);
+	}
+
 	CPlayer *player = g_Players.GetPlayerByIndex(index);
 	if (!player || !player->IsConnected())
 		return false;


### PR DESCRIPTION
Fixes regression in #2244 