### PR TITLE
Fix `IForward` definition

### DIFF
--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -446,12 +446,6 @@ int CForward::PushCell(cell_t cell)
 	return SP_ERROR_NONE;
 }
 
-int CForward::PushInt64(int64_t value)
-{
-	// Not supported yet
-	return SetError(SP_ERROR_PARAM);
-}
-
 int CForward::PushFloat(float number)
 {
 	if (m_curparam < m_numparams)

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -41,21 +41,19 @@ typedef ReentrantList<IPluginFunction *>::iterator FuncIter;
 
 class CForward : public IChangeableForward
 {
-public: //ICallable
-	virtual int PushCell(cell_t cell);
-	virtual int PushCellByRef(cell_t *cell, int flags);
-	virtual int PushFloat(float number);
-	virtual int PushFloatByRef(float *number, int flags);
-	virtual int PushArray(cell_t *inarray, unsigned int cells, int flags);
-	virtual int PushString(const char *string);
-	virtual int PushStringEx(char *buffer, size_t length, int sz_flags, int cp_flags);
-	virtual int PushInt64(int64_t value);
-	virtual void Cancel();
 public: //IForward
-	virtual const char *GetForwardName();
-	virtual unsigned int GetFunctionCount();
-	virtual ExecType GetExecType();
-	virtual int Execute(cell_t *result, IForwardFilter *filter);
+	virtual int PushCell(cell_t cell) override;
+	virtual int PushCellByRef(cell_t *cell, int flags) override;
+	virtual int PushFloat(float number) override;
+	virtual int PushFloatByRef(float *number, int flags) override;
+	virtual int PushArray(cell_t *inarray, unsigned int cells, int flags) override;
+	virtual int PushString(const char *string) override;
+	virtual int PushStringEx(char *buffer, size_t length, int sz_flags, int cp_flags) override;
+	virtual void Cancel() override;
+	virtual const char *GetForwardName() override;
+	virtual unsigned int GetFunctionCount() override;
+	virtual ExecType GetExecType() override;
+	virtual int Execute(cell_t *result, IForwardFilter *filter) override;
 public: //IChangeableForward
 	virtual bool RemoveFunction(IPluginFunction *func);
 	virtual unsigned int RemoveFunctionsOfPlugin(IPlugin *plugin);

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -41,7 +41,6 @@ HandleType_t g_GlobalFwdType = 0;
 HandleType_t g_PrivateFwdType = 0;
 
 static bool s_CallStarted = false;
-static ICallable *s_pCallable = NULL;
 static IPluginFunction *s_pFunction = NULL;
 static IForward *s_pForward = NULL;
 
@@ -102,7 +101,6 @@ inline void ResetCall()
 	s_CallStarted = false;
 	s_pFunction = NULL;
 	s_pForward = NULL;
-	s_pCallable = NULL;
 }
 
 static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *params)
@@ -346,8 +344,6 @@ static cell_t sm_CallStartFunction(IPluginContext *pContext, const cell_t *param
 		return pContext->ThrowNativeError("Invalid function id (%X)", funcid);
 	}
 
-	s_pCallable = static_cast<ICallable *>(s_pFunction);
-
 	s_CallStarted = true;
 
 	return 1;
@@ -372,8 +368,6 @@ static cell_t sm_CallStartForward(IPluginContext *pContext, const cell_t *params
 
 	s_pForward = pForward;
 
-	s_pCallable = static_cast<ICallable *>(pForward);
-
 	s_CallStarted = true;
 
 	return 1;
@@ -388,11 +382,11 @@ static cell_t sm_CallPushCell(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	err = s_pCallable->PushCell(params[1]);
+	err = (s_pForward) ? s_pForward->PushCell(params[1]) : s_pFunction->PushCell(params[1]);
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -412,11 +406,11 @@ static cell_t sm_CallPushCellRef(IPluginContext *pContext, const cell_t *params)
 
 	pContext->LocalToPhysAddr(params[1], &addr);
 
-	err = s_pCallable->PushCellByRef(addr);
+	err = (s_pForward) ? s_pForward->PushCellByRef(addr) : s_pFunction->PushCellByRef(addr);
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -433,11 +427,11 @@ static cell_t sm_CallPushFloat(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	err = s_pCallable->PushFloat(sp_ctof(params[1]));
+	err = (s_pForward) ? s_pForward->PushFloat(sp_ctof(params[1])) : s_pFunction->PushFloat(sp_ctof(params[1]));
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -457,11 +451,11 @@ static cell_t sm_CallPushFloatRef(IPluginContext *pContext, const cell_t *params
 
 	pContext->LocalToPhysAddr(params[1], &addr);
 
-	err = s_pCallable->PushFloatByRef(reinterpret_cast<float *>(addr));
+	err = (s_pForward) ? s_pForward->PushFloatByRef(reinterpret_cast<float *>(addr)) : s_pFunction->PushFloatByRef(reinterpret_cast<float *>(addr));
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -481,11 +475,11 @@ static cell_t sm_CallPushArray(IPluginContext *pContext, const cell_t *params)
 
 	pContext->LocalToPhysAddr(params[1], &addr);
 
-	err = s_pCallable->PushArray(addr, params[2]);
+	err = (s_pForward) ? s_pForward->PushArray(addr, params[2]) : s_pFunction->PushArray(addr, params[2]);
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -505,11 +499,11 @@ static cell_t sm_CallPushArrayEx(IPluginContext *pContext, const cell_t *params)
 
 	pContext->LocalToPhysAddr(params[1], &addr);
 
-	err = s_pCallable->PushArray(addr, params[2], params[3]);
+	err = (s_pForward) ? s_pForward->PushArray(addr, params[2], params[3]) : s_pFunction->PushArray(addr, params[2], params[3]);
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -529,11 +523,11 @@ static cell_t sm_CallPushString(IPluginContext *pContext, const cell_t *params)
 
 	pContext->LocalToString(params[1], &value);
 
-	err = s_pCallable->PushString(value);
+	err = (s_pForward) ? s_pForward->PushString(value) : s_pFunction->PushString(value);
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -553,11 +547,11 @@ static cell_t sm_CallPushStringEx(IPluginContext *pContext, const cell_t *params
 
 	pContext->LocalToString(params[1], &value);
 
-	err = s_pCallable->PushStringEx(value, params[2], params[3], params[4]);
+	err = (s_pForward) ? s_pForward->PushStringEx(value, params[2], params[3], params[4]) : s_pFunction->PushStringEx(value, params[2], params[3], params[4]);
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -589,7 +583,7 @@ static cell_t sm_CallPushNullVector(IPluginContext *pContext, const cell_t *para
 		err = runtime->GetPubvarAddrs(null_vector_idx, &null_vector, nullptr);
 
 		if (!err)
-			err = s_pCallable->PushCell(null_vector);
+			err = s_pFunction->PushCell(null_vector);
 	}
 	else if (s_pForward)
 	{
@@ -598,7 +592,7 @@ static cell_t sm_CallPushNullVector(IPluginContext *pContext, const cell_t *para
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -630,7 +624,7 @@ static cell_t sm_CallPushNullString(IPluginContext *pContext, const cell_t *para
 		err = runtime->GetPubvarAddrs(null_string_idx, &null_string, nullptr);
 
 		if (!err)
-			err = s_pCallable->PushCell(null_string);
+			err = s_pFunction->PushCell(null_string);
 	}
 	else if (s_pForward)
 	{
@@ -639,7 +633,7 @@ static cell_t sm_CallPushNullString(IPluginContext *pContext, const cell_t *para
 
 	if (err)
 	{
-		s_pCallable->Cancel();
+		(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 		ResetCall();
 		return pContext->ThrowNativeErrorEx(err, NULL);
 	}
@@ -681,7 +675,7 @@ static cell_t sm_CallCancel(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot cancel call when there is no call in progress");
 	}
 
-	s_pCallable->Cancel();
+	(s_pForward) ? s_pForward->Cancel() : s_pFunction->Cancel();
 	ResetCall();
 
 	return 1;

--- a/public/IForwardSys.h
+++ b/public/IForwardSys.h
@@ -50,7 +50,7 @@
 using namespace SourcePawn;
 
 #define SMINTERFACE_FORWARDMANAGER_NAME		"IForwardManager"
-#define SMINTERFACE_FORWARDMANAGER_VERSION	4
+#define SMINTERFACE_FORWARDMANAGER_VERSION	5
 
 /*
  * There is some very important documentation at the bottom of this file.
@@ -136,34 +136,120 @@ namespace SourceMod
 	 * Some functions are repeated in here because their documentation differs from their IPluginFunction equivalents.
 	 * Missing are the Push functions, whose only doc change is that they throw SP_ERROR_PARAM on type mismatches.
 	 */
-	class IForward : public ICallable
+	class IForward
 	{
 	public:
 		/** Virtual Destructor */
 		virtual ~IForward()
 		{
 		}
-	public:
+
+	    /**
+		* @brief Pushes a cell onto the forward.
+		*
+		* @param cell    Parameter value to push.
+		* @return      Error code, if any.
+		*/
+		virtual int PushCell(cell_t cell) = 0;
+
+		/**
+		* @brief Pushes a cell by reference onto the forward.
+		* NOTE: On Execute, the pointer passed will be modified if copyback is enabled.
+		* NOTE: By reference parameters are cached and thus are not read until execution.
+		*     This means you cannot push a pointer, change it, and push it again and expect
+		*       two different values to come out.
+		*
+		* @param cell    Address containing parameter value to push.
+		* @param flags    Copy-back flags.
+		* @return      Error code, if any.
+		*/
+		virtual int PushCellByRef(cell_t* cell, int flags = SM_PARAM_COPYBACK) = 0;
+
+		/**
+		* @brief Pushes a float onto the forward.
+		*
+		* @param number  Parameter value to push.
+		* @return      Error code, if any.
+		*/
+		virtual int PushFloat(float number) = 0;
+
+		/**
+		* @brief Pushes a float onto the forward by reference.
+		* NOTE: On Execute, the pointer passed will be modified if copyback is enabled.
+		* NOTE: By reference parameters are cached and thus are not read until execution.
+		*     This means you cannot push a pointer, change it, and push it again and expect
+		*       two different values to come out.
+		*
+		* @param number  Parameter value to push.
+		* @param flags    Copy-back flags.
+		* @return      Error code, if any.
+		*/
+		virtual int PushFloatByRef(float* number, int flags = SM_PARAM_COPYBACK) = 0;
+
+		/**
+		* @brief Pushes an array of cells onto the forward.
+		*
+		* On Execute, the pointer passed will be modified if non-NULL and copy-back
+		* is enabled.
+		*
+		* By reference parameters are cached and thus are not read until execution.
+		* This means you cannot push a pointer, change it, and push it again and expect
+		* two different values to come out.
+		*
+		* @param inarray  Array to copy, NULL if no initial array should be copied.
+		* @param cells    Number of cells to allocate and optionally read from the input array.
+		* @param flags    Whether or not changes should be copied back to the input array.
+		* @return      Error code, if any.
+		*/
+		virtual int PushArray(cell_t* inarray, unsigned int cells, int flags = 0) = 0;
+
+		/**
+		* @brief Pushes a string onto the forward.
+		*
+		* @param string  String to push.
+		* @return      Error code, if any.
+		*/
+		virtual int PushString(const char* string) = 0;
+
+		/**
+		* @brief Pushes a string or string buffer.
+		*
+		* NOTE: On Execute, the pointer passed will be modified if copy-back is enabled.
+		*
+		* @param buffer  Pointer to string buffer.
+		* @param length  Length of buffer.
+		* @param sz_flags  String flags.  In copy mode, the string will be copied
+		*          according to the handling (ascii, utf-8, binary, etc).
+		* @param cp_flags  Copy-back flags.
+		* @return      Error code, if any.
+		*/
+		virtual int PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags) = 0;
+
+		/**
+		* @brief Cancels a forward call that is being pushed but not yet executed.
+		*/
+		virtual void Cancel() = 0;
+
 		/**
 		 * @brief Returns the name of the forward.
 		 *
 		 * @return			Forward name.
 		 */
-		virtual const char *GetForwardName() =0;
+		virtual const char *GetForwardName() = 0;
 
 		/**
 		 * @brief Returns the number of functions in this forward.
 		 *
 		 * @return			Number of functions in forward.
 		 */
-		virtual unsigned int GetFunctionCount() =0;
+		virtual unsigned int GetFunctionCount() = 0;
 
 		/**
 		 * @brief Returns the method of multi-calling this forward has.
 		 *
 		 * @return			ExecType of the forward.
 		 */
-		virtual ExecType GetExecType() =0;
+		virtual ExecType GetExecType() = 0;
 
 		/**
 		 * @brief Executes the forward.
@@ -172,27 +258,7 @@ namespace SourceMod
 		 * @param filter		Do not use.
 		 * @return				Error code, if any.
 		 */
-		virtual int Execute(cell_t *result=NULL, IForwardFilter *filter=NULL) =0;
-
-		/**
-		 * @brief Pushes an array of cells onto the current call.  Different rules than ICallable.
-		 * NOTE: On Execute, the pointer passed will be modified according to the copyback rule.
-		 *
-		 * @param inarray	Array to copy.  If NULL and cells is 3 pushes a reference to the NULL_VECTOR pubvar to each callee.
-		 *                  Pushing other number of cells is not allowed, unlike ICallable's version.
-		 * @param cells		Number of cells to allocate and optionally read from the input array.
-		 * @param flags		Whether or not changes should be copied back to the input array.
-		 * @return			Error code, if any.
-		 */
-		virtual int PushArray(cell_t *inarray, unsigned int cells, int flags=0) =0;
-
-		/**
-		* @brief Pushes a string onto the current call.
-		*
-		* @param string  String to push.  If NULL pushes a reference to the NULL_STRING pubvar to each callee.
-		* @return      Error code, if any.
-		*/
-		virtual int PushString(const char *string) = 0;
+		virtual int Execute(cell_t *result=NULL, IForwardFilter *filter=NULL) = 0;
 	};
 
 	/**


### PR DESCRIPTION
Fixes #2456 

This bug was known for a while (9th of April 2026), but unfortunately the lack of issue on the tracker made me forget how urgent it was.
https://discord.com/channels/335290997317697536/335290997317697536/1491812815860797532

This PR hopefully fixes vtable shift bugs with `IForward` forever. I have removed the inheritance of `ICallable` by `IForward`, if any extension out there relied on the ability to mix `IForward(s)` with `ICallable(s)` this is unfortunately permanently broken. However I am highly doubtful this is a feature that was desired by extensions.

An alternative fix to this PR would be to have sourcepawn's `ICallable` be turned into a new class `ICallable2`. I don't think I need to argue why this is a bad solution and avoided it.

One more fix would be to find a method so that gcc,clang,msvc doesn't merge the vtable of `IForward` with `ICallable`. However even if that is possible, this won't help already compiled extensions. So this fix is a no go as well.