### PR TITLE
Hide statically-linked symbols on Linux

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -415,6 +415,7 @@ class SMConfig(object):
     elif cxx.family == 'clang':
       cxx.linkflags += ['-lgcc_eh']
     cxx.linkflags += ['-static-libstdc++']
+    cxx.linkflags += ['-Wl,--exclude-libs,ALL']
 
   def configure_mac(self, cxx):
     cxx.defines += ['OSX', '_OSX', 'POSIX', 'KE_ABSOLUTELY_NO_STL']


### PR DESCRIPTION
SourceMod statically links libstdc++ but still exports its symbols because `-fvisibility=hidden` doesn't apply to symbols coming from a static library. So the private copy isn't actually private, and ends up polluting other modules and getting mixed with whatever other libstdc++ is in the process. `-Wl,--exclude-libs,ALL` marks those symbols local.

Related MM:S PR: https://github.com/alliedmodders/metamod-source/pull/282