### PR TITLE
Reconcile with the new SourcePawn API

### DIFF
--- a/bridge/include/CoreProvider.h
+++ b/bridge/include/CoreProvider.h
@@ -32,11 +32,6 @@
 #include <IAdminSystem.h>
 #include <amtl/am-function.h>
 
-namespace SourcePawn {
-class ISourcePawnEngine;
-class ISourcePawnEngine2;
-} // namespace SourcePawn
-
 // SDK types.
 #if defined(SM_LOGIC)
 class ConCommandBase {};

--- a/bridge/include/IScriptManager.h
+++ b/bridge/include/IScriptManager.h
@@ -78,7 +78,6 @@ public:
 	virtual SMPlugin *FindPluginByOrder(unsigned num) = 0;
 	virtual SMPlugin *FindPluginByIdentity(IdentityToken_t *ident) = 0;
 	virtual SMPlugin *FindPluginByContext(IPluginContext *ctx) = 0;
-	virtual SMPlugin *FindPluginByContext(sp_context_t *ctx) = 0;
 	virtual SMPlugin *FindPluginByConsoleArg(const char *text) = 0;
 	virtual SMPlugin *FindPluginByHandle(Handle_t hndl, HandleError *errp) = 0;
 	virtual bool UnloadPlugin(IPlugin *plugin) = 0;

--- a/bridge/include/LogicProvider.h
+++ b/bridge/include/LogicProvider.h
@@ -75,6 +75,8 @@ struct sm_logic_t
 	bool			(*ParseEntityLumpString)(const char *entityString, int &status, size_t &position);
 	const char *	(*GetEntityLumpString)();
 	void            (*Shutdown)();
+	void            (*SetJitEnabled)(bool enabled);
+	void            (*SetDebugMetadataFlags)(int flags);
 	IScriptManager	*scripts;
 	IShareSys		*sharesys;
 	IExtensionSys	*extsys;

--- a/core/ConCmdManager.cpp
+++ b/core/ConCmdManager.cpp
@@ -82,7 +82,7 @@ void ConCmdManager::OnUnlinkConCommandBase(ConCommandBase *pBase, const char *na
 		CmdHook *hook = *iter;
 
 		IPluginContext *pContext = hook->pf->GetParentContext();
-		IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+		IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 		// The list is guaranteed to exist.
 		PluginHookList *list;

--- a/core/ConVarManager.cpp
+++ b/core/ConVarManager.cpp
@@ -356,7 +356,7 @@ Handle_t ConVarManager::CreateConVar(IPluginContext *pContext, const char *name,
 	ConVarInfo *pInfo = NULL;
 	Handle_t hndl = 0;
 
-	IPlugin *plugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *plugin = scripts->FindPluginByContext(pContext);
 
 	/* Find out if the convar exists already */
 	pConVar = icvar->FindVar(name);

--- a/core/CoreConfig.cpp
+++ b/core/CoreConfig.cpp
@@ -764,7 +764,7 @@ void SM_ConfigsExecuted_Plugin(unsigned int serial)
 
 void SM_ExecuteForPlugin(IPluginContext *ctx)
 {
-	SMPlugin *plugin = scripts->FindPluginByContext(ctx->GetContext());
+	SMPlugin *plugin = scripts->FindPluginByContext(ctx);
 
 	unsigned int num = plugin->GetConfigCount();
 	if (!num)

--- a/core/EventManager.cpp
+++ b/core/EventManager.cpp
@@ -184,7 +184,7 @@ EventHookError EventManager::HookEvent(const char *name, IPluginFunction *pFunct
 	if (!m_EventHooks.retrieve(name, &pHook))
 	{
 		EventHookList *pHookList;
-		IPlugin *plugin = scripts->FindPluginByContext(pFunction->GetParentContext()->GetContext());
+		IPlugin *plugin = scripts->FindPluginByContext(pFunction->GetParentContext());
 
 		/* Check plugin for an existing EventHook list */
 		if (!plugin->GetProperty("EventHooks", (void **)&pHookList))
@@ -297,7 +297,7 @@ EventHookError EventManager::UnhookEvent(const char *name, IPluginFunction *pFun
 		/* If reference count is now 0, free hook structure */
 
 		EventHookList *pHookList;
-		IPlugin *plugin = scripts->FindPluginByContext(pFunction->GetParentContext()->GetContext());
+		IPlugin *plugin = scripts->FindPluginByContext(pFunction->GetParentContext());
 
 		/* Get plugin's event hook list */
 		if (!plugin->GetProperty("EventHooks", (void**)&pHookList))

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -16,6 +16,7 @@ for cxx in builder.targets:
     'SM_DEFAULT_THREADER',
     'SM_LOGIC'
   ]
+  SP.AddVmFlags(binary)
   
   if binary.compiler.target.platform == 'linux':
     binary.compiler.postlink += ['-lpthread', '-lrt', '-lm']

--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -34,12 +34,13 @@
 #include <stdarg.h>
 #include "DebugReporter.h"
 #include "Logger.h"
+#include "sourcepawn/vm/environment.h"
 
 DebugReport g_DbgReporter;
 
 void DebugReport::OnSourceModAllInitialized()
 {
-	g_pSourcePawn->SetDebugListener(this);
+	g_pPawnEnv->SetDebugListener(this);
 }
 
 void DebugReport::OnDebugSpew(const char *msg, ...)
@@ -68,10 +69,10 @@ void DebugReport::GenerateErrorVA(IPluginContext *ctx, cell_t func_idx, int err,
 	char buffer[512];
 	ke::SafeVsprintf(buffer, sizeof(buffer), message, ap);
 
-	const char *plname = pluginsys->FindPluginByContext(ctx->GetContext())->GetFilename();
+	const char *plname = pluginsys->FindPluginByContext(ctx)->GetFilename();
 
 	if (err >= 0) {
-		const char *error = g_pSourcePawn2->GetErrorString(err);
+		const char *error = g_pPawnEnv->GetErrorString(err);
 		if (error)
 			g_Logger.LogError("[SM] Plugin \"%s\" encountered error %d: %s", plname, err, error);
 		else
@@ -134,7 +135,7 @@ void DebugReport::ReportError(const IErrorReport &report, IFrameIterator &iter)
 		{
 			if (iter.IsScriptedFrame()) 
 			{
-				IPlugin *plugin = pluginsys->FindPluginByContext(iter.Context()->GetContext());
+				IPlugin *plugin = pluginsys->FindPluginByContext(iter.Context());
 				if (plugin)
 				{
 					blame = plugin->GetFilename();

--- a/core/logic/DebugReporter.cpp
+++ b/core/logic/DebugReporter.cpp
@@ -34,6 +34,7 @@
 #include <stdarg.h>
 #include "DebugReporter.h"
 #include "Logger.h"
+#include "sourcepawn/vm/base-runtime.h"
 #include "sourcepawn/vm/environment.h"
 
 DebugReport g_DbgReporter;
@@ -87,7 +88,7 @@ void DebugReport::GenerateErrorVA(IPluginContext *ctx, cell_t func_idx, int err,
 		{
 			func_idx >>= 1;
 			sp_public_t *function;
-			if (ctx->GetRuntime()->GetPublicByIndex(func_idx, &function) == SP_ERROR_NONE)
+			if (ctx->GetBaseRuntime()->GetPublicByIndex(func_idx, &function) == SP_ERROR_NONE)
 			{
 				g_Logger.LogError("[SM] Unable to call function \"%s\" due to above error(s).", function->name);
 			}

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -283,6 +283,11 @@ bool CExtension::PerformAPICheck(char *error, size_t maxlength)
 		ke::SafeStrcpy(error, maxlength, "No IExtensionInterface instance provided");
 		return false;
 	}
+
+	if (m_pAPI->GetExtensionVersion() < SMINTERFACE_EXTENSIONAPI_VERSION_MIN) {
+		ke::SafeSprintf(error, maxlength, "Extension version is too old to load (%d, max is %d)", m_pAPI->GetExtensionVersion(), SMINTERFACE_EXTENSIONAPI_VERSION_MIN);
+		return false;
+	}
 	
 	if (m_pAPI->GetExtensionVersion() > SMINTERFACE_EXTENSIONAPI_VERSION)
 	{

--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -36,6 +36,7 @@
 #include <ReentrantList.h>
 
 using namespace ke;
+using sp::CallArgs;
 
 CForwardManager g_Forwards;
 
@@ -165,9 +166,7 @@ void CForwardManager::OnPluginPauseChange(IPlugin *plugin, bool paused)
 
 CForward::CForward(ExecType et, const char *name, const ParamType *types, unsigned num_params)
 	: m_numparams(0),
-	  m_varargs(0),
 	  m_ExecType(et),
-	  m_curparam(0),
 	  m_errstate(SP_ERROR_NONE)
 {
 	ke::SafeStrcpy(m_name, sizeof(m_name), name ? name : "");
@@ -175,13 +174,7 @@ CForward::CForward(ExecType et, const char *name, const ParamType *types, unsign
 	for (unsigned i = 0; i < num_params; i++)
 		m_types[i] = types[i];
 
-	if (num_params && types[num_params - 1] == Param_VarArgs) {
-		m_varargs = num_params;
-		m_numparams = num_params - 1;
-	} else {
-		m_varargs = 0;
-		m_numparams = num_params;
-	}
+	m_numparams = num_params;
 }
 
 CForward *CForward::CreateForward(const char *name, ExecType et, unsigned int num_params, const ParamType *types, va_list ap)
@@ -196,497 +189,241 @@ CForward *CForward::CreateForward(const char *name, ExecType et, unsigned int nu
 	if (types == NULL && num_params)
 	{
 		for (unsigned int i=0; i<num_params; i++)
-		{
 			_types[i] = (ParamType)va_arg(ap, int);
-			if (_types[i] == Param_VarArgs && (i != num_params - 1))
-			{
-				return NULL;
-			}
-		}
 		types = _types;
 	} else {
 		for (unsigned int i=0; i<num_params; i++)
-		{
 			_types[i] = types[i];
-			if (types[i] == Param_VarArgs && (i != num_params - 1))
-			{
-				return NULL;
-			}
-		}
-	}
-
-	/* First parameter can never be varargs */
-	if (num_params && _types[0] == Param_VarArgs)
-	{
-		return NULL;
 	}
 
 	return new CForward(et, name, _types, num_params);
 }
 
+bool CForward::ProcessArguments(const CallArgs& args) {
+	if (args.error)
+		return !!SetError(SP_ERROR_PARAMS_MAX);
+
+	for (uint32_t i = 0; i < args.argc; i++) {
+		if (i >= m_numparams)
+			return !!SetError(SP_ERROR_PARAM);
+
+		ParamType pt = m_types[i];
+		if (pt == Param_Any)
+			continue;
+
+		auto& arg = args.argv[i];
+		switch (arg.type) {
+			case CallArgs::ARG_CELL:
+				if (arg.flags & CallArgs::FLAG_CELL_TYPE_FLOAT) {
+					if (pt != Param_Float)
+						return !!SetError(SP_ERROR_PARAM);
+				} else {
+					if (pt != Param_Cell)
+						return !!SetError(SP_ERROR_PARAM);
+				}
+				break;
+			case CallArgs::ARG_CELL_BY_REF:
+				if (arg.flags & CallArgs::FLAG_CELL_TYPE_FLOAT) {
+					if (pt != Param_FloatByRef)
+						return !!SetError(SP_ERROR_PARAM);
+				} else {
+					if (pt != Param_CellByRef)
+						return !!SetError(SP_ERROR_PARAM);
+				}
+				break;
+			case CallArgs::ARG_ARRAY:
+			case CallArgs::ARG_NULL_VECTOR:
+				if (pt != Param_Array)
+					return !!SetError(SP_ERROR_PARAM);
+				break;
+			case CallArgs::ARG_CHAR_ARRAY:
+			case CallArgs::ARG_NULL_STRING:
+				if (pt != Param_String)
+					return !!SetError(SP_ERROR_PARAM);
+				break;
+		}
+	}
+
+	return true;
+}
+
 int CForward::Execute(cell_t *result, IForwardFilter *filter)
 {
-	if (m_errstate)
-	{
+	int rv = Execute(default_args_, result, filter);
+	default_args_.Reset();
+	return rv;
+}
+
+int CForward::Execute(const sp::CallArgs& in_args, cell_t *result, IForwardFilter *filter)
+{
+	if (m_errstate) {
 		int err = m_errstate;
 		Cancel();
 		return err;
 	}
 
-	cell_t cur_result = 0;
+	auto args = in_args;
+	unsigned int success = 0;
 	cell_t high_result = 0;
 	cell_t low_result = 0;
-	int err;
-	unsigned int success=0;
-	unsigned int num_params = m_curparam;
-	FwdParamInfo temp_info[SP_MAX_EXEC_PARAMS];
+	cell_t cur_result = 0;
 
-	/* Save local, reset */
-	memcpy(temp_info, m_params, sizeof(m_params));
-	m_curparam = 0;
+	if (!ProcessArguments(args)) {
+		int err = m_errstate;
+		Cancel();
+		return err;
+	}
 
 	for (FuncIter iter(m_functions); !iter.done(); iter.next())
 	{
 		IPluginFunction *func = (*iter);
 
 		if (filter)
-			filter->Preprocess(func, temp_info);
+			filter->Preprocess(func, args);
 
 		if (func->GetParentRuntime()->IsPaused())
 			continue;
 
-		for (unsigned int i=0; i<num_params; i++)
-		{
-			int err = SP_ERROR_PARAM;
-			FwdParamInfo *param = &temp_info[i];
+		ExceptionHandler eh(func->GetParentRuntime());
 
-			ParamType type;
-			if (i >= m_numparams || m_types[i] == Param_Any)
-				type = param->pushedas;
-			else
-				type = m_types[i];
+		if (!func->Invoke(args, &cur_result))
+			continue;
 
-			if ((i >= m_numparams) || (type & SP_PARAMFLAG_BYREF))
-			{
-				/* If we're byref or we're vararg, we always push everything by ref.
-				* Even if they're byval, we must push them byref.
-				*/
-				err = _ExecutePushRef(func, type, param);
-			}
-			else
-			{
-				/* If we're not byref or not vararg, our job is a bit easier. */
-				assert(type == Param_Cell || type == Param_Float);
-				err = func->PushCell(param->val);
-			}
-
-			if (err != SP_ERROR_NONE)
-			{
-				g_DbgReporter.GenerateError(func->GetParentContext(), 
-					func->GetFunctionID(), 
-					err, 
-					"Failed to push parameter while executing forward");
-				continue;
-			}
-		}
-		
-		/* Call the function and deal with the return value. */
-		if ((err=func->Execute(&cur_result)) == SP_ERROR_NONE)
-		{
-			success++;
-			switch (m_ExecType)
-			{
-			case ET_Event:
-				{
-					if (cur_result > high_result)
-					{
-						high_result = cur_result;
-					}
-					break;
-				}
-			case ET_Hook:
-				{
-					if (cur_result > high_result)
-					{
-						high_result = cur_result;
-						if ((ResultType)high_result == Pl_Stop)
-						{
-							goto done;
-						}
-					}
-					break;
-				}
-			case ET_LowEvent:
-				{
-					/* Check if the current result is the lowest so far (or if it's the first result) */
-					if (cur_result < low_result || success == 1)
-					{
-						low_result = cur_result;
-					}
-					break;
-				}
-			default:
-				{
-					break;
-				}
-			}
-		}
-	}
-
-done:
-
-	if (success)
-	{
+		success++;
 		switch (m_ExecType)
 		{
-		case ET_Ignore:
-			{
-				cur_result = 0;
+			case ET_Event:
+				if (cur_result > high_result)
+					high_result = cur_result;
 				break;
-			}
-		case ET_Event:
-		case ET_Hook:
-			{
-				cur_result = high_result;
+			case ET_Hook:
+				if (cur_result > high_result)
+					high_result = cur_result;
 				break;
-			}
-		case ET_LowEvent:
-			{
-				cur_result = low_result;
+			case ET_LowEvent:
+				/* Check if the current result is the lowest so far (or if it's the first result) */
+				if (cur_result < low_result || success == 1)
+					low_result = cur_result;
 				break;
-			}
-		default:
-			{
+			default:
 				break;
-			}
 		}
 
-		if (result)
-		{
-			*result = cur_result;
-		}
+		if ((ResultType)high_result == Pl_Stop)
+			break;
 	}
+
+	switch (m_ExecType)
+	{
+		case ET_Ignore:
+			cur_result = 0;
+			break;
+		case ET_Event:
+		case ET_Hook:
+			cur_result = high_result;
+			break;
+		case ET_LowEvent:
+			cur_result = low_result;
+			break;
+		default:
+			break;
+	}
+
+	if (result)
+		*result = cur_result;
 
 	return SP_ERROR_NONE;
 }
 
-int CForward::_ExecutePushRef(IPluginFunction *func, ParamType type, FwdParamInfo *param)
-{
-	/* If we're byref or we're vararg, we always push everything by ref.
-	* Even if they're byval, we must push them byref.
-	*/
-	int err;
-	IPluginRuntime *runtime = func->GetParentRuntime();
-	switch (type)
-	{
-	case Param_String:
-		// Normal string was pushed.
-		if (!param->isnull)
-			return func->PushStringEx((char *)param->byref.orig_addr, param->byref.cells, param->byref.sz_flags, param->byref.flags);
-
-		// If NULL_STRING was pushed, push the reference to the pubvar of the callee instead.
-		uint32_t null_string_idx;
-		err = runtime->FindPubvarByName("NULL_STRING", &null_string_idx);
-		if (err)
-			return err;
-
-		cell_t null_string;
-		err = runtime->GetPubvarAddrs(null_string_idx, &null_string, nullptr);
-		if (err)
-			return err;
-
-		return func->PushCell(null_string);
-	
-	case Param_Float:
-	case Param_Cell:
-		return func->PushCellByRef(&param->val);
-
-	default:
-		assert(type == Param_Array || type == Param_FloatByRef || type == Param_CellByRef);
-		// No NULL_VECTOR was pushed.
-		if (type != Param_Array || !param->isnull)
-			return func->PushArray(param->byref.orig_addr, param->byref.cells, param->byref.flags);
-
-		// If NULL_VECTOR was pushed, push the reference to the pubvar of the callee instead.
-		uint32_t null_vector_idx;
-		err = runtime->FindPubvarByName("NULL_VECTOR", &null_vector_idx);
-		if (err)
-			return err;
-
-		cell_t null_vector;
-		err = runtime->GetPubvarAddrs(null_vector_idx, &null_vector, nullptr);
-		if (err)
-			return err;
-
-		return func->PushCell(null_vector);
-	}
-}
-
 int CForward::PushCell(cell_t cell)
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_Cell;
-		} else if (m_types[m_curparam] != Param_Cell) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_numparams > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_Cell;
-	}
-
-	m_params[m_curparam].isnull = false;
-	m_params[m_curparam++].val = cell;
-
+	default_args_.PushCell(cell);
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
 }
 
 int CForward::PushInt64(int64_t value)
 {
-	// Not supported yet
-	return SetError(SP_ERROR_PARAM);
+	default_args_.PushInt64(value);
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
+	return SP_ERROR_NONE;
 }
 
 int CForward::PushFloat(float number)
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_Float;
-		} else if (m_types[m_curparam] != Param_Float) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_numparams > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_Float;
-	}
-
-	m_params[m_curparam].isnull = false;
-	m_params[m_curparam++].val = *(cell_t *)&number;
-
+	default_args_.PushFloat(number);
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
 }
 
 int CForward::PushCellByRef(cell_t *cell, int flags)
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_CellByRef;
-		} else if (m_types[m_curparam] != Param_CellByRef) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_numparams > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_CellByRef;
-	}
-
-	_Int_PushArray(cell, 1, flags);
-	m_curparam++;
-
+	default_args_.PushCellByRef(cell, flags);
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
 }
 
 int CForward::PushFloatByRef(float *num, int flags)
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_FloatByRef;
-		} else if (m_types[m_curparam] != Param_FloatByRef) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_numparams > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_FloatByRef;
-	}
-
-	_Int_PushArray((cell_t *)num, 1, flags);
-	m_curparam++;
-
+	default_args_.PushFloatByRef(num, flags);
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
-}
-
-void CForward::_Int_PushArray(cell_t *inarray, unsigned int cells, int flags)
-{
-	m_params[m_curparam].byref.cells = cells;
-	m_params[m_curparam].byref.flags = flags;
-	m_params[m_curparam].byref.orig_addr = inarray;
-	m_params[m_curparam].isnull = false;
 }
 
 int CForward::PushArray(cell_t *inarray, unsigned int cells, int flags)
 {
-	/* Push a reference to the NULL_VECTOR pubvar if NULL was passed. */
-	if (!inarray)
-	{
-		/* Make sure this was intentional. */
-		if (cells == 3)
-		{
-			return PushNullVector();
-		} else {
-			/* We don't allow this here */
-			return SetError(SP_ERROR_PARAM);
-		}
-	}
-
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_Array;
-		} else if (m_types[m_curparam] != Param_Array) {
-			return SetError(SP_ERROR_PARAM);
-		}
+	if (inarray) {
+		default_args_.PushArray(inarray, cells, flags);
 	} else {
-		if (!m_varargs || m_curparam > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_Array;
+		if (cells != 3)
+			return SetError(SP_ERROR_PARAM);
+		default_args_.PushNullVector();
 	}
-
-	_Int_PushArray(inarray, cells, flags);
-
-	m_curparam++;
-
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
-}
-
-void CForward::_Int_PushString(cell_t *inarray, unsigned int cells, int sz_flags, int cp_flags)
-{
-	m_params[m_curparam].byref.cells = cells;	/* Notice this contains the char count not cell count */
-	m_params[m_curparam].byref.flags = cp_flags;
-	m_params[m_curparam].byref.orig_addr = inarray;
-	m_params[m_curparam].byref.sz_flags = sz_flags;
-	m_params[m_curparam].isnull = false;
 }
 
 int CForward::PushString(const char *string)
 {
-	/* Push a reference to the NULL_STRING pubvar if NULL was passed. */
-	if (!string)
-	{
-		return PushNullString();
-	}
-
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_String;
-		} else if (m_types[m_curparam] != Param_String) {
-			return SetError(SP_ERROR_PARAM);
-		}
+	if (string) {
+		default_args_.PushString(string);
 	} else {
-		if (!m_varargs || m_curparam > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_String;
+		default_args_.PushNullString();
 	}
-
-	_Int_PushString((cell_t *)string, strlen(string)+1, SM_PARAM_STRING_COPY, 0);
-	m_curparam++;
-
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
 }
 
 int CForward::PushStringEx(char *buffer, size_t length, int sz_flags, int cp_flags)
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_String;
-		} else if (m_types[m_curparam] != Param_String) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_curparam > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_String;
-	}
-
-	_Int_PushString((cell_t *)buffer, length, sz_flags, cp_flags);
-	m_curparam++;
-
+	default_args_.PushString(buffer, length, sz_flags | cp_flags);
+	if (default_args_.error)
+		return SetError(SP_ERROR_PARAMS_MAX);
 	return SP_ERROR_NONE;
 }
 
 int CForward::PushNullString()
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_String;
-		} else if (m_types[m_curparam] != Param_String) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_numparams > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_String;
-	}
-
-	m_params[m_curparam++].isnull = true;
-
+	default_args_.PushNullString();
 	return SP_ERROR_NONE;
 }
 
 int CForward::PushNullVector()
 {
-	if (m_curparam < m_numparams)
-	{
-		if (m_types[m_curparam] == Param_Any)
-		{
-			m_params[m_curparam].pushedas = Param_Array;
-		} else if (m_types[m_curparam] != Param_Array) {
-			return SetError(SP_ERROR_PARAM);
-		}
-	} else {
-		if (!m_varargs || m_numparams > SP_MAX_EXEC_PARAMS)
-		{
-			return SetError(SP_ERROR_PARAMS_MAX);
-		}
-		m_params[m_curparam].pushedas = Param_Array;
-	}
-
-	m_params[m_curparam++].isnull = true;
-
+	default_args_.PushNullVector();
 	return SP_ERROR_NONE;
 }
 
 void CForward::Cancel()
 {
-	if (!m_curparam)
-	{
-		return;
-	}
-
-	m_curparam = 0;
+	default_args_.Reset();
 	m_errstate = SP_ERROR_NONE;
 }
 
@@ -732,8 +469,8 @@ bool CForward::RemoveFunction(IPluginFunction *func)
 	}
 
 	/* Cancel a call, if any */
-	if (found || m_curparam)
-		func->Cancel();
+	if (found || default_args_.argc)
+		default_args_.Reset();
 
 	return found;
 }
@@ -753,7 +490,7 @@ unsigned int CForward::RemoveFunctionsOfPlugin(IPlugin *plugin)
 
 bool CForward::AddFunction(IPluginFunction *func)
 {
-	if (m_curparam)
+	if (default_args_.argc)
 		return false;
 
 	if (func->IsRunnable())

--- a/core/logic/ForwardSys.h
+++ b/core/logic/ForwardSys.h
@@ -41,7 +41,7 @@ typedef ReentrantList<IPluginFunction *>::iterator FuncIter;
 
 class CForward : public IChangeableForward
 {
-public: //ICallable
+public: //IForward
 	virtual int PushCell(cell_t cell);
 	virtual int PushCellByRef(cell_t *cell, int flags);
 	virtual int PushFloat(float number);
@@ -51,11 +51,11 @@ public: //ICallable
 	virtual int PushStringEx(char *buffer, size_t length, int sz_flags, int cp_flags);
 	virtual int PushInt64(int64_t value);
 	virtual void Cancel();
-public: //IForward
 	virtual const char *GetForwardName();
 	virtual unsigned int GetFunctionCount();
 	virtual ExecType GetExecType();
 	virtual int Execute(cell_t *result, IForwardFilter *filter);
+	virtual int Execute(const sp::CallArgs& args, cell_t *result = nullptr, IForwardFilter *filter = nullptr);
 public: //IChangeableForward
 	virtual bool RemoveFunction(IPluginFunction *func);
 	virtual unsigned int RemoveFunctionsOfPlugin(IPlugin *plugin);
@@ -75,28 +75,25 @@ private:
 
 	int PushNullString();
 	int PushNullVector();
-	int _ExecutePushRef(IPluginFunction *func, ParamType type, FwdParamInfo *param);
-	void _Int_PushArray(cell_t *inarray, unsigned int cells, int flags);
-	void _Int_PushString(cell_t *inarray, unsigned int cells, int sz_flags, int cp_flags);
 	inline int SetError(int err)
 	{
 		m_errstate = err;
 		return err;
 	}
+	bool ProcessArguments(const sp::CallArgs& args);
+
 protected:
 	mutable ReentrantList<IPluginFunction *> m_functions;
 	mutable ReentrantList<IPluginFunction *> m_paused;
 
 	/* Type and name information */
-	FwdParamInfo m_params[SP_MAX_EXEC_PARAMS];
+	sp::CallArgs default_args_;
 	ParamType m_types[SP_MAX_EXEC_PARAMS];
 	char m_name[FORWARDS_NAME_MAX+1];
 	unsigned int m_numparams;
-	unsigned int m_varargs;
 	ExecType m_ExecType;
 
 	/* State information */
-	unsigned int m_curparam;
 	int m_errstate;
 };
 

--- a/core/logic/NativeOwner.cpp
+++ b/core/logic/NativeOwner.cpp
@@ -31,6 +31,7 @@
 #include "NativeOwner.h"
 #include "ShareSys.h"
 #include "PluginSys.h"
+#include <sourcepawn/vm/plugin-runtime.h>
 
 CNativeOwner::CNativeOwner() : m_nMarkSerial(0)
 {
@@ -67,10 +68,8 @@ void CNativeOwner::AddNatives(const sp_nativeinfo_t *natives)
 
 void CNativeOwner::UnbindWeakRef(const WeakNative &ref)
 {
-	IPluginContext *pContext;
-
-	pContext = ref.pl->GetBaseContext();
-	pContext->GetRuntime()->UpdateNativeBinding(
+	auto pContext = ref.pl->runtime();
+	pContext->UpdateNativeBinding(
 	  ref.idx,
 	  nullptr,
 	  SP_NTVFLAG_OPTIONAL,

--- a/core/logic/NativeOwner.cpp
+++ b/core/logic/NativeOwner.cpp
@@ -31,7 +31,7 @@
 #include "NativeOwner.h"
 #include "ShareSys.h"
 #include "PluginSys.h"
-#include <sourcepawn/vm/plugin-runtime.h>
+#include <sourcepawn/vm/base-runtime.h>
 
 CNativeOwner::CNativeOwner() : m_nMarkSerial(0)
 {

--- a/core/logic/NativeOwner.h
+++ b/core/logic/NativeOwner.h
@@ -8,7 +8,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -45,13 +45,13 @@ using namespace SourceMod;
 
 struct WeakNative
 {
-	WeakNative(IPlugin *plugin, uint32_t index) : 
+	WeakNative(CPlugin *plugin, uint32_t index) :
 		pl(plugin), idx(index)
 	{
 		pl = plugin;
 		idx = index;
 	}
-	IPlugin *pl;
+	CPlugin *pl;
 	uint32_t idx;
 };
 

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -38,6 +38,7 @@
 #include <IHandleSys.h>
 #include <IForwardSys.h>
 #include <IPlayerHelpers.h>
+#include <sourcepawn/vm/environment.h>
 #include "ExtensionSys.h"
 #include "GameConfigs.h"
 #include "common_logic.h"
@@ -479,11 +480,6 @@ void CPlugin::Call_OnLibraryAdded(const char *lib)
 	pFunction->Execute(&result);
 }
 
-void *CPlugin::GetPluginStructure()
-{
-	return NULL;
-}
-
 // Only called during plugin construction.
 bool CPlugin::TryCompile()
 {
@@ -491,7 +487,7 @@ bool CPlugin::TryCompile()
 	g_pSM->BuildPath(Path_SM, fullpath, sizeof(fullpath), "plugins/%s", m_filename);
 
 	char loadmsg[255];
-	m_pRuntime.reset(g_pSourcePawn2->LoadBinaryFromFile(fullpath, loadmsg, sizeof(loadmsg)));
+	m_pRuntime.reset(g_pPawnEnv->LoadBinaryFromFile(fullpath, loadmsg, sizeof(loadmsg)));
 	if (!m_pRuntime) {
 		EvictWithError(Plugin_BadLoad, "Unable to load plugin (%s)", loadmsg);
 		return false;
@@ -513,11 +509,6 @@ IPluginContext *CPlugin::GetBaseContext()
 	}
 
 	return m_pRuntime->GetDefaultContext();
-}
-
-sp_context_t *CPlugin::GetContext()
-{
-	return NULL;
 }
 
 const char *CPlugin::GetFilename()
@@ -1535,12 +1526,9 @@ void CPluginManager::UnloadPluginImpl(CPlugin *pPlugin)
 	delete pPlugin;
 }
 
-IPlugin *CPluginManager::FindPluginByContext(const sp_context_t *ctx)
+SMPlugin *CPluginManager::FindPluginByContext(IPluginContext *pContext)
 {
-	IPlugin *pPlugin;
-	IPluginContext *pContext;
-
-	pContext = reinterpret_cast<IPluginContext *>(const_cast<sp_context_t *>(ctx));
+	SMPlugin *pPlugin;
 
 	if (pContext->GetKey(2, (void **)&pPlugin))
 	{
@@ -1550,7 +1538,7 @@ IPlugin *CPluginManager::FindPluginByContext(const sp_context_t *ctx)
 	return NULL;
 }
 
-CPlugin *CPluginManager::GetPluginByCtx(const sp_context_t *ctx)
+CPlugin *CPluginManager::GetPluginByCtx(IPluginContext *ctx)
 {
 	return (CPlugin *)FindPluginByContext(ctx);
 }
@@ -2355,7 +2343,7 @@ public:
 		return g_PluginSys.UnloadPlugin(plugin);
 	}
 
-	IPlugin *FindPluginByContext(const sp_context_t *ctx) override
+	IPlugin *FindPluginByContext(IPluginContext *ctx) override
 	{
 		return g_PluginSys.FindPluginByContext(ctx);
 	}

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -99,8 +99,8 @@ void CPlugin::InitIdentity()
 
 	m_ident = g_ShareSys.CreateIdentity(g_PluginIdent, this);
 	m_handle = handlesys->CreateHandle(g_PluginType, this, g_PluginSys.GetIdentity(), g_PluginSys.GetIdentity(), NULL);
-	m_pRuntime->GetDefaultContext()->SetKey(1, m_ident);
-	m_pRuntime->GetDefaultContext()->SetKey(2, (IPlugin *)this);
+	m_pRuntime->SetKey(1, m_ident);
+	m_pRuntime->SetKey(2, (IPlugin *)this);
 }
 
 void CPlugin::DestroyIdentity()
@@ -1283,7 +1283,7 @@ CPlugin *CPluginManager::CompileAndPrep(const char *path)
 
 bool CPluginManager::MalwareCheckPass(CPlugin *pPlugin)
 {
-	unsigned char *pCodeHash = pPlugin->GetRuntime()->GetCodeHash();
+	unsigned char *pCodeHash = pPlugin->runtime()->GetCodeHash();
 
 	char codeHashBuf[40];
 	ke::SafeStrcpy(codeHashBuf, sizeof(codeHashBuf), "plugin_");
@@ -1323,11 +1323,10 @@ bool CPluginManager::RunSecondPass(CPlugin *pPlugin)
 	g_ShareSys.BindNativesToPlugin(pPlugin, false);
 
 	// Find any unbound natives. Right now, these are not allowed.
-	IPluginContext *pContext = pPlugin->GetBaseContext();
-	uint32_t num = pContext->GetNativesNum();
+	uint32_t num = pPlugin->runtime()->GetNativesNum();
 	for (unsigned int i=0; i<num; i++)
 	{
-		const sp_native_t *native = pContext->GetRuntime()->GetNative(i);
+		const sp_native_t *native = pPlugin->runtime()->GetNative(i);
 		if (!native)
 			break;
 		if (native->status == SP_NATIVE_UNBOUND &&
@@ -1416,11 +1415,10 @@ void CPluginManager::TryRefreshDependencies(CPlugin *pPlugin)
 	/* Find any unbound natives
 	 * Right now, these are not allowed
 	 */
-	IPluginContext *pContext = pPlugin->GetBaseContext();
-	uint32_t num = pContext->GetNativesNum();
+	uint32_t num = pPlugin->runtime()->GetNativesNum();
 	for (unsigned int i=0; i<num; i++)
 	{
-		const sp_native_t *native = pContext->GetRuntime()->GetNative(i);
+		const sp_native_t *native = pPlugin->runtime()->GetNative(i);
 		if (!native)
 			break;
 		if (native->status == SP_NATIVE_UNBOUND &&
@@ -1969,7 +1967,7 @@ void CPluginManager::OnRootConsoleCommand(const char *cmdname, const ICommandArg
 					rootmenu->ConsolePrint("  Timestamp: %s", pl->GetDateTime());
 				}
 
-				if (IPluginRuntime *runtime = pl->GetRuntime()) {
+				if (auto runtime = pl->runtime()) {
 				  unsigned char *pCodeHash = runtime->GetCodeHash();
 				  unsigned char *pDataHash = runtime->GetDataHash();
 
@@ -2345,7 +2343,7 @@ public:
 
 	IPlugin *FindPluginByContext(IPluginContext *ctx) override
 	{
-		return g_PluginSys.FindPluginByContext(ctx);
+		return g_PluginSys.FindPluginByContext(ctx->GetBaseRuntime());
 	}
 
 	unsigned int GetPluginCount() override
@@ -2406,3 +2404,4 @@ IPluginManager *CPluginManager::GetOldAPI()
 {
 	return &sOldPluginAPI;
 }
+

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -118,7 +118,8 @@ public:
 	bool SetProperty(const char *prop, void *ptr);
 	bool GetProperty(const char *prop, void **ptr, bool remove=false);
 	void DropEverything();
-	SourcePawn::IPluginRuntime *GetRuntime();
+	IPluginRuntime *GetRuntime();
+	sp::BaseRuntime *runtime() const { return m_pRuntime.get(); }
 	CNativeOwner *ToNativeOwner() {
 		return this;
 	}
@@ -268,7 +269,7 @@ private:
 	char m_errormsg[256];
 
 	// Internal properties that must by reset if the runtime is evicted.
-	std::unique_ptr<IPluginRuntime> m_pRuntime;
+	std::unique_ptr<sp::BaseRuntime> m_pRuntime;
 	std::unique_ptr<CPhraseCollection> m_pPhrases;
 	IPluginContext *m_pContext;
 	sp_pubvar_t *m_MaxClientsVar;

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -105,8 +105,6 @@ public:
 public:
 	PluginType GetType();
 	SourcePawn::IPluginContext *GetBaseContext();
-	sp_context_t *GetContext();
-	void *GetPluginStructure();
 	const char *GetFilename();
 	bool IsDebugging();
 	PluginStatus GetStatus();
@@ -332,7 +330,7 @@ public: //IScriptManager
 								size_t maxlength,
 								bool *wasloaded);
 	bool UnloadPlugin(IPlugin *plugin);
-	IPlugin *FindPluginByContext(const sp_context_t *ctx);
+	SMPlugin *FindPluginByContext(IPluginContext *ctx);
 	unsigned int GetPluginCount();
 	IPluginIterator *GetPluginIterator();
 	void AddPluginsListener(IPluginsListener *listener);
@@ -344,12 +342,6 @@ public: //IScriptManager
 	}
 	SMPlugin *FindPluginByIdentity(IdentityToken_t *ident) {
 		return GetPluginFromIdentity(ident);
-	}
-	SMPlugin *FindPluginByContext(IPluginContext *ctx) {
-		return GetPluginByCtx(ctx->GetContext());
-	}
-	SMPlugin *FindPluginByContext(sp_context_t *ctx) {
-		return GetPluginByCtx(ctx);
 	}
 	SMPlugin *FindPluginByConsoleArg(const char *text);
 	SMPlugin *FindPluginByHandle(Handle_t hndl, HandleError *errp) {
@@ -399,7 +391,7 @@ public:
 	/** 
 	 * Internal version of FindPluginByContext()
 	 */
-	CPlugin *GetPluginByCtx(const sp_context_t *ctx);
+	CPlugin *GetPluginByCtx(IPluginContext *ctx);
 
 	/**
 	 * Gets status text for a status code 

--- a/core/logic/ProfileTools.cpp
+++ b/core/logic/ProfileTools.cpp
@@ -28,6 +28,7 @@
 #include "ProfileTools.h"
 #include <stdarg.h>
 #include <am-string.h>
+#include <sourcepawn/vm/environment.h>
 
 ProfileToolManager g_ProfileToolManager;
 
@@ -87,8 +88,8 @@ ProfileToolManager::StartFromConsole(IProfilingTool *tool)
 		return;
 	}
 
-	g_pSourcePawn2->SetProfilingTool(active_);
-	g_pSourcePawn2->EnableProfiling();
+	g_pPawnEnv->SetProfilingTool(active_);
+	g_pPawnEnv->EnableProfiling();
 	rootmenu->ConsolePrint("Started profiling with %s.", active_->Name());
 
 	default_ = active_;
@@ -117,8 +118,8 @@ ProfileToolManager::OnRootConsoleCommand(const char *cmdname, const ICommandArgs
 				rootmenu->ConsolePrint("No profiler is active.");
 				return;
 			}
-			g_pSourcePawn2->DisableProfiling();
-			g_pSourcePawn2->SetProfilingTool(nullptr);
+			g_pPawnEnv->DisableProfiling();
+			g_pPawnEnv->SetProfilingTool(nullptr);
 			active_->Stop(render_help);
 			active_ = nullptr;
 			return;

--- a/core/logic/RootConsoleMenu.cpp
+++ b/core/logic/RootConsoleMenu.cpp
@@ -30,6 +30,7 @@
 #include <ISourceMod.h>
 #include <bridge/include/CoreProvider.h>
 #include "HandleSys.h"
+#include <sourcepawn/vm/environment.h>
 
 RootConsoleMenu g_RootMenu;
 
@@ -235,11 +236,10 @@ void RootConsoleMenu::OnRootConsoleCommand(const char *cmdname, const ICommandAr
 	{
 		ConsolePrint(" SourceMod Version Information:");
 		ConsolePrint("    SourceMod Version: %s", SOURCEMOD_VERSION);
-		if (g_pSourcePawn2->IsJitEnabled())
-			ConsolePrint("    SourcePawn Engine: %s (build %s)", g_pSourcePawn2->GetEngineName(), g_pSourcePawn2->GetVersionString());
+		if (g_pPawnEnv->IsJitEnabled())
+			ConsolePrint("    SourcePawn Engine: %s (build %s)", g_pPawnEnv->GetEngineName(), g_pPawnEnv->GetVersionString());
 		else
-			ConsolePrint("    SourcePawn Engine: %s (build %s NO JIT)", g_pSourcePawn2->GetEngineName(), g_pSourcePawn2->GetVersionString());
-		ConsolePrint("    SourcePawn API: v1 = %d, v2 = %d", g_pSourcePawn->GetEngineAPIVersion(), g_pSourcePawn2->GetAPIVersion());
+			ConsolePrint("    SourcePawn Engine: %s (build %s NO JIT)", g_pPawnEnv->GetEngineName(), g_pPawnEnv->GetVersionString());
 		ConsolePrint("    Compiled on: %s", SOURCEMOD_BUILD_TIME);
 #if defined(SM_GENERATED_BUILD)
 		ConsolePrint("    Built from: https://github.com/alliedmodders/sourcemod/commit/%s", SOURCEMOD_SHA);

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -433,7 +433,7 @@ AlreadyRefed<Native> ShareSystem::AddFakeNative(IPluginFunction *pFunc, const ch
 	std::unique_ptr<FakeNative> fake(new FakeNative(name, pFunc));
 	fake->wrapper = new DynamicNative(func, fake.get());
 
-	CNativeOwner *owner = g_PluginSys.GetPluginByCtx(fake->ctx->GetContext());
+	CNativeOwner *owner = g_PluginSys.GetPluginByCtx(fake->ctx);
 
 	entry = new Native(owner, std::move(fake));
 	m_NtvCache.insert(name, entry);

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -39,6 +39,7 @@
 #include "common_logic.h"
 #include "PluginSys.h"
 #include "HandleSys.h"
+#include <sourcepawn/vm/plugin-runtime.h>
 
 using namespace ke;
 
@@ -277,14 +278,14 @@ void ShareSystem::BeginBindingFor(CPlugin *pPlugin)
 
 void ShareSystem::BindNativesToPlugin(CPlugin *pPlugin, bool bCoreOnly)
 {
-	IPluginContext *pContext = pPlugin->GetBaseContext();
+	sp::BaseRuntime *pContext = pPlugin->GetBaseContext()->GetBaseRuntime();
 
 	BeginBindingFor(pPlugin);
 
 	uint32_t native_count = pContext->GetNativesNum();
 	for (uint32_t i = 0; i < native_count; i++)
 	{
-		const sp_native_t *native = pContext->GetRuntime()->GetNative(i);
+		const sp_native_t *native = pContext->GetNative(i);
 		if (!native)
 			continue;
 
@@ -309,13 +310,13 @@ void ShareSystem::BindNativeToPlugin(CPlugin *pPlugin, const RefPtr<Native> &ent
 	if (!entry->owner)
 		return;
 
-	IPluginContext *pContext = pPlugin->GetBaseContext();
+	sp::BaseRuntime *pContext = pPlugin->GetBaseContext()->GetBaseRuntime();
 
 	uint32_t i;
 	if (pContext->FindNativeByName(entry->name(), &i) != SP_ERROR_NONE)
 		return;
 
-	const sp_native_t *native = pContext->GetRuntime()->GetNative(i);
+	const sp_native_t *native = pContext->GetNative(i);
 	if (!native)
 		return;
 
@@ -364,7 +365,7 @@ void ShareSystem::BindNativeToPlugin(CPlugin *pPlugin, const sp_native_t *native
 		}
 	}
 
-	auto rt = pPlugin->GetRuntime();
+	auto rt = pPlugin->runtime();
 	if (pEntry->fake)
 		rt->UpdateNativeBindingObject(index, pEntry->fake->wrapper, flags, nullptr);
 	else
@@ -485,10 +486,11 @@ FeatureStatus ShareSystem::TestFeature(IPluginRuntime *pRuntime, FeatureType fea
 FeatureStatus ShareSystem::TestNative(IPluginRuntime *pRuntime, const char *name)
 {
 	uint32_t index;
+	sp::BaseRuntime *pBase = pRuntime->GetBaseRuntime();
 
-	if (pRuntime->FindNativeByName(name, &index) == SP_ERROR_NONE)
+	if (pBase->FindNativeByName(name, &index) == SP_ERROR_NONE)
 	{
-		if (const sp_native_t *native = pRuntime->GetNative(index)) {
+		if (const sp_native_t *native = pBase->GetNative(index)) {
 			if (native->status == SP_NATIVE_BOUND)
 				return FeatureStatus_Available;
 			else
@@ -511,3 +513,4 @@ FeatureStatus ShareSystem::TestCap(const char *name)
 
 	return r->value.provider->GetFeatureStatus(FeatureType_Capability, name);
 }
+

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -39,7 +39,7 @@
 #include "common_logic.h"
 #include "PluginSys.h"
 #include "HandleSys.h"
-#include <sourcepawn/vm/plugin-runtime.h>
+#include <sourcepawn/vm/base-runtime.h>
 
 using namespace ke;
 

--- a/core/logic/common_logic.cpp
+++ b/core/logic/common_logic.cpp
@@ -81,8 +81,7 @@ IPluginManager *pluginsys = g_PluginSys.GetOldAPI();
 IForwardManager *forwardsys = &g_Forwards;
 ServerGlobals serverGlobals;
 IAdminSystem *adminsys = &g_Admins;
-ISourcePawnEngine *g_pSourcePawn;
-ISourcePawnEngine2 *g_pSourcePawn2;
+sp::Environment *g_pPawnEnv;
 IScriptManager *scripts = &g_PluginSys;
 IExtensionSys *extsys = &g_Extensions;
 ILogger *logger = &g_Logger;
@@ -161,16 +160,24 @@ public:
 	}
 } sProviderCallbackListener;
 
-static sp::Environment *g_pEnv = nullptr;
-
 static void logic_shutdown()
 {
-	if (g_pEnv)
+	if (g_pPawnEnv)
 	{
-		g_pEnv->Shutdown();
-		delete g_pEnv;
-		g_pEnv = nullptr;
+		g_pPawnEnv->Shutdown();
+		delete g_pPawnEnv;
+		g_pPawnEnv = nullptr;
 	}
+}
+
+static void logic_SetJitEnabled(bool enabled)
+{
+	g_pPawnEnv->SetJitEnabled(enabled);
+}
+
+static void logic_SetDebugMetadataFlags(int flags)
+{
+	g_pPawnEnv->SetDebugMetadataFlags(flags);
 }
 
 static sm_logic_t logic =
@@ -196,6 +203,8 @@ static sm_logic_t logic =
 	ParseEntityLumpString,
 	GetEntityLumpString,
 	logic_shutdown,
+	logic_SetJitEnabled,
+	logic_SetDebugMetadataFlags,
 	&g_PluginSys,
 	&g_ShareSys,
 	&g_Extensions,
@@ -224,13 +233,30 @@ static void logic_init(CoreProvider* core, sm_logic_t* _logic)
 	gamehelpers = core->gamehelpers;
 	menus = core->menus;
 
-	g_pEnv = sp::Environment::New();
-	g_pSourcePawn = g_pEnv->APIv1();
-	g_pSourcePawn2 = g_pEnv->APIv2();
+	g_pPawnEnv = sp::Environment::New();
+	ISourcePawnEngine *spe1 = g_pPawnEnv->APIv1();
 
-	*core->spe1 = g_pSourcePawn;
-	*core->spe2 = g_pSourcePawn2;
-	*core->spe_env = g_pEnv;
+	*core->spe1 = spe1;
+	*core->spe2 = g_pPawnEnv->APIv2();
+	*core->spe_env = g_pPawnEnv;
+
+	g_pPawnEnv->SetDebugListener(&g_DbgReporter);
+
+	const char *timeout = core->GetCoreConfigValue("SlowScriptTimeout");
+	if (timeout == NULL)
+	{
+		timeout = "8";
+	}
+	if (atoi(timeout) != 0)
+	{
+		g_pPawnEnv->InstallWatchdogTimer(atoi(timeout) * 1000);
+	}
+
+	const char *linedebugger = core->GetCoreConfigValue("EnableLineDebugging");
+	if (linedebugger != NULL && strcasecmp(linedebugger, "yes") == 0)
+	{
+		g_pPawnEnv->EnableDebugBreak();
+	}
 
 	SMGlobalClass::head = core->listeners;
 

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -45,7 +45,7 @@
 
 #include <sourcehook.h>
 #include <sh_memory.h>
-#include <sourcepawn/vm/plugin-runtime.h>
+#include <sourcepawn/vm/base-runtime.h>
 
 #if defined PLATFORM_WINDOWS
 #include <windows.h>

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -438,7 +438,7 @@ IPlugin *GetPluginFromHandle(IPluginContext *pContext, Handle_t hndl)
 {
 	if (hndl == BAD_HANDLE)
 	{
-		return scripts->FindPluginByContext(pContext->GetContext());
+		return scripts->FindPluginByContext(pContext);
 	} else {
 		HandleError err;
 		IPlugin *pPlugin = scripts->FindPluginByHandle(hndl, &err);
@@ -557,7 +557,7 @@ static cell_t SetFailState(IPluginContext *pContext, const cell_t *params)
 	SMPlugin *pPlugin;
 
 	pContext->LocalToString(params[1], &str);
-	pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	pPlugin = scripts->FindPluginByContext(pContext);
 
 	if (params[0] == 1)
 	{
@@ -606,7 +606,7 @@ static cell_t GetSysTickCount(IPluginContext *pContext, const cell_t *params)
 
 static cell_t AutoExecConfig(IPluginContext *pContext, const cell_t *params)
 {
-	SMPlugin *plugin = scripts->FindPluginByContext(pContext->GetContext());
+	SMPlugin *plugin = scripts->FindPluginByContext(pContext);
 
 	char *cfg, *folder;
 	pContext->LocalToString(params[2], &cfg);
@@ -653,7 +653,7 @@ static cell_t MarkNativeAsOptional(IPluginContext *pContext, const cell_t *param
 static cell_t RegPluginLibrary(IPluginContext *pContext, const cell_t *params)
 {
 	char *name;
-	SMPlugin *pl = scripts->FindPluginByContext(pContext->GetContext());
+	SMPlugin *pl = scripts->FindPluginByContext(pContext);
 
 	pContext->LocalToString(params[1], &name);
 
@@ -695,7 +695,7 @@ static cell_t sm_LogAction(IPluginContext *pContext, const cell_t *params)
 			return 0;
 	}
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 	LogAction(pPlugin->GetMyHandle(), 2, params[1], params[2], buffer);
 
@@ -727,7 +727,7 @@ static cell_t LogToFile(IPluginContext *pContext, const cell_t *params)
 		}
 	}
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 	g_Logger.LogToOpenFile(fp, "[%s] %s", pPlugin->GetFilename(), buffer);
 
@@ -834,7 +834,7 @@ static cell_t RequireFeature(IPluginContext *pContext, const cell_t *params)
 		char buffer[255];
 		char *msg = buffer;
 		char default_message[255];
-		SMPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+		SMPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 		DetectExceptions eh(pContext);
 		g_pSM->FormatString(buffer, sizeof(buffer), pContext, params, 3);
@@ -1206,7 +1206,7 @@ static cell_t LogStackTrace(IPluginContext *pContext, const cell_t *params)
 	std::vector<std::string> arr = g_DbgReporter.GetStackTrace(it);
 	pContext->DestroyFrameIterator(it);
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 	g_Logger.LogError("[SM] Stack trace requested: %s", buffer);
 	g_Logger.LogError("[SM] Called from: %s", pPlugin->GetFilename());

--- a/core/logic/smn_core.cpp
+++ b/core/logic/smn_core.cpp
@@ -45,6 +45,7 @@
 
 #include <sourcehook.h>
 #include <sh_memory.h>
+#include <sourcepawn/vm/plugin-runtime.h>
 
 #if defined PLATFORM_WINDOWS
 #include <windows.h>
@@ -638,15 +639,16 @@ static cell_t MarkNativeAsOptional(IPluginContext *pContext, const cell_t *param
 {
 	char *name;
 	uint32_t idx;
+	sp::BaseRuntime *pBase = pContext->GetBaseRuntime();
 
 	pContext->LocalToString(params[1], &name);
-	if (pContext->FindNativeByName(name, &idx) != SP_ERROR_NONE)
+	if (pBase->FindNativeByName(name, &idx) != SP_ERROR_NONE)
 	{
 		/* Oops! This HAS to silently fail! */
 		return 0;
 	}
 
-	pContext->GetRuntime()->UpdateNativeBinding(idx, nullptr, SP_NTVFLAG_OPTIONAL, nullptr);
+	pBase->UpdateNativeBinding(idx, nullptr, SP_NTVFLAG_OPTIONAL, nullptr);
 	return 1;
 }
 

--- a/core/logic/smn_database.cpp
+++ b/core/logic/smn_database.cpp
@@ -190,7 +190,7 @@ class TQueryOp : public IDBThreadOperation
 public:
 	TQueryOp(IDatabase *db, IPluginFunction *pf, const char *query, cell_t data) : 
 	  m_pDatabase(db), m_pFunction(pf), m_Query(query), m_Data(data),
-	  me(scripts->FindPluginByContext(pf->GetParentContext()->GetContext())),
+	  me(scripts->FindPluginByContext(pf->GetParentContext())),
 	  m_pQuery(NULL)
 	{
 		/* We always increase the reference count because this is potentially
@@ -315,7 +315,7 @@ public:
 		m_Data = data;
 		error[0] = '\0';
 		strncopy(dbname, _dbname, sizeof(dbname));
-		me = scripts->FindPluginByContext(m_pFunction->GetParentContext()->GetContext());
+		me = scripts->FindPluginByContext(m_pFunction->GetParentContext());
 		
 		m_pInfo = g_DBMan.GetDatabaseConf(dbname);
 		if (!m_pInfo)
@@ -424,7 +424,7 @@ static cell_t SQL_Connect(IPluginContext *pContext, const cell_t *params)
 	IExtension *pExt = g_Extensions.GetExtensionFromIdent(driver->GetIdentity());
 	if (pExt)
 	{
-		g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext->GetContext()));
+		g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext));
 	}
 
 	return hndl;
@@ -483,12 +483,12 @@ static cell_t ConnectToDbAsync(IPluginContext *pContext, const cell_t *params, A
 	IExtension *pExt = g_Extensions.GetExtensionFromIdent(driver->GetIdentity());
 	if (pExt)
 	{
-		g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext->GetContext()));
+		g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext));
 	}
 
 	/* Finally, add to the thread if we can */
 	TConnectOp *op = new TConnectOp(pf, driver, conf, acm, params[3]);
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 	if (pPlugin->GetProperty("DisallowDBThreads", NULL)
 		|| !g_DBMan.AddToThreadQueue(op, PrioQueue_High))
 	{
@@ -564,7 +564,7 @@ static cell_t SQL_ConnectEx(IPluginContext *pContext, const cell_t *params)
 		IExtension *pExt = g_Extensions.GetExtensionFromIdent(driver->GetIdentity());
 		if (pExt)
 		{
-			g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext->GetContext()));
+			g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext));
 		}
 
 		return hndl;
@@ -865,7 +865,7 @@ static cell_t SQL_TQuery(IPluginContext *pContext, const cell_t *params)
 		level = PrioQueue_Low;
 	}
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 	TQueryOp *op = new TQueryOp(db, pf, query, data);
 	if (pPlugin->GetProperty("DisallowDBThreads", NULL)
@@ -1488,7 +1488,7 @@ static cell_t SQL_ConnectCustom(IPluginContext *pContext, const cell_t *params)
 	IExtension *pExt = g_Extensions.GetExtensionFromIdent(driver->GetIdentity());
 	if (pExt)
 	{
-		g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext->GetContext()));
+		g_Extensions.BindChildPlugin(pExt, scripts->FindPluginByContext(pContext));
 	}
 
 	return hndl;
@@ -1808,7 +1808,7 @@ static cell_t SQL_ExecuteTransaction(IPluginContext *pContext, const cell_t *par
 	// close the plugin's handle here.
 	handlesys->FreeHandle(params[2], &sec);
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 	if (pPlugin->GetProperty("DisallowDBThreads", NULL) || !g_DBMan.AddToThreadQueue(op, priority))
 	{
 		// Do everything right now.

--- a/core/logic/smn_fakenatives.cpp
+++ b/core/logic/smn_fakenatives.cpp
@@ -59,7 +59,7 @@ cell_t FakeNativeRouter(IPluginContext *pContext, const cell_t *params, void *pD
 		return pContext->ThrowNativeError("Plugin owning this native is currently paused.");
 	}
 
-	CPlugin *pCaller = g_PluginSys.GetPluginByCtx(pContext->GetContext());
+	CPlugin *pCaller = g_PluginSys.GetPluginByCtx(pContext);
 
 	/* Save any old data on the stack */
 	FakeNative *pSaveNative = s_curnative;
@@ -116,7 +116,7 @@ static cell_t CreateNative(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Failed to create native \"%s\", function %x is not a valid function", name, params[2]);
 	}
 
-	pPlugin = g_PluginSys.GetPluginByCtx(pContext->GetContext());
+	pPlugin = g_PluginSys.GetPluginByCtx(pContext);
 
 	if (!pPlugin->AddFakeNative(pFunction, name, FakeNativeRouter))
 	{

--- a/core/logic/smn_filesystem.cpp
+++ b/core/logic/smn_filesystem.cpp
@@ -945,7 +945,7 @@ static cell_t sm_LogMessage(IPluginContext *pContext, const cell_t *params)
 			return 0;
 	}
 
-	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext);
 	g_Logger.LogMessage("[%s] %s", pPlugin->GetFilename(), buffer);
 
 	return 1;
@@ -963,7 +963,7 @@ static cell_t sm_LogError(IPluginContext *pContext, const cell_t *params)
 			return 0;
 	}
 
-	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext);
 	g_Logger.LogError("[%s] %s", pPlugin->GetFilename(), buffer);
 
 	return 1;
@@ -1010,7 +1010,7 @@ static cell_t sm_LogToOpenFile(IPluginContext *pContext, const cell_t *params)
 			return 0;
 	}
 
-	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext);
 	g_Logger.LogToOpenFile(sysfile->fp(), "[%s] %s", pPlugin->GetFilename(), buffer);
 
 	return 1;

--- a/core/logic/smn_float.cpp
+++ b/core/logic/smn_float.cpp
@@ -321,7 +321,7 @@ public:
 	
 	MTRand *RandObjForPlugin(IPluginContext *ctx)
 	{
-		IPlugin *plugin = pluginsys->FindPluginByContext(ctx->GetContext());
+		IPlugin *plugin = pluginsys->FindPluginByContext(ctx);
 		MTRand *mtrand;	
 		if (!plugin->GetProperty("core.logic.mtrand", (void**)&mtrand))
 		{

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -36,6 +36,7 @@
 #include <IHandleSys.h>
 #include <IForwardSys.h>
 #include <ISourceMod.h>
+#include <sourcepawn/vm/base-runtime.h>
 
 HandleType_t g_GlobalFwdType = 0;
 HandleType_t g_PrivateFwdType = 0;
@@ -128,7 +129,7 @@ static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *param
 	pContext->LocalToString(params[2], &name);
 
 	/* Get public function index */
-	if (pPlugin->GetBaseContext()->FindPublicByName(name, &idx) == SP_ERROR_NOT_FOUND)
+	if (pContext->GetBaseRuntime()->FindPublicByName(name, &idx) == SP_ERROR_NOT_FOUND)
 	{
 		/* Return INVALID_FUNCTION if not found */
 		return pContext->GetNullFunctionValue();

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -115,7 +115,7 @@ static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *param
 
 	if (hndl == 0)
 	{
-		pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+		pPlugin = pluginsys->FindPluginByContext(pContext);
 	} else {
 		pPlugin = pluginsys->PluginFromHandle(hndl, &err);
 
@@ -218,7 +218,7 @@ static cell_t sm_AddToForward(IPluginContext *pContext, const cell_t *params)
 
 	if (plHandle == 0)
 	{
-		pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+		pPlugin = pluginsys->FindPluginByContext(pContext);
 	} else {
 		pPlugin = pluginsys->PluginFromHandle(plHandle, &err);
 
@@ -259,7 +259,7 @@ static cell_t sm_RemoveFromForward(IPluginContext *pContext, const cell_t *param
 
 	if (plHandle == 0)
 	{
-		pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+		pPlugin = pluginsys->FindPluginByContext(pContext);
 	} else {
 		pPlugin = pluginsys->PluginFromHandle(plHandle, &err);
 
@@ -300,7 +300,7 @@ static cell_t sm_RemoveAllFromForward(IPluginContext *pContext, const cell_t *pa
 
 	if (plHandle == 0)
 	{
-		pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+		pPlugin = pluginsys->FindPluginByContext(pContext);
 	} else {
 		pPlugin = pluginsys->PluginFromHandle(plHandle, &err);
 
@@ -325,7 +325,7 @@ static cell_t sm_CallStartFunction(IPluginContext *pContext, const cell_t *param
 
 	if (hndl == 0)
 	{
-		pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+		pPlugin = pluginsys->FindPluginByContext(pContext);
 	} else {
 		pPlugin = pluginsys->PluginFromHandle(hndl, &err);
 
@@ -721,7 +721,7 @@ static void PawnFrameAction(void *pData)
 
 static cell_t sm_AddFrameAction(IPluginContext *pContext, const cell_t *params)
 {
-	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext);
 	IPluginFunction *pFunction = pPlugin->GetBaseContext()->GetFunctionById(params[1]);
 	if (!pFunction)
 	{

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -42,7 +42,7 @@ HandleType_t g_GlobalFwdType = 0;
 HandleType_t g_PrivateFwdType = 0;
 
 static bool s_CallStarted = false;
-static ICallable *s_pCallable = NULL;
+static sp::CallArgs sArgs;
 static IPluginFunction *s_pFunction = NULL;
 static IForward *s_pForward = NULL;
 
@@ -103,7 +103,7 @@ inline void ResetCall()
 	s_CallStarted = false;
 	s_pFunction = NULL;
 	s_pForward = NULL;
-	s_pCallable = NULL;
+	sArgs.Reset();
 }
 
 static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *params)
@@ -347,8 +347,6 @@ static cell_t sm_CallStartFunction(IPluginContext *pContext, const cell_t *param
 		return pContext->ThrowNativeError("Invalid function id (%X)", funcid);
 	}
 
-	s_pCallable = static_cast<ICallable *>(s_pFunction);
-
 	s_CallStarted = true;
 
 	return 1;
@@ -373,8 +371,6 @@ static cell_t sm_CallStartForward(IPluginContext *pContext, const cell_t *params
 
 	s_pForward = pForward;
 
-	s_pCallable = static_cast<ICallable *>(pForward);
-
 	s_CallStarted = true;
 
 	return 1;
@@ -389,14 +385,27 @@ static cell_t sm_CallPushCell(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	err = s_pCallable->PushCell(params[1]);
+	sArgs.PushCell(params[1]);
 
-	if (err)
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
+
+	return 1;
+}
+
+static cell_t sm_CallPushFloat(IPluginContext *pContext, const cell_t *params)
+{
+	int err;
+
+	if (!s_CallStarted)
 	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
+		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
+
+	sArgs.PushFloat(sp_ctof(params[1]));
+
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
@@ -411,37 +420,13 @@ static cell_t sm_CallPushCellRef(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	pContext->LocalToPhysAddr(params[1], &addr);
+	if (int err = pContext->LocalToPhysAddr(params[1], &addr); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
 
-	err = s_pCallable->PushCellByRef(addr);
+	sArgs.PushCellByRef(addr);
 
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
-
-	return 1;
-}
-
-static cell_t sm_CallPushFloat(IPluginContext *pContext, const cell_t *params)
-{
-	int err;
-
-	if (!s_CallStarted)
-	{
-		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
-	}
-
-	err = s_pCallable->PushFloat(sp_ctof(params[1]));
-
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
@@ -456,23 +441,19 @@ static cell_t sm_CallPushFloatRef(IPluginContext *pContext, const cell_t *params
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	pContext->LocalToPhysAddr(params[1], &addr);
+	if (int err = pContext->LocalToPhysAddr(params[1], &addr); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
 
-	err = s_pCallable->PushFloatByRef(reinterpret_cast<float *>(addr));
+	sArgs.PushFloatByRef(reinterpret_cast<float*>(addr));
 
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallPushArray(IPluginContext *pContext, const cell_t *params)
 {
-	int err;
 	cell_t *addr;
 
 	if (!s_CallStarted)
@@ -480,23 +461,19 @@ static cell_t sm_CallPushArray(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	pContext->LocalToPhysAddr(params[1], &addr);
+	if (int err = pContext->LocalToPhysAddr(params[1], &addr); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
 
-	err = s_pCallable->PushArray(addr, params[2]);
+	sArgs.PushArray(addr, params[2]);
 
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallPushArrayEx(IPluginContext *pContext, const cell_t *params)
 {
-	int err;
 	cell_t *addr;
 
 	if (!s_CallStarted)
@@ -504,23 +481,19 @@ static cell_t sm_CallPushArrayEx(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	pContext->LocalToPhysAddr(params[1], &addr);
+	if (int err = pContext->LocalToPhysAddr(params[1], &addr); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
 
-	err = s_pCallable->PushArray(addr, params[2], params[3]);
+	sArgs.PushArray(addr, params[2], params[3]);
 
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallPushString(IPluginContext *pContext, const cell_t *params)
 {
-	int err;
 	char *value;
 
 	if (!s_CallStarted)
@@ -528,23 +501,19 @@ static cell_t sm_CallPushString(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	pContext->LocalToString(params[1], &value);
+	if (int err = pContext->LocalToString(params[1], &value); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
 
-	err = s_pCallable->PushString(value);
+	sArgs.PushString(value);
 
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallPushStringEx(IPluginContext *pContext, const cell_t *params)
 {
-	int err;
 	char *value;
 
 	if (!s_CallStarted)
@@ -552,105 +521,49 @@ static cell_t sm_CallPushStringEx(IPluginContext *pContext, const cell_t *params
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	pContext->LocalToString(params[1], &value);
+	if (int err = pContext->LocalToString(params[1], &value); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
 
-	err = s_pCallable->PushStringEx(value, params[2], params[3], params[4]);
+	sArgs.PushString(value, params[2], params[3] | params[4]);
 
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallPushNullVector(IPluginContext *pContext, const cell_t *params)
 {
-	int err = SP_ERROR_NOT_FOUND;
-
 	if (!s_CallStarted)
 	{
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	if (s_pFunction)
-	{
-		// Find the NULL_VECTOR pubvar in the target plugin and push the local address.
-		IPluginRuntime *runtime = s_pFunction->GetParentRuntime();
-		uint32_t null_vector_idx;
-		err = runtime->FindPubvarByName("NULL_VECTOR", &null_vector_idx);
-		if (err)
-		{
-			return pContext->ThrowNativeErrorEx(err, "Target plugin has no NULL_VECTOR.");
-		}
+	sArgs.PushNullVector();
 
-		cell_t null_vector;
-		err = runtime->GetPubvarAddrs(null_vector_idx, &null_vector, nullptr);
-
-		if (!err)
-			err = s_pCallable->PushCell(null_vector);
-	}
-	else if (s_pForward)
-	{
-		err = s_pForward->PushArray(NULL, 3);
-	}
-
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallPushNullString(IPluginContext *pContext, const cell_t *params)
 {
-	int err = SP_ERROR_NOT_FOUND;
-
 	if (!s_CallStarted)
 	{
 		return pContext->ThrowNativeError("Cannot push parameters when there is no call in progress");
 	}
 
-	if (s_pFunction)
-	{
-		// Find the NULL_STRING pubvar in the target plugin and push the local address.
-		IPluginRuntime *runtime = s_pFunction->GetParentRuntime();
-		uint32_t null_string_idx;
-		err = runtime->FindPubvarByName("NULL_STRING", &null_string_idx);
-		if (err)
-		{
-			return pContext->ThrowNativeErrorEx(err, "Target plugin has no NULL_STRING.");
-		}
+	sArgs.PushNullString();
 
-		cell_t null_string;
-		err = runtime->GetPubvarAddrs(null_string_idx, &null_string, nullptr);
-
-		if (!err)
-			err = s_pCallable->PushCell(null_string);
-	}
-	else if (s_pForward)
-	{
-		err = s_pForward->PushString(NULL);
-	}
-
-	if (err)
-	{
-		s_pCallable->Cancel();
-		ResetCall();
-		return pContext->ThrowNativeErrorEx(err, NULL);
-	}
+	if (sArgs.error)
+		return pContext->ThrowNativeErrorEx(SP_ERROR_PARAMS_MAX, nullptr);
 
 	return 1;
 }
 
 static cell_t sm_CallFinish(IPluginContext *pContext, const cell_t *params)
 {
-	int err = SP_ERROR_NOT_RUNNABLE;
 	cell_t *result;
 
 	if (!s_CallStarted)
@@ -658,21 +571,26 @@ static cell_t sm_CallFinish(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot finish call when there is no call in progress");
 	}
 
-	pContext->LocalToPhysAddr(params[1], &result);
+	if (int err = pContext->LocalToPhysAddr(params[1], &result); err != SP_ERROR_NONE)
+		return pContext->ThrowNativeErrorEx(err, nullptr);
+
+	auto local_args = sArgs;
 
 	// Note: Execute() swallows exceptions, so this is okay.
 	if (s_pFunction)
 	{
 		IPluginFunction *pFunction = s_pFunction;
 		ResetCall();
-		err = pFunction->Execute(result);
-	} else if (s_pForward) {
+		if (!pFunction->Invoke(local_args, result))
+			return 0;
+	} else {
 		IForward *pForward = s_pForward;
 		ResetCall();
-		err = pForward->Execute(result, NULL);
+		if (int err = pForward->Execute(local_args, result); err != SP_ERROR_NONE)
+			return pContext->ThrowNativeErrorEx(err, nullptr);
 	}
 
-	return err;
+	return 1;
 }
 
 static cell_t sm_CallCancel(IPluginContext *pContext, const cell_t *params)
@@ -682,7 +600,6 @@ static cell_t sm_CallCancel(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Cannot cancel call when there is no call in progress");
 	}
 
-	s_pCallable->Cancel();
 	ResetCall();
 
 	return 1;

--- a/core/logic/smn_handles.cpp
+++ b/core/logic/smn_handles.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "common_logic.h"
+#include <bridge/include/IScriptManager.h>
 #include <IHandleSys.h>
 #include <IPluginSys.h>
 
@@ -108,7 +109,7 @@ static cell_t sm_CloneHandle(IPluginContext *pContext, const cell_t *params)
 
 static cell_t sm_GetMyHandle(IPluginContext *pContext, const cell_t *params)
 {
-	IPlugin *pPlugin = pluginsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 
 	return pPlugin->GetMyHandle();
 }

--- a/core/logic/smn_lang.cpp
+++ b/core/logic/smn_lang.cpp
@@ -38,7 +38,7 @@
 
 static cell_t sm_TranslationPhraseExists(IPluginContext *pCtx, const cell_t *params)
 {
-	IPlugin *pl = pluginsys->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = pluginsys->FindPluginByContext(pCtx);
 	IPhraseCollection *collection = pl->GetPhrases();
 	
 	char *phrase;
@@ -49,7 +49,7 @@ static cell_t sm_TranslationPhraseExists(IPluginContext *pCtx, const cell_t *par
 
 static cell_t sm_IsTranslatedForLanguage(IPluginContext *pCtx, const cell_t *params)
 {
-	IPlugin *pl = pluginsys->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = pluginsys->FindPluginByContext(pCtx);
 	IPhraseCollection *collection = pl->GetPhrases();
 	
 	char *phrase;
@@ -65,7 +65,7 @@ static cell_t sm_LoadTranslations(IPluginContext *pCtx, const cell_t *params)
 {
 	char *filename, *ext;
 	char buffer[PLATFORM_MAX_PATH];
-	IPlugin *pl = pluginsys->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = pluginsys->FindPluginByContext(pCtx);
 
 	pCtx->LocalToString(params[1], &filename);
 	ke::SafeStrcpy(buffer, sizeof(buffer), filename);

--- a/core/logic/smn_menus.cpp
+++ b/core/logic/smn_menus.cpp
@@ -245,7 +245,7 @@ public:
 			m_FreePanelHandlers.pop();
 		}
 		handler->m_pFunc = pFunction;
-		handler->m_pPlugin = scripts->FindPluginByContext(pFunction->GetParentContext()->GetContext());
+		handler->m_pPlugin = scripts->FindPluginByContext(pFunction->GetParentContext());
 		return handler;
 	}
 

--- a/core/logic/smn_players.cpp
+++ b/core/logic/smn_players.cpp
@@ -240,7 +240,7 @@ AddMultiTargetFilter(IPluginContext *ctx, const cell_t *params)
 	ctx->LocalToString(params[3], &phrase);
 
 	bool phraseIsML = !!params[4];
-	IPlugin *plugin = pluginsys->FindPluginByContext(ctx->GetContext());
+	IPlugin *plugin = pluginsys->FindPluginByContext(ctx);
 
 	s_PlayerLogicHelpers.AddMultiTargetFilter(plugin, pattern, fun, phrase, phraseIsML);
 

--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -37,6 +37,7 @@
 #include "stringutil.h"
 #include "sprintf.h"
 #include <am-string.h>
+#include <sourcepawn/vm/base-runtime.h>
 
 inline const char *_strstr(const char *str, const char *substr)
 {
@@ -232,7 +233,7 @@ static cell_t sm_vformat(IPluginContext *pContext, const cell_t *params)
 	int vargPos = static_cast<int>(params[4]);
 
 	/* Get the parent parameter array */
-	cell_t *local_params = pContext->GetLocalParams();
+	cell_t *local_params = pContext->GetBaseRuntime()->GetLocalParams();
 
 	cell_t max = local_params[0];
 	if (vargPos > (int)max + 1)

--- a/core/logic/sprintf.cpp
+++ b/core/logic/sprintf.cpp
@@ -75,7 +75,7 @@ size_t Translate(char *buffer,
 	unsigned int langid;
 	*error = false;
 	Translation pTrans;
-	IPlugin *pl = scripts->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = scripts->FindPluginByContext(pCtx);
 	unsigned int max_params = 0;
 	IPhraseCollection *pPhrases;
 

--- a/core/logic_bridge.cpp
+++ b/core/logic_bridge.cpp
@@ -422,8 +422,8 @@ CoreProviderImpl::CoreProviderImpl()
 	this->playerhelpers = &g_Players;
 	this->gamehelpers = &g_HL2;
 	this->menus = &g_Menus;
-	this->spe1 = &g_pSourcePawn;
-	this->spe2 = &g_pSourcePawn2;
+	this->spe1 = &g_pPawnEnv;
+	this->spe2 = &g_pPawnEnv;
 	this->spe_env = &g_pPawnEnv;
 	this->GetCoreConfigValue = get_core_config_value;
 	this->DoGlobalPluginLoads = do_global_plugin_loads;

--- a/core/sm_globals.h
+++ b/core/sm_globals.h
@@ -195,9 +195,11 @@ public:
 	static SMGlobalClass *head;
 };
 
-extern SourcePawn::ISourcePawnEngine *g_pSourcePawn;
-extern SourcePawn::ISourcePawnEngine2 *g_pSourcePawn2;
+#if defined SM_LOGIC
+extern sp::Environment *g_pPawnEnv;
+#else
 extern SourcePawn::ISourcePawnEnvironment *g_pPawnEnv;
+#endif
 extern IdentityToken_t *g_pCoreIdent;
 
 namespace SourceMod

--- a/core/smn_console.cpp
+++ b/core/smn_console.cpp
@@ -750,7 +750,7 @@ static cell_t sm_RegServerCmd(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid function id (%X)", params[2]);
 	}
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 	if (!g_ConCmds.AddServerCommand(pFunction, name, help, params[4], pPlugin))
 	{
 		return pContext->ThrowNativeError("Command \"%s\" could not be created. A convar with the same name already exists.", name);
@@ -779,7 +779,7 @@ static cell_t sm_RegConsoleCmd(IPluginContext *pContext, const cell_t *params)
 		return pContext->ThrowNativeError("Invalid function id (%X)", params[2]);
 	}
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 	const char *group = pPlugin->GetFilename();
 	if (!g_ConCmds.AddAdminCommand(pFunction, name, group, 0, help, params[4], pPlugin))
 	{
@@ -808,7 +808,7 @@ static cell_t sm_RegAdminCmd(IPluginContext *pContext, const cell_t *params)
 	pContext->LocalToString(params[5], (char **)&group);
 	pFunction = pContext->GetFunctionById(params[2]);
 
-	IPlugin *pPlugin = scripts->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = scripts->FindPluginByContext(pContext);
 	if (group[0] == '\0')
 	{
 		group = pPlugin->GetFilename();

--- a/core/smn_usermsgs.cpp
+++ b/core/smn_usermsgs.cpp
@@ -169,7 +169,7 @@ MsgListenerWrapper *UsrMessageNatives::CreateListener(IPluginContext *pCtx)
 {
 	MsgWrapperList *pList;
 	MsgListenerWrapper *pListener;
-	IPlugin *pl = scripts->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = scripts->FindPluginByContext(pCtx);
 
 	if (m_FreeListeners.empty())
 	{
@@ -195,7 +195,7 @@ bool UsrMessageNatives::FindListener(int msgid, IPluginContext *pCtx, IPluginFun
 	MsgWrapperList *pList;
 	MsgWrapperIter _iter;
 	MsgListenerWrapper *pListener;
-	IPlugin *pl = scripts->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = scripts->FindPluginByContext(pCtx);
 
 	if (!pl->GetProperty("MsgListeners", reinterpret_cast<void **>(&pList)))
 	{
@@ -221,7 +221,7 @@ bool UsrMessageNatives::DeleteListener(IPluginContext *pCtx, MsgWrapperIter iter
 {
 	MsgWrapperList *pList;
 	MsgListenerWrapper *pListener;
-	IPlugin *pl = scripts->FindPluginByContext(pCtx->GetContext());
+	IPlugin *pl = scripts->FindPluginByContext(pCtx);
 
 	if (!pl->GetProperty("MsgListeners", reinterpret_cast<void **>(&pList)))
 	{

--- a/core/sourcemod.cpp
+++ b/core/sourcemod.cpp
@@ -59,8 +59,6 @@ SH_DECL_HOOK0(IVEngineServer, GetMapEntitiesString, SH_NOATTRIB, 0, const char *
 SourceModBase g_SourceMod;
 
 SourceHook::String g_BaseDir;
-ISourcePawnEngine *g_pSourcePawn = NULL;
-ISourcePawnEngine2 *g_pSourcePawn2 = NULL;
 ISourcePawnEnvironment *g_pPawnEnv = NULL;
 IdentityToken_t *g_pCoreIdent = NULL;
 IForward *g_pOnMapInit = nullptr;
@@ -119,9 +117,7 @@ ConfigResult SourceModBase::OnSourceModConfigChanged(const char *key,
 	{
 		sm_disable_jit = (strcasecmp(value, "yes") == 0) ? true : false;
 
-		if (g_pSourcePawn2) {
-			g_pSourcePawn2->SetJitEnabled(!sm_disable_jit);
-		}
+		logicore.SetJitEnabled(!sm_disable_jit);
 
 		return ConfigResult_Accept;
 	}
@@ -145,9 +141,7 @@ ConfigResult SourceModBase::OnSourceModConfigChanged(const char *key,
 			return ConfigResult_Reject;
 		}
 
-		if (g_pPawnEnv) {
-			g_pPawnEnv->SetDebugMetadataFlags(jit_metadata_flags);
-		}
+		logicore.SetDebugMetadataFlags(jit_metadata_flags);
 
 		return ConfigResult_Accept;
 	}
@@ -199,13 +193,6 @@ bool SourceModBase::InitializeSourceMod(char *error, size_t maxlength, bool late
 
 	/* There will always be a path by this point, since it was force-set above. */
 	m_GotBasePath = true;
-
-	g_pSourcePawn2->SetDebugListener(logicore.debugger);
-
-	if (sm_disable_jit)
-		g_pSourcePawn2->SetJitEnabled(!sm_disable_jit);
-
-	g_pPawnEnv->SetDebugMetadataFlags(jit_metadata_flags);
 
 	sSourceModInitialized = true;
 
@@ -283,22 +270,6 @@ void SourceModBase::StartSourceMod(bool late)
 	if (disabled == NULL || strcasecmp(disabled, "yes") != 0)
 	{
 		extsys->LoadAutoExtension("updater.ext." PLATFORM_LIB_EXT);
-	}
-
-	const char *timeout = GetCoreConfigValue("SlowScriptTimeout");
-	if (timeout == NULL)
-	{
-		timeout = "8";
-	}
-	if (atoi(timeout) != 0)
-	{
-		g_pSourcePawn2->InstallWatchdogTimer(atoi(timeout) * 1000);
-	}
-
-	const char *linedebugger = GetCoreConfigValue("EnableLineDebugging");
-	if (linedebugger != NULL && strcasecmp(linedebugger, "yes") == 0)
-	{
-		g_pPawnEnv->EnableDebugBreak();
 	}
 
 	SH_ADD_HOOK(IServerGameDLL, Think, gamedll, SH_MEMBER(logicore.callbacks, &IProviderCallbacks::OnThink), false);
@@ -507,8 +478,6 @@ void SourceModBase::CloseSourceMod()
 	sCoreProviderImpl.ShutdownBridge();
 
 	g_pPawnEnv = NULL;
-	g_pSourcePawn2 = NULL;
-	g_pSourcePawn = NULL;
 }
 
 void SourceModBase::ShutdownServices()
@@ -659,7 +628,7 @@ const char *SourceModBase::GetGameFolderName() const
 
 ISourcePawnEngine *SourceModBase::GetScriptingEngine()
 {
-	return g_pSourcePawn;
+	return g_pPawnEnv;
 }
 
 IVirtualMachine *SourceModBase::GetScriptingVM()

--- a/extensions/clientprefs/natives.cpp
+++ b/extensions/clientprefs/natives.cpp
@@ -354,7 +354,7 @@ cell_t AddSettingsMenuItem(IPluginContext *pContext, const cell_t *params)
 
 	/* Track this in case the plugin unloads */
 
-	IPlugin *pPlugin = plsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = plsys->FindPluginByContext(pContext);
 	std::vector<char *> *pList = NULL;
 
 	if (!pPlugin->GetProperty("SettingsMenuItems", (void **)&pList, false) || !pList)
@@ -424,7 +424,7 @@ cell_t AddSettingsPrefabMenuItem(IPluginContext *pContext, const cell_t *params)
 
 	/* Track this in case the plugin unloads */
 
-	IPlugin *pPlugin = plsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = plsys->FindPluginByContext(pContext);
 	std::vector<char *> *pList = NULL;
 
 	if (!pPlugin->GetProperty("SettingsMenuItems", (void **)&pList, false) || !pList)

--- a/extensions/sdktools/output.cpp
+++ b/extensions/sdktools/output.cpp
@@ -255,7 +255,7 @@ void EntityOutputManager::CleanUpHook(omg_hooks *hook)
 
 	OnHookRemoved();
 
-	IPlugin *pPlugin = plsys->FindPluginByContext(hook->pf->GetParentContext()->GetContext());
+	IPlugin *pPlugin = plsys->FindPluginByContext(hook->pf->GetParentContext());
 	SourceHook::List<omg_hooks *> *pList = NULL;
 
 	if (!pPlugin->GetProperty("OutputHookList", (void **)&pList, false) || !pList)

--- a/extensions/sdktools/outputnatives.cpp
+++ b/extensions/sdktools/outputnatives.cpp
@@ -94,7 +94,7 @@ cell_t HookSingleEntityOutput(IPluginContext *pContext, const cell_t *params)
 
 	g_OutputManager.OnHookAdded();
 
-	IPlugin *pPlugin = plsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = plsys->FindPluginByContext(pContext);
 	SourceHook::List<omg_hooks *> *pList = NULL;
 
 	if (!pPlugin->GetProperty("OutputHookList", (void **)&pList, false) || !pList)
@@ -157,7 +157,7 @@ cell_t HookEntityOutput(IPluginContext *pContext, const cell_t *params)
 
 	g_OutputManager.OnHookAdded();
 
-	IPlugin *pPlugin = plsys->FindPluginByContext(pContext->GetContext());
+	IPlugin *pPlugin = plsys->FindPluginByContext(pContext);
 	SourceHook::List<omg_hooks *> *pList = NULL;
 
 	if (!pPlugin->GetProperty("OutputHookList", (void **)&pList, false) || !pList)

--- a/plugins/include/functions.inc
+++ b/plugins/include/functions.inc
@@ -47,7 +47,6 @@ enum ParamType
 	Param_Float         = (2<<1),                       /**< Only floats can be pushed */
 	Param_String        = (3<<1)|SP_PARAMFLAG_BYREF,    /**< Only strings can be pushed */
 	Param_Array         = (4<<1)|SP_PARAMFLAG_BYREF,    /**< Only arrays can be pushed */
-	Param_VarArgs       = (5<<1),                       /**< Same as "..." in plugins, anything can be pushed, but it will always be byref */
 	Param_CellByRef     = (1<<1)|SP_PARAMFLAG_BYREF,    /**< Only a cell by reference can be pushed */
 	Param_FloatByRef    = (2<<1)|SP_PARAMFLAG_BYREF     /**< Only a float by reference can be pushed */
 };

--- a/plugins/testsuite/fwdtest1.sp
+++ b/plugins/testsuite/fwdtest1.sp
@@ -53,7 +53,7 @@ public Action:Command_CreatePrivateForward(args)
 		delete g_PrivateFwd;
 	}
 	
-	g_PrivateFwd = CreateForward(ET_Hook, Param_Cell, Param_String, Param_VarArgs);
+	g_PrivateFwd = CreateForward(ET_Hook, Param_Cell, Param_String);
 	
 	if (g_PrivateFwd == null)
 	{
@@ -134,13 +134,7 @@ public Action:Command_ExecPrivateForward(args)
 	
 	Call_StartForward(g_PrivateFwd);
 	Call_PushCell(24);
-	Call_PushString("I am a format string: %d %d %d %d %d %d");
-	Call_PushCell(0);
-	Call_PushCell(1);
-	Call_PushCell(2);
-	Call_PushCell(3);
-	Call_PushCell(4);
-	Call_PushCell(5);
+	Call_PushString("I am a string");
 	err = Call_Finish(ret);
 	
 	PrintToServer("Call to private forward completed");

--- a/plugins/testsuite/fwdtest2.sp
+++ b/plugins/testsuite/fwdtest2.sp
@@ -9,7 +9,7 @@ public Plugin:myinfo =
 	url = "http://www.sourcemod.net/"
 };
 
-public Action:OnPrivateForward(num, const String:format[], ...)
+public Action:OnPrivateForward(num, const String:format[])
 {
 	decl String:buffer[128];
 	
@@ -17,8 +17,7 @@ public Action:OnPrivateForward(num, const String:format[], ...)
 	
 	PrintToServer("num = %d (expected: %d)", num, 24);
 	
-	VFormat(buffer, sizeof(buffer), format, 3);
-	PrintToServer("buffer = \"%s\" (expected: \"%s\")", buffer, "I am a format string: 0 1 2 3 4 5");
+	PrintToServer("buffer = \"%s\" (expected: \"%s\")", buffer, "I am a string");
 	
 	PrintToServer("End private forward #2");
 	

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -137,8 +137,10 @@ namespace SourceMod
 	 * V6 - added TestFeature() to IShareSys.
 	 * V7 - added OnDependenciesDropped() to IExtensionInterface.
 	 * V8 - added OnCoreMapEnd() to IExtensionInterface.
+	 * V9 - SourcePawn API revamp
 	 */
-	#define SMINTERFACE_EXTENSIONAPI_VERSION	8
+	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	9
+	#define SMINTERFACE_EXTENSIONAPI_VERSION		9
 
 	/**
 	 * @brief The interface an extension must expose.

--- a/public/IForwardSys.h
+++ b/public/IForwardSys.h
@@ -53,8 +53,13 @@ using namespace SourcePawn;
 #define SMINTERFACE_FORWARDMANAGER_VERSION	4
 
 /*
- * There is some very important documentation at the bottom of this file.
- * Readers interested in knowing more about the forward system, scrolling down is a must!
+ * A Forward is just a collection of IPluginFunctions.  Thus, the same API can
+ * be easily wrapped around a simple list, and it will look transparent to the
+ * user.
+ *
+ * Forwards are function based, rather than plugin based, and are thus far more flexible at runtime..
+ * Individual functions can be paused and more than one function from the same plugin can be hooked.
+ * Parameter pushing is type-checked and allows for variable arguments.
  */
 
 namespace SourceMod
@@ -88,7 +93,6 @@ namespace SourceMod
 	#define SP_PARAMTYPE_FLOAT	(2<<1)
 	#define SP_PARAMTYPE_STRING	(3<<1)|SP_PARAMFLAG_BYREF
 	#define SP_PARAMTYPE_ARRAY	(4<<1)|SP_PARAMFLAG_BYREF
-	#define SP_PARAMTYPE_VARARG	(5<<1)
 
 	/**
 	 * @brief Describes the various ways to pass parameters to plugins.
@@ -100,7 +104,6 @@ namespace SourceMod
 		Param_Float = SP_PARAMTYPE_FLOAT,			/**< Only floats can be pushed */
 		Param_String = SP_PARAMTYPE_STRING,			/**< Only strings can be pushed */
 		Param_Array = SP_PARAMTYPE_ARRAY,			/**< Only arrays can be pushed */
-		Param_VarArgs = SP_PARAMTYPE_VARARG,		/**< Same as "..." in plugins, anything can be pushed, but it will always be byref */
 		Param_CellByRef = SP_PARAMTYPE_CELL|SP_PARAMFLAG_BYREF,		/**< Only a cell by reference can be pushed */
 		Param_FloatByRef = SP_PARAMTYPE_FLOAT|SP_PARAMFLAG_BYREF,	/**< Only a float by reference can be pushed */
 	};
@@ -124,7 +127,7 @@ namespace SourceMod
 	class IForwardFilter
 	{
 	public:
-		virtual void Preprocess(IPluginFunction *fun, FwdParamInfo *params)
+		virtual void Preprocess(IPluginFunction *fun, sp::CallArgs& args)
 		{
 		}
 	};
@@ -136,7 +139,7 @@ namespace SourceMod
 	 * Some functions are repeated in here because their documentation differs from their IPluginFunction equivalents.
 	 * Missing are the Push functions, whose only doc change is that they throw SP_ERROR_PARAM on type mismatches.
 	 */
-	class IForward : public ICallable
+	class IForward
 	{
 	public:
 		/** Virtual Destructor */
@@ -193,6 +196,88 @@ namespace SourceMod
 		* @return      Error code, if any.
 		*/
 		virtual int PushString(const char *string) = 0;
+
+		/**
+		 * @brief Pushes a cell onto the current call.
+		 *
+		 * @param cell	Parameter value to push.
+		 * @return	  Error code, if any.
+		 */
+		virtual int PushCell(cell_t cell) = 0;
+	
+		/**
+		 * @brief Pushes a cell by reference onto the current call.
+		 * NOTE: On Execute, the pointer passed will be modified if copyback is enabled.
+		 * NOTE: By reference parameters are cached and thus are not read until execution.
+		 *	 This means you cannot push a pointer, change it, and push it again and expect
+		 *	   two different values to come out.
+		 *
+		 * @param cell	Address containing parameter value to push.
+		 * @param flags	Copy-back flags.
+		 * @return	  Error code, if any.
+		 */
+		virtual int PushCellByRef(cell_t* cell, int flags = SM_PARAM_COPYBACK) = 0;
+	
+		/**
+		 * @brief Pushes a float onto the current call.
+		 *
+		 * @param number  Parameter value to push.
+		 * @return	  Error code, if any.
+		 */
+		virtual int PushFloat(float number) = 0;
+	
+		/**
+		 * @brief Pushes a float onto the current call by reference.
+		 * NOTE: On Execute, the pointer passed will be modified if copyback is enabled.
+		 * NOTE: By reference parameters are cached and thus are not read until execution.
+		 *	 This means you cannot push a pointer, change it, and push it again and expect
+		 *	   two different values to come out.
+		 *
+		 * @param number  Parameter value to push.
+		 * @param flags	Copy-back flags.
+		 * @return	  Error code, if any.
+		 */
+		virtual int PushFloatByRef(float* number, int flags = SM_PARAM_COPYBACK) = 0;
+	
+		/**
+		 * @brief Pushes a string or string buffer.
+		 *
+		 * NOTE: On Execute, the pointer passed will be modified if copy-back is enabled.
+		 *
+		 * @param buffer  Pointer to string buffer.
+		 * @param length  Length of buffer.
+		 * @param sz_flags  String flags.  In copy mode, the string will be copied
+		 *		  according to the handling (ascii, utf-8, binary, etc).
+		 * @param cp_flags  Copy-back flags.
+		 * @return	  Error code, if any.
+		 */
+		virtual int PushStringEx(char* buffer, size_t length, int sz_flags, int cp_flags) = 0;
+	
+		/**
+		 * @brief Cancels a function call that is being pushed but not yet executed.
+		 * This can be used be reset for CallFunction() use.
+		 */
+		virtual void Cancel() = 0;
+	
+		/**
+		 * @brief Pushes an int64 value onto the current call.
+		 *
+		 * @param number	Parameter to push.
+		 * @return		  Error code, if any.
+		 */
+		virtual int PushInt64(int64_t value) = 0;
+
+		/**
+		 * @brief Alternate version of Execute() that uses CallArgs rather than
+		 * individual Push methods.
+		 *
+		 * Each Push() method on CallArgs supports the same behavior as the
+		 * Push methods on IForward.
+		 *
+		 * Unlike IPluginFunction::Invoke, this does not automatically propagate
+		 * an exception.
+		 */
+		virtual int Execute(const sp::CallArgs& args, cell_t *result = nullptr, IForwardFilter *filter = nullptr) = 0;
 	};
 
 	/**
@@ -201,7 +286,7 @@ namespace SourceMod
 	class IChangeableForward : public IForward
 	{
 	public:
-		/** 
+		/**
 		 * @brief Removes a function from the call list.
 		 * NOTE: Only removes one instance.
 		 *
@@ -210,7 +295,7 @@ namespace SourceMod
 		 */
 		virtual bool RemoveFunction(IPluginFunction *func) =0;
 
-		/** 
+		/**
 		 * @brief Removes all instances of a plugin from the call list.
 		 *
 		 * @param plugin	Plugin to remove instances of.
@@ -240,7 +325,7 @@ namespace SourceMod
 		 */
 		virtual bool AddFunction(IPluginContext *ctx, funcid_t index) =0;
 
-		/** 
+		/**
 		 * @brief Removes a function from the call list.
 		 * NOTE: Only removes one instance.
 		 *
@@ -289,10 +374,10 @@ namespace SourceMod
 		 * @param ...			If types is NULL, num_params ParamTypes should be pushed.
 		 * @return				A new IForward on success, NULL if type combination is impossible.
 		 */
-		virtual IForward *CreateForward(const char *name, 
-										ExecType et, 
-										unsigned int num_params, 
-										const ParamType *types, 
+		virtual IForward *CreateForward(const char *name,
+										ExecType et,
+										unsigned int num_params,
+										const ParamType *types,
 										...) =0;
 
 		/**
@@ -309,10 +394,10 @@ namespace SourceMod
 		 * @param ...			If types is NULL, num_params ParamTypes should be pushed.
 		 * @return				A new IChangeableForward on success, NULL if type combination is impossible.
 		 */
-		virtual IChangeableForward *CreateForwardEx(const char *name, 
-													ExecType et, 
-													int num_params, 
-													const ParamType *types, 
+		virtual IChangeableForward *CreateForwardEx(const char *name,
+													ExecType et,
+													int num_params,
+													const ParamType *types,
 													...) =0;
 
 		/**
@@ -333,67 +418,5 @@ namespace SourceMod
 		virtual void ReleaseForward(IForward *forward) =0;
 	};
 }
-
-/*
- *  In the AMX Mod X model of forwarding, each forward contained a list of pairs, each pair containing
- * a function ID and an AMX structure.  The forward structure itself did very little but hold parameter types.
- * An execution call worked like this:
- *  - executeForward() took in a function id and a list of parameters
- *  - for each contained plugin:
- *   - the list of parameters was preprocessed and pushed
- *   - the call was made
- *   - the list was freed and copybacks were made
- *  - return
- * 
- *  The advantages to this is that the system is very easy to implement, and it's fast. The disadvantage is 
- * varargs tend to be very unforgiving and inflexible, and thus weird problems arose with casting.  You also 
- * lose flexibility, type checking, and the ability to reasonably use variable arguments lists in the VM.
- *
- *  SourceMod replaces this forward system with a far more advanced, but a bit bulkier one. The idea is that 
- * each plugin has a table of functions, and each function is an ICallable object.  As well as being an ICallable, 
- * each function is an IPluginFunction.  An ICallable simply describes the process of adding parameters to a 
- * function call.  An IPluginFunction describes the process of actually calling a function and performing allocation, 
- * copybacks, and deallocations.
- *
- * A very powerful forward system emerges: a Forward is just a collection of IPluginFunctions.  Thus, the same 
- * API can be easily wrapped around a simple list, and it will look transparent to the user.
- * Advantages:
- * 1) "SP Forwards" from AMX Mod X are simply IPluginFunctions without a collection.
- * 2) Forwards are function based, rather than plugin based, and are thus far more flexible at runtime..
- * 3) [2] Individual functions can be paused and more than one function from the same plugin can be hooked.
- * 4) [2] One hook type that used to map to many SP Forwards can now be centralized as one Forward.
- *    This helps alleviate messes like Fakemeta.
- * 5) Parameter pushing is type-checked and allows for variable arguments.
- *
- *  Note that while #2,3,4 could be added to AMX Mod X, the real binding property is #1, which makes the system
- * object oriented, rather than AMX Mod X, which hides the objects behind static functions.  It is entirely a design
- * issue, rather than a usability one.  The interesting part is when it gets to implementation, which has to cache
- * parameter pushing until execution.  Without this, multiple function calls can be started across one plugin, which
- * will result in heap corruption given SourcePawn's implementation.
- *
- * Observe the new calling process:
- * - Each parameter is pushed into a local cache using the ICallable interface.
- * - For each function in the collection:
- *  - Each parameter is decoded and -pushed into the function.
- *  - The call is made.
- * - Return
- *
- *  Astute readers will note the (minor) problems:
- * 1) More memory is used.  Specifically, rather than N params of memory, you now have N params * M plugins.
- *    This is because, again, parameters are cached both per-function and per-forward.
- * 2) There are slightly more calls going around: one extra call for each parameter, since each push is manual.
- *
- * HISTORICAL NOTES:
- *  There used to be a # about copy backs.  
- *  Note that originally, the Forward implementation was a thin wrapper around IForwards.  It did not cache pushes,
- * and instead immediately fired them to each internal plugin.  This was to allow users to know that pointers would 
- * be immediately resolved.  Unfortunately, this became extremely burdensome on the API and exposed many problems,
- * the major (and breaking) one was that two separate Function objects cannot be in a calling process on the same 
- * plugin at once. (:TODO: perhaps prevent that in the IPlugin object?) This is because heap functions lose their order
- * and become impossible to re-arrange without some global heap tracking mechanism.  It also made iterative copy backs 
- * for arrays/references overwhelmingly complex, since each plugin had to have its memory back-patched for each copy.
- *  Therefore, this was scrapped for cached parameters (current implementation), which is the implementation AMX Mod X 
- * uses.  It is both faster and works better.
- */
 
 #endif //_INCLUDE_SOURCEMOD_FORWARDINTERFACE_H_

--- a/public/IPluginSys.h
+++ b/public/IPluginSys.h
@@ -143,20 +143,6 @@ namespace SourceMod
 		virtual SourcePawn::IPluginContext *GetBaseContext() =0;
 
 		/**
-		 * @brief Deprecated, returns NULL.
-		 *
-		 * @return	NULL.
-		 */
-		virtual sp_context_t *GetContext() =0;
-
-		/**
-		 * @brief Deprecated, returns NULL.
-		 *
-		 * @return	NULL.
-		 */
-		virtual void *GetPluginStructure() =0;
-
-		/**
 		 * @brief Returns information about the plugin by reference.
 		 *
 		 * @return			Pointer to a sm_plugininfo_t object, NULL if plugin is not loaded.
@@ -388,10 +374,10 @@ namespace SourceMod
 		 * @brief Finds a plugin by its context.
 		 * Note: This function should be considered O(1).
 		 *
-		 * @param ctx		Pointer to an sp_context_t.
+		 * @param ctx		Pointer to an IPluginContext.
 		 * @return			Pointer to a matching IPlugin, or NULL if none found.
 		 */
-		virtual IPlugin *FindPluginByContext(const sp_context_t *ctx) =0;
+		virtual IPlugin *FindPluginByContext(SourcePawn::IPluginContext *ctx) =0;
 
 		/**
 		 * @brief Returns the number of plugins (both failed and loaded).


### PR DESCRIPTION
This updates the SourcePawn library, which breaks binary compatibility for extensions (not for plugins) due to many changes to the public API.

The most significant change is that ICallable is removed. Instead, arguments are now packed into a CallArgs structure which is then passed to the VM. CallArgs is much more efficient than the old ICallable::Push API, reducing invocation overhead by about 15% on my computer.  `functions.inc` now uses CallArgs internally, and `IForwardSys` has been augmented to use CallArgs as well.

Extensions do need to be recompiled. However, the old "Push" API is retained for source-level compatibility, which is why almost no first-party extensions were changed in this PR. Well-behaving extensions will recompile with no issues.

Some extremely esoteric features were removed, so extensions using them will no longer work.

- IForwardSys no longer supports variadic functions. This feature had no use in the corpus or internally, and was almost impossible to actually use in any meaningful way.
- An IPluginContext function specifically to make VFormat() work is now restricted to core.
- Any function in sp_vm_api.h that was not used by SourceMod's first-party extensions has been removed from the public API. These should generally have never been used, and were mostly related to native binding or named function lookup (which should be done via ForwardSys or GetFunctionById).