### PR TITLE
Fix convar hook crash

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -650,10 +650,16 @@ void ConVarManager::OnConVarChanged(ConVar *pConVar, const char *oldValue, float
 	{
 		ConVarReentrancyGuard guard(pConVar);
 
+		/* Copy the new value to a local buffer so it survives reentrant
+		 * ChangeStringValue calls that may delete[] + reallocate m_pszString
+		 * while the forward is still iterating plugin callbacks. */
+		char newValue[512];
+		strncpy(newValue, pConVar->GetString(), sizeof(newValue));
+
 		/* Now call forwards in plugins that have hooked this */
 		pForward->PushCell(pInfo->handle);
 		pForward->PushString(oldValue);
-		pForward->PushString(pConVar->GetString());
+		pForward->PushString(newValue);
 		pForward->Execute(NULL);
 	}
 }


### PR DESCRIPTION
If you hook a convar and make it longer inside the callback, srcds will move the string to another address. 

Sourcemod continues to copy the old invalid address to the other plugins hooking the same convar.

```
// plugin 1 must be picked by sourcemod to run hook first

public void OnPluginStart() {
    HookConVarChange(FindConVar("hostname"), OnChange);
}

public void OnChange(ConVar cvar, const char[] old, const char[] new) {
    cvar.SetString("trigger_realloc_with_a_longer_string_than_before");
}


// plugin 2

public void OnPluginStart() {
    HookConVarChange(FindConVar("hostname"), OnChange);
}

public void OnChange(ConVar cvar, const char[] old, const char[] new) {
    // crash
}
```