### PR TITLE
Update DoD:S Gamedata

### DIFF
--- a/gamedata/sdktools.games/game.dod.txt
+++ b/gamedata/sdktools.games/game.dod.txt
@@ -121,6 +121,13 @@
 				"linux"		"259"
 				"linux64"	"259"
 			}
+			"GetAttachment"
+			{
+				"windows"	"211"
+				"windows64"	"211"
+				"linux"		"212"
+				"linux64"	"212"
+			}
 		}
 		
 		"Keys"


### PR DESCRIPTION
Adds missing GetAttachment vtable offset.