### PR TITLE
Fixed "0[width]%d" formatting negative integers

### DIFF
--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -485,12 +485,14 @@ void AddInt(char **buf_p, size_t &maxlen, int val, int width, int flags)
 		unsignedVal /= 10;
 	} while (unsignedVal);
 
-	if (signedVal < 0)
-	{
-		text[digits++] = '-';
-	}
-
 	buf = *buf_p;
+
+	// minus sign BEFORE left padding if padding with zeros
+	if (signedVal < 0 && maxlen && (flags & ZEROPAD))
+	{
+		*buf++ = '-';
+		maxlen--;
+	}
 
 	if (!(flags & LADJUST))
 	{
@@ -500,6 +502,13 @@ void AddInt(char **buf_p, size_t &maxlen, int val, int width, int flags)
 			width--;
 			maxlen--;
 		}
+	}
+
+	// minus sign AFTER left padding if padding with spaces
+	if (signedVal < 0 && maxlen && !(flags & ZEROPAD))
+	{
+		*buf++ = '-';
+		maxlen--;
 	}
 
 	while (digits-- && maxlen)


### PR DESCRIPTION
Related to: #2328 

Fixed when formatting **negative integers** with **"%0[width]d"**, the **minus sign** should be formatted before the padding '0' instead of after the padding '0'.

