### PR TITLE
fix geoip chi and zho not return chinese translation

### DIFF
--- a/extensions/geoip/geoip_util.cpp
+++ b/extensions/geoip/geoip_util.cpp
@@ -183,6 +183,9 @@ const char *getLang(int target)
 
 		if (translator->GetLanguageInfo(langid, &code, NULL))
 		{
+			if (strcmp(code, "chi") == 0 || strcmp(code, "zho") == 0) {
+				code = "zh-CN";
+			}
 			for (size_t i = 0; i < mmdb.metadata.languages.count; i++)
 			{
 				if (strcmp(code, mmdb.metadata.languages.names[i]) == 0)


### PR DESCRIPTION
GeoLite2-City.mmdb supports zh-CN, but does not support chi and zho in sourcemod

The Chinese translation cannot be returned.
![图片](https://github.com/user-attachments/assets/8e08ada5-11eb-4504-af3c-b02c8888cf9a)

This is a fix when GetLanguageInfo got chi or zho, convert to zh-CN to match GeoLite2-City.mmdb