### PR TITLE
Throw error if using invalid open mode with OpenFile native

### DIFF
--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -499,6 +499,44 @@ static cell_t sm_OpenFile(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToString(params[1], &name);
 	pContext->LocalToString(params[2], &mode);
 
+    if (mode == nullptr || mode[0] == '\0') {
+        return pContext->ThrowNativeError("File open mode cannot be empty!");
+    }
+    
+    if (mode[0] != 'r' && mode[0] != 'w' && mode[0] != 'a') {
+		return pContext->ThrowNativeError("File open mode is invalid \"%s\"!", mode);
+    }
+
+	bool has_plus = false, has_b = false, has_x = false, is_invalid = false;
+    for (int pos = 1; mode[pos] && !is_invalid; pos++) {
+        if (mode[pos] == '+') {
+            if (has_plus) {
+				is_invalid = true;
+			}
+            has_plus = true;
+        } else if (mode[pos] == 'b') {
+            if (has_b) {
+				is_invalid = true;
+			}
+            has_b = true;
+        } else if (mode[pos] == 'x') {
+            if (has_x) {
+				is_invalid = true;
+			}
+			// 'x' mode is only valid with 'w'
+            if (mode[0] != 'w') {
+				is_invalid = true;
+			}
+            has_x = true;
+        } else {
+            is_invalid = true;
+        }
+    }
+
+	if (is_invalid) {
+		return pContext->ThrowNativeError("File open mode is invalid \"%s\"!", mode);
+	}
+
 	FileObject *file = NULL;
 	if (params[0] <= 2 || !params[3]) {
 		char realpath[PLATFORM_MAX_PATH];


### PR DESCRIPTION
Fixes #2069 

Assumed it would be a simple matter of intercepting an exception, except it wasn't. Looks like this is more of microsoft randomness.

This PR throws in a quick open mode check on the string passed by the plugin. If anything this will help devs narrow down mistakes. Open mode check isn't my own nor do I think its perfect, but its good enough for us, it complies with what I read of the standard. I slightly tweaked it to our needs.