### PR TITLE
Add GitHub Actions release CI and spcomp container build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,230 @@
+name: Build master branch
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+.[0-9]+-dev'
+env:
+  ARCH: x86,x86_64
+  DUMP_SYMS_VERSION: '2.3.7'
+  # Used for caching
+  # TODO: Handle this better so that we don't have to update this in lockstep with checkout-deps
+  MYSQL_VERSION: '5.7'
+  MMSOURCE_VERSION: '1.12'
+jobs:
+  build:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - platform: windows
+            os: windows-latest
+            os_short: win
+          - platform: linux
+            os: ubuntu-latest
+            os_short: linux
+            container_image: ghcr.io/alliedmodders/build-containers/debian11:latest
+      fail-fast: false
+    name: ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container_image }}
+    steps:
+      - name: Checkout SourceMod
+        uses: actions/checkout@v6
+        with:
+          path: sourcemod
+          fetch-depth: 0
+          submodules: recursive
+      
+      - name: Install Windows dependencies
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        run: |
+          # Add DIA SDK bin directory to PATH for dump_syms
+          # vswhere.exe is pre-installed on GitHub Windows runners
+          $vsRoot = & vswhere -latest -property installationPath
+          $diaDir = Join-Path $vsRoot 'DIA SDK\bin'
+          $diaDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          
+          $toolsDir = New-Item -Path '_tools' -ItemType Directory -Force
+          $toolsDir.FullName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Push-Location $toolsDir
+          $dumpsymsUrl = "https://github.com/mozilla/dump_syms/releases/download/v${{ env.DUMP_SYMS_VERSION }}/dump_syms-x86_64-pc-windows-msvc.zip"
+          curl -sSL -o dump_syms.zip $dumpsymsUrl
+          Expand-Archive -Path dump_syms.zip -DestinationPath .
+          Remove-Item dump_syms.zip
+          # Flatten if extracted into a subdirectory
+          Get-ChildItem -Recurse -Filter 'dump_syms.exe' | Move-Item -Destination . -ErrorAction SilentlyContinue
+          Pop-Location
+      
+      # Largely a workaround for issue where github.workspace doesn't match $GITHUB_WORKSPACE
+      # in containerized jobs. See https://github.com/actions/runner/issues/2058
+      - name: Resolve paths
+        id: path_helper
+        shell: bash
+        run: |
+          echo "dependencies=$GITHUB_WORKSPACE/dependencies" >> $GITHUB_OUTPUT
+      
+      - name: Generate SDK list
+        id: sdk_list
+        shell: bash
+        run: |
+            sdk_list=()
+            for file in sourcemod/hl2sdk-manifests/manifests/*.json; do
+              sdk=$(basename "$file" .json)
+              if [[ $sdk == "mock" ]]; then
+                # We don't need to ship a build for the mock SDK
+                continue
+              fi
+
+              platform=$(jq -r '.platforms.${{ matrix.platform }}' "$file")
+              if [[ -z $platform || $platform == "null" || ${#platform[@]} -eq 0 ]]; then
+                continue
+              fi
+
+              source2=$(jq -r '.source2' "$file")
+              if [[ $source2 == "null" || $source2 == "true" ]]; then
+                continue
+              fi
+
+              sdk_list+=("$sdk")
+            done
+            echo "sdk_list=$(printf '%s\n' "${sdk_list[@]}" | jq --raw-input . | jq --slurp --compact-output .)" >> $GITHUB_OUTPUT
+      
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        env:
+          cache-name: hl2sdk-mysql-mmsource
+        with:
+          path: ${{ steps.path_helper.outputs.dependencies }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-mysql${{ env.MYSQL_VERSION }}-mmsource${{ env.MMSOURCE_VERSION }}-${{ join(fromJson(steps.sdk_list.outputs.sdk_list), '') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-mysql${{ env.MYSQL_VERSION }}-mmsource${{ env.MMSOURCE_VERSION }}-
+            ${{ runner.os }}-build-${{ env.cache-name }}-mysql${{ env.MYSQL_VERSION }}-
+      
+      - name: Install dependencies
+        shell: bash
+        run: |
+          mkdir -p '${{ steps.path_helper.outputs.dependencies }}'
+          cd '${{ steps.path_helper.outputs.dependencies }}'
+
+          # Satisfy checkout-deps requirement for a "sourcemod" folder.
+          mkdir -p sourcemod
+          ../sourcemod/tools/checkout-deps.sh -s ${{ join(fromJson(steps.sdk_list.outputs.sdk_list), ',') }}
+
+          if [ ! -f GeoLite2-City_20191217/GeoLite2-City.mmdb ]; then
+            geotar="GeoLite2-City_20191217.tar.gz"
+            curl -sSL "https://sm.alliedmods.net/$geotar" -o $geotar
+            tar -xzf "$geotar"
+            rm "$geotar"
+          fi
+
+      - name: Build
+        working-directory: sourcemod
+        shell: bash
+        env:
+          BREAKPAD_SYMBOL_SERVER: ${{ vars.BREAKPAD_SYMBOL_SERVER }}
+          BREAKPAD_SYMBOL_SERVER_TOKEN: ${{ secrets.BREAKPAD_SYMBOL_SERVER_TOKEN }}
+        run: |
+          mkdir build
+          cd build
+          python3 ../configure.py \
+            --enable-optimize \
+            --breakpad-dump \
+            --no-color \
+            --symbol-files \
+            --sdks=${{ join(fromJson(steps.sdk_list.outputs.sdk_list), ',') }} \
+            --targets=${{ env.ARCH }} \
+            '--mms-path=${{ steps.path_helper.outputs.dependencies }}/mmsource-${{ env.MMSOURCE_VERSION }}' \
+            '--hl2sdk-root=${{ steps.path_helper.outputs.dependencies }}' \
+            '--mysql-path=${{ steps.path_helper.outputs.dependencies }}/mysql-${{ env.MYSQL_VERSION }}' \
+            '--mysql64-path=${{ steps.path_helper.outputs.dependencies }}/mysql-${{ env.MYSQL_VERSION }}-x86_64'
+          ambuild
+
+          mkdir -p addons/sourcemod/configs/geoip
+          cp '${{ steps.path_helper.outputs.dependencies }}/GeoLite2-City_20191217/GeoLite2-City.mmdb' addons/sourcemod/configs/geoip/GeoLite2-City.mmdb
+      
+      - name: Package
+        id: package
+        working-directory: sourcemod/build/package
+        shell: bash
+        run: |
+          version_base=$(cat ../../product.version)
+          version_base=${version_base%-dev} # Ex. 1.12.0
+          version_rev=$(git rev-list --count HEAD)
+          version="${version_base}.${version_rev}"
+          expanded_version="${version_base}-git${version_rev}"
+
+          if [ "${{ matrix.platform}}" == "windows" ]; then
+            filename="sourcemod-${expanded_version}-${{ matrix.platform }}.zip"
+            7z a "$filename" addons cfg
+            content_type="application/zip"
+          else
+            filename="sourcemod-${expanded_version}-${{ matrix.platform }}.tar.gz"
+            tar zcf "$filename" addons cfg
+            content_type="application/gzip"
+          fi
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "expanded_version=$expanded_version" >> $GITHUB_OUTPUT
+          echo "filename=$filename" >> $GITHUB_OUTPUT
+          echo "content_type=$content_type" >> $GITHUB_OUTPUT
+        
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          # Windows and Linux packages will need to upload to the same release
+          allowUpdates: true
+          replacesArtifacts: false
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
+          artifacts: sourcemod/build/package/${{ steps.package.outputs.filename }}
+          artifactContentType: ${{ steps.package.outputs.content_type }}
+          artifactErrorsFailBuild: true
+
+          tag: ${{ steps.package.outputs.version }}
+          commit: ${{ github.sha }}
+          generateReleaseNotes: true
+                    
+          draft: false
+          prerelease: ${{ github.ref == 'refs/heads/master' }}
+          makeLatest: ${{ github.ref != 'refs/heads/master' }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Output PDBs
+        if: startsWith(matrix.os, 'windows')
+        shell: pwsh
+        id: output_pdbs
+        working-directory: sourcemod/build
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $buildDir = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'sourcemod/build'
+          $outDir = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'pdbs'
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          Get-Content -LiteralPath (Join-Path -Path $buildDir -ChildPath 'pdblog.txt') |
+            ForEach-Object -Process {
+              $fullPdbPathInfo = (Get-Item -Path (Join-Path -Path $buildDir -ChildPath $_))
+              $baseName = $fullPdbPathInfo.BaseName
+              $dir = $fullPdbPathInfo.DirectoryName
+              
+              '.pdb', '.exe', '.dll' | ForEach-Object -Process {
+                  $binPath = Join-Path $dir ($baseName + $_)
+                  if (Test-Path $binPath) {
+                    Copy-Item -Path $binPath -Destination $outDir
+                  }
+              }
+          }
+      
+      - name: Upload PDBs
+        if: startsWith(matrix.os, 'windows')
+        id: upload_pdbs
+        uses: actions/upload-artifact@v4
+        with:
+          name: pdbs
+          path: pdbs/*

--- a/.github/workflows/build-spcomp.yml
+++ b/.github/workflows/build-spcomp.yml
@@ -1,0 +1,60 @@
+name: Build and Push spcomp Container
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !contains(github.ref, '-dev') }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-spcomp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./containers/Containerfile.spcomp
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,13 +1,13 @@
-name: Continuous Integration
+name: PR Checks
 on: 
-  push:
-    branches:
-     - master
-     - '[0-9]+.[0-9]+-dev'
   pull_request:
     branches:
      - master
      - '[0-9]+.[0-9]+-dev'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     strategy:

--- a/containers/Containerfile.spcomp
+++ b/containers/Containerfile.spcomp
@@ -1,0 +1,16 @@
+# Build stage - use the same image as sourcemod CI builds
+FROM ghcr.io/alliedmodders/build-containers/debian11:latest AS builder
+
+COPY sourcepawn/ /build/sourcepawn/
+
+WORKDIR /build/sourcepawn
+RUN mkdir build && cd build && \
+    python3 ../configure.py --enable-optimize --targets=x86_64 && \
+    ambuild
+
+# Runtime stage
+FROM debian:bullseye-slim
+
+COPY --from=builder /build/sourcepawn/build/spcomp /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/spcomp"]


### PR DESCRIPTION
Supersedes !2189. It's largely the same, but further tweaks and accounting for the past 1.5 years of changes to the repo as this was stalled.

> This change, starting with the master/dev builds, shifts to crafting our release builds with GitHub Actions as an alternative to our aging Buildbot infrastructure. Additionally, this offers increased transparency of how the binaries are generated.
> 
> Some scattered notes:
> 
>     The Linux builds use a [custom container image](https://github.com/alliedmodders/build-containers/blob/main/debian11.containerfile) mocked to be as close to our existing build VM, primarily as to not introduce additional runtime dependencies or different compiler version behavior.
>     The Windows builds use the stock GHA Windows Server 2022 runner with its default of Visual Studio 2022. We have the option to downgrade back to VS 2019 if that becomes an issue
>     Builds are created for the same SDKs / engines as our Buildbot builds
>     Builds submit symbols in Breakpad format for usage with Accelerator, just as with our Buildbot builds
>     Release package format and naming is identical to the Buildbot builds, with a Release and Tag being created for each master push, and the Windows and Linux package being uploaded to each release
>     PDBs are not yet piped through to our symbol server, but are exposed as Workflow Artifacts
> 
> Our scheduled scripts that manage the download data on the SourceMod downloads page would be able to be updated to optionally download the releases locally, and to either point at the local versions as we do now, or to point to them on GitHub. We can use a similar process to fetch the PDBs and add to our symbol server.
> 
> The full workflow currently takes 30-50 minutes to run. There is room for improvement there, but any significant improvement would likely require a significant rework.
> 