### PR TITLE
Fix "no active hook" false report

### DIFF
--- a/core/EventManager.cpp
+++ b/core/EventManager.cpp
@@ -302,7 +302,7 @@ EventHookError EventManager::UnhookEvent(const char *name, IPluginFunction *pFun
 
 		/* Make sure the event was actually being hooked */
 		auto iter = pHookList->begin();
-		while (iter != pHookList->end() && *iter == pHook) {
+		while (iter != pHookList->end() && *iter != pHook) {
 			iter++;
 		}
 		if (iter == pHookList->end())


### PR DESCRIPTION
d0664a882 introduced a regression in `EventManager::UnhookEvent`. Its inverted list check falsely returns `EventHookErr_NotActive` when a plugin unhooks its only hook on an event.