### PR TITLE
Fix crash when selecting a vote item that contains a format specifier

### DIFF
--- a/core/MenuVoting.cpp
+++ b/core/MenuVoting.cpp
@@ -561,7 +561,7 @@ void VoteMenuHandler::OnMenuSelect(IBaseMenu *menu, int client, unsigned int ite
 
 						if (sm_vote_client_console.GetBool())
 						{
-							ClientConsolePrint(pPlayer->GetEdict(), buffer);
+							ClientConsolePrint(pPlayer->GetEdict(), "%s", buffer);
 						}		
 					}
 				}


### PR DESCRIPTION
During a vote, selecting a vote menu item will by default print a console message containing the selected item's display name as the format string. If the menu item's display contains a `%`, the server will crash upon selection. 

Example:
`sm_vote "What are the chances that this crashes the server?" "100%" "Definitely 100%"`

This PR simply specifies the format string to be `"%s"` before passing the string that contains menu item's display name so that any format specifiers will be ignored.