### PR TITLE
Fix Call_Finish propagating exceptions to the caller

### DIFF
--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -558,7 +558,7 @@ static cell_t sm_CallFinish(IPluginContext *pContext, const cell_t *params)
 
 	auto local_args = sArgs;
 
-	// Note: Execute() swallows exceptions, so this is okay.
+	// Note: ExceptionHandler and Execute() swallow exceptions, so this is okay.
 	if (s_pFunction)
 	{
 		IPluginFunction *pFunction = s_pFunction;

--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -563,7 +563,7 @@ static cell_t sm_CallFinish(IPluginContext *pContext, const cell_t *params)
 	{
 		IPluginFunction *pFunction = s_pFunction;
 		ResetCall();
-		DetectExceptions eh(pContext);
+		ExceptionHandler eh(pContext);
 		if (!pFunction->Invoke(local_args, result))
 			return eh.Code();
 	} else {


### PR DESCRIPTION
 A regression introduced by 468760c (present on master). An exception thrown by the invoked function now propagates out of `Call_Finish` and aborts the calling function, whereas previously it was swallowed.