### PR TITLE
Update python version for gh ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
 
       # Setup Python for AMBuild
       - uses: actions/setup-python@v6
-        name: Setup Python 3.8
+        name: Setup Python 3.12
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
It seems ambuild can no longer be installed properly by the windows runner. Logs are unclear as to the why
```
Requirement already satisfied: wheel in c:\hostedtoolcache\windows\python\3.8.10\x64\lib\site-packages (0.45.1)
Processing d:\a\sourcemod\sourcemod\dependencies\ambuild
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  Getting requirements to build wheel did not run successfully.
  exit code: 1
  
  [32 lines of output]
  Traceback (most recent call last):
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 389, in <module>
      main()
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 143, in get_requires_for_build_wheel
      return hook(config_settings)
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-6eqnm0dw\overlay\Lib\site-packages\setuptools\build_meta.py", line 333, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=[])
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-6eqnm0dw\overlay\Lib\site-packages\setuptools\build_meta.py", line 303, in _get_build_requires
      self.run_setup()
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-6eqnm0dw\overlay\Lib\site-packages\setuptools\build_meta.py", line 319, in run_setup
      exec(code, locals())
    File "<string>", line 28, in <module>
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\process.py", line 121, in start
      self._popen = self._Popen(self)
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\context.py", line 224, in _Popen
      return _default_context.get_context().Process._Popen(process_obj)
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\context.py", line 327, in _Popen
      return Popen(process_obj)
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\popen_spawn_win32.py", line 93, in __init__
      reduction.dump(process_obj, to_child)
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\reduction.py", line 60, in dump
      ForkingPickler(file, protocol).dump(obj)
  _pickle.PicklingError: Can't pickle <function detect_distutils at 0x000002751F354B80>: attribute lookup detect_distutils on __main__ failed
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\spawn.py", line 107, in spawn_main
      new_handle = reduction.duplicate(pipe_handle,
    File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\multiprocessing\reduction.py", line 79, in duplicate
      return _winapi.DuplicateHandle(
  PermissionError: [WinError 5] Access is denied
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

Getting requirements to build wheel did not run successfully.
exit code: 1
```

In any case, let's move forward the python version to 3.12 so we're in sync with the version used by metamod ci. Hopefully this also solves the above problem.