### PR TITLE
Fix TF2_OnConditionAdded/Removed breaking after player gains TF_COND_CRITBOOSTED

### DIFF
--- a/extensions/tf2/conditions.cpp
+++ b/extensions/tf2/conditions.cpp
@@ -57,25 +57,9 @@ void PlayerConditionsMgr::ProcessCondChange(CondChangeData_t *pCondData)
 		return;
 
 	int client = pCondData->hPlayer.GetEntryIndex();
-	int newConds = 0;
-	int prevConds = 0;
 	CondVar var = pCondData->var;
-
-	if (var == m_nPlayerCond)
-	{
-		prevConds = m_OldConds[client][_condition_bits] | m_OldConds[client][var];
-		newConds = m_OldConds[client][_condition_bits] | pCondData->newConds;
-	}
-	else if (var == _condition_bits)
-	{
-		prevConds = m_OldConds[client][m_nPlayerCond] | m_OldConds[client][var];
-		newConds = m_OldConds[client][m_nPlayerCond] | pCondData->newConds;
-	}
-	else
-	{
-		prevConds = m_OldConds[client][var];
-		newConds = pCondData->newConds;
-	}
+	int newConds = pCondData->newConds;
+	int prevConds = m_OldConds[client][var];
 
 	if (prevConds != newConds)
 	{


### PR DESCRIPTION
When detecting cond changes to call `TF2_OnConditionAdded`/`TF2_OnConditionRemoved`, the values of the `m_nPlayerCond` and `_condition_bits` netprops are merged together when either of them change (`_condition_bits` is a special legacy netprop that only handles cond 11 `TF_COND_CRITBOOSTED`). This behavior is not implemented correctly and can break the tracking of some conditions for a client if they gain `TF_COND_CRITBOOSTED` due to the way the merged value is saved to `m_OldConds`.

It don't believe this special handling is actually necessary at all. `_condition_bits` is *only* used for cond 11, and bit 11 is never set on `m_nPlayerCond`, so keeping the two props completely separate seems to work fine.

Fixes #840
