### PR TITLE
Fixed "%s" always being left justify

### DIFF
--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -188,6 +188,15 @@ bool AddString(char **buf_p, size_t &maxlen, const char *string, int width, int 
 
 	width -= size;
 
+	if (!(flags & LADJUST))
+	{
+		while ((width-- > 0) && maxlen)
+		{
+			*buf++ = ' ';
+			maxlen--;
+		}
+	}
+
 	if (g_FormatEscapeDatabase && (flags & NOESCAPE) == 0)
 	{
 		char *tempBuffer = NULL;
@@ -226,10 +235,13 @@ bool AddString(char **buf_p, size_t &maxlen, const char *string, int width, int 
 		}
 	}
 
-	while ((width-- > 0) && maxlen)
+	if (flags & LADJUST)
 	{
-		*buf++ = ' ';
-		maxlen--;
+		while ((width-- > 0) && maxlen)
+		{
+			*buf++ = ' ';
+			maxlen--;
+		}
 	}
 
 	*buf_p = buf;


### PR DESCRIPTION
Related to: #2331 

This only fixes **"%s"** to always be **left-aligned**, not include the fix for **padding '0'**.

If need, I can add a commit to fix the padding '0'.

**Test cases**

```sourcepawn
#include <sourcemod>

public void OnPluginStart()
{
    char[] text = "abcde1234567890";

    PrintToServer("|%s|", NULL_STRING);
    PrintToServer("|%s|", text);

    PrintToServer("|%.10s|", text);
    PrintToServer("|%0.10s|", text);
    PrintToServer("|%-.10s|", text);
    PrintToServer("|%-0.10s|", text);

    PrintToServer("|%20s|", text);
    PrintToServer("|%020s|", text);
    PrintToServer("|%-20s|", text);
    PrintToServer("|%-020s|", text);
}
```

<details>

<summary>Click to expand the output before fix</summary>

```shell
sm plugins reload test
||
|abcde1234567890|
|abcde12345|
|abcde12345|
|abcde12345|
|abcde12345|
|abcde1234567890     |
|abcde1234567890     |
|abcde1234567890     |
|abcde1234567890     |
[SM] Plugin test.smx reloaded successfully.

```

</details>


<details>

<summary>Click to expand the output after fix</summary>

```shell
sm plugins reload test
||
|abcde1234567890|
|abcde12345|
|abcde12345|
|abcde12345|
|abcde12345|
|     abcde1234567890|
|     abcde1234567890|
|abcde1234567890     |
|abcde1234567890     |
[SM] Plugin test.smx reloaded successfully.

```

</details>
