### PR TITLE
Make PostgreSQL setup scripts idempotent

### DIFF
--- a/configs/sql-init-scripts/pgsql/clientprefs-pgsql.sql
+++ b/configs/sql-init-scripts/pgsql/clientprefs-pgsql.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS sm_cookie_cache
 	PRIMARY KEY (player, cookie_id)
 );
 
-CREATE LANGUAGE plpgsql;
+CREATE OR REPLACE LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION add_or_update_cookie(in_player VARCHAR(65), in_cookie INT, in_value VARCHAR(100), in_time INT) RETURNS VOID AS
 $$

--- a/configs/sql-init-scripts/pgsql/create_admins.sql
+++ b/configs/sql-init-scripts/pgsql/create_admins.sql
@@ -1,4 +1,4 @@
-CREATE TABLE sm_admins (
+CREATE TABLE IF NOT EXISTS sm_admins (
   id serial,
   authtype varchar(6) NOT NULL,
   CHECK (authtype in ('steam', 'name', 'ip')),
@@ -10,7 +10,7 @@ CREATE TABLE sm_admins (
   PRIMARY KEY (id)
 );
 
-CREATE TABLE sm_groups (
+CREATE TABLE IF NOT EXISTS sm_groups (
   id serial,
   flags varchar(30) NOT NULL,
   name varchar(120) NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE sm_groups (
   PRIMARY KEY (id)
 );
 
-CREATE TABLE sm_group_immunity (
+CREATE TABLE IF NOT EXISTS sm_group_immunity (
   group_id int NOT NULL,
   other_id int NOT NULL,
   FOREIGN KEY (group_id) REFERENCES sm_groups(id) ON DELETE CASCADE,
@@ -26,7 +26,7 @@ CREATE TABLE sm_group_immunity (
   PRIMARY KEY (group_id, other_id)
 );
 
-CREATE TABLE sm_group_overrides (
+CREATE TABLE IF NOT EXISTS sm_group_overrides (
   group_id int NOT NULL,
   FOREIGN KEY (group_id) REFERENCES sm_groups(id) ON DELETE CASCADE,
   type varchar(10) NOT NULL,
@@ -37,7 +37,7 @@ CREATE TABLE sm_group_overrides (
   PRIMARY KEY (group_id, type, name)
 );
 
-CREATE TABLE sm_overrides (
+CREATE TABLE IF NOT EXISTS sm_overrides (
   type varchar(10) NOT NULL,
   CHECK (type in ('command', 'group')),
   name varchar(32) NOT NULL,
@@ -45,7 +45,7 @@ CREATE TABLE sm_overrides (
   PRIMARY KEY (type,name)
 );
 
-CREATE TABLE sm_admins_groups (
+CREATE TABLE IF NOT EXISTS sm_admins_groups (
   admin_id int NOT NULL,
   group_id int NOT NULL,
   FOREIGN KEY (admin_id) REFERENCES sm_admins(id) ON DELETE CASCADE,
@@ -56,10 +56,10 @@ CREATE TABLE sm_admins_groups (
 
 -- side note, this is pgsql module, sm_config will not exist if the above stuff exists... and it's being left to the admin
 -- to figure out if it exists.
-CREATE TABLE sm_config (
+CREATE TABLE IF NOT EXISTS sm_config (
   cfg_key varchar(32) NOT NULL,
   cfg_value varchar(255) NOT NULL,
   PRIMARY KEY (cfg_key)
 );
 
-INSERT INTO sm_config (cfg_key, cfg_value) VALUES ('admin_version', '1.0.0.1409');
+INSERT INTO sm_config (cfg_key, cfg_value) VALUES ('admin_version', '1.0.0.1409') ON CONFLICT (cfg_key) DO UPDATE SET cfg_value = EXCLUDED.cfg_value;


### PR DESCRIPTION
This makes the PostgreSQL setup scripts idempotent, so that they can be repeatedly ran against a database without failing. This is useful for applying database migrations upon server restart.

By definition this should have zero effect on existing installs, and is therefore 100% backwards compatible.

Closes https://github.com/alliedmodders/sourcemod/issues/2373