### PR TITLE
Fix crash when deleting a Menu handle during callbacks

### DIFF
--- a/core/MenuStyle_Base.cpp
+++ b/core/MenuStyle_Base.cpp
@@ -97,6 +97,9 @@ void BaseMenuStyle::_CancelClientMenu(int client, MenuCancelReason reason, bool 
 		RemoveClientFromWatch(client);
 	}
 
+	Handle_t hndl = menu ? menu->GetHandle() : BAD_HANDLE;
+	AutoHandleRooter ahr(hndl);
+
 	/* Fire callbacks */
 	mh->OnMenuCancel(menu, client, reason);
 	
@@ -575,6 +578,8 @@ bool BaseMenuStyle::RedoClientMenu(int client, ItemOrder order)
 #endif
 	CBaseMenuPlayer *player = GetMenuPlayer(client);
 	menu_states_t &states = player->states;
+
+	AutoHandleRooter ahr(states.menu ? states.menu->GetHandle() : BAD_HANDLE);
 
 	player->bAutoIgnore = true;
 	IMenuPanel *display = g_Menus.RenderMenu(client, states, order);

--- a/core/MenuVoting.cpp
+++ b/core/MenuVoting.cpp
@@ -364,7 +364,9 @@ void VoteMenuHandler::StartVoting()
 
 	m_bStarted = true;
 
-	m_pHandler->OnMenuVoteStart(m_pCurMenu);
+	IBaseMenu *menu = m_pCurMenu;
+	AutoHandleRooter ahr(menu->GetHandle());
+	m_pHandler->OnMenuVoteStart(menu);
 
 	if (!m_bStarted)
 	{

--- a/core/MenuVoting.cpp
+++ b/core/MenuVoting.cpp
@@ -41,6 +41,7 @@
 #include <const.h>
 #include <ITranslator.h>
 #include "logic_bridge.h"
+#include "AutoHandleRooter.h"
 
 float g_next_vote = 0.0f;
 
@@ -426,6 +427,7 @@ void VoteMenuHandler::EndVoting()
 		IBaseMenu *menu = m_pCurMenu;
 		IMenuHandler *handler = m_pHandler;
 		InternalReset();
+		AutoHandleRooter ahr(menu ? menu->GetHandle() : BAD_HANDLE);
 		handler->OnMenuVoteCancel(menu, VoteCancel_Generic);
 		handler->OnMenuEnd(menu, MenuEnd_VotingCancelled);
 		return;
@@ -455,6 +457,7 @@ void VoteMenuHandler::EndVoting()
 		IBaseMenu *menu = m_pCurMenu;
 		IMenuHandler *handler = m_pHandler;
 		InternalReset();
+		AutoHandleRooter ahr(menu ? menu->GetHandle() : BAD_HANDLE);
 		handler->OnMenuVoteCancel(menu, VoteCancel_NoVotes);
 		handler->OnMenuEnd(menu, MenuEnd_VotingCancelled);
 		return;
@@ -486,6 +489,7 @@ void VoteMenuHandler::EndVoting()
 	InternalReset();
 
 	/* Send vote info */
+	AutoHandleRooter ahr(menu ? menu->GetHandle() : BAD_HANDLE);
 	handler->OnMenuVoteResults(menu, &vote);
 	handler->OnMenuEnd(menu, MenuEnd_VotingDone);
 }

--- a/core/MenuVoting.cpp
+++ b/core/MenuVoting.cpp
@@ -366,6 +366,11 @@ void VoteMenuHandler::StartVoting()
 
 	m_pHandler->OnMenuVoteStart(m_pCurMenu);
 
+	if (!m_bStarted)
+	{
+		return;
+	}
+
 	m_displayTimer = g_Timers.CreateTimer(this, 1.0, NULL, TIMER_FLAG_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 
 	/* By now we know how many clients were set.  

--- a/core/logic/HandleSys.h
+++ b/core/logic/HandleSys.h
@@ -243,27 +243,4 @@ private:
 
 extern HandleSystem g_HandleSys;
 
-struct AutoHandleRooter
-{
-public:
-	AutoHandleRooter(Handle_t hndl)
-	{
-		if (hndl != BAD_HANDLE)
-			this->hndl = g_HandleSys.FastCloneHandle(hndl);
-		else
-			this->hndl = BAD_HANDLE;
-	}
-
-	~AutoHandleRooter()
-	{
-		if (hndl != BAD_HANDLE)
-		{
-			HandleSecurity sec(g_pCoreIdent, g_pCoreIdent);
-			g_HandleSys.FreeHandle(hndl, &sec);
-		}
-	}
-private:
-	Handle_t hndl;
-};
-
 #endif //_INCLUDE_SOURCEMOD_HANDLESYSTEM_H_


### PR DESCRIPTION
Fixes a crash when deleting a `Menu` handle during `MenuAction_Cancel`, `MenuAction_VoteCancel` and `MenuAction_VoteEnd`, which would result in a UAF. It now invalidates the handle properly.
The same applies to `MenuAction_Display`, `MenuAction_DrawItem` and `MenuAction_DisplayItem` while paging through a menu.

Also fixes a crash when `CancelVote()` is called from `MenuAction_VoteStart`, and removes the duplicated `AutoHandleRooter` struct.

Closes #2073