### PR TITLE
[clientprefs] Supress expected postgres error with ON CONFLICT

### DIFF
--- a/extensions/clientprefs/query.cpp
+++ b/extensions/clientprefs/query.cpp
@@ -183,7 +183,7 @@ bool TQueryOp::BindParamsAndRun()
 				g_pSM->Format(query,
 					sizeof(query),
 					"INSERT INTO sm_cookies (name, description, access) \
-					VALUES ('%s', '%s', %d)",
+					VALUES ('%s', '%s', %d) ON CONFLICT (name) DO NOTHING",
 					safe_name,
 					safe_desc,
 					m_params.cookie->access);


### PR DESCRIPTION
Bring the same ignore functionality to the query as the sqlite/mysql queries and stops the annoying error spam.

The `ON CONFLICT` support was added to pg 9.5, and sm is built against 9.6, so should be no issues there.

```
L 03/04/2026 - 23:34:26: [CLIENTPREFS] Failed SQL Query, Error: "ERROR:  duplicate key value violates unique constraint "sm_cookies_name_key"
DETAIL:  Key (name)=(remember_class) already exists.
" (Query id 0 - serial 0)
L 03/04/2026 - 23:34:26: [CLIENTPREFS] Failed SQL Query, Error: "ERROR:  duplicate key value violates unique constraint "sm_cookies_name_key"
DETAIL:  Key (name)=(latest_class) already exists.
```