### PR TITLE
Fix gamedata gamebin paths for x64, CS:GO-based games (#2370)

### DIFF
--- a/bridge/include/IFileSystemBridge.h
+++ b/bridge/include/IFileSystemBridge.h
@@ -58,6 +58,7 @@ public:
 	virtual bool IsDirectory(const char *pFileName, const char *pathID = 0) = 0;
 	virtual void CreateDirHierarchy(const char *path, const char *pathID = 0) = 0;
 	virtual int GetSearchPath(const char* pathID, bool bGetPackFiles, char* pPath, int nMaxLen) = 0;
+	virtual const char * GetGameBinArchSubdirectory() = 0;
 };
 
 } // namespace SourceMod

--- a/core/logic/GameConfigs.cpp
+++ b/core/logic/GameConfigs.cpp
@@ -1094,13 +1094,18 @@ void GameBinPathManager::Init()
 	std::istringstream iss(search_path);
 	for (std::string path; std::getline(iss, path, ';');)
 	{
-		if (path.length() > 0
-			&& path.find(addons_folder) == std::string::npos
-			&& m_lookup.find(path) == m_lookup.cend()
-			)
+		if (path.length() > 0)
 		{
-			m_lookup.insert(path);
-			m_ordered.push_back(path);
+			const char* arch_subdir = bridge->filesystem->GetGameBinArchSubdirectory();
+			std::string full_path = path + arch_subdir;
+			if (full_path.find(addons_folder) == std::string::npos
+				&& m_lookup.find(full_path) == m_lookup.cend()
+				)
+			{
+				m_lookup.insert(full_path);
+				m_ordered.push_back(full_path);
+
+			}
 		}
 	}
 

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -194,6 +194,26 @@ public:
 	{
 		return filesystem->GetSearchPath(pathID, bGetPackFiles, pPath, nMaxLen);
 	}
+	const char* GetGameBinArchSubdirectory() override
+	{
+#if defined KE_ARCH_X64
+#if SOURCE_ENGINE >= SE_BLADE
+#ifdef PLATFORM_WINDOWS
+#if SOURCE_ENGINE == SE_MCV
+		return "win64" PLATFORM_SEP;
+#else
+		return "x64" PLATFORM_SEP;
+#endif // SOURCE_ENGINE == SE_MCV
+#else
+		return "linux64" PLATFORM_SEP;
+#endif // PLATFORM_WINDOWS
+#else
+		// Already included in the GameBin path(s), if required
+		return "";
+#endif // SOURCE_ENGINE >= SE_BLADE
+#endif // KE_ARCH_X64
+		return "win32" PLATFORM_SEP;
+	}
 } fs_wrapper;
 
 class VPlayerInfo_Logic : public IPlayerInfoBridge


### PR DESCRIPTION
Fixes regression in #1626 due to games on the CS:GO engine not including the arch subdirectory in GAMEBIN paths (but rather hacking them in on-the-fly in `filesystem->LoadModule`)

Fixes #2370