### PR TITLE
Update CTakeDamageInfoHack for l4d2 game

### DIFF
--- a/extensions/sdkhooks/natives.cpp
+++ b/extensions/sdkhooks/natives.cpp
@@ -170,7 +170,7 @@ cell_t Native_TakeDamage(IPluginContext *pContext, const cell_t *params)
 	}
 	else
 	{
-		 vecDamagePosition = vec3_origin;
+		 vecDamagePosition.Init();
 	}
 
 	CTakeDamageInfoHack info(pInflictor, pAttacker, flDamage, iDamageType, pWeapon, vecDamageForce, vecDamagePosition);

--- a/extensions/sdkhooks/takedamageinfohack.cpp
+++ b/extensions/sdkhooks/takedamageinfohack.cpp
@@ -60,7 +60,7 @@ CTakeDamageInfoHack::CTakeDamageInfoHack( CBaseEntity *pInflictor, CBaseEntity *
 	m_flMaxDamage = flDamage;
 	m_vecDamageForce = vecDamageForce;
 	m_vecDamagePosition = vecDamagePosition;
-	m_vecReportedPosition = vec3_origin;
+	m_vecReportedPosition.Init();
 	m_iAmmoType = -1;
 
 #if SOURCE_ENGINE < SE_ORANGEBOX
@@ -85,7 +85,7 @@ CTakeDamageInfoHack::CTakeDamageInfoHack( CBaseEntity *pInflictor, CBaseEntity *
 	m_eCritType = CRIT_NONE;
 #endif
 
-#if SOURCE_ENGINE >= SE_ALIENSWARM
+#if SOURCE_ENGINE >= SE_LEFT4DEAD2
 	m_flRadius = 0.0f;
 #endif
 
@@ -94,6 +94,12 @@ CTakeDamageInfoHack::CTakeDamageInfoHack( CBaseEntity *pInflictor, CBaseEntity *
 	m_iObjectsPenetrated = 0;
 	m_uiBulletID = 0;
 	m_uiRecoilIndex = 0;
+#endif
+
+#if SOURCE_ENGINE == SE_LEFT4DEAD2
+	m_vecDamageDirection.Init();
+	m_iDamageStats = 0;
+	m_iDamageVictimIndex = 0;
 #endif
 }
 


### PR DESCRIPTION
1) Added initialization of missing properties to avoid calling the damage function with garbage parameters
2) The global parameter vec3_origin has been removed from the code that references the mathlib.lib library; in essence, vector initialization is no different.