### PR TITLE
Fix the funcommands plugin resetting all players' color and transparency on round end

### DIFF
--- a/plugins/funcommands/beacon.sp
+++ b/plugins/funcommands/beacon.sp
@@ -44,11 +44,6 @@ void CreateBeacon(int client)
 void KillBeacon(int client)
 {
 	g_BeaconSerial[client] = 0;
-
-	if (IsClientInGame(client))
-	{
-		SetEntityRenderColor(client, 255, 255, 255, 255);
-	}
 }
 
 void KillAllBeacons()

--- a/plugins/funcommands/beacon.sp
+++ b/plugins/funcommands/beacon.sp
@@ -55,7 +55,10 @@ void KillAllBeacons()
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		KillBeacon(i);
+		if (g_BeaconSerial[i] != 0)
+		{
+			KillBeacon(i);
+		}
 	}
 }
 

--- a/plugins/funcommands/fire.sp
+++ b/plugins/funcommands/fire.sp
@@ -60,7 +60,10 @@ void KillAllFireBombs()
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		KillFireBomb(i);
+		if (g_FireBombSerial[i] != 0)
+		{
+			KillFireBomb(i);
+		}
 	}
 }
 

--- a/plugins/funcommands/fire.sp
+++ b/plugins/funcommands/fire.sp
@@ -48,6 +48,11 @@ void CreateFireBomb(int client)
 
 void KillFireBomb(int client)
 {
+	if (g_FireBombSerial[client] == 0)
+	{
+		return;
+	}
+
 	g_FireBombSerial[client] = 0;
 
 	if (IsClientInGame(client))
@@ -60,10 +65,7 @@ void KillAllFireBombs()
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		if (g_FireBombSerial[i] != 0)
-		{
-			KillFireBomb(i);
-		}
+		KillFireBomb(i);
 	}
 }
 
@@ -83,7 +85,6 @@ void PerformFireBomb(int client, int target)
 	else
 	{
 		KillFireBomb(target);
-		SetEntityRenderColor(client, 255, 255, 255, 255);
 		LogAction(client, target, "\"%L\" removed a FireBomb on \"%L\"", client, target);
 	}
 }
@@ -176,7 +177,6 @@ public Action Timer_FireBomb(Handle timer, any value)
 
 		IgniteEntity(client, g_Cvar_BurnDuration.FloatValue);
 		KillFireBomb(client);
-		SetEntityRenderColor(client, 255, 255, 255, 255);
 		
 		if (g_Cvar_FireBombMode.IntValue > 0)
 		{

--- a/plugins/funcommands/fire.sp
+++ b/plugins/funcommands/fire.sp
@@ -77,7 +77,7 @@ void PerformBurn(int client, int target, float seconds)
 
 void PerformFireBomb(int client, int target)
 {
-	if (g_FireBombSerial[client] == 0)
+	if (g_FireBombSerial[target] == 0)
 	{
 		CreateFireBomb(target);
 		LogAction(client, target, "\"%L\" set a FireBomb on \"%L\"", client, target);

--- a/plugins/funcommands/timebomb.sp
+++ b/plugins/funcommands/timebomb.sp
@@ -59,7 +59,10 @@ void KillAllTimeBombs()
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		KillTimeBomb(i);
+		if (g_TimeBombSerial[i] != 0)
+		{
+			KillTimeBomb(i);
+		}
 	}
 }
 

--- a/plugins/funcommands/timebomb.sp
+++ b/plugins/funcommands/timebomb.sp
@@ -47,6 +47,11 @@ void CreateTimeBomb(int client)
 
 void KillTimeBomb(int client)
 {
+	if (g_TimeBombSerial[client] == 0)
+	{
+		return;
+	}
+
 	g_TimeBombSerial[client] = 0;
 
 	if (IsClientInGame(client))
@@ -59,10 +64,7 @@ void KillAllTimeBombs()
 {
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		if (g_TimeBombSerial[i] != 0)
-		{
-			KillTimeBomb(i);
-		}
+		KillTimeBomb(i);
 	}
 }
 
@@ -76,7 +78,6 @@ void PerformTimeBomb(int client, int target)
 	else
 	{
 		KillTimeBomb(target);
-		SetEntityRenderColor(client, 255, 255, 255, 255);
 		LogAction(client, target, "\"%L\" removed a TimeBomb on \"%L\"", client, target);
 	}
 }
@@ -152,7 +153,6 @@ public Action Timer_TimeBomb(Handle timer, any value)
 
 		ForcePlayerSuicide(client);
 		KillTimeBomb(client);
-		SetEntityRenderColor(client, 255, 255, 255, 255);
 		
 		if (g_Cvar_TimeBombMode.IntValue > 0)
 		{


### PR DESCRIPTION
The code does not check if the command is active before removing its effects. Since these reset functions are also ran at the end of the round, they cause every player's set color and transparency to be reset when round ends even if the command was not activated and it was set by other means such as other plugins or maps. This goes against the default behaviour where player color and transparency persists between round resets, some maps may prefer to keep these between rounds.

Also removed the unnecessary color and transparency reset in beacon code as this plugin never sets those, so no need to reset it.