### PR TITLE
Fix out-of-bounds crash in PluginIterator_Next

### DIFF
--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -151,6 +151,8 @@ public:
 	}
 	virtual IPlugin *GetPlugin() override
 	{
+		if (m_current == m_list.end())
+			return nullptr;
 		return *m_current;
 	}
 	virtual void NextPlugin() override
@@ -161,7 +163,8 @@ public:
 			return;
 		}
 
-		m_current++;
+		if (m_current != m_list.end())
+			m_current++;
 	}
 	virtual void Release() override
 	{
@@ -171,7 +174,7 @@ public:
 public:
 	virtual void OnPluginDestroyed(IPlugin *plugin) override
 	{
-		if (*m_current == plugin)
+		if (m_current != m_list.end() && *m_current == plugin)
 			m_current = m_list.erase(m_current);
 		else
 			m_list.remove(static_cast<SMPlugin *>(plugin));
@@ -402,12 +405,12 @@ static cell_t PluginIterator_Next(IPluginContext *pContext, const cell_t *params
 		return pContext->ThrowNativeError("Could not read Handle %x (error %d)", hndl, err);
 	}
 	
+	if(!pIter->MorePlugins())
+		return pContext->ThrowNativeError("PluginIterator %x is exhausted.", hndl);
+	
 	pIter->NextPlugin();
 	
-	if(!pIter->MorePlugins())
-		return 0;
-	
-	return 1;
+	return pIter->MorePlugins() ? 1 : 0;
 }
 
 static cell_t PluginIterator_Plugin_get(IPluginContext *pContext, const cell_t *params)

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -401,11 +401,12 @@ static cell_t PluginIterator_Next(IPluginContext *pContext, const cell_t *params
 	{
 		return pContext->ThrowNativeError("Could not read Handle %x (error %d)", hndl, err);
 	}
-
+	
+	pIter->NextPlugin();
+	
 	if(!pIter->MorePlugins())
 		return 0;
-
-	pIter->NextPlugin();
+	
 	return 1;
 }
 

--- a/plugins/include/sourcemod.inc
+++ b/plugins/include/sourcemod.inc
@@ -262,7 +262,7 @@ methodmap PluginIterator < Handle
 	// Advances the iterator. Returns whether there are more plugins available in the iterator.
 	//
 	// @return              True on more plugins, false otherwise.
-	// @error               Invalid Handle.
+	// @error               Invalid Handle, or called when the iterator is already exhausted.
 	public native bool Next();
 
 	// Returns the current plugin in the iterator.


### PR DESCRIPTION
fixes [#1880](https://github.com/alliedmodders/sourcemod/issues/1880)
Previously, `PluginIterator_Next` checked `MorePlugins()` before calling `NextPlugin()`. This flawed logic caused the native to return true even when `NextPlugin()` pushed the internal iterator to the `end()` of the list. 

This commit swaps the execution order: the iterator is now advanced first, and then validated. This ensures `Next()` correctly returns false when reaching the end of the plugin list.