### PR TITLE
Fix GetFunctionByName ignoring its plugin handle

### DIFF
--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -129,7 +129,7 @@ static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *param
 	pContext->LocalToString(params[2], &name);
 
 	/* Get public function index */
-	if (pContext->GetBaseRuntime()->FindPublicByName(name, &idx) == SP_ERROR_NOT_FOUND)
+	if (pPlugin->GetBaseContext()->GetBaseRuntime()->FindPublicByName(name, &idx) == SP_ERROR_NOT_FOUND)
 	{
 		/* Return INVALID_FUNCTION if not found */
 		return pContext->GetNullFunctionValue();


### PR DESCRIPTION
e70cddf (present on `master`) introduced a regression in `GetFunctionByName`. It looks the function up in the calling plugin's runtime instead of the target's, so any cross-plugin call usually returns `INVALID_FUNCTION`.