### PR TITLE
Fix Address this pointer outliving its stack buffer

### DIFF
--- a/extensions/dhooks/src/capsule.hpp
+++ b/extensions/dhooks/src/capsule.hpp
@@ -137,6 +137,8 @@ void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post) const {
                     continue;
                 }
 
+                std::int64_t sm_address = reinterpret_cast<std::int64_t>(this_ptr);
+
                 if (hook.this_pointer_type != sp::ThisPointer_Ignore) {
                     // Push the associated this pointer
                     if (hook.this_pointer_type == sp::ThisPointer_CBaseEntity) {
@@ -146,7 +148,6 @@ void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post) const {
                         hook.callback->PushCell(entity_index.value_or(-1));
                     } else if (hook.this_pointer_type == sp::ThisPointer_Address) {
                         if (hook.using_int64_address) {
-                            std::int64_t sm_address = reinterpret_cast<std::int64_t>(this_ptr);
                             hook.callback->PushArray((cell_t*)&sm_address, 2);
                         } else {
                             hook.callback->PushCell(reinterpret_cast<std::intptr_t>(this_ptr));


### PR DESCRIPTION
`ThisPointer_Address` hooks currently hand the callback a null address on 64-bit.
The this pointer is pushed with `PushArray((cell_t*)&sm_address, 2)`, but `PushArray` only records the pointer and the VM copies the data when the callback actually runs. `sm_address` is scoped to the inner if, so it's already dead by the time `Execute()` copies from it.