### PR TITLE
Update Python version from 3.8 to 3.12

### DIFF
--- a/.github/workflows/scripting.yml
+++ b/.github/workflows/scripting.yml
@@ -31,9 +31,9 @@ jobs:
 
       # Setup Python for AMBuild
       - uses: actions/setup-python@v6
-        name: Setup Python 3.8
+        name: Setup Python 3.12
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install AMBuild
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Looks like this was missed in #2367 because the cache key for plugins wasn't refreshed. I've looked through the other yml files, everything else uses python 3.10 or higher (3.9 and earlier being the problematic versions on windows), so this should be the only file that needs correcting.