### PR TITLE
Command for refresh mapchooser map list and vote

### DIFF
--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -138,6 +138,7 @@ public void OnPluginStart()
 	
 	RegAdminCmd("sm_mapvote", Command_Mapvote, ADMFLAG_CHANGEMAP, "sm_mapvote - Forces MapChooser to attempt to run a map vote now.");
 	RegAdminCmd("sm_setnextmap", Command_SetNextmap, ADMFLAG_CHANGEMAP, "sm_setnextmap <map>");
+	RegAdminCmd("sm_mapchooser_refresh", Command_MapchooserRefresh, ADMFLAG_CONVARS, "sm_mapchooser_refresh - refresh map vote map list.");
 
 	g_Cvar_Winlimit = FindConVar("mp_winlimit");
 	g_Cvar_Maxrounds = FindConVar("mp_maxrounds");
@@ -211,7 +212,6 @@ public void OnConfigsExecuted()
 					 "mapchooser",
 					 MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_MAPSFOLDER)
 		!= null)
-		
 	{
 		if (g_mapFileSerial == -1)
 		{
@@ -332,6 +332,33 @@ public Action Command_SetNextmap(int client, int args)
 	g_MapVoteCompleted = true;
 
 	return Plugin_Handled;
+}
+
+public Action Command_MapchooserRefresh(int client, int args)
+{
+	CreateTimer(0.0, refreshmapchoosermaplist, _, TIMER_FLAG_NO_MAPCHANGE); // delaying by extra CPU cycles helps to get fresh 'mapcyclefile' map list
+	return Plugin_Handled;
+}
+
+public Action refreshmapchoosermaplist(Handle timer)
+{
+	if (g_HasVoteStarted) return Plugin_Stop;
+
+	if (ReadMapList(g_MapList,
+					 g_mapFileSerial, 
+					 "mapchooser",
+					 MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_MAPSFOLDER)
+		!= null)
+	{
+		if (g_mapFileSerial == -1)
+		{
+			LogError("Unable to create a valid map list. (Command_MapchooserRefresh)");
+		}
+	}
+
+	CreateNextVote();
+
+	return Plugin_Stop;
 }
 
 public void OnMapTimeLeftChanged()

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -212,6 +212,7 @@ public void OnConfigsExecuted()
 					 "mapchooser",
 					 MAPLIST_FLAG_CLEARARRAY|MAPLIST_FLAG_MAPSFOLDER)
 		!= null)
+		
 	{
 		if (g_mapFileSerial == -1)
 		{
@@ -336,11 +337,11 @@ public Action Command_SetNextmap(int client, int args)
 
 public Action Command_MapchooserRefresh(int client, int args)
 {
-	CreateTimer(0.0, refreshmapchoosermaplist, _, TIMER_FLAG_NO_MAPCHANGE); // delaying by extra CPU cycles helps to get fresh 'mapcyclefile' map list
+	CreateTimer(0.0, Timer_RefreshMapchooserList, _, TIMER_FLAG_NO_MAPCHANGE); // delaying by extra CPU cycles helps to get fresh 'mapcyclefile' map list
 	return Plugin_Handled;
 }
 
-public Action refreshmapchoosermaplist(Handle timer)
+public Action Timer_RefreshMapchooserList(Handle timer)
 {
 	if (g_HasVoteStarted) return Plugin_Stop;
 

--- a/plugins/mapchooser.sp
+++ b/plugins/mapchooser.sp
@@ -337,13 +337,7 @@ public Action Command_SetNextmap(int client, int args)
 
 public Action Command_MapchooserRefresh(int client, int args)
 {
-	CreateTimer(0.0, Timer_RefreshMapchooserList, _, TIMER_FLAG_NO_MAPCHANGE); // delaying by extra CPU cycles helps to get fresh 'mapcyclefile' map list
-	return Plugin_Handled;
-}
-
-public Action Timer_RefreshMapchooserList(Handle timer)
-{
-	if (g_HasVoteStarted) return Plugin_Stop;
+	if (g_HasVoteStarted) return Plugin_Handled;
 
 	if (ReadMapList(g_MapList,
 					 g_mapFileSerial, 
@@ -359,7 +353,7 @@ public Action Timer_RefreshMapchooserList(Handle timer)
 
 	CreateNextVote();
 
-	return Plugin_Stop;
+	return Plugin_Handled;
 }
 
 public void OnMapTimeLeftChanged()


### PR DESCRIPTION
Add new command for refresh Mapchooser map list and reconsture map vote.

Mapchooser plugin collect list of maps _on map start_ and also create readyup map vote handle.
These do not update until next map *or map vote "extended" or map vote "don't change" (or reloading plugin).

Mapchooser plugin also have ability to read list of maps based from cvar `mapcyclefile` file.
- Idea of this code change is, server owner have option to rebuild mapchooser plugin map vote after changing mapcyclefile list, middle of gameplay, not losing `g_NominateList` and exluded map list `g_OldMapList`.
- For example, if mapcyclefile list change happens on by player count using plugin, new command will help rebuild map vote.
