### PR TITLE
Fix Plugin_Stop stopping ET_Event forwards early

### DIFF
--- a/core/logic/ForwardSys.cpp
+++ b/core/logic/ForwardSys.cpp
@@ -308,7 +308,7 @@ int CForward::Execute(const sp::CallArgs& in_args, cell_t *result, IForwardFilte
 				break;
 		}
 
-		if ((ResultType)high_result == Pl_Stop)
+		if (m_ExecType == ET_Hook && (ResultType)high_result == Pl_Stop)
 			break;
 	}
 


### PR DESCRIPTION
As of 468760c (present on `master`), `ET_Event` forwards violate the documented ["no mid-Stops allowed"](https://github.com/alliedmodders/sourcemod/blob/0732992c4fe8e9df418a0601d3b5867e83d83094/public/IForwardSys.h#L85) contract. One plugin returning `Plugin_Stop` in a forward skips later plugin callbacks.

I'm not entirely sure whether this was an intentional behavior change that the docs simply weren't updated to reflect, but feel free to close if so.