### PR TITLE
Incrase SetVariantString string limit

### DIFF
--- a/extensions/sdktools/variant-t.cpp
+++ b/extensions/sdktools/variant-t.cpp
@@ -34,7 +34,7 @@
 #include <datamap.h>
 
 variant_t g_Variant_t;
-char g_Variant_str_Value[128];
+char g_Variant_str_Value[1024];
 
 // copy this definition as the original file includes cbase.h which explodes in a shower of compile errors
 void variant_t::SetEntity( CBaseEntity *val ) 


### PR DESCRIPTION
from AM discord:
https://discord.com/channels/335290997317697536/335290997317697536/1422743151851995277

> I have an issue with SetVariantString because I'm trying to call the vscript function TakeDamageEx with a formatted string that's over 128 bytes, but I can't because the buffer that's used for it is 128 bytes. Is it necessary to limit the size to be that small? Could it be raised? The SetString function takes a string_t so I don't think it needs to be this small. I need to call EntIndexToHScript a bunch, which is the reason I'm going over the 128 limit. 