### PR TITLE
RemoveDisguise GameData fix

### DIFF
--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -31,8 +31,8 @@
 				/* String : "reveal_disguised_victim_on_hit", follow the xref, RemoveDisguise is the subroutine that's called if the return value of CALL_ATTRIB_HOOK_INT( iRevealDisguisedSpyOnHit, reveal_disguised_victim_on_hit ); was true */
 				
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x51\x53\x56\x8B\xF1\x57\x6A\x03"
-				"windows64"	"\x48\x89\x5C\x24\x10\x48\x89\x74\x24\x18\x57\x48\x83\xEC\x20\x48\x8B\xD9\xBA\x03\x00\x00\x00"
+				"windows"	"\x55\x8B\xEC\x51\x56\x8B\xF1\x57\xF7\x86\xD0\x00\x00\x00\x00\x00\x02\x00"
+				"windows64"	"\x48\x89\x5C\x24\x10\x57\x48\x83\xEC\x40\xF7\x81\xF0\x00\x00\x00\x00\x00\x02\x00"
 				"linux"		"@_ZN15CTFPlayerShared14RemoveDisguiseEv"
 				"linux64"	"@_ZN15CTFPlayerShared14RemoveDisguiseEv"
 			}


### PR DESCRIPTION
https://crash.limetech.org/gvjiwehomlvu
`RemoveDisguise` still have crash issue after #2273. I have already tested this and confirmed that there are no issues.