### PR TITLE
Fix crash reading return value in superseded callbacks

### DIFF
--- a/core/PlayerManager.cpp
+++ b/core/PlayerManager.cpp
@@ -559,7 +559,7 @@ KHook::Return<bool> PlayerManager::OnClientConnect(IServerGameClients* clients, 
 KHook::Return<bool> PlayerManager::OnClientConnect_Post(IServerGameClients*, edict_t *pEntity, const char *pszName, const char *pszAddress, char *reject, int maxrejectlen)
 {
 	int client = IndexOfEdict(pEntity);
-	bool orig_value = *(bool*)KHook::GetOriginalValuePtr();
+	bool orig_value = *(bool*)KHook::GetCurrentValuePtr();
 	CPlayer *pPlayer = &m_Players[client];
 
 	if (orig_value)

--- a/core/UserMessages.cpp
+++ b/core/UserMessages.cpp
@@ -614,7 +614,7 @@ KHook::Return<bf_write*> UserMessages::OnStartMessage_Post(IVEngineServer*, IRec
 	else
 		m_OrigBuffer = m_FakeEngineBuffer;
 #else
-	m_OrigBuffer = *(bf_write**)KHook::GetOriginalValuePtr();
+	m_OrigBuffer = *(bf_write**)KHook::GetCurrentValuePtr();
 #endif
 
 	UM_RETURN_META_VALUE(KHook::Action::Ignore, NULL)

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -1450,7 +1450,7 @@ KHook::Return<bool> SDKHooks::Hook_ReloadPost(CBaseEntity* this_ptr)
 		}
 
 		int entity = gamehelpers->EntityToBCompatRef(pEntity);
-		cell_t origreturn = (*(bool*)::KHook::GetOriginalValuePtr()) ? 1 : 0;
+		cell_t origreturn = (*(bool*)::KHook::GetCurrentValuePtr()) ? 1 : 0;
 
 		std::vector<IPluginFunction *> callbackList;
 		PopulateCallbackList(vtablehooklist[entry]->hooks, callbackList, entity);


### PR DESCRIPTION
`KHook::GetOriginalValuePtr()` returns null when a pre callback supersedes the original call, so post callbacks that read it crashed.