### PR TITLE
Fix UAF in SDKHooks::Unhook

### DIFF
--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -809,12 +809,12 @@ void SDKHooks::Unhook(CBaseEntity *pEntity)
 
 				pawnhooks.erase(pawnhooks.begin() + entry);
 				entry--;
+			}
 
-				if (pawnhooks.size() == 0)
-				{
-					vtablehooklist.erase(vtablehooklist.begin() + listentry);
-					listentry--;
-				}
+			if (pawnhooks.size() == 0)
+			{
+				vtablehooklist.erase(vtablehooklist.begin() + listentry);
+				listentry--;
 			}
 		}
 	}
@@ -837,12 +837,12 @@ void SDKHooks::Unhook(IPluginContext *pContext)
 
 				pawnhooks.erase(pawnhooks.begin() + entry);
 				entry--;
+			}
 
-				if (pawnhooks.size() == 0)
-				{
-					vtablehooklist.erase(vtablehooklist.begin() + listentry);
-					listentry--;
-				}
+			if (pawnhooks.size() == 0)
+			{
+				vtablehooklist.erase(vtablehooklist.begin() + listentry);
+				listentry--;
 			}
 		}
 	}
@@ -878,12 +878,12 @@ void SDKHooks::Unhook(int entity, SDKHookType type, IPluginFunction *pCallback)
 
 			pawnhooks.erase(pawnhooks.begin() + entry);
 			entry--;
+		}
 
-			if (pawnhooks.size() == 0)
-			{
-				vtablehooklist.erase(vtablehooklist.begin() + listentry);
-				listentry--;
-			}
+		if (pawnhooks.size() == 0)
+		{
+			vtablehooklist.erase(vtablehooklist.begin() + listentry);
+			listentry--;
 		}
 
 		break;


### PR DESCRIPTION
One of the follow-up commits in #2513 accidentally introduced another use-after-free.
`vtablehooklist.erase()` ended up in the loop that reads the `pawnhooks` vector it destroys.