### PR TITLE
Statically link SourcePawn

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -42,7 +42,6 @@ class SMConfig(object):
     self.sdks = {}
     self.sdk_targets = []
     self.binaries = []
-    self.spvm = []
     self.extensions = []
     self.generated_headers = None
     self.mms_root = None
@@ -647,12 +646,6 @@ for spcomp in SP.spcomp:
 if SM.spcomp.target.arch == 'universal':
     SM.spcomp_bins = [SM.spcomp]
 
-if not getattr(builder.options, 'scripting_only', False):
-  for cxx in SM.all_targets:
-    SM.spvm += [
-      SP.libsourcepawn[cxx.target.arch]
-    ]
-
 if getattr(builder.options, 'scripting_only', False):
   BuildScripts = [
     'tools/buildbot/PackageHelpers',
@@ -687,7 +680,7 @@ else:
       'tools/buildbot/PackageScript',
     ]
 
-builder.Build(BuildScripts, { 'SM': SM })
+builder.Build(BuildScripts, { 'SM': SM, 'SP': SP })
 
 if builder.options.breakpad_dump:
   builder.Build('tools/buildbot/BreakpadSymbols', { 'SM': SM })

--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -83,6 +83,7 @@ public:
 	IMenuManager	*menus;
 	SourcePawn::ISourcePawnEngine **spe1;
 	SourcePawn::ISourcePawnEngine2 **spe2;
+	SourcePawn::ISourcePawnEnvironment **spe_env;
 	const char		*gamesuffix;
 	/* Data */
 	ServerGlobals   *serverGlobals;

--- a/bridge/include/LogicProvider.h
+++ b/bridge/include/LogicProvider.h
@@ -74,6 +74,7 @@ struct sm_logic_t
 	void			(*SetEntityLumpWritable)(bool writable);
 	bool			(*ParseEntityLumpString)(const char *entityString, int &status, size_t &position);
 	const char *	(*GetEntityLumpString)();
+	void            (*Shutdown)();
 	IScriptManager	*scripts;
 	IShareSys		*sharesys;
 	IExtensionSys	*extsys;

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -18,13 +18,20 @@ for cxx in builder.targets:
   ]
   
   if binary.compiler.target.platform == 'linux':
-    binary.compiler.postlink += ['-lpthread', '-lrt']
+    binary.compiler.postlink += ['-lpthread', '-lrt', '-lm']
   elif binary.compiler.target.platform == 'mac':
     binary.compiler.cflags += ['-Wno-deprecated-declarations']
-    binary.compiler.postlink += ['-framework', 'CoreServices']
+    binary.compiler.postlink += ['-framework', 'CoreServices', '-lm']
+
+  arch = binary.compiler.target.arch
+  binary.compiler.linkflags += [
+    SP.static_libsp[arch],
+    SP.libamtl[arch],
+    SP.zlib[arch],
+  ]
 
   if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':
-    binary.compiler.cxxflags += ['-fno-rtti']
+    binary.compiler.cxxflags += ['-fno-rtti', '-Wno-invalid-offsetof']
   elif binary.compiler.family == 'msvc':
     binary.compiler.cxxflags += ['/GR-']
 

--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -94,45 +94,6 @@ void DebugReport::GenerateErrorVA(IPluginContext *ctx, cell_t func_idx, int err,
 	}
 }
 
-void DebugReport::GenerateCodeError(IPluginContext *pContext, uint32_t code_addr, int err, const char *message, ...)
-{
-	va_list ap;
-	char buffer[512];
-
-	va_start(ap, message);
-	ke::SafeVsprintf(buffer, sizeof(buffer), message, ap);
-	va_end(ap);
-
-	const char *plname = pluginsys->FindPluginByContext(pContext->GetContext())->GetFilename();
-	const char *error = g_pSourcePawn2->GetErrorString(err);
-
-	if (error)
-	{
-		g_Logger.LogError("[SM] Plugin \"%s\" encountered error %d: %s", plname, err, error);
-	} else {
-		g_Logger.LogError("[SM] Plugin \"%s\" encountered unknown error %d", plname, err);
-	}
-
-	g_Logger.LogError("[SM] %s", buffer);
-
-	IPluginDebugInfo *pDebug;
-	if ((pDebug = pContext->GetRuntime()->GetDebugInfo()) == NULL)
-	{
-		g_Logger.LogError("[SM] Debug mode is not enabled for \"%s\"", plname);
-		g_Logger.LogError("[SM] To enable debug mode, edit plugin_settings.cfg, or type: sm plugins debug %d on",
-			_GetPluginIndex(pContext));
-		return;
-	}
-
-	const char *name;
-	if (pDebug->LookupFunction(code_addr, &name) == SP_ERROR_NONE)
-	{
-		g_Logger.LogError("[SM] Unable to call function \"%s\" due to above error(s).", name);
-	} else {
-		g_Logger.LogError("[SM] Unable to call function (name unknown, address \"%p\").", code_addr);
-	}
-}
-
 int DebugReport::_GetPluginIndex(IPluginContext *ctx)
 {
 	int id = 1;

--- a/core/logic/DebugReporter.h
+++ b/core/logic/DebugReporter.h
@@ -51,7 +51,6 @@ public:
 	// good enough, and only wants the supplemental logging provided here.
 	void GenerateError(IPluginContext *ctx, cell_t func_idx, int err, const char *message, ...);
 	void GenerateErrorVA(IPluginContext *ctx, cell_t func_idx, int err, const char *message, va_list ap); 
-	void GenerateCodeError(IPluginContext *ctx, uint32_t code_addr, int err, const char *message, ...);
 	std::vector<std::string> GetStackTrace(IFrameIterator *iter);
 private:
 	int _GetPluginIndex(IPluginContext *ctx);

--- a/core/logic/common_logic.cpp
+++ b/core/logic/common_logic.cpp
@@ -57,6 +57,7 @@
 #include "RootConsoleMenu.h"
 #include "CellArray.h"
 #include "smn_entitylump.h"
+#include "sourcepawn/vm/environment.h"
 #include <bridge/include/BridgeAPI.h>
 #include <bridge/include/IProviderCallbacks.h>
 
@@ -160,6 +161,18 @@ public:
 	}
 } sProviderCallbackListener;
 
+static sp::Environment *g_pEnv = nullptr;
+
+static void logic_shutdown()
+{
+	if (g_pEnv)
+	{
+		g_pEnv->Shutdown();
+		delete g_pEnv;
+		g_pEnv = nullptr;
+	}
+}
+
 static sm_logic_t logic =
 {
 	NULL,
@@ -182,6 +195,7 @@ static sm_logic_t logic =
 	SetEntityLumpWritable,
 	ParseEntityLumpString,
 	GetEntityLumpString,
+	logic_shutdown,
 	&g_PluginSys,
 	&g_ShareSys,
 	&g_Extensions,
@@ -209,8 +223,15 @@ static void logic_init(CoreProvider* core, sm_logic_t* _logic)
 	playerhelpers = core->playerhelpers;
 	gamehelpers = core->gamehelpers;
 	menus = core->menus;
-	g_pSourcePawn = *core->spe1;
-	g_pSourcePawn2 = *core->spe2;
+
+	g_pEnv = sp::Environment::New();
+	g_pSourcePawn = g_pEnv->APIv1();
+	g_pSourcePawn2 = g_pEnv->APIv2();
+
+	*core->spe1 = g_pSourcePawn;
+	*core->spe2 = g_pSourcePawn2;
+	*core->spe_env = g_pEnv;
+
 	SMGlobalClass::head = core->listeners;
 
 	g_ShareSys.Initialize();

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -424,6 +424,7 @@ CoreProviderImpl::CoreProviderImpl()
 	this->menus = &g_Menus;
 	this->spe1 = &g_pSourcePawn;
 	this->spe2 = &g_pSourcePawn2;
+	this->spe_env = &g_pPawnEnv;
 	this->GetCoreConfigValue = get_core_config_value;
 	this->DoGlobalPluginLoads = do_global_plugin_loads;
 	this->AreConfigsExecuted = SM_AreConfigsExecuted;
@@ -796,6 +797,9 @@ void CoreProviderImpl::ShutdownHooks()
 
 void CoreProviderImpl::ShutdownBridge()
 {
+	if (logicore.Shutdown) {
+		logicore.Shutdown();
+	}
 	logic_ = nullptr;
 }
 

--- a/core/sm_globals.h
+++ b/core/sm_globals.h
@@ -195,8 +195,9 @@ public:
 	static SMGlobalClass *head;
 };
 
-extern ISourcePawnEngine *g_pSourcePawn;
-extern ISourcePawnEngine2 *g_pSourcePawn2;
+extern SourcePawn::ISourcePawnEngine *g_pSourcePawn;
+extern SourcePawn::ISourcePawnEngine2 *g_pSourcePawn2;
+extern SourcePawn::ISourcePawnEnvironment *g_pPawnEnv;
 extern IdentityToken_t *g_pCoreIdent;
 
 namespace SourceMod

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -58,7 +58,6 @@ SH_DECL_HOOK0(IVEngineServer, GetMapEntitiesString, SH_NOATTRIB, 0, const char *
 
 SourceModBase g_SourceMod;
 
-ke::RefPtr<ke::SharedLib> g_JIT;
 SourceHook::String g_BaseDir;
 ISourcePawnEngine *g_pSourcePawn = NULL;
 ISourcePawnEngine2 *g_pSourcePawn2 = NULL;
@@ -78,20 +77,6 @@ ConVar sm_basepath("sm_basepath", "addons\\sourcemod", 0, "SourceMod base path (
 #elif defined PLATFORM_LINUX || defined PLATFORM_APPLE
 ConVar sm_basepath("sm_basepath", "addons/sourcemod", 0, "SourceMod base path (set via command line)");
 #endif
-
-void ShutdownJIT()
-{
-	if (g_pPawnEnv) {
-		g_pPawnEnv->Shutdown();
-		delete g_pPawnEnv;
-
-		g_pPawnEnv = NULL;
-		g_pSourcePawn2 = NULL;
-		g_pSourcePawn = NULL;
-	}
-
-	g_JIT = nullptr;
-}
 
 SourceModBase::SourceModBase()
 {
@@ -210,63 +195,10 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 		return false;
 	}
 
+	sCoreProviderImpl.InitializeBridge();
+
 	/* There will always be a path by this point, since it was force-set above. */
 	m_GotBasePath = true;
-
-#if defined KE_ARCH_X86
-# define SOURCEPAWN_DLL "sourcepawn.jit.x86"
-#else
-# define SOURCEPAWN_DLL "sourcepawn.vm"
-#endif
-
-	/* Attempt to load the JIT! */
-	char file[PLATFORM_MAX_PATH];
-	char myerror[255];
-	g_SMAPI->PathFormat(file, sizeof(file), "%s/bin/" PLATFORM_ARCH_FOLDER SOURCEPAWN_DLL ".%s",
-		GetSourceModPath(),
-		PLATFORM_LIB_EXT
-		);
-
-	g_JIT = ke::SharedLib::Open(file, myerror, sizeof(myerror));
-	if (!g_JIT)
-	{
-		if (error && maxlength)
-		{
-			ke::SafeSprintf(error, maxlength, "%s (failed to load bin/" PLATFORM_ARCH_FOLDER SOURCEPAWN_DLL ".%s)", 
-				myerror,
-				PLATFORM_LIB_EXT);
-		}
-		return false;
-	}
-
-	GetSourcePawnFactoryFn factoryFn =
-	  g_JIT->get<decltype(factoryFn)>("GetSourcePawnFactory");
-
-	if (!factoryFn) {
-		if (error && maxlength)
-			ke::SafeStrcpy(error, maxlength, "SourcePawn library is out of date");
-		ShutdownJIT();
-		return false;
-	}
-
-	ISourcePawnFactory *factory = factoryFn(SOURCEPAWN_API_VERSION);
-	if (!factory) {
-		if (error && maxlength)
-			ke::SafeStrcpy(error, maxlength, "SourcePawn library is out of date");
-		ShutdownJIT();
-		return false;
-	}
-
-	g_pPawnEnv = factory->NewEnvironment();
-	if (!g_pPawnEnv) {
-		if (error && maxlength)
-			ke::SafeStrcpy(error, maxlength, "Could not create a SourcePawn environment!");
-		ShutdownJIT();
-		return false;
-	}
-
-	g_pSourcePawn = g_pPawnEnv->APIv1();
-	g_pSourcePawn2 = g_pPawnEnv->APIv2();
 
 	g_pSourcePawn2->SetDebugListener(logicore.debugger);
 
@@ -297,8 +229,6 @@ void SourceModBase::StartSourceMod(bool late)
 
 	enginePatch = SH_GET_CALLCLASS(engine);
 	gamedllPatch = SH_GET_CALLCLASS(gamedll);
-
-	sCoreProviderImpl.InitializeBridge();
 
 	/* Initialize CoreConfig to get the SourceMod base path properly - this parses core.cfg */
 	g_CoreConfig.Initialize();
@@ -575,7 +505,10 @@ void SourceModBase::CloseSourceMod()
 
 	/* Rest In Peace */
 	sCoreProviderImpl.ShutdownBridge();
-	ShutdownJIT();
+
+	g_pPawnEnv = NULL;
+	g_pSourcePawn2 = NULL;
+	g_pSourcePawn = NULL;
 }
 
 void SourceModBase::ShutdownServices()

--- a/public/jit/jit_helpers.h
+++ b/public/jit/jit_helpers.h
@@ -148,7 +148,6 @@ public:
 	cell_t *inbase;		/* input base */
 	jitcode_t outbase;	/* output pointer */
 	jitcode_t outptr;	/* output base */
-	SourcePawn::ICompilation *data;	/* compiler live info */
 };
 
 #endif //_INCLUDE_SOURCEPAWN_JIT_HELPERS_H_

--- a/tools/buildbot/PackageScript
+++ b/tools/buildbot/PackageScript
@@ -62,22 +62,13 @@ for cxx_task in SM.extensions:
     builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/extensions/x64'])
   else:
     builder.AddCopy(cxx_task.binary, folder_map['addons/sourcemod/extensions'])
-for cxx_task in SM.spvm:
-  if cxx_task.target.arch == 'x86':
-    dest_path = os.path.join('addons/sourcemod/bin',
-                             'sourcepawn.jit.x86' + os.path.splitext(cxx_task.binary.path)[1])
-    builder.AddCopy(cxx_task.binary, dest_path)
-  elif cxx_task.target.arch == 'x86_64':
-    dest_path = os.path.join('addons/sourcemod/bin/x64',
-                             'sourcepawn.vm' + os.path.splitext(cxx_task.binary.path)[1])
-    builder.AddCopy(cxx_task.binary, dest_path)
 
 helpers.CopySpcomp('addons/sourcemod/scripting')
 
 # Export PDB files. We write to a file in the build folder which is pretty
 # verboten, but it's okay if it's in the root since AMBuild will never try
 # to rmdir the root.
-full_binary_list = SM.binaries + SM.extensions + SM.spvm + SM.spcomp_bins
+full_binary_list = SM.binaries + SM.extensions + SM.spcomp_bins
 with open(os.path.join(builder.buildPath, 'pdblog.txt'), 'w') as fp:
   for task in full_binary_list:
     fp.write(task.debug.path + '\n')


### PR DESCRIPTION
This removes the SourcePawn shared library from the distrubtion, and
statically links the VM to sourcemod.logic instead. This means we can
stop designing public APIs that only SourceMod will ever use, since now
SourceMod can just keep directly inside the VM.

We still need a public API for extensions (and the "core" binary). But
that API surface is a lot smaller than what the logic binary needs.