### PR TITLE
Update hl1mp gamdata

### DIFF
--- a/gamedata/sdkhooks.games/game.hl1mp.txt
+++ b/gamedata/sdkhooks.games/game.hl1mp.txt
@@ -4,120 +4,180 @@
 	{
 		"Offsets"
 		{
+			"EntityListeners"
+			{
+				"windows"	"131108"
+				"windows64"	"262200"
+				"linux"		"131108"
+				"linux64"	"262200"
+			}
 			"Blocked"
 			{
-				"windows"	"102"
-				"linux"		"103"
+				"windows"	"104"
+				"windows64"	"104"
+				"linux"		"105"
+				"linux64"	"105"
 			}
 			"EndTouch"
 			{
-				"windows"	"100"
-				"linux"		"101"
+				"windows"	"102"
+				"windows64"	"102"
+				"linux"		"103"
+				"linux64"	"103"
 			}
 			"FireBullets"
 			{
-				"windows"	"112"
-				"linux"		"113"
+				"windows"	"114"
+				"windows64"	"114"
+				"linux"		"115"
+				"linux64"	"115"
+			}
+			"GetMaxHealth"
+			{
+				"windows"	"119"
+				"windows64"	"119"
+				"linux"		"120"
+				"linux64"	"120"
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"177" 
-				"linux"		"179"
+				"windows"	"180"
+				"windows64"	"180"
+				"linux"		"182"
+				"linux64"	"182"
 			}
 			"OnTakeDamage"
 			{
-				"windows"	"62"
-				"linux"		"63"
+				"windows"	"64"
+				"windows64"	"64"
+				"linux"		"65"
+				"linux64"	"65"
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"272"
-				"linux"		"273"
+				"windows"	"278"
+				"windows64"	"278"
+				"linux"		"279"
+				"linux64"	"279"
 			}
 			"PreThink"
 			{
-				"windows"	"332"
-				"linux"		"333"
+				"windows"	"338"
+				"windows64"	"338"
+				"linux"		"339"
+				"linux64"	"339"
 			}
 			"PostThink"
 			{
-				"windows"	"333"
-				"linux"		"334"
+				"windows"	"339"
+				"windows64"	"339"
+				"linux"		"340"
+				"linux64"	"340"
 			}
 			"Reload"
 			{
-				"windows"	"270"
-				"linux"		"271"
+				"windows"	"276"
+				"windows64"	"276"
+				"linux"		"277"
+				"linux64"	"277"
 			}
 			"SetTransmit"
 			{
-				"windows"	"20"
-				"linux"		"21"
+				"windows"	"22"
+				"windows64"	"22"
+				"linux"		"23"
+				"linux64"	"23"
 			}
 			"ShouldCollide"
 			{
-				"windows"	"16"
-				"linux"		"17"
+				"windows"	"17"
+				"windows64"	"17"
+				"linux"		"16"
+				"linux64"	"16"
 			}
 			"Spawn"
 			{
-				"windows"	"22"
-				"linux"		"23"
+				"windows"	"29"
+				"windows64"	"29"
+				"linux"		"30"
+				"linux64"	"30"
 			}
 			"StartTouch"
 			{
-				"windows"	"98"
-				"linux"		"99"
+				"windows"	"100"
+				"windows64"	"100"
+				"linux"		"101"
+				"linux64"	"101"
 			}
 			"Think"
 			{
-				"windows"	"47"
-				"linux"		"48"
+				"windows"	"49"
+				"windows64"	"49"
+				"linux"		"50"
+				"linux64"	"50"
 			}
 			"Touch"
 			{
-				"windows"	"99"
-				"linux"		"100"
+				"windows"	"101"
+				"windows64"	"101"
+				"linux"		"102"
+				"linux64"	"102"
 			}
 			"TraceAttack"
 			{
-				"windows"	"60"
-				"linux"		"61"
+				"windows"	"62"
+				"windows64"	"62"
+				"linux"		"63"
+				"linux64"	"63"
 			}
 			"Use"
 			{
-				"windows"	"97"
-				"linux"		"98"
+				"windows"	"99"
+				"windows64"	"99"
+				"linux"		"100"
+				"linux64"	"100"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"157"
-				"linux"		"158"
+				"windows"	"160"
+				"windows64"	"160"
+				"linux"		"161"
+				"linux64"	"161"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"266"
-				"linux"		"267"
+				"windows"	"272"
+				"windows64"	"272"
+				"linux"		"273"
+				"linux64"	"273"
 			}
 			"Weapon_CanUse"
 			{
-				"windows"	"260"
-				"linux"		"261"
+				"windows"	"266"
+				"windows64"	"266"
+				"linux"		"267"
+				"linux64"	"267"
 			}
 			"Weapon_Drop"
 			{
-				"windows"	"263"
-				"linux"		"264"
+				"windows"	"269"
+				"windows64"	"269"
+				"linux"		"270"
+				"linux64"	"270"
 			}
 			"Weapon_Equip"
 			{
-				"windows"	"261"
-				"linux"		"262"
+				"windows"	"267"
+				"windows64"	"267"
+				"linux"		"268"
+				"linux64"	"268"
 			}
 			"Weapon_Switch"
 			{
-				"windows"	"264"
-				"linux"		"265"
+				"windows"	"270"
+				"windows64"	"270"
+				"linux"		"271"
+				"linux64"	"271"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.hl1mp.txt
+++ b/gamedata/sdktools.games/game.hl1mp.txt
@@ -82,88 +82,122 @@
 		{
 			"SetOwnerEntity"
 			{
-				"windows"	"17"
-				"linux"		"18"
+				"windows"	"18"
+				"windows64"	"18"
+				"linux"		"19"
+				"linux64"	"19"
 			}
 			"GiveNamedItem"
 			{
-				"windows"	"400"
-				"linux"		"401"
+				"windows"	"412"
+				"windows64"	"412"
+				"linux"		"413"
+				"linux64"	"413"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"270"
-				"linux"		"271"
+				"windows"	"280"
+				"windows64"	"280"
+				"linux"		"281"
+				"linux64"	"281"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"268"
-				"linux"		"269"
+				"windows"	"278"
+				"windows64"	"278"
+				"linux"		"279"
+				"linux64"	"279"
 			}
 			"Ignite"
 			{
-				"windows"	"209"
-				"linux"		"210"
+				"windows"	"219"
+				"windows64"	"219"
+				"linux"		"220"
+				"linux64"	"220"
 			}
 			"Extinguish"
 			{
-				"windows"	"213"
-				"linux"		"214"
+				"windows"	"223"
+				"windows64"	"223"
+				"linux"		"224"
+				"linux64"	"224"
 			}
 			"Teleport"
 			{
-				"windows"	"108"
-				"linux"		"109"
+				"windows"	"113"
+				"windows64"	"113"
+				"linux"		"114"
+				"linux64"	"114"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"439"
-				"linux"		"439"
+				"windows"	"453"
+				"windows64"	"453"
+				"linux"		"453"
+				"linux64"	"453"
 			}
 			"GetVelocity"
 			{
-				"windows"	"140"
-				"linux"		"141"
+				"windows"	"146"
+				"windows64"	"146"
+				"linux"		"147"
+				"linux64"	"147"
 			}
 			"EyeAngles"
 			{
-				"windows"	"131"
-				"linux"		"132"
-			}
-			"AcceptInput"
-			{
-				"windows"	"36"
-				"linux"		"37"
+				"windows"	"137"
+				"windows64"	"137"
+				"linux"		"138"
+				"linux64"	"138"
 			}
 			"SetEntityModel"
 			{
-				"windows"	"24"
-				"linux"		"25"
+				"windows"	"26"
+				"windows64"	"26"
+				"linux"		"27"
+				"linux64"	"27"
+			}
+			"AcceptInput"
+			{
+				"windows"	"38"
+				"windows64"	"38"
+				"linux"		"39"
+				"linux64"	"39"
 			}
 			"WeaponEquip"
 			{
-				"windows"	"261"
-				"linux"		"262"
+				"windows"	"271"
+				"windows64"	"271"
+				"linux"		"272"
+				"linux64"	"272"
 			}
 			"Activate"
 			{
-				"windows"	"33"
-				"linux"		"34"
+				"windows"	"35"
+				"windows64"	"35"
+				"linux"		"36"
+				"linux64"	"36"
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"418"
-				"linux"		"419"
+				"windows"	"430"
+				"windows64"	"430"
+				"linux"		"431"
+				"linux64"	"431"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"252"
-				"linux"		"253"
+				"windows"	"262"
+				"windows64"	"262"
+				"linux"		"263"
+				"linux64"	"263"
 			}
 			"GetAttachment"
 			{
-				"windows"	"205"
-				"linux"		"206"
+				"windows"	"215"
+				"windows64"	"215"
+				"linux"		"216"
+				"linux64"	"216"
 			}
 		}
 		


### PR DESCRIPTION
Not tested yet. Also note that if https://github.com/alliedmodders/metamod-source/pull/210 lands, hl1mp will be detected as the "hl2dm" engine rather than sdk2013 (which represents the pre-2025 variants).