### PR TITLE
Add Windows x64 DHooks support

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -564,14 +564,14 @@ inline uint8_t MapFloatToIntReg(uint8_t floatReg)
 	}
 }
 
-inline void Write_VarArgFloatCopy(JitWriter *jit, const SourceHook::PassInfo *info, uint8_t *floatRegs)
+inline void Write_VarArgFloatCopy(JitWriter *jit, const PassInfo &info, uint8_t *floatRegs)
 {
 	if (!floatRegs || floatRegs[0] == STACK_PARAM)
 		return;
-		
+
 	uint8_t intReg1 = MapFloatToIntReg(floatRegs[0]);
 
-	switch (info->size)
+	switch (info.size)
 	{
 		case 4:
 			//movd intReg1, floatReg[0]
@@ -787,14 +787,14 @@ inline void Write_PushObject(JitWriter *jit, const PassInfo& info, unsigned int 
 		return;
 
 #elif defined PLATFORM_WINDOWS
-		if (info->size > 8 || (info->size & (info->size - 1)) != 0)
+		if (info.size > 8 || (info.size & (info.size - 1)) != 0)
 			goto push_byref;
 		else {
-			SourceHook::PassInfo podInfo;
-			podInfo.size = info->size;
-			podInfo.type = SourceHook::PassInfo::PassType_Basic;
-			podInfo.flags = SourceHook::PassInfo::PassFlag_ByVal;
-			Write_PushPOD(jit, &podInfo, offset);
+			PassInfo podInfo;
+			podInfo.size = info.size;
+			podInfo.type = PassType_Basic;
+			podInfo.flags = PASSFLAG_BYVAL;
+			Write_PushPOD(jit, podInfo, offset);
 		}
 		
 		return;
@@ -1128,11 +1128,11 @@ skip_retbuffer:
 		case PassType::PassType_Float:
 			{
 #ifdef PLATFORM_WINDOWS
-				if ((info->flags & PASSFLAG_BYVAL) && (pWrapper->GetFunctionFlags() & FNFLAG_VARARGS))
+				if ((info->info.flags & PASSFLAG_BYVAL) && (pWrapper->GetFunctionFlags() & FNFLAG_VARARGS))
 				{
 					uint8_t floatRegs[2];
-					Write_PushFloat(jit, info, offset, floatRegs);
-					Write_VarArgFloatCopy(jit, info, floatRegs);
+					Write_PushFloat(jit, info->info, offset, floatRegs);
+					Write_VarArgFloatCopy(jit, info->info, floatRegs);
 				}
 				else
 #endif

--- a/extensions/dhooks/AMBuilder
+++ b/extensions/dhooks/AMBuilder
@@ -20,16 +20,20 @@ sources = [
 ]
 
 for cxx in builder.targets:
-  if cxx.target.platform != 'linux' or cxx.target.arch != 'x86_64':
+  if cxx.target.arch != 'x86_64':
+    continue
+
+  if cxx.target.platform == 'linux':
+    abi_source = 'src/abi/system_v_amd64.cpp'
+  elif cxx.target.platform == 'windows':
+    abi_source = 'src/abi/msvc_amd64.cpp'
+  else:
     continue
 
   binary = SM.ExtLibrary(builder, cxx, 'dhooks.ext')
   binary.compiler.includes += [os.path.join(builder.sourcePath, 'extensions', 'dhooks', 'src')]
   binary.sources += sources
-
-  if cxx.target.platform == 'linux':
-    if cxx.target.arch == 'x86_64':
-      binary.sources += ['src/abi/system_v_amd64.cpp']
+  binary.sources += [abi_source]
 
   if binary.compiler.target.arch == "x86":
     binary.compiler.defines += ['DHOOKS_X86']

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -202,7 +202,7 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 	jit.push(rbp);
 	jit.mov(rbp, rsp);
 
-	static constexpr size_t save_area = (MAX_GENERAL_REGISTERS * 0x8) + (MAX_FLOAT_REGISTERS * 0x10);
+	static constexpr size_t save_area = (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister)) + (MAX_FLOAT_REGISTERS * sizeof(FloatRegister));
 	static_assert(save_area % 16 == 0); // Windows requires the stack to be aligned for any call operation
 	jit.sub(rsp, save_area);
 
@@ -216,9 +216,9 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 		if (reg == STACK_REG) {
 			// We modified the stack, so RSP no longer holds the correct value
 			// RBP is entry RSP - 8, which is what we want anyway
-			jit.mov(rsp(i * 0x8), rbp);
+			jit.mov(rsp(sizeof(GeneralRegister) * i), rbp);
 		} else {
-			jit.mov(rsp(i * 0x8), reg);
+			jit.mov(rsp(sizeof(GeneralRegister) * i), reg);
 		}
 	}
 
@@ -227,7 +227,7 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 		if (!save_float_register[i]) {
 			continue;
 		}
-		jit.movsd(rsp(i * 0x10 + (MAX_GENERAL_REGISTERS * 0x8)), reg);
+		jit.movsd(rsp(i * sizeof(FloatRegister) + (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister))), reg);
 	}
 
 	// void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post)
@@ -369,7 +369,7 @@ void JIT_Recall(AsmJit& jit, bool save_general_register[MAX_GENERAL_REGISTERS], 
 		if (!save_float_register[i]) {
 			continue;
 		}
-		jit.movsd(reg, r11(i * 0x10 + (MAX_GENERAL_REGISTERS * 0x8)));
+		jit.movsd(reg, r11(i * sizeof(FloatRegister) + (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister))));
 	}
 
 	for (size_t i = 1; i < MAX_GENERAL_REGISTERS; i++) {

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -382,6 +382,10 @@ void JIT_Recall(AsmJit& jit, bool save_general_register[MAX_GENERAL_REGISTERS], 
 			jit.mov(reg, r11(sizeof(GeneralRegister) * i));
 		}
 	}
+	// R11 is restored last
+	if (save_general_register[R11]) {
+		jit.mov(r11, r11(sizeof(GeneralRegister) * R11));
+	}
 
 	// Call the recall
 	jit.retn();

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -40,6 +40,7 @@ const char* TypeToString(TypeClass type) {
 
 std::optional<TypeClass> Classify_ParamType(sp::HookParamType type) {
 	switch (type) {
+	case sp::HookParamType_String:
 	case sp::HookParamType_StringPtr:
 	case sp::HookParamType_CharPtr:
 	case sp::HookParamType_VectorPtr:
@@ -153,16 +154,14 @@ bool Proccess(sp::CallingConvention conv, std::vector<Variable>& params, ReturnV
 		auto& param = params[i];
 		if (param.dhook_custom_register == sp::DHookRegister_Default) {
 			auto cls = Classify_ParamType(param.dhook_type);
-			if (!cls.has_value()) {
-				if (param.dhook_pass_flags & sp::DHookPass_ByRef) {
-					// Its a pointer
-					cls = TypeClass::INTEGER;
-				} else {
-					// Otherwise not supported, end
-					// TO-DO: Update and support objects passed on the stack
-					globals::sourcemod->LogError(globals::myself, "ABI could not classify parameter (%d)!", i);
-					return false;
-				}
+			if (param.dhook_pass_flags & sp::DHookPass_ByRef) {
+				// Its a pointer
+				cls = TypeClass::INTEGER;
+			} else if (!cls.has_value()) {
+				// Otherwise not supported, end
+				// TO-DO: Update and support objects passed on the stack
+				globals::sourcemod->LogError(globals::myself, "ABI could not classify parameter (%d)!", i);
+				return false;
 			}
 
 			if (cls.value() != TypeClass::INTEGER && cls.value() != TypeClass::SSE) {

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -477,16 +477,16 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 	// 5th and 6th arguments go on the stack
 	jit.mov(rcx, (std::uint8_t)KHook::Action::Ignore); // action
 	if (cls == TypeClass::VOID) {
-		jit.mov(rdx, 0x0); // ptr_to_return
-		jit.mov(r8, 0x0);  // return_size
-		jit.mov(r9, 0x0);  // init_op
+		jit.mov(rdx, 0x0);       // ptr_to_return
+		jit.mov(r8, 0x0);        // return_size
+		jit.mov(r9, 0x0);        // init_op
 		jit.mov(rsp(0x20), 0x0); // deinit_op
 	} else {
-		jit.lea(rdx, rsp(0x30));      // ptr_to_return
-		jit.mov(r8, ret.dhook_size);  // return_size
-		jit.mov(r9, init_op);         // init_op
+		jit.lea(rdx, rsp(0x30));     // ptr_to_return
+		jit.mov(r8, ret.dhook_size); // return_size
+		jit.mov(r9, init_op);        // init_op
 		jit.mov(rax, deinit_op);
-		jit.mov(rsp(0x20), rax);      // deinit_op
+		jit.mov(rsp(0x20), rax);     // deinit_op
 	}
 	jit.mov(rax, 1);
 	jit.mov(rsp(0x28), rax); // original

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -442,6 +442,7 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 	// Store the return value in a local variable
 	std::uintptr_t init_op = 0;
 	std::uintptr_t deinit_op = 0;
+	std::size_t return_size = 0;
 	switch (cls) {
 		case TypeClass::VOID:
 		break;
@@ -450,11 +451,13 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 		jit.mov(rsp(0x30), rax);
 		init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<std::uintptr_t>);
 		deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<std::uintptr_t>);
+		return_size = sizeof(std::uintptr_t);
 		break;
 		case TypeClass::SSE:
 		jit.movsd(rsp(0x30), xmm0);
 		init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<float>);
 		deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<float>);
+		return_size = sizeof(float);
 		break;
 		case TypeClass::MEMORY:
 		// RAX points at the returned object
@@ -467,9 +470,11 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 		if (ret.dhook_type == sp::ReturnType_String) {
 			init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<sdk::string_t>);
 			deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<sdk::string_t>);
+			return_size = sizeof(sdk::string_t);
 		} else {
 			init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<sdk::Vector>);
 			deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<sdk::Vector>);
+			return_size = sizeof(sdk::Vector);
 		}
 		break;
 		default:
@@ -486,11 +491,11 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 		jit.mov(r9, 0x0);        // init_op
 		jit.mov(rsp(0x20), 0x0); // deinit_op
 	} else {
-		jit.lea(rdx, rsp(0x30));     // ptr_to_return
-		jit.mov(r8, ret.dhook_size); // return_size
-		jit.mov(r9, init_op);        // init_op
+		jit.lea(rdx, rsp(0x30));  // ptr_to_return
+		jit.mov(r8, return_size); // return_size
+		jit.mov(r9, init_op);     // init_op
 		jit.mov(rax, deinit_op);
-		jit.mov(rsp(0x20), rax);     // deinit_op
+		jit.mov(rsp(0x20), rax);  // deinit_op
 	}
 	jit.mov(rax, 1);
 	jit.mov(rsp(0x28), rax); // original

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -1,0 +1,504 @@
+#include "../sp_inc.hpp"
+#include "../capsule.hpp"
+#include "../sdk_types.hpp"
+
+#include <cstdlib>
+#include <vector>
+#include <optional>
+
+// Reference: https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention
+// KHook copies stack_size bytes from entry rsp + 8, shadow space included
+
+namespace dhooks::abi {
+
+using namespace KHook::Asm;
+
+// windows.h defines VOID, get rid of it
+#undef VOID
+
+enum class TypeClass {
+	VOID,
+	INTEGER,
+	SSE,
+	MEMORY
+};
+
+const char* TypeToString(TypeClass type) {
+	switch (type) {
+	case TypeClass::VOID:
+		return "VOID";
+	case TypeClass::INTEGER:
+		return "INTEGER";
+	case TypeClass::SSE:
+		return "SSE";
+	case TypeClass::MEMORY:
+		return "MEMORY";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+std::optional<TypeClass> Classify_ParamType(sp::HookParamType type) {
+	switch (type) {
+	case sp::HookParamType_StringPtr:
+	case sp::HookParamType_CharPtr:
+	case sp::HookParamType_VectorPtr:
+	case sp::HookParamType_Bool:
+	case sp::HookParamType_Int:
+	case sp::HookParamType_CBaseEntity:
+	case sp::HookParamType_ObjectPtr:
+	case sp::HookParamType_Edict:
+		return TypeClass::INTEGER;
+	case sp::HookParamType_Float:
+		return TypeClass::SSE;
+	default:
+		break;
+	}
+	return {};
+}
+
+std::optional<TypeClass> Classify_ReturnType(const ReturnVariable& info) {
+	switch (info.dhook_type) {
+	case sp::ReturnType_Int:
+	case sp::ReturnType_Bool:
+	case sp::ReturnType_StringPtr:
+	case sp::ReturnType_CharPtr:
+	case sp::ReturnType_VectorPtr:
+	case sp::ReturnType_CBaseEntity:
+	case sp::ReturnType_Edict:
+		return TypeClass::INTEGER;
+	case sp::ReturnType_Float:
+		return TypeClass::SSE;
+	case sp::ReturnType_String:
+		// string_t isn't a POD, MSVC hands it back through a hidden pointer
+		return TypeClass::MEMORY;
+	case sp::ReturnType_Vector:
+		// 12 bytes, too big to come back in RAX
+		return TypeClass::MEMORY;
+	case sp::ReturnType_Void:
+		return TypeClass::VOID;
+	default:
+		break;
+	}
+	return {};
+}
+
+// Args are positional, ints and floats share the same 4 slots
+static const AsmReg available_general_registers[] = { rcx, rdx, r8, r9 };
+static const AsmFloatReg available_float_registers[] = { xmm0, xmm1, xmm2, xmm3 };
+static constexpr size_t positional_register_count = sizeof(available_general_registers) / sizeof(AsmReg);
+
+static constexpr size_t SHADOW_SPACE = 32;
+
+bool Proccess(sp::CallingConvention conv, std::vector<Variable>& params, ReturnVariable& ret, size_t& stack_size) {
+	bool return_in_memory = false;
+
+	if (ret.dhook_custom_register == sp::DHookRegister_Default) {
+		auto cls = Classify_ReturnType(ret);
+		if (!cls.has_value()) {
+			globals::sourcemod->LogError(globals::myself, "Couldn't classify return type!");
+			return false;
+		}
+		if (cls.value() == TypeClass::MEMORY) {
+			return_in_memory = true;
+		} else if (cls.value() != TypeClass::INTEGER
+			&& cls.value() != TypeClass::SSE
+			&& cls.value() != TypeClass::VOID) {
+			globals::sourcemod->LogError(globals::myself, "ABI classified return type as \"%s\", we don't know how to handle it!", TypeToString(cls.value()));
+			return false;
+		}
+	} else {
+		ret.reg_index = Translate_DHookRegister(ret.dhook_custom_register);
+		ret.float_reg_index = Translate_DHookRegister_Float(ret.dhook_custom_register);
+		ret.reg_offset = {};
+		// Need better support
+		globals::sourcemod->LogError(globals::myself, "Custom register for return isn't supported!");
+		return false;
+	}
+
+	size_t position = 0;
+
+	// Calling conventions don't really exist in this ABI, however for easier user experience
+	// We still use CallConv_THISCALL to figure whether or not we're dealing with a member func
+	bool has_this = (conv == sp::CallConv_THISCALL);
+	if (has_this) {
+		Variable this_ptr;
+		this_ptr.dhook_type = sp::HookParamType_Int;
+		this_ptr.dhook_custom_register = sp::DHookRegister_Default;
+		this_ptr.dhook_pass_flags = sp::DHookPass_ByVal;
+		this_ptr.dhook_size = sizeof(void*);
+		params.insert(params.begin(), this_ptr);
+	}
+
+	// this comes first, then the hidden return pointer
+	if (has_this) {
+		Variable& this_ptr = params[0];
+		this_ptr.reg_index = available_general_registers[position];
+		this_ptr.float_reg_index = {};
+		this_ptr.reg_offset = {};
+		position++;
+	}
+	if (return_in_memory) {
+		ret.reg_index = available_general_registers[position];
+		ret.float_reg_index = {};
+		ret.reg_offset = 0;
+		position++;
+	} else {
+		ret.reg_offset = 0;
+	}
+
+	size_t stack_args = 0;
+
+	{auto len = params.size(); for (unsigned int i = (has_this ? 1 : 0); i < len; i++) {
+		auto& param = params[i];
+		if (param.dhook_custom_register == sp::DHookRegister_Default) {
+			auto cls = Classify_ParamType(param.dhook_type);
+			if (!cls.has_value()) {
+				if (param.dhook_pass_flags & sp::DHookPass_ByRef) {
+					// Its a pointer
+					cls = TypeClass::INTEGER;
+				} else {
+					// Otherwise not supported, end
+					// TO-DO: Update and support objects passed on the stack
+					globals::sourcemod->LogError(globals::myself, "ABI could not classify parameter (%d)!", i);
+					return false;
+				}
+			}
+
+			if (cls.value() != TypeClass::INTEGER && cls.value() != TypeClass::SSE) {
+				globals::sourcemod->LogError(globals::myself, "ABI classified parameter (%d) as %s, we don't know how to handle it!", i, TypeToString(cls.value()));
+				return false;
+			}
+
+			if (position < positional_register_count) {
+				if (cls.value() == TypeClass::INTEGER) {
+					param.reg_index = available_general_registers[position];
+					param.float_reg_index = {};
+				} else {
+					param.float_reg_index = available_float_registers[position];
+					param.reg_index = {};
+				}
+				param.reg_offset = {};
+			} else {
+				// No regs left, its on the stack
+				param.reg_index = RSP;
+				// Skip the saved stack pointer, the return address and the shadow space
+				param.reg_offset = (2 * sizeof(void*)) + SHADOW_SPACE + (stack_args * sizeof(void*));
+				param.float_reg_index = {};
+				stack_args++;
+			}
+			position++;
+		} else {
+			param.reg_index = Translate_DHookRegister(param.dhook_custom_register);
+			param.float_reg_index = Translate_DHookRegister_Float(param.dhook_custom_register);
+			param.reg_offset = {};
+		}
+	}}
+
+	stack_size = SHADOW_SPACE + (stack_args * sizeof(void*));
+	return true;
+}
+
+void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_REGISTERS], bool save_float_register[MAX_FLOAT_REGISTERS], void* this_ptr, const void* mfp, bool post) {
+	jit.push(rbp);
+	jit.mov(rbp, rsp);
+
+	static constexpr size_t save_area = (MAX_GENERAL_REGISTERS * 0x8) + (MAX_FLOAT_REGISTERS * 0x10);
+	static_assert(save_area % 16 == 0); // Windows requires the stack to be aligned for any call operation
+	jit.sub(rsp, save_area);
+
+	// Independently of anything else, RAX gets saved always
+	jit.mov(rsp(), rax);
+	for (size_t i = 1; i < MAX_GENERAL_REGISTERS; i++) {
+		auto reg = AsmReg((AsmRegCode)i);
+		if (!save_general_register[i]) {
+			continue;
+		}
+		if (reg == STACK_REG) {
+			// We modified the stack, so RSP no longer holds the correct value
+			// RBP is entry RSP - 8, which is what we want anyway
+			jit.mov(rsp(i * 0x8), rbp);
+		} else {
+			jit.mov(rsp(i * 0x8), reg);
+		}
+	}
+
+	for (size_t i = 0; i < MAX_FLOAT_REGISTERS; i++) {
+		auto reg = AsmFloatReg((AsmFloatRegCode)i);
+		if (!save_float_register[i]) {
+			continue;
+		}
+		jit.movsd(rsp(i * 0x10 + (MAX_GENERAL_REGISTERS * 0x8)), reg);
+	}
+
+	// void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post)
+	jit.mov(r8, post);
+	jit.mov(rdx, rsp);
+	jit.mov(rcx, reinterpret_cast<std::uintptr_t>(this_ptr));
+	jit.sub(rsp, SHADOW_SPACE);
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(mfp));
+	jit.call(rax);
+
+	jit.mov(rsp, rbp);
+	jit.pop(rbp);
+}
+
+void JIT_MakeReturn(AsmJit& jit, ReturnVariable& ret) {
+	auto cls = Classify_ReturnType(ret).value();
+
+	jit.push(rbp);
+	jit.sub(rsp, 0x40); // 0x20 shadow + 0x20 locals
+	jit.mov(rbp, rsp);
+
+	// KHook restored the entry registers for us, the return buffer is still where it was
+	if (cls == TypeClass::MEMORY) {
+		AsmReg sret_reg = AsmReg((AsmRegCode)ret.reg_index.value());
+		jit.mov(rbp(0x30), sret_reg);
+	}
+
+	jit.mov(rcx, true); // Pop
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(::KHook::GetCurrentValuePtr));
+	jit.call(rax);
+	// RAX now contains the return value ptr
+
+	switch (cls) {
+		case TypeClass::VOID:
+		break;
+		case TypeClass::INTEGER:
+		jit.mov(rax, rax());
+		// Save RAX, we're gonna call a function which could modify rax
+		jit.mov(rbp(0x20), rax);
+		break;
+		case TypeClass::SSE:
+		jit.movsd(xmm0, rax());
+		jit.movsd(rbp(0x20), xmm0);
+		break;
+		case TypeClass::MEMORY:
+		// Copy the object into the caller's buffer
+		jit.mov(rcx, rbp(0x30));
+		jit.movsd(xmm0, rax());
+		jit.movsd(rcx(), xmm0);
+		if (ret.dhook_size > 8) {
+			jit.movsd(xmm1, rax(ret.dhook_size - 8));
+			jit.movsd(rcx(ret.dhook_size - 8), xmm1);
+		}
+		break;
+		default:
+		std::abort();
+		return;
+	}
+
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(::KHook::DestroyReturnValue));
+	jit.call(rax);
+
+	switch (cls) {
+		case TypeClass::VOID:
+		break;
+		case TypeClass::INTEGER:
+		jit.mov(rax, rbp(0x20));
+		break;
+		case TypeClass::SSE:
+		jit.movsd(xmm0, rbp(0x20));
+		break;
+		case TypeClass::MEMORY:
+		jit.mov(rax, rbp(0x30)); // Hand the buffer back in RAX
+		break;
+		default:
+		std::abort();
+		return;
+	}
+
+	jit.add(rsp, 0x40);
+	jit.pop(rbp);
+	jit.retn();
+}
+
+void JIT_Recall(AsmJit& jit, bool save_general_register[MAX_GENERAL_REGISTERS], bool save_float_register[MAX_FLOAT_REGISTERS], size_t stack_size, std::uintptr_t* jit_start) {
+	jit.push(rbp);
+	jit.mov(rbp, rsp);
+
+	// 1st - rcx - is ptr to function to call
+	// 2nd - rdx - is ptr to registers
+	// Stash both, we're about to overwrite the arg registers
+	jit.mov(r10, rcx);
+	jit.mov(r11, rdx);
+
+	jit.sub(rsp, stack_size + (16 - (stack_size % 16)) % 16);
+
+	// Only worth rebuilding the stack if something actually spilled
+	if (stack_size > SHADOW_SPACE) {
+		if (save_general_register[STACK_REG] == false) {
+			// What the hell
+			std::abort();
+		}
+		// Have RAX act as the previous stack
+		jit.mov(rax, r11(sizeof(GeneralRegister) * STACK_REG));
+
+		// Save the 2 parameters, then open the shadow space
+		jit.push(r10);
+		jit.push(r11);
+		jit.sub(rsp, SHADOW_SPACE);
+
+		// Skip the two parameters we just saved and the shadow space
+		jit.lea(rcx, rsp(SHADOW_SPACE + (2 * sizeof(void*))));
+		// Skip return value contained in the stack
+		jit.lea(rdx, rax(2 * sizeof(void*)));
+		jit.mov(r8, stack_size);
+
+		jit.mov(rax, reinterpret_cast<std::uintptr_t>(memcpy));
+		jit.call(rax);
+
+		jit.add(rsp, SHADOW_SPACE);
+		jit.pop(r11);
+		jit.pop(r10);
+	}
+
+	// Prepare function to call
+	jit.push(r10);
+	jit.push(r10);
+
+	// Figure out the return address
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(jit_start));
+	jit.mov(rax, rax());
+	jit.add(rax, INT32_MAX);
+	auto add = jit.get_outputpos();
+	jit.mov(rsp(0x8), rax);
+
+	// Restore the registers
+	for (size_t i = 0; i < MAX_FLOAT_REGISTERS; i++) {
+		auto reg = AsmFloatReg((AsmFloatRegCode)i);
+		if (!save_float_register[i]) {
+			continue;
+		}
+		jit.movsd(reg, r11(i * 0x10 + (MAX_GENERAL_REGISTERS * 0x8)));
+	}
+
+	for (size_t i = 1; i < MAX_GENERAL_REGISTERS; i++) {
+		auto reg = AsmReg((AsmRegCode)i);
+		if (!save_general_register[i]) {
+			continue;
+		}
+		// Stack isn't a register to restore, R11 still holds the buffer
+		if (reg != STACK_REG && reg != r11) {
+			jit.mov(reg, r11(sizeof(GeneralRegister) * i));
+		}
+	}
+
+	// Call the recall
+	jit.retn();
+	// Rewrite the add value
+	jit.rewrite<std::int32_t>(add - sizeof(std::int32_t), jit.get_outputpos());
+
+	jit.mov(rsp, rbp);
+	jit.pop(rbp);
+	jit.retn();
+}
+
+void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original_function, size_t stack_size, std::uintptr_t* jit_start) {
+	auto cls = Classify_ReturnType(ret).value();
+
+	// save rax (and re-align stack)
+	jit.push(rax);
+
+	// Ensure stack size is aligned on 16 bytes
+	stack_size = (stack_size + 15) & ~15;
+	jit.sub(rsp, stack_size);
+
+	// Now copy stack over
+	for (int i = 0; i < stack_size; i += sizeof(void*)) {
+		// Skip saved RAX, skip return value
+		jit.mov(rax, rsp(stack_size + 0x8 + 0x8 + i));
+		jit.mov(rsp(i), rax);
+	}
+
+	// Setup the return address to later in this function
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(jit_start));
+	jit.mov(rax, rax());
+	jit.add(rax, INT32_MAX);
+	auto add = jit.get_outputpos();
+
+	// Place the return address
+	jit.push(rax);
+
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(original_function));
+	jit.mov(rax, rax());
+
+	// Place the call address
+	jit.push(rax);
+	// Restore rax (call addr, return addr) + stack_size
+	jit.mov(rax, rsp(0x8 + 0x8 + stack_size));
+	jit.retn();
+
+	jit.rewrite<std::int32_t>(add - sizeof(std::int32_t), jit.get_outputpos());
+
+	// Free up the stack
+	jit.add(rsp, stack_size);
+	// Make some space for local save data, the stack args and the shadow space
+	jit.sub(rsp, 0x40);
+
+	// Store the return value in a local variable
+	std::uintptr_t init_op = 0;
+	std::uintptr_t deinit_op = 0;
+	switch (cls) {
+		case TypeClass::VOID:
+		break;
+		case TypeClass::INTEGER:
+		// Store RAX
+		jit.mov(rsp(0x30), rax);
+		init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<std::uintptr_t>);
+		deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<std::uintptr_t>);
+		break;
+		case TypeClass::SSE:
+		jit.movsd(rsp(0x30), xmm0);
+		init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<float>);
+		deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<float>);
+		break;
+		case TypeClass::MEMORY:
+		// RAX points at the returned object
+		jit.movsd(xmm0, rax());
+		jit.movsd(rsp(0x30), xmm0);
+		if (ret.dhook_size > 8) {
+			jit.movsd(xmm1, rax(ret.dhook_size - 8));
+			jit.movsd(rsp(0x30 + (ret.dhook_size - 8)), xmm1);
+		}
+		if (ret.dhook_type == sp::ReturnType_String) {
+			init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<sdk::string_t>);
+			deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<sdk::string_t>);
+		} else {
+			init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<sdk::Vector>);
+			deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<sdk::Vector>);
+		}
+		break;
+		default:
+		std::abort();
+		return;
+	}
+
+	// KHook::SaveReturnValue(KHook::Action action, void* ptr_to_return, std::size_t return_size, void* init_op, void* delete_op, bool original)
+	// 5th and 6th arguments go on the stack
+	jit.mov(rcx, (std::uint8_t)KHook::Action::Ignore); // action
+	if (cls == TypeClass::VOID) {
+		jit.mov(rdx, 0x0); // ptr_to_return
+		jit.mov(r8, 0x0);  // return_size
+		jit.mov(r9, 0x0);  // init_op
+		jit.mov(rsp(0x20), 0x0); // deinit_op
+	} else {
+		jit.lea(rdx, rsp(0x30));      // ptr_to_return
+		jit.mov(r8, ret.dhook_size);  // return_size
+		jit.mov(r9, init_op);         // init_op
+		jit.mov(rax, deinit_op);
+		jit.mov(rsp(0x20), rax);      // deinit_op
+	}
+	jit.mov(rax, 1);
+	jit.mov(rsp(0x28), rax); // original
+
+	jit.mov(rax, reinterpret_cast<std::uintptr_t>(::KHook::SaveReturnValue));
+	jit.call(rax);
+
+	// Free local save data + RAX
+	jit.add(rsp, 0x40 + 0x8);
+
+	jit.retn();
+}
+
+}

--- a/extensions/dhooks/src/abi/msvc_amd64.cpp
+++ b/extensions/dhooks/src/abi/msvc_amd64.cpp
@@ -405,7 +405,7 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 	jit.sub(rsp, stack_size);
 
 	// Now copy stack over
-	for (int i = 0; i < stack_size; i += sizeof(void*)) {
+	for (size_t i = 0; i < stack_size; i += sizeof(void*)) {
 		// Skip saved RAX, skip return value
 		jit.mov(rax, rsp(stack_size + 0x8 + 0x8 + i));
 		jit.mov(rsp(i), rax);

--- a/extensions/dhooks/src/abi/system_v_amd64.cpp
+++ b/extensions/dhooks/src/abi/system_v_amd64.cpp
@@ -52,6 +52,7 @@ const char* TypeToString(TypeClass type) {
 // Chapter 3.2.3 Parameter Passing
 std::optional<TypeClass> Classify_ParamType(sp::HookParamType type) {
 	switch (type) {
+	case sp::HookParamType_String:
 	case sp::HookParamType_StringPtr:
 	case sp::HookParamType_CharPtr:
 	case sp::HookParamType_VectorPtr:
@@ -151,16 +152,14 @@ bool Proccess(sp::CallingConvention conv, std::vector<Variable>& params, ReturnV
 		auto& param = params[i];
 		if (param.dhook_custom_register == sp::DHookRegister_Default) {
 			auto cls = Classify_ParamType(param.dhook_type);
-			if (!cls.has_value()) {
-				if (param.dhook_pass_flags & sp::DHookPass_ByRef) {
-					// Its a pointer
-					cls = TypeClass::INTEGER;
-				} else {
-					// Otherwise not supported, end
-					// TO-DO: Update and support objects passed on the stack
-					globals::sourcemod->LogError(globals::myself, "ABI could not classify parameter (%d)!", i);
-					return false;
-				}
+			if (param.dhook_pass_flags & sp::DHookPass_ByRef) {
+				// Its a pointer
+				cls = TypeClass::INTEGER;
+			} else if (!cls.has_value()) {
+				// Otherwise not supported, end
+				// TO-DO: Update and support objects passed on the stack
+				globals::sourcemod->LogError(globals::myself, "ABI could not classify parameter (%d)!", i);
+				return false;
 			}
 			switch (cls.value()) {
 				case TypeClass::INTEGER:

--- a/extensions/dhooks/src/abi/system_v_amd64.cpp
+++ b/extensions/dhooks/src/abi/system_v_amd64.cpp
@@ -203,7 +203,7 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 	jit.push(rbp);
 	jit.mov(rbp, rsp);
 
-	static constexpr size_t stack_size = (MAX_GENERAL_REGISTERS * 0x8) + (MAX_FLOAT_REGISTERS * 0x10);
+	static constexpr size_t stack_size = (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister)) + (MAX_FLOAT_REGISTERS * sizeof(FloatRegister));
 	static_assert(stack_size % 16 == 0); // System-V requires the stack to be aligned for any call operation
 	jit.sub(rsp, stack_size);
 
@@ -217,9 +217,9 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 		if (reg == STACK_REG) {
 			// We modified the stack, so RSP no longer holds the correct value
 			jit.lea(rax, rsp(stack_size));
-			jit.mov(rsp(i * 0x8), rax);
+			jit.mov(rsp(sizeof(GeneralRegister) * i), rax);
 		} else {
-			jit.mov(rsp(i * 0x8), reg);
+			jit.mov(rsp(sizeof(GeneralRegister) * i), reg);
 		}
 	}
 
@@ -228,7 +228,7 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 		if (!save_float_register[i]) {
 			continue;
 		}
-		jit.movsd(rsp(i * 0x10 + (MAX_GENERAL_REGISTERS * 0x8)), reg);
+		jit.movsd(rsp(i * sizeof(FloatRegister) + (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister))), reg);
 	}
 	// void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post)
 	jit.mov(rdx, post);
@@ -364,7 +364,7 @@ void JIT_Recall(AsmJit& jit, bool save_general_register[MAX_GENERAL_REGISTERS], 
 		if (!save_float_register[i]) {
 			continue;
 		}
-		jit.movsd(reg, rsi(i * 0x10 + (MAX_GENERAL_REGISTERS * 0x8)));
+		jit.movsd(reg, rsi(i * sizeof(FloatRegister) + (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister))));
 	}
 
 	for (size_t i = 1; i < MAX_GENERAL_REGISTERS; i++) {

--- a/extensions/dhooks/src/abi/system_v_amd64.cpp
+++ b/extensions/dhooks/src/abi/system_v_amd64.cpp
@@ -438,6 +438,7 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 	// Store the return value in a local variable
 	std::uintptr_t init_op = 0;
 	std::uintptr_t deinit_op = 0;
+	std::size_t return_size = 0;
 	switch (Classify_ReturnType(ret).value()) {
 		case TypeClass::VOID:
 		break;
@@ -447,6 +448,7 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 
 		init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<std::uintptr_t>);
 		deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<std::uintptr_t>);
+		return_size = sizeof(std::uintptr_t);
 		break;
 		case TypeClass::SSE:
 			// TO-DO: handle this better...
@@ -456,11 +458,13 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 
 				init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<sdk::Vector>);
 				deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<sdk::Vector>);
+				return_size = sizeof(sdk::Vector);
 			} else {
 				jit.movsd(rsp(), xmm0);
 
 				init_op = reinterpret_cast<std::uintptr_t>(KHook::init_operator<float>);
 				deinit_op = reinterpret_cast<std::uintptr_t>(KHook::deinit_operator<float>);
+				return_size = sizeof(float);
 			}
 		break;
 		default:
@@ -476,10 +480,10 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 		jit.mov(rcx, 0x0); // init_op
 		jit.mov(r8,  0x0); // deinit_op
 	} else {
-		jit.mov(rsi, rsp);            // ptr_to_return
-		jit.mov(rdx, ret.dhook_size); // return_size
-		jit.mov(rcx, init_op);        // init_op
-		jit.mov(r8,  deinit_op);      // deinit_op	
+		jit.mov(rsi, rsp);         // ptr_to_return
+		jit.mov(rdx, return_size); // return_size
+		jit.mov(rcx, init_op);     // init_op
+		jit.mov(r8,  deinit_op);   // deinit_op
 	}
 	jit.mov(r9, true); // original
 

--- a/extensions/dhooks/src/abi/system_v_amd64.cpp
+++ b/extensions/dhooks/src/abi/system_v_amd64.cpp
@@ -404,7 +404,7 @@ void JIT_CallOriginal(AsmJit& jit, ReturnVariable& ret, std::uintptr_t* original
 	jit.sub(rsp, stack_size);
 
 	// Now copy stack over
-	for (int i = 0; i < stack_size; i += sizeof(void*)) {
+	for (size_t i = 0; i < stack_size; i += sizeof(void*)) {
 		// Skip saved RAX, skip return value
 		jit.mov(rax, rsp(stack_size + 0x8 + 0x8 + i));
 		jit.mov(rsp(i), rax);

--- a/extensions/dhooks/src/abi/system_v_amd64.cpp
+++ b/extensions/dhooks/src/abi/system_v_amd64.cpp
@@ -146,8 +146,8 @@ bool Proccess(sp::CallingConvention conv, std::vector<Variable>& params, ReturnV
 		params.insert(params.begin(), this_ptr);
 	}
 
-	/* Skip the return address */
-	size_t stack_offset = sizeof(void*);
+	/* Skip the saved stack pointer and the return address */
+	size_t stack_offset = 2 * sizeof(void*);
 	{auto len = params.size(); for (unsigned int i = 0; i < len; i++) {
 		auto& param = params[i];
 		if (param.dhook_custom_register == sp::DHookRegister_Default) {
@@ -194,8 +194,8 @@ bool Proccess(sp::CallingConvention conv, std::vector<Variable>& params, ReturnV
 			param.reg_offset = {};
 		}
 	}}
-	/* Stack size here only means the size the parameters occupy, so remove the space occupied by return address */
-	stack_size = stack_offset - sizeof(void*);
+	/* Stack size here only means the size the parameters occupy, so remove the base offset */
+	stack_size = stack_offset - (2 * sizeof(void*));
 	return true;
 }
 
@@ -335,9 +335,9 @@ void JIT_Recall(AsmJit& jit, bool save_general_register[MAX_GENERAL_REGISTERS], 
 		jit.push(rsi);
 
 		// Skip the two parameters we just saved
-		jit.lea(rdi, rsp(0x8 * 2));
+		jit.lea(rdi, rsp(2 * sizeof(void*)));
 		// Skip return value contained in the stack
-		jit.lea(rsi, rax(0x8));
+		jit.lea(rsi, rax(2 * sizeof(void*)));
 		jit.mov(rdx, stack_size);
 
 		jit.mov(rax, reinterpret_cast<std::uintptr_t>(memcpy));

--- a/extensions/dhooks/src/abi/system_v_amd64.cpp
+++ b/extensions/dhooks/src/abi/system_v_amd64.cpp
@@ -230,6 +230,7 @@ void JIT_CallMemberFunction(AsmJit& jit, bool save_general_register[MAX_GENERAL_
 		}
 		jit.movsd(rsp(i * sizeof(FloatRegister) + (MAX_GENERAL_REGISTERS * sizeof(GeneralRegister))), reg);
 	}
+
 	// void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post)
 	jit.mov(rdx, post);
 	jit.mov(rsi, rsp);

--- a/extensions/dhooks/src/capsule.cpp
+++ b/extensions/dhooks/src/capsule.cpp
@@ -18,7 +18,7 @@ static std::unique_ptr<Capsule> nullptr_capsule(nullptr);
 }
 
 const std::unique_ptr<Capsule>& Capsule::FindOrCreate(const handle::HookSetup* setup, void** vtable) {
-	auto dyndetour = dynamic_cast<const handle::DynamicDetour*>(setup);
+	auto dyndetour = setup->IsVirtualHook() ? nullptr : static_cast<const handle::DynamicDetour*>(setup);
 	if (dyndetour) {
 		// Let's see if a hook already exists
 		auto it = locals::address_detours.find(dyndetour->GetAddress());
@@ -38,7 +38,7 @@ const std::unique_ptr<Capsule>& Capsule::FindOrCreate(const handle::HookSetup* s
 		}
 		return it->second;
 	}
-	auto dynhook = dynamic_cast<const handle::DynamicHook*>(setup);
+	auto dynhook = setup->IsVirtualHook() ? static_cast<const handle::DynamicHook*>(setup) : nullptr;
 	if (dynhook) {
 		auto key = reinterpret_cast<void*>(reinterpret_cast<std::uintptr_t>(vtable) + dynhook->GetOffset());
 		// Let's see if a hook already exists

--- a/extensions/dhooks/src/capsule.hpp
+++ b/extensions/dhooks/src/capsule.hpp
@@ -169,7 +169,7 @@ void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post) const {
                 KHook::Action this_action = KHook::Action::Ignore;
                 if (result == (cell_t)sp::MRES_Supercede) {
                     this_action = KHook::Action::Supersede;
-                } else if (result != (cell_t)sp::MRES_Ignored) {
+                } else if (result == (cell_t)sp::MRES_Override || result == (cell_t)sp::MRES_ChangedOverride) {
                     this_action = KHook::Action::Override;
                 }
                 if (this_action > final_action) {

--- a/extensions/dhooks/src/capsule.hpp
+++ b/extensions/dhooks/src/capsule.hpp
@@ -95,7 +95,7 @@ void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post) const {
 	void* delete_op = nullptr;
 	size_t return_size = 0;
 
-    if constexpr(!std::is_same<RETURN, void>::value) {	
+    if constexpr(!std::is_same<RETURN, void>::value) {
 		return_ptr = new RETURN;
 		init_op = reinterpret_cast<void*>(::KHook::init_operator<RETURN>);
 		delete_op = reinterpret_cast<void*>(::KHook::deinit_operator<RETURN>);

--- a/extensions/dhooks/src/capsule.hpp
+++ b/extensions/dhooks/src/capsule.hpp
@@ -96,7 +96,7 @@ void Capsule::PrePostHookLoop(std::uint8_t* saved_register, bool post) const {
 	size_t return_size = 0;
 
     if constexpr(!std::is_same<RETURN, void>::value) {
-		return_ptr = new RETURN;
+		return_ptr = new RETURN();
 		init_op = reinterpret_cast<void*>(::KHook::init_operator<RETURN>);
 		delete_op = reinterpret_cast<void*>(::KHook::deinit_operator<RETURN>);
 		return_size = sizeof(RETURN);

--- a/extensions/dhooks/src/handle.hpp
+++ b/extensions/dhooks/src/handle.hpp
@@ -61,6 +61,8 @@ public:
 	virtual ~HookSetup() = default;
 	static SourceMod::HandleType_t HANDLE_TYPE;
 
+	virtual bool IsVirtualHook() const { return false; }
+
 	bool IsImmutable() const { return _immutable; }
 	void SetImmutable() { _immutable = true; }
 
@@ -93,6 +95,8 @@ public:
 	static SourceMod::HandleType_t HANDLE_TYPE;
 
 	virtual ~DynamicHook();
+
+	bool IsVirtualHook() const override { return true; }
 
 	void SetOffset(int offset) {
 		if (offset < 0) {

--- a/extensions/dhooks/src/natives/dhooksetup.cpp
+++ b/extensions/dhooks/src/natives/dhooksetup.cpp
@@ -88,7 +88,7 @@ cell_t DHookSetup_SetFromConf(SourcePawn::IPluginContext* context, const cell_t*
 	context->LocalToString(params[4], &key);
 
 	// Only change offset if HookSetup is a virtual hook
-	auto virtual_setup = dynamic_cast<handle::DynamicHook*>(setup);
+	auto virtual_setup = setup->IsVirtualHook() ? static_cast<handle::DynamicHook*>(setup) : nullptr;
 	if (virtual_setup) {
 		int offset = 0;
 		if (source == sp::SDKConf_Virtual && conf->GetOffset(key, &offset)) {
@@ -99,7 +99,7 @@ cell_t DHookSetup_SetFromConf(SourcePawn::IPluginContext* context, const cell_t*
 	}
 
 	// Only change address if HookSetup is an address hook
-	auto detour_setup = dynamic_cast<handle::DynamicDetour*>(setup);
+	auto detour_setup = setup->IsVirtualHook() ? nullptr : static_cast<handle::DynamicDetour*>(setup);
 	if (detour_setup) {
 		void* addr = nullptr;
 		if (source == sp::SDKConf_Signature && conf->GetMemSig(key, &addr)) {

--- a/extensions/dhooks/src/natives/dynamicdetour.cpp
+++ b/extensions/dhooks/src/natives/dynamicdetour.cpp
@@ -9,13 +9,17 @@ inline handle::DynamicDetour* Get(SourcePawn::IPluginContext* context, const cel
 	security.pOwner = globals::myself->GetIdentity();
 	security.pIdentity = globals::myself->GetIdentity();
 	SourceMod::Handle_t hndl = static_cast<SourceMod::Handle_t>(param);
-	handle::DynamicDetour* obj = nullptr;
+	handle::HookSetup* obj = nullptr;
 	SourceMod::HandleError chnderr = globals::handlesys->ReadHandle(hndl, handle::DynamicDetour::HANDLE_TYPE, &security, (void **)&obj);
 	if (chnderr != SourceMod::HandleError_None) {
 		context->ThrowNativeError("Invalid DynamicDetour Handle %x (error %i: %s)", hndl, chnderr, globals::HandleErrorToString(chnderr));
 		return nullptr;
 	}
-	return obj;
+	if (obj->IsVirtualHook()) {
+		context->ThrowNativeError("Hook not setup for a detour.");
+		return nullptr;
+	}
+	return static_cast<handle::DynamicDetour*>(obj);
 }
 
 cell_t DynamicDetour_DynamicDetour(SourcePawn::IPluginContext* context, const cell_t* params) {

--- a/extensions/dhooks/src/natives/dynamichook.cpp
+++ b/extensions/dhooks/src/natives/dynamichook.cpp
@@ -10,13 +10,17 @@ inline handle::DynamicHook* Get(SourcePawn::IPluginContext* context, const cell_
 	security.pOwner = globals::myself->GetIdentity();
 	security.pIdentity = globals::myself->GetIdentity();
 	SourceMod::Handle_t hndl = static_cast<SourceMod::Handle_t>(param);
-	handle::DynamicHook* obj = nullptr;
+	handle::HookSetup* obj = nullptr;
 	SourceMod::HandleError chnderr = globals::handlesys->ReadHandle(hndl, handle::DynamicHook::HANDLE_TYPE, &security, (void **)&obj);
 	if (chnderr != SourceMod::HandleError_None) {
 		context->ThrowNativeError("Invalid DynamicHook Handle %x (error %i: %s)", hndl, chnderr, globals::HandleErrorToString(chnderr));
 		return nullptr;
 	}
-	return obj;
+	if (!obj->IsVirtualHook()) {
+		context->ThrowNativeError("Hook not setup for a virtual hook.");
+		return nullptr;
+	}
+	return static_cast<handle::DynamicHook*>(obj);
 }
 
 cell_t DynamicHook_DynamicHook(SourcePawn::IPluginContext* context, const cell_t* params) {

--- a/extensions/dhooks/src/register.cpp
+++ b/extensions/dhooks/src/register.cpp
@@ -68,6 +68,24 @@ std::optional<AsmRegCode> Translate_DHookRegister(sp::DHookRegister reg) {
 #else
 		return KHook::Asm::edi;
 #endif
+#ifdef DHOOKS_X86_64
+		case sp::DHookRegister_R8:
+		return KHook::Asm::r8;
+		case sp::DHookRegister_R9:
+		return KHook::Asm::r9;
+		case sp::DHookRegister_R10:
+		return KHook::Asm::r10;
+		case sp::DHookRegister_R11:
+		return KHook::Asm::r11;
+		case sp::DHookRegister_R12:
+		return KHook::Asm::r12;
+		case sp::DHookRegister_R13:
+		return KHook::Asm::r13;
+		case sp::DHookRegister_R14:
+		return KHook::Asm::r14;
+		case sp::DHookRegister_R15:
+		return KHook::Asm::r15;
+#endif
     }
 	return {};
 }
@@ -90,6 +108,24 @@ std::optional<AsmFloatReg> Translate_DHookRegister_Float(sp::DHookRegister reg) 
 			return KHook::Asm::xmm6;
 		case sp::DHookRegister_XMM7:
 			return KHook::Asm::xmm7;
+#ifdef DHOOKS_X86_64
+		case sp::DHookRegister_XMM8:
+			return KHook::Asm::xmm8;
+		case sp::DHookRegister_XMM9:
+			return KHook::Asm::xmm9;
+		case sp::DHookRegister_XMM10:
+			return KHook::Asm::xmm10;
+		case sp::DHookRegister_XMM11:
+			return KHook::Asm::xmm11;
+		case sp::DHookRegister_XMM12:
+			return KHook::Asm::xmm12;
+		case sp::DHookRegister_XMM13:
+			return KHook::Asm::xmm13;
+		case sp::DHookRegister_XMM14:
+			return KHook::Asm::xmm14;
+		case sp::DHookRegister_XMM15:
+			return KHook::Asm::xmm15;
+#endif
 	}
 	return {};
 }

--- a/extensions/dhooks/version.rc
+++ b/extensions/dhooks/version.rc
@@ -1,0 +1,104 @@
+// Microsoft Visual C++ generated resource script.
+//
+//#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+#include <sourcemod_version.h>
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (U.S.) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+#ifdef _WIN32
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+#endif //_WIN32
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION  SM_VERSION_FILE
+ PRODUCTVERSION SM_VERSION_FILE
+ FILEFLAGSMASK 0x17L
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x4L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "000004b0"
+        BEGIN
+            VALUE "Comments", "Dynamic Hooks Extension"
+            VALUE "FileDescription", "SourceMod Dynamic Hooks Extension"
+            VALUE "FileVersion", SM_VERSION_STRING
+            VALUE "InternalName", "SourceMod Dynamic Hooks Extension"
+            VALUE "LegalCopyright", "Copyright (c) 2004-2008, AlliedModders LLC"
+            VALUE "OriginalFilename", BINARY_NAME
+            VALUE "ProductName", "SourceMod Dynamic Hooks Extension"
+            VALUE "ProductVersion", SM_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0, 1200
+    END
+END
+
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (U.S.) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+


### PR DESCRIPTION
Implements the Windows x64 ABI for DHooks, plus fixes needed to make Windows x64 build at all and various others I found along the way.

I copied the Linux ABI and worked forward from there, you should be able to diff them easily. I tried not to modify the Linux ABI too much, but I did port over any applicable improvements I discovered while working on the Windows side.

Related to #2403.