### PR TITLE
Fix return values of some natives.

### DIFF
--- a/plugins/include/admin.inc
+++ b/plugins/include/admin.inc
@@ -175,7 +175,7 @@ methodmap AdminId {
 	// @param name          String buffer to store name.
 	// @param maxlength     Maximum size of string buffer.
 	// @return              Number of bytes written.
-	public native void GetUsername(char[] name, int maxlength);
+	public native bool GetUsername(char[] name, int maxlength);
 
 	// Binds an admin to an identity for fast lookup later on.  The bind must be unique.
 	//

--- a/plugins/include/textparse.inc
+++ b/plugins/include/textparse.inc
@@ -191,7 +191,7 @@ methodmap SMCParser < Handle
 	// @param buffer        A string buffer for the error (contents undefined on failure).
 	// @param buf_max       The maximum size of the buffer.
 	// @return              The number of characters written to buffer.
-	public native void GetErrorString(SMCError error, char[] buffer, int buf_max);
+	public native bool GetErrorString(SMCError error, char[] buffer, int buf_max);
 };
 
 /**


### PR DESCRIPTION
These are listed as returning void, but actually have non-void returns in their implementation and pre-methodmap signatures.