### PR TITLE
Fix SDKCall mis-decoding int64 Address parameters

### DIFF
--- a/extensions/sdktools/vdecoder.cpp
+++ b/extensions/sdktools/vdecoder.cpp
@@ -617,12 +617,6 @@ DataStatus DecodeValveParam(IPluginContext *pContext,
 		}
 	case Valve_SMAddress:
 	    {
-			if (data->decflags & VDECODE_FLAG_BYREF)
-			{
-				cell_t *addr;
-				pContext->LocalToPhysAddr(param, &addr);
-				param = *addr;
-			}
 			if (data->flags & PASSFLAG_ASPOINTER)
 			{
 				*(void **)buffer = (unsigned char *)_buffer + pCall->stackEnd + data->obj_offset;


### PR DESCRIPTION
Remove a leftover extra dereference in `DecodeValveParam`'s `Valve_SMAddress` case that double-indirected every `Address` argument passed to SDKCall, so the call usually failed to decode.