### PR TITLE
Add TFHoliday_Summer

### DIFF
--- a/extensions/tf2/holiday.cpp
+++ b/extensions/tf2/holiday.cpp
@@ -148,8 +148,8 @@ void HolidayManager::OnPluginLoaded(IPlugin *plugin)
 	PopulateHolidayVar(pRuntime, "TFHoliday_Birthday");
 	PopulateHolidayVar(pRuntime, "TFHoliday_Halloween");
 	PopulateHolidayVar(pRuntime, "TFHoliday_Christmas");
-	PopulateHolidayVar(pRuntime, "TFHoliday_EndOfTheLine");
 	PopulateHolidayVar(pRuntime, "TFHoliday_CommunityUpdate");
+	PopulateHolidayVar(pRuntime, "TFHoliday_EndOfTheLine");
 	PopulateHolidayVar(pRuntime, "TFHoliday_ValentinesDay");
 	PopulateHolidayVar(pRuntime, "TFHoliday_MeetThePyro");
 	PopulateHolidayVar(pRuntime, "TFHoliday_FullMoon");
@@ -157,6 +157,7 @@ void HolidayManager::OnPluginLoaded(IPlugin *plugin)
 	PopulateHolidayVar(pRuntime, "TFHoliday_HalloweenOrFullMoonOrValentines");
 	PopulateHolidayVar(pRuntime, "TFHoliday_AprilFools");
 	PopulateHolidayVar(pRuntime, "TFHoliday_Soldier");
+	PopulateHolidayVar(pRuntime, "TFHoliday_Summer");
 }
 
 void HolidayManager::OnPluginUnloaded(IPlugin *plugin)

--- a/gamedata/sm-tf2.games.txt
+++ b/gamedata/sm-tf2.games.txt
@@ -222,6 +222,7 @@
 			"TFHoliday_HalloweenOrFullMoonOrValentines"	"10"
 			"TFHoliday_AprilFools"		"11"
 			"TFHoliday_Soldier"			"12"
+			"TFHoliday_Summer"			"13"
 		}
 	}
 }

--- a/plugins/include/tf2.inc
+++ b/plugins/include/tf2.inc
@@ -222,8 +222,8 @@ enum TFHoliday
 public const TFHoliday TFHoliday_Birthday;
 public const TFHoliday TFHoliday_Halloween;
 public const TFHoliday TFHoliday_Christmas;
-public const TFHoliday TFHoliday_EndOfTheLine;
 public const TFHoliday TFHoliday_CommunityUpdate;
+public const TFHoliday TFHoliday_EndOfTheLine;
 public const TFHoliday TFHoliday_ValentinesDay;
 public const TFHoliday TFHoliday_MeetThePyro;
 public const TFHoliday TFHoliday_FullMoon;
@@ -231,6 +231,7 @@ public const TFHoliday TFHoliday_HalloweenOrFullMoon;
 public const TFHoliday TFHoliday_HalloweenOrFullMoonOrValentines;
 public const TFHoliday TFHoliday_AprilFools;
 public const TFHoliday TFHoliday_Soldier;
+public const TFHoliday TFHoliday_Summer;
 
 enum TFObjectType
 {


### PR DESCRIPTION
Valve has updated this holiday this year to use 2025 dates (2025-07-16 to 2025-09-16) so semi-relevant to add

https://github.com/SteamDatabase/GameTracking-TF2/commit/53251b5cdf6e051b34e42211d87a4670e10ce1b5#diff-ec0ad6965eb1aa76e7d13d323684e84757d3eaf714b05e24fffb5c9c55bb3215L5376
<img width="613" height="56" alt="image" src="https://github.com/user-attachments/assets/2619b612-b716-4ac5-98b3-218ec89c34ba" />

2024 dates at https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/econ/econ_holidays.cpp#L334
Evidence from https://github.com/SteamDatabase/GameTracking-TF2/blob/786fe2cb84b0fe335e46465cc369ef32124584f5/tf/bin/server_strings.txt indicates that the same dates as 2024 were used in 2023 when this event was first made.
