### PR TITLE
Fix strncpy buffer overflow in OnConVarChanged

### DIFF
--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -654,7 +654,7 @@ void ConVarManager::OnConVarChanged(ConVar *pConVar, const char *oldValue, float
 		 * ChangeStringValue calls that may delete[] + reallocate m_pszString
 		 * while the forward is still iterating plugin callbacks. */
 		char newValue[512];
-		strncpy(newValue, pConVar->GetString(), sizeof(newValue));
+		ke::SafeStrcpy(newValue, sizeof(newValue), pConVar->GetString());
 
 		/* Now call forwards in plugins that have hooked this */
 		pForward->PushCell(pInfo->handle);


### PR DESCRIPTION
strncpy does not append '\0' when the source is >= sizeof(dst). 
If a convar value is 512+ chars, PushString(newValue) leaks stack garbage into SP callbacks' newValue parameter.