### PR TITLE
Fix bogus CreateDialog deprecation warning on every compile

### DIFF
--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -326,7 +326,7 @@ native bool PrecacheSound(const char[] sound, bool preload=false);
  * @return              True if precached, false otherwise.
  * @deprecated          Doesn't work correctly, always returns true.
  */
-#pragma deprecated Doesn't work correctly, always returns true.
+#pragma deprecated Does not work correctly, always returns true.
 native bool IsSoundPrecached(const char[] sound);
 
 /**


### PR DESCRIPTION
## Problem

Since the `#pragma deprecated` was added to `IsSoundPrecached`, every plugin compile emits this warning, even for an empty plugin that only does `#include <sourcemod>`:

```
halflife.inc(655) : warning 234: symbol "CreateDialog" is marked as deprecated: Doesn't work correctly, always returns true.
native bool IsSoundPrecached(const char[] sound);
   655 |         kv.SetString("title", destination);
-----------------------------^
```

Note the warning names `CreateDialog` but prints `IsSoundPrecached`'s deprecation message — and `CreateDialog` returns `void`, so "always returns true" cannot apply to it.

## Cause

The apostrophe in `Doesn't` is lexed as the start of a character literal, so the `#pragma deprecated` message swallows the following line — the entire `native bool IsSoundPrecached(...)` declaration (which is why it appears verbatim in the warning output). As a result:

1. `IsSoundPrecached` becomes an undefined symbol (calling it fails with `error 017: undefined symbol "IsSoundPrecached"`).
2. The deprecation attaches to the next declared symbol, `CreateDialog`.
3. The stock `DisplayAskConnectBox` in the same file calls `CreateDialog`, and stocks are analyzed even when unused, so the warning fires on every compile of every plugin.

Minimal repro of the compiler behavior:

```sourcepawn
#pragma deprecated Doesn't work correctly
native bool FirstNative();

native void SecondNative();

stock void CallsSecond() { SecondNative(); }   // warns: SecondNative deprecated (wrong symbol)
public void OnPluginStart() {}                 // FirstNative is now an undefined symbol
```

## Fix

Reword the message to avoid the apostrophe (`Doesn't` -> `Does not`). Verified with spcomp 1.12.0.7246:

- Empty plugin compiles with no warnings.
- `IsSoundPrecached` resolves again, and actual call sites get the intended warning 234 on `IsSoundPrecached` itself.

The underlying lexer behavior is arguably a separate sourcepawn bug, but rewording the message fixes the fallout for every SourceMod user today.

## Backport

Since the warning affects everyone compiling against 1.12 includes, a backport to `1.12-dev` would be appreciated.
