### PR TITLE
Add direct int64-to-string support

### DIFF
--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -175,6 +175,18 @@ static cell_t Int64ToString(IPluginContext *pCtx, const cell_t *params)
 	return static_cast<cell_t>(res);
 }
 
+static cell_t Int64ToStringEx(IPluginContext *pCtx, const cell_t *params)
+{
+	char *str;
+	pCtx->LocalToString(params[3], &str);
+
+	int64_t number = (int64_t)(((uint64_t)(uint32_t)params[2] << 32ull) | (uint32_t)params[1]);
+
+	size_t res = ke::SafeSprintf(str, params[4], "%" KE_FMT_I64, number);
+
+	return static_cast<cell_t>(res);
+}
+
 static cell_t sm_strtofloat(IPluginContext *pCtx, const cell_t *params)
 {
 	char *str, *dummy;
@@ -619,6 +631,7 @@ REGISTER_NATIVES(basicStrings)
 	{"GetCharBytes",		GetCharBytes},
 	{"IntToString",			sm_numtostr},
 	{"Int64ToString",		Int64ToString},
+    {"Int64ToStringEx",	    Int64ToStringEx},
 	{"IsCharAlpha",			IsCharAlpha},
 	{"IsCharLower",			IsCharLower},
 	{"IsCharMB",			IsCharMB},

--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -175,18 +175,6 @@ static cell_t Int64ToString(IPluginContext *pCtx, const cell_t *params)
 	return static_cast<cell_t>(res);
 }
 
-static cell_t Int64ToStringEx(IPluginContext *pCtx, const cell_t *params)
-{
-	char *str;
-	pCtx->LocalToString(params[3], &str);
-
-	int64_t number = (int64_t)(((uint64_t)(uint32_t)params[2] << 32ull) | (uint32_t)params[1]);
-
-	size_t res = ke::SafeSprintf(str, params[4], "%" KE_FMT_I64, number);
-
-	return static_cast<cell_t>(res);
-}
-
 static cell_t sm_strtofloat(IPluginContext *pCtx, const cell_t *params)
 {
 	char *str, *dummy;
@@ -631,7 +619,6 @@ REGISTER_NATIVES(basicStrings)
 	{"GetCharBytes",		GetCharBytes},
 	{"IntToString",			sm_numtostr},
 	{"Int64ToString",		Int64ToString},
-	{"Int64ToStringEx",		Int64ToStringEx},
 	{"IsCharAlpha",			IsCharAlpha},
 	{"IsCharLower",			IsCharLower},
 	{"IsCharMB",			IsCharMB},

--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -631,7 +631,7 @@ REGISTER_NATIVES(basicStrings)
 	{"GetCharBytes",		GetCharBytes},
 	{"IntToString",			sm_numtostr},
 	{"Int64ToString",		Int64ToString},
-    {"Int64ToStringEx",	    Int64ToStringEx},
+	{"Int64ToStringEx",		Int64ToStringEx},
 	{"IsCharAlpha",			IsCharAlpha},
 	{"IsCharLower",			IsCharLower},
 	{"IsCharMB",			IsCharMB},

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -434,7 +434,7 @@ void AddBinary(char **buf_p, size_t &maxlen, unsigned int val, int width, int fl
 	*buf_p = buf;
 }
 
-void AddUInt(char **buf_p, size_t &maxlen, unsigned int val, int width, int flags)
+void AddUInt(char **buf_p, size_t &maxlen, uint64_t val, int width, int flags)
 {
 	char text[32];
 	int digits;
@@ -478,24 +478,23 @@ void AddUInt(char **buf_p, size_t &maxlen, unsigned int val, int width, int flag
 	*buf_p = buf;
 }
 
-void AddInt(char **buf_p, size_t &maxlen, int val, int width, int flags)
+void AddInt(char **buf_p, size_t &maxlen, int64_t val, int width, int flags)
 {
 	char text[32];
 	int digits;
-	int signedVal;
+	int64_t signedVal;
 	char *buf;
-	unsigned int unsignedVal;
+	uint64_t unsignedVal;
 
 	digits = 0;
 	signedVal = val;
 	if (val < 0)
 	{
-		/* we want the unsigned version */
-		unsignedVal = abs(val);
+		unsignedVal = 0 - static_cast<uint64_t>(val);
 	}
 	else
 	{
-		unsignedVal = val;
+		unsignedVal = static_cast<uint64_t>(val);
 	}
 
 	do
@@ -1115,6 +1114,31 @@ reswitch:
 			{
 				flags |= ZEROPAD;
 				goto rflag;
+			}
+		case 'l':
+			{
+				CHECK_ARGS(0);
+				ch = *fmt++;
+
+				if (ch != 'd' && ch != 'i' && ch != 'u')
+				{
+					return pCtx->ThrowNativeError("Invalid formatter. Only %%ld, %%li, %%lu are allowed.");
+				}
+
+				cell_t *addr;
+				pCtx->LocalToPhysAddr(params[arg], &addr);
+
+				if (ch == 'u')
+				{
+					AddUInt(&buf_p, llen, *reinterpret_cast<uint64_t *>(addr), width, flags);
+				}
+				else
+				{
+					AddInt(&buf_p, llen, *reinterpret_cast<int64_t *>(addr), width, flags);
+				}
+
+				arg++;
+				break;
 			}
 		case '1':
 		case '2':

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -244,7 +244,10 @@ native int Int64ToString(const int num[2], char[] str, int maxlength);
  * @return              Number of characters written to the buffer,
  *                      not including the null terminator.
  */
-native int Int64ToStringEx(int64 num, char[] str, int maxlength);
+stock int Int64ToStringEx(int64 num, char[] str, int maxlength)
+{
+	return Format(str, maxlength, "%li", num);
+}
 
 /** 
  * Converts a string to a floating point number.

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -224,7 +224,7 @@ native int StringToInt64(const char[] str, int result[2], int nBase=10);
 native int IntToString(int num, char[] str, int maxlength);
 
 /**
- * Converts a 64-bit integer to a string.
+ * Converts a 64-bit integer in the legacy 2-cell representation to a string.
  *
  * @param num           Array containing the upper and lower
  *                      32-bits of a 64-bit integer.
@@ -234,6 +234,17 @@ native int IntToString(int num, char[] str, int maxlength);
  *                      not including the null terminator.
  */
 native int Int64ToString(const int num[2], char[] str, int maxlength);
+
+/**
+ * Converts an int64 value to a string.
+ *
+ * @param num           int64 value to convert.
+ * @param str           Buffer to store string in.
+ * @param maxlength     Maximum length of string buffer.
+ * @return              Number of characters written to the buffer,
+ *                      not including the null terminator.
+ */
+native int Int64ToStringEx(int64 num, char[] str, int maxlength);
 
 /** 
  * Converts a string to a floating point number.


### PR DESCRIPTION
## Summary

Add direct string conversion support for the newer `int64` type.

## Why

Issue #2413 points out that while `int64` now exists, there is no direct way to convert it to a string. This makes it harder to display values in menus, chat, logs, and debugging output.

## Changes

* add a direct conversion native for `int64`
* keep the legacy `Int64ToString(const int num[2], ...)` API unchanged
* clarify the legacy `Int64ToString` documentation in `string.inc`

## Notes

This is intentionally kept small and additive for backwards compatibility.

Draft PR for early feedback on API naming and parameter handling.

Refs #2413