### PR TITLE
Fix ClientPrefs pointer string formatting

### DIFF
--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -129,7 +129,7 @@ void DebugReport::GenerateCodeError(IPluginContext *pContext, uint32_t code_addr
 	{
 		g_Logger.LogError("[SM] Unable to call function \"%s\" due to above error(s).", name);
 	} else {
-		g_Logger.LogError("[SM] Unable to call function (name unknown, address \"%x\").", code_addr);
+		g_Logger.LogError("[SM] Unable to call function (name unknown, address \"%p\").", code_addr);
 	}
 }
 

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -875,7 +875,7 @@ static cell_t LoadFromAddress(IPluginContext *pContext, const cell_t *params)
 	}
 	else if (reinterpret_cast<uintptr_t>(addr) < VALID_MINIMUM_MEMORY_ADDRESS)
 	{
-		return pContext->ThrowNativeError("Invalid address 0x%x is pointing to reserved memory.", addr);
+		return pContext->ThrowNativeError("Invalid address %p is pointing to reserved memory.", addr);
 	}
 	NumberType size = static_cast<NumberType>(params[2]);
 
@@ -907,7 +907,7 @@ static cell_t StoreToAddress(IPluginContext *pContext, const cell_t *params)
 	}
 	else if (reinterpret_cast<uintptr_t>(addr) < VALID_MINIMUM_MEMORY_ADDRESS)
 	{
-		return pContext->ThrowNativeError("Invalid address 0x%x is pointing to reserved memory.", addr);
+		return pContext->ThrowNativeError("Invalid address %p is pointing to reserved memory.", addr);
 	}
 	cell_t data = params[2];
 

--- a/core/smn_entities.cpp
+++ b/core/smn_entities.cpp
@@ -736,7 +736,7 @@ static cell_t LoadEntityFromHandleAddress(IPluginContext *pContext, const cell_t
 	}
 	else if (reinterpret_cast<uintptr_t>(addr) < VALID_MINIMUM_MEMORY_ADDRESS)
 	{
-		return pContext->ThrowNativeError("Invalid address 0x%x is pointing to reserved memory.", addr);
+		return pContext->ThrowNativeError("Invalid address %p is pointing to reserved memory.", addr);
 	}
 
 	CBaseHandle &hndl = *reinterpret_cast<CBaseHandle*>(addr);

--- a/extensions/clientprefs/cookie.cpp
+++ b/extensions/clientprefs/cookie.cpp
@@ -344,7 +344,7 @@ void CookieManager::OnPluginDestroyed(IPlugin *plugin)
 
 				if (strcmp(draw.display, name) == 0)
 				{
-					data = (AutoMenuData *)strtoul(info, NULL, 16);
+					data = (AutoMenuData *)strtoull(info, nullptr, 16);
 
 					if (data->handler->forward != NULL)
 					{

--- a/extensions/clientprefs/menus.cpp
+++ b/extensions/clientprefs/menus.cpp
@@ -40,7 +40,7 @@ void ClientMenuHandler::OnMenuSelect(IBaseMenu *menu, int client, unsigned int i
 
 	const char *info = menu->GetItemInfo(item, &draw);
 
-	AutoMenuData *data = (AutoMenuData *)strtoul(info, NULL, 16);
+	AutoMenuData *data = (AutoMenuData *)strtoull(info, nullptr, 16);
 
 	if (data->handler->forward != NULL)
 	{
@@ -94,7 +94,7 @@ unsigned int ClientMenuHandler::OnMenuDisplayItem(IBaseMenu *menu,
 
 	const char *info = menu->GetItemInfo(item, &draw);
 
-	AutoMenuData *data = (AutoMenuData *)strtoul(info, NULL, 16);
+	AutoMenuData *data = (AutoMenuData *)strtoull(info, nullptr, 16);
 
 	if (data->handler->forward != NULL)
 	{
@@ -123,7 +123,7 @@ void AutoMenuHandler::OnMenuSelect(SourceMod::IBaseMenu *menu, int client, unsig
 
 	const char *info = menu->GetItemInfo(item, &draw);
 
-	AutoMenuData *data = (AutoMenuData *)strtoul(info, NULL, 16);
+	AutoMenuData *data = (AutoMenuData *)strtoull(info, nullptr, 16);
 
 	g_CookieManager.SetCookieValue(data->pCookie, client, settings[data->type][item]);
 	

--- a/extensions/clientprefs/natives.cpp
+++ b/extensions/clientprefs/natives.cpp
@@ -347,7 +347,7 @@ cell_t AddSettingsMenuItem(IPluginContext *pContext, const cell_t *params)
 	AutoMenuData *data = new AutoMenuData;
 	data->datavalue = params[2];
 	data->handler = pItem;
-	g_pSM->Format(info, sizeof(info), "%x", data);
+	g_pSM->Format(info, sizeof(info), "%" PRIxPTR, reinterpret_cast<uintptr_t>(data));
 
 	ItemDrawInfo draw(display, 0);
 
@@ -419,7 +419,7 @@ cell_t AddSettingsPrefabMenuItem(IPluginContext *pContext, const cell_t *params)
 	data->pCookie = pCookie;
 	data->type = (CookieMenu)params[2];
 	data->handler = pItem;
-	g_pSM->Format(info, sizeof(info), "%x", data);
+	g_pSM->Format(info, sizeof(info), "%" PRIxPTR, reinterpret_cast<uintptr_t>(data));
 
 	g_CookieManager.clientMenu->AppendItem(info, draw);
 

--- a/extensions/clientprefs/natives.cpp
+++ b/extensions/clientprefs/natives.cpp
@@ -83,10 +83,9 @@ cell_t FindClientPrefCookie(IPluginContext *pContext, const cell_t *params)
 		NULL);
 }
 
-size_t IsAuthIdConnected(char *authID)
+int IsAuthIdConnected(char *authID)
 {
 	IGamePlayer *player;
-	const char *authString;
 	
 	for (int playerIndex = playerhelpers->GetMaxClients()+1; --playerIndex > 0;)
 	{

--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -406,7 +406,7 @@ static cell_t SDKCall(IPluginContext *pContext, const cell_t *params)
 				else if (reinterpret_cast<uintptr_t>(thisptr) < VALID_MINIMUM_MEMORY_ADDRESS)
 				{
 					vc->stk_put(ptr);
-					return pContext->ThrowNativeError("Invalid ThisPtr address 0x%x is pointing to reserved memory.", thisptr);
+					return pContext->ThrowNativeError("Invalid ThisPtr address %p is pointing to reserved memory.", thisptr);
 				}
 
 				*(void **)ptr = thisptr;


### PR DESCRIPTION
Fix for #2305 

On at least linux-x64, our usage of `%x` for formatting a ClientPrefs menu data pointer to string was leading to a truncated pointer being included. This fixes that, the same issue in some less impactful places, and tidies up a couple of other warnings in ClientPrefs.