### PR TITLE
Fix alltalk vote for CSGO

### DIFF
--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -64,7 +64,6 @@ ConVar g_Cvar_FF;
 bool g_bIsCSGO = false;
 ConVar g_Cvar_TalkEnemyDead;
 ConVar g_Cvar_TalkEnemyLiving;
-ConVar g_Cvar_DeadTalk;
 
 // ConVar g_Cvar_Show = null;
 
@@ -132,7 +131,6 @@ public void OnPluginStart()
 		g_bIsCSGO = true;
 		g_Cvar_TalkEnemyDead = FindConVar("sv_talk_enemy_dead");
 		g_Cvar_TalkEnemyLiving = FindConVar("sv_talk_enemy_living");
-		g_Cvar_DeadTalk = FindConVar("sv_deadtalk");
 	}
 	
 	/*
@@ -299,15 +297,12 @@ public int Handler_VoteCallback(Menu menu, MenuAction action, int param1, int pa
 					}
 					else
 					{
-						// set all the cvars based on sv_talk_enemy_living
-						bool value = !g_Cvar_TalkEnemyLiving.BoolValue;
+						bool value = !(g_Cvar_TalkEnemyLiving.BoolValue && g_Cvar_TalkEnemyDead.BoolValue);
 						PrintToChatAll("[SM] %t", "Cvar changed", "sv_talk_enemy_living", (!value ? "0" : "1"));
 						PrintToChatAll("[SM] %t", "Cvar changed", "sv_talk_enemy_dead", (!value ? "0" : "1"));
-						PrintToChatAll("[SM] %t", "Cvar changed", "sv_deadtalk", (!value ? "0" : "1"));
 						LogAction(-1, -1, "Changing alltalk to %s due to vote.", (!value ? "0" : "1"));
 						g_Cvar_TalkEnemyLiving.BoolValue = value;
 						g_Cvar_TalkEnemyDead.BoolValue = value;
-						g_Cvar_DeadTalk.BoolValue = value;
 					}
 				}
 				

--- a/plugins/funvotes.sp
+++ b/plugins/funvotes.sp
@@ -60,6 +60,12 @@ ConVar g_Cvar_Gravity;
 ConVar g_Cvar_Alltalk;
 ConVar g_Cvar_FF;
 
+// CSGO alltalk replacements
+bool g_bIsCSGO = false;
+ConVar g_Cvar_TalkEnemyDead;
+ConVar g_Cvar_TalkEnemyLiving;
+ConVar g_Cvar_DeadTalk;
+
 // ConVar g_Cvar_Show = null;
 
 enum voteType
@@ -118,6 +124,16 @@ public void OnPluginStart()
 	g_Cvar_Gravity = FindConVar("sv_gravity");
 	g_Cvar_Alltalk = FindConVar("sv_alltalk");
 	g_Cvar_FF = FindConVar("mp_friendlyfire");
+
+	char game[128];
+	GetGameFolderName(game, sizeof(game));
+	if (StrEqual(game, "csgo", false))
+	{
+		g_bIsCSGO = true;
+		g_Cvar_TalkEnemyDead = FindConVar("sv_talk_enemy_dead");
+		g_Cvar_TalkEnemyLiving = FindConVar("sv_talk_enemy_living");
+		g_Cvar_DeadTalk = FindConVar("sv_deadtalk");
+	}
 	
 	/*
 	g_Cvar_Show = FindConVar("sm_vote_show");
@@ -275,9 +291,24 @@ public int Handler_VoteCallback(Menu menu, MenuAction action, int param1, int pa
 				
 				case (alltalk):
 				{
-					PrintToChatAll("[SM] %t", "Cvar changed", "sv_alltalk", (g_Cvar_Alltalk.BoolValue ? "0" : "1"));
-					LogAction(-1, -1, "Changing alltalk to %s due to vote.", (g_Cvar_Alltalk.BoolValue ? "0" : "1"));
-					g_Cvar_Alltalk.BoolValue = !g_Cvar_Alltalk.BoolValue;
+					if (!g_bIsCSGO)
+					{
+						PrintToChatAll("[SM] %t", "Cvar changed", "sv_alltalk", (g_Cvar_Alltalk.BoolValue ? "0" : "1"));
+						LogAction(-1, -1, "Changing alltalk to %s due to vote.", (g_Cvar_Alltalk.BoolValue ? "0" : "1"));
+						g_Cvar_Alltalk.BoolValue = !g_Cvar_Alltalk.BoolValue;
+					}
+					else
+					{
+						// set all the cvars based on sv_talk_enemy_living
+						bool value = !g_Cvar_TalkEnemyLiving.BoolValue;
+						PrintToChatAll("[SM] %t", "Cvar changed", "sv_talk_enemy_living", (!value ? "0" : "1"));
+						PrintToChatAll("[SM] %t", "Cvar changed", "sv_talk_enemy_dead", (!value ? "0" : "1"));
+						PrintToChatAll("[SM] %t", "Cvar changed", "sv_deadtalk", (!value ? "0" : "1"));
+						LogAction(-1, -1, "Changing alltalk to %s due to vote.", (!value ? "0" : "1"));
+						g_Cvar_TalkEnemyLiving.BoolValue = value;
+						g_Cvar_TalkEnemyDead.BoolValue = value;
+						g_Cvar_DeadTalk.BoolValue = value;
+					}
 				}
 				
 				case (ff):

--- a/plugins/funvotes/votealltalk.sp
+++ b/plugins/funvotes/votealltalk.sp
@@ -52,7 +52,7 @@ void DisplayVoteAllTalkMenu(int client)
 
 	g_hVoteMenu = new Menu(Handler_VoteCallback, MENU_ACTIONS_ALL);
 
-	bool alltalkValue = g_bIsCSGO ? g_Cvar_TalkEnemyLiving.BoolValue : g_Cvar_Alltalk.BoolValue;	
+	bool alltalkValue = g_bIsCSGO ? (g_Cvar_TalkEnemyLiving.BoolValue && g_Cvar_TalkEnemyDead.BoolValue) : g_Cvar_Alltalk.BoolValue;
 	if (alltalkValue)
 	{
 		g_hVoteMenu.SetTitle("Votealltalk Off");

--- a/plugins/funvotes/votealltalk.sp
+++ b/plugins/funvotes/votealltalk.sp
@@ -51,8 +51,9 @@ void DisplayVoteAllTalkMenu(int client)
 	g_voteInfo[VOTE_NAME][0] = '\0';
 
 	g_hVoteMenu = new Menu(Handler_VoteCallback, MENU_ACTIONS_ALL);
-	
-	if (g_Cvar_Alltalk.BoolValue)
+
+	bool alltalkValue = g_bIsCSGO ? g_Cvar_TalkEnemyLiving.BoolValue : g_Cvar_Alltalk.BoolValue;	
+	if (alltalkValue)
 	{
 		g_hVoteMenu.SetTitle("Votealltalk Off");
 	}


### PR DESCRIPTION
sv_alltalk has been deprecated in CSGO and it currently does nothing

```
] find sv_alltalk
"sv_alltalk" = "1" ( def. "0" ) client notify replicated                         - Deprecated. Replaced with sv_talk_enemy_dead and sv_talk_enemy_living.
```

This patch replaces the sv_alltalk assignment with equivalent cvars on CSGO

Fixes #1095