### PR TITLE
Fix x86 sign-extension of high pointers

### DIFF
--- a/extensions/sdktools/vcaller.cpp
+++ b/extensions/sdktools/vcaller.cpp
@@ -559,7 +559,7 @@ static cell_t SDKCall(IPluginContext *pContext, const cell_t *params)
 			if (int err = pContext->LocalToPhysAddr(params[retparam], &sp_addr); err != SP_ERROR_NONE) {
 				return pContext->ThrowNativeErrorEx(err, "Could not read argument");
 			}
-			*reinterpret_cast<int64_t*>(sp_addr) = reinterpret_cast<intptr_t>(addr);
+			*reinterpret_cast<int64_t*>(sp_addr) = reinterpret_cast<uintptr_t>(addr);
 			return 0;
 		} else {
 			cell_t *addr = (cell_t *)vc->retbuf;

--- a/extensions/sdktools/vdecoder.cpp
+++ b/extensions/sdktools/vdecoder.cpp
@@ -304,7 +304,7 @@ DataStatus EncodeValveParam(IPluginContext *pContext,
 			if (pContext->LocalToPhysAddr(param, &sp_addr) != SP_ERROR_NONE) {
 				return Data_Fail;
 			}
-			*reinterpret_cast<int64_t*>(sp_addr) = reinterpret_cast<intptr_t>(*(void**)buffer);
+			*reinterpret_cast<int64_t*>(sp_addr) = reinterpret_cast<uintptr_t>(*(void**)buffer);
 
 			return Data_Okay;
 		}
@@ -634,7 +634,6 @@ DataStatus DecodeValveParam(IPluginContext *pContext,
 				return Data_Fail;
 			}
 			void* addr = (void*)(*reinterpret_cast<int64_t*>(sp_addr));
-
 
 			if (addr == nullptr && (data->decflags & VDECODE_FLAG_ALLOWNULL) == 0)
 			{


### PR DESCRIPTION
On x86 a pointer `0x90000000` sign-extends to `0xFFFFFFFF90000000`. Use `uintptr_t` to zero-extend instead.