### PR TITLE
DHooks: Fix setting CBaseEntity* params

### DIFF
--- a/extensions/dhooks/natives.cpp
+++ b/extensions/dhooks/natives.cpp
@@ -794,13 +794,13 @@ cell_t Native_SetParam(IPluginContext *pContext, const cell_t *params)
 			break;
 		case HookParamType_CBaseEntity:
 		{
-			if(params[2] == -1)
+			if(params[3] == -1)
 			{
 				*(CBaseEntity **)addr = nullptr;
 			}
 			else
 			{
-				CBaseEntity *pEnt = gamehelpers->ReferenceToEntity(params[2]);
+				CBaseEntity *pEnt = gamehelpers->ReferenceToEntity(params[3]);
 
 				if(!pEnt)
 				{
@@ -813,7 +813,7 @@ cell_t Native_SetParam(IPluginContext *pContext, const cell_t *params)
 		}
 		case HookParamType_Edict:
 		{
-			edict_t *pEdict = gamehelpers->EdictOfIndex(params[2]);
+			edict_t *pEdict = gamehelpers->EdictOfIndex(params[3]);
 
 			if(!pEdict || pEdict->IsFree())
 			{


### PR DESCRIPTION
This code was copied from `Native_SetReturn()`, but the index into `params` wasn't changed to account for the different position of the `value` param in this function, so it would always try to use the parameter number as the value.

Thanks to @bigmazi for pointing out that this was broken.