### PR TITLE
Supports "%f" formatting value as negative inf float

### DIFF
--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -269,7 +269,8 @@ void AddFloat(char **buf_p, size_t &maxlen, double fval, int width, int prec, in
 
 	if (ke::IsInfinite(static_cast<float>(fval)))
 	{
-		AddString(buf_p, maxlen, "Inf", width, prec, flags | NOESCAPE);
+		const char *str = ((fval < 0) ? "-Inf" : "Inf");
+		AddString(buf_p, maxlen, str, width, prec, flags | NOESCAPE);
 		return;
 	}
 


### PR DESCRIPTION
#2324 supports formatting float values ​​as the string "inf" instead of "0.0", but both positive and negative inf values ​​will be formatted as "inf".

The purpose of this PR is to support formatting negative inf values ​​as "-inf".
