### PR TITLE
Extend thread check to all sdkhooks

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -499,6 +499,11 @@ FeatureStatus SDKHooks::GetFeatureStatus(FeatureType type, const char *name)
 
 static void PopulateCallbackList(const std::vector<HookList> &source, std::vector<IPluginFunction *> &destination, int entity)
 {
+	// SourcePawn cannot be called from worker threads. This can happen on some
+	// engine variants, where the engine invokes ShouldCollide off-thread.
+	if (g_MainThreadId != std::this_thread::get_id())
+		return;
+	
 	destination.reserve(8);
 	for (size_t iter = 0; iter < source.size(); ++iter)
 	{
@@ -1386,11 +1391,6 @@ void SDKHooks::Hook_SetTransmit(CCheckTransmitInfo *pInfo, bool bAlways)
 
 bool SDKHooks::Hook_ShouldCollide(int collisionGroup, int contentsMask)
 {
-	// SourcePawn cannot be called from worker threads. This can happen on some
-	// engine variants, where the engine invokes ShouldCollide off-thread.
-	if (g_MainThreadId != std::this_thread::get_id())
-		RETURN_META_VALUE(MRES_IGNORED, false);
-
 	CBaseEntity *pEntity = META_IFACEPTR(CBaseEntity);
 
 	CVTableHook vhook(pEntity);


### PR DESCRIPTION
Not much to be said, other than I'm moving the thread check to all sdkhooks. This is something I'm already doing for #2403

https://github.com/alliedmodders/sourcemod/blob/274f4f92d6f96d17ffd855432ab01954eb2ec7de/public/vtable_hook_helper.h#L93

but rather than wait for this to land, I backported the fix. This also seems like something that we should have in general.