### PR TITLE
Add Missing SetOwnerEntity Offset For DoD:S

### DIFF
--- a/gamedata/sdktools.games/game.dod.txt
+++ b/gamedata/sdktools.games/game.dod.txt
@@ -16,6 +16,13 @@
 	{
 		"Offsets"
 		{
+			"SetOwnerEntity"
+			{
+				"windows"	"18"
+				"windows64"	"18"
+				"linux"		"19"
+				"linux64"	"19"
+			}
 			"GiveNamedItem"
 			{
 				"windows"	"407"


### PR DESCRIPTION
Adds missing vtable offset. Should fix `SetEntitiyCollisionGroup` and `EntityCollisionRulesChanged` throwing unsupported mod error.