### PR TITLE
Extend WeaponSwitch/Use callbacks

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -523,6 +523,11 @@ cell_t SDKHooks::Call(CBaseEntity *pEnt, SDKHookType type, int other)
 
 cell_t SDKHooks::Call(CBaseEntity *pEnt, SDKHookType type, CBaseEntity *pOther)
 {
+	return Call(pEnt, type, pOther, {});
+}
+
+cell_t SDKHooks::Call(CBaseEntity *pEnt, SDKHookType type, CBaseEntity *pOther, std::optional<cell_t> originalreturn)
+{
 	cell_t ret = Pl_Continue;
 
 	CVTableHook vhook(pEnt);
@@ -544,6 +549,10 @@ cell_t SDKHooks::Call(CBaseEntity *pEnt, SDKHookType type, CBaseEntity *pOther)
 			IPluginFunction *callback = callbackList[entry];
 			callback->PushCell(entity);
 			callback->PushCell(other);
+
+			if (originalreturn) {
+				callback->PushCell(originalreturn.value());
+			}
 
 			cell_t res;
 			callback->Execute(&res);
@@ -1780,7 +1789,8 @@ bool SDKHooks::Hook_WeaponCanSwitchTo(CBaseCombatWeapon *pWeapon)
 
 bool SDKHooks::Hook_WeaponCanSwitchToPost(CBaseCombatWeapon *pWeapon)
 {
-	Call(META_IFACEPTR(CBaseEntity), SDKHook_WeaponCanSwitchToPost, pWeapon);
+	cell_t origreturn = META_RESULT_ORIG_RET(bool) ? 1 : 0;
+	Call(META_IFACEPTR(CBaseEntity), SDKHook_WeaponCanSwitchToPost, pWeapon, origreturn);
 	RETURN_META_VALUE(MRES_IGNORED, true);
 }
 
@@ -1796,7 +1806,8 @@ bool SDKHooks::Hook_WeaponCanUse(CBaseCombatWeapon *pWeapon)
 
 bool SDKHooks::Hook_WeaponCanUsePost(CBaseCombatWeapon *pWeapon)
 {
-	Call(META_IFACEPTR(CBaseEntity), SDKHook_WeaponCanUsePost, pWeapon);
+	cell_t origreturn = META_RESULT_ORIG_RET(bool) ? 1 : 0;
+	Call(META_IFACEPTR(CBaseEntity), SDKHook_WeaponCanUsePost, pWeapon, origreturn);
 	RETURN_META_VALUE(MRES_IGNORED, true);
 }
 
@@ -1844,7 +1855,8 @@ bool SDKHooks::Hook_WeaponSwitch(CBaseCombatWeapon *pWeapon, int viewmodelindex)
 
 bool SDKHooks::Hook_WeaponSwitchPost(CBaseCombatWeapon *pWeapon, int viewmodelindex)
 {
-	cell_t result = Call(META_IFACEPTR(CBaseEntity), SDKHook_WeaponSwitchPost, pWeapon);
+	cell_t origreturn = META_RESULT_ORIG_RET(bool) ? 1 : 0;
+	cell_t result = Call(META_IFACEPTR(CBaseEntity), SDKHook_WeaponSwitchPost, pWeapon, origreturn);
 	RETURN_META_VALUE(MRES_IGNORED, true);
 }
 

--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -26,6 +26,7 @@
 #define GAMEDESC_CAN_CHANGE
 #endif
 
+#include <optional>
 
 /**
  * Globals
@@ -271,6 +272,7 @@ public:
 	cell_t Call(int entity, SDKHookType type, int other=INVALID_EHANDLE_INDEX);
 	cell_t Call(CBaseEntity *pEnt, SDKHookType type, int other=INVALID_EHANDLE_INDEX);
 	cell_t Call(CBaseEntity *pEnt, SDKHookType type, CBaseEntity *pOther);
+	cell_t Call(CBaseEntity *pEnt, SDKHookType type, CBaseEntity *pOther, std::optional<cell_t> originalreturn);
 	void SetupHooks();
 
 	HookReturn Hook(int entity, SDKHookType type, IPluginFunction *pCallback);

--- a/plugins/include/sdkhooks.inc
+++ b/plugins/include/sdkhooks.inc
@@ -274,6 +274,11 @@ typeset SDKHookCB
 	// WeaponSwitchPost
 	function void (int client, int weapon);
 
+	// WeaponCanUsePost
+	// WeaponSwitchPost
+	// WeaponCanSwitchToPost
+	function void (int client, int weapon, bool success);
+
 	// GetMaxHealth (ep2v and later)
 	function Action (int entity, int &maxhealth);
 
@@ -332,7 +337,7 @@ typeset SDKHookCB
 	// Reload
 	function Action (int weapon);
 
-	// Reload post
+	// ReloadPost
 	function void (int weapon, bool bSuccessful);
 
 	// CanBeAutobalanced


### PR DESCRIPTION
Fullfill feature request #2532 

It is indeed odd for sdkhooks to expose the return value of one post callback (weaponreload) but not weaponswitch/use. Let's correct that.