### PR TITLE
Fix a Windows64 crash when unloading a plugin that DHooked something

### DIFF
--- a/extensions/dhooks/DynamicHooks/hook.cpp
+++ b/extensions/dhooks/DynamicHooks/hook.cpp
@@ -88,10 +88,13 @@ CHook::~CHook()
 		m_Hook.disable();
 	}
 
+	// x64 will free these in the m_bridge/m_postCallback destructors.
+#ifndef DYNAMICHOOKS_x86_64
 	if (m_pBridge) {
 		smutils->GetScriptingEngine()->FreePageMemory(m_pBridge);
 		smutils->GetScriptingEngine()->FreePageMemory(m_pNewRetAddr);
 	}
+#endif
 
 	delete m_pRegisters;
 	delete m_pCallingConvention;


### PR DESCRIPTION
(I was using [this](https://github.com/xen-000/SuppressViewpunch/pull/2) to test the crash)

