### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/extensions/curl/curl-src/src/writeout.c
+++ b/extensions/curl/curl-src/src/writeout.c
@@ -109,7 +109,7 @@ void ourWriteOut(CURL *curl, const char *writeinfo)
   double doubleinfo;
 
   while(*ptr) {
-    if('%' == *ptr) {
+    if('%' == *ptr && ptr[1]) {
       if('%' == ptr[1]) {
         /* an escaped %-letter */
         fputc('%', stream);


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a  clone function in `extensions/curl/curl-src/src/writeout.c` sourced from [curl/curl](https://github.com/curl/curl). This issue, originally reported in [CVE-2017-7407](https://nvd.nist.gov/vuln/detail/CVE-2017-7407), was resolved in the repository via this commit https://github.com/curl/curl/commit/1890d59905414ab84a35892b2e45833654aa5c13.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!