### PR TITLE
Fix multiple commands execution in adminmenu_custom.txt

### DIFF
--- a/plugins/adminmenu/dynamicmenu.sp
+++ b/plugins/adminmenu/dynamicmenu.sp
@@ -584,14 +584,22 @@ public void ParamCheck(int client)
 		char unquotedCommand[CMD_LENGTH];
 		UnQuoteString(g_command[client], unquotedCommand, sizeof(unquotedCommand), "#@");
 		
-		if (outputItem.execute == Execute_Player) // assume 'player' type execute option
+		// Use commands directly without unnecessary unquoting
+		char commands[10][CMD_LENGTH];
+		int count = ExplodeString(g_command[client], ";", commands, sizeof(commands), sizeof(commands[]));
+
+		for (int i = 0; i < count; i++)
 		{
-			FakeClientCommand(client, unquotedCommand);
-		}
-		else // assume 'server' type execute option
-		{
-			InsertServerCommand(unquotedCommand);
-			ServerExecute();
+			TrimString(commands[i]);
+			if (outputItem.execute == Execute_Player) // assume 'player' type execute option
+			{
+				FakeClientCommand(client, commands[i]);
+			}
+			else // assume 'server' type execute option
+			{
+				InsertServerCommand(commands[i]);
+				ServerExecute();
+			}
 		}
 
 		g_command[client][0] = '\0';


### PR DESCRIPTION
This PR fixes the semicolon parsing issue for adminmenu_custom.txt - player type cmd execution.

Below is an example ```adminmenu_custom.txt``` to reproduce the semicolon ";" not working before this fix - multiple commands delimited with ";" will not work.

```
"Commands"
{
	"PlayerCommands"
	{
		"Punishments"
		{
		        "admin"	"sm_ban"
        
		        "[BURN] TeamKill"
		        {
			        "cmd"	"sm_burn #1; sm_psay #1 No TeamKill!"
			        "execute"	"player"
			        "1" { "type" "player" "method" "name" "title" "Player:" }
		        }
		}
	}
}
```