### PR TITLE
Fix crash when a vtable hook only sets a pre or post callback

### DIFF
--- a/public/vtable_hook_helper.h
+++ b/public/vtable_hook_helper.h
@@ -97,7 +97,12 @@ public:
 			}
 		}
 
-		auto ret = (pre) ? (_ctx->*_pre)(original_this, args...) : (_ctx->*_post)(original_this, args...);
+		KHook::Return<RETURN> ret { KHook::Action::Ignore };
+		if (pre && _pre) {
+			ret = (_ctx->*_pre)(original_this, args...);
+		} else if (!pre && _post) {
+			ret = (_ctx->*_post)(original_this, args...);
+		}
 
 		RETURN* return_ptr = nullptr;
 		void* init_op = nullptr;


### PR DESCRIPTION
`CVTableHookDetails` always registers both a pre and post trampoline but each hook sets only one callback, so the unused side called through a null member function pointer and crashed on the first invocation.