### PR TITLE
Fix NULL Crash on ReferenceToIndex

### DIFF
--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1102,7 +1102,7 @@ int CHalfLife2::ReferenceToIndex(cell_t entRef)
 
 		CEntInfo *pInfo = LookupEntity(hndl.GetEntryIndex());
 
-		if (pInfo->m_SerialNumber != hndl.GetSerialNumber())
+		if (!pInfo || pInfo->m_SerialNumber != hndl.GetSerialNumber())
 		{
 			return INVALID_EHANDLE_INDEX;
 		}


### PR DESCRIPTION
# Description

This PR fixes a crash caused by passing a bad reference value to `CHalfLife2::ReferenceToIndex`.

Example crash: https://crash.limetech.org/xyv66kz6dkvd

# Code to Reproduce

```
#include <sourcemod>

#pragma newdecls required
#pragma semicolon 1

const int ENTREF_MASK = (1 << 31);

public void OnMapStart()
{
	int ref = 9000 | ENTREF_MASK;
	int index = EntRefToEntIndex(ref);
	PrintToServer("%i", index);
}
```
