### PR TITLE
[ANY] Added prohibition on changes to `rcon_password` via `sm_cvar`

### DIFF
--- a/plugins/basecommands.sp
+++ b/plugins/basecommands.sp
@@ -120,7 +120,16 @@ bool IsVarProtected(const char[] cvar)
 
 bool IsClientAllowedToChangeCvar(int client, const char[] cvarname)
 {
+	if (StrEqual(cvarname, "rcon_password", false))
+	{
+		return false;
+	}
+
 	ConVar hndl = FindConVar(cvarname);
+	if (hndl == null)
+	{
+		return false;
+	}
 
 	bool allowed = false;
 	int client_flags = client == 0 ? ADMFLAG_ROOT : GetUserFlagBits(client);


### PR DESCRIPTION
On a regular server, it is impossible to change/leak `rcon_password` in any way: not via VScript, not via `point_servercommand`, not even via RCON itself, but it remains possible to change/leak it via `sm_cvar`.

Example:
```
ent_create point_servercommand targetname psc;
ent_create logic_relay onspawn "psc,Command,rcon_password 1234;"; // Fail
ent_create logic_relay onspawn "psc,Command,sm_cvar rcon_password 1234;"; // Success
```