### PR TITLE
Fix x64 float parameter bugs

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -389,7 +389,7 @@ inline jit_uint8_t Write_PushPOD(JitWriter *jit, const SourceHook::PassInfo *inf
 			if (g_StackUsage + 8 < SCHAR_MAX)
 				X64_Mov_RmRSP_Disp8_Reg(jit, reg2, (jit_int8_t)g_StackUsage + 8);
 			else
-				X64_Mov_RmRSP_Disp32_Reg(jit, reg2, (jit_int8_t)g_StackUsage + 8);
+				X64_Mov_RmRSP_Disp32_Reg(jit, reg2, g_StackUsage + 8);
 			g_StackUsage += 16;
 		} else {
 			g_StackUsage += 8;
@@ -470,25 +470,28 @@ inline void Write_PushFloat(JitWriter *jit, const SourceHook::PassInfo *info, un
 
 				if (!offset) {
 					X64_Movaps_Rm(jit, floatReg, kREG_EBX);
-					X64_Movups_Rm_Disp8(jit, floatReg2, kREG_EBX, offset+8);
 				} else if (offset < SCHAR_MAX) {
 					if (offset % 16 == 0)
 						X64_Movaps_Rm_Disp8(jit, floatReg, kREG_EBX, (jit_int8_t)offset);
 					else
 						X64_Movups_Rm_Disp8(jit, floatReg, kREG_EBX, (jit_int8_t)offset);
-					if ((offset + 8) % 16 == 0)
-						X64_Movaps_Rm_Disp8(jit, floatReg2, kREG_EBX, (jit_int8_t)offset+8);
-					else
-						X64_Movups_Rm_Disp8(jit, floatReg2, kREG_EBX, (jit_int8_t)offset+8);
 				} else {
 					if (offset % 16 == 0)
 						X64_Movaps_Rm_Disp32(jit, floatReg, kREG_EBX, offset);
 					else
 						X64_Movups_Rm_Disp32(jit, floatReg, kREG_EBX, offset);
+				}
+
+				if (offset + 8 < SCHAR_MAX) {
 					if ((offset + 8) % 16 == 0)
-						X64_Movaps_Rm_Disp32(jit, floatReg2, kREG_EBX, offset+8);
+						X64_Movaps_Rm_Disp8(jit, floatReg2, kREG_EBX, (jit_int8_t)(offset + 8));
 					else
-						X64_Movups_Rm_Disp32(jit, floatReg2, kREG_EBX, offset+8);
+						X64_Movups_Rm_Disp8(jit, floatReg2, kREG_EBX, (jit_int8_t)(offset + 8));
+				} else {
+					if ((offset + 8) % 16 == 0)
+						X64_Movaps_Rm_Disp32(jit, floatReg2, kREG_EBX, offset + 8);
+					else
+						X64_Movups_Rm_Disp32(jit, floatReg2, kREG_EBX, offset + 8);
 				}
 		}
 	} else if (info->flags & PASSFLAG_BYREF) {

--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -566,9 +566,9 @@ inline uint8_t MapFloatToIntReg(uint8_t floatReg)
 
 inline void Write_VarArgFloatCopy(JitWriter *jit, const SourceHook::PassInfo *info, uint8_t *floatRegs)
 {
-	if (!floatRegs || floatRegs[0] == STACK_PARAM)
+	if (!floatRegs || MapFloatToIntReg(floatRegs[0]) == INVALID_REG)
 		return;
-		
+
 	uint8_t intReg1 = MapFloatToIntReg(floatRegs[0]);
 
 	switch (info->size)
@@ -585,11 +585,11 @@ inline void Write_VarArgFloatCopy(JitWriter *jit, const SourceHook::PassInfo *in
 			//movq intReg1, floatReg[0]
 			//movq intReg2, floatReg[1]
 			X64_Movq_Reg_Xmm(jit, intReg1, floatRegs[0]);
-			if (floatRegs[1] != STACK_PARAM)
+			if (MapFloatToIntReg(floatRegs[1]) != INVALID_REG)
 			{
 				int intReg2 = MapFloatToIntReg(floatRegs[1]);
 				X64_Movq_Reg_Xmm(jit, intReg2, floatRegs[1]);
-			} 
+			}
 			break;
 	}
 }

--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -529,9 +529,9 @@ inline void Write_PushFloat(JitWriter *jit, const SourceHook::PassInfo *info, un
 					X64_Movups_Rm_Disp8_Reg(jit, kREG_RSP, floatReg2, (jit_int8_t)g_StackUsage+8);
 			} else {
 				if ((g_StackUsage + 8) % 16 == 0)
-					X64_Movaps_Rm_Disp32_Reg(jit, kREG_RSP, floatReg, g_StackUsage+8);
+					X64_Movaps_Rm_Disp32_Reg(jit, kREG_RSP, floatReg2, g_StackUsage+8);
 				else
-					X64_Movups_Rm_Disp32_Reg(jit, kREG_RSP, floatReg, g_StackUsage+8);
+					X64_Movups_Rm_Disp32_Reg(jit, kREG_RSP, floatReg2, g_StackUsage+8);
 			}
 			g_StackUsage += 16;
 		} else {

--- a/extensions/bintools/x64_macros.h
+++ b/extensions/bintools/x64_macros.h
@@ -312,6 +312,8 @@ inline void X64_Movaps_Rm_Disp8_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8_
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x29);
 	jit->write_ubyte(ia32_modrm(MOD_DISP8, src & 7, dest & 7));
+	if ((dest & 7) == kREG_RSP)
+		jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, dest & 7));
 	jit->write_byte(disp);
 }
 
@@ -322,6 +324,8 @@ inline void X64_Movups_Rm_Disp8_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8_
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x11);
 	jit->write_ubyte(ia32_modrm(MOD_DISP8, src & 7, dest & 7));
+	if ((dest & 7) == kREG_RSP)
+		jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, dest & 7));
 	jit->write_byte(disp);
 }
 
@@ -332,6 +336,8 @@ inline void X64_Movaps_Rm_Disp32_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x29);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, src & 7, dest & 7));
+	if ((dest & 7) == kREG_RSP)
+		jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, dest & 7));
 	jit->write_byte(disp);
 }
 
@@ -342,6 +348,8 @@ inline void X64_Movups_Rm_Disp32_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x11);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, src & 7, dest & 7));
+	if ((dest & 7) == kREG_RSP)
+		jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, dest & 7));
 	jit->write_byte(disp);
 }
 

--- a/extensions/bintools/x64_macros.h
+++ b/extensions/bintools/x64_macros.h
@@ -170,7 +170,7 @@ inline void X64_Movzx_Reg64_Rm8_Disp32(JitWriter *jit, jit_uint8_t dest, jit_uin
 
 inline void X64_Mov_RmRSP_Reg(JitWriter *jit, jit_uint8_t src)
 {
-	jit->write_ubyte(x64_rex(true, kREG_RSP, 0, src));
+	jit->write_ubyte(x64_rex(true, src, 0, kREG_RSP));
 	jit->write_ubyte(IA32_MOV_RM_REG);
 	jit->write_ubyte(ia32_modrm(MOD_MEM_REG, src & 7, kREG_RSP));
 	jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, kREG_RSP));
@@ -185,13 +185,13 @@ inline void X64_Mov_RmRSP_Disp8_Reg(JitWriter *jit, jit_uint8_t src, jit_int8_t 
 	jit->write_byte(disp);
 }
 
-inline void X64_Mov_RmRSP_Disp32_Reg(JitWriter *jit, jit_uint8_t src, jit_int8_t disp)
+inline void X64_Mov_RmRSP_Disp32_Reg(JitWriter *jit, jit_uint8_t src, jit_int32_t disp)
 {
 	jit->write_ubyte(x64_rex(true, src, 0, kREG_RSP));
 	jit->write_ubyte(IA32_MOV_RM_REG);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, src & 7, kREG_RSP));
 	jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, kREG_RSP));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Movzx_Reg64_Rm16(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_uint8_t mode)
@@ -338,7 +338,7 @@ inline void X64_Movaps_Rm_Disp32_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, src & 7, dest & 7));
 	if ((dest & 7) == kREG_RSP)
 		jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, dest & 7));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Movups_Rm_Disp32_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_int32_t disp)
@@ -350,7 +350,7 @@ inline void X64_Movups_Rm_Disp32_Reg(JitWriter *jit, jit_uint8_t dest, jit_uint8
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, src & 7, dest & 7));
 	if ((dest & 7) == kREG_RSP)
 		jit->write_ubyte(ia32_sib(NOSCALE, kREG_NOIDX, dest & 7));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Movlps_Rm(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src)
@@ -418,7 +418,7 @@ inline void X64_Movaps_Rm_Disp32(JitWriter *jit, jit_uint8_t dest, jit_uint8_t s
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x28);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, dest & 7, src & 7));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Movups_Rm_Disp32(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_int32_t disp)
@@ -428,14 +428,14 @@ inline void X64_Movups_Rm_Disp32(JitWriter *jit, jit_uint8_t dest, jit_uint8_t s
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x10);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, dest & 7, src & 7));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Movapd_Rm(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src)
 {
+	jit->write_ubyte(0x66);
 	if (dest >= kREG_XMM8 || src >= kREG_XMM8)
 		jit->write_ubyte(x64_rex(false, dest, 0, src));
-	jit->write_ubyte(0x66);
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x28);
 	jit->write_ubyte(ia32_modrm(MOD_MEM_REG, dest & 7, src & 7));
@@ -443,9 +443,9 @@ inline void X64_Movapd_Rm(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src)
 
 inline void X64_Movupd_Rm(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src)
 {
+	jit->write_ubyte(0x66);
 	if (dest >= kREG_XMM8 || src >= kREG_XMM8)
 		jit->write_ubyte(x64_rex(false, dest, 0, src));
-	jit->write_ubyte(0x66);
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x10);
 	jit->write_ubyte(ia32_modrm(MOD_MEM_REG, dest & 7, src & 7));
@@ -453,9 +453,9 @@ inline void X64_Movupd_Rm(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src)
 
 inline void X64_Movapd_Rm_Disp8(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_int8_t disp)
 {
+	jit->write_ubyte(0x66);
 	if (dest >= kREG_XMM8 || src >= kREG_XMM8)
 		jit->write_ubyte(x64_rex(false, dest, 0, src));
-	jit->write_ubyte(0x66);
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x28);
 	jit->write_ubyte(ia32_modrm(MOD_DISP8, dest & 7, src & 7));
@@ -464,9 +464,9 @@ inline void X64_Movapd_Rm_Disp8(JitWriter *jit, jit_uint8_t dest, jit_uint8_t sr
 
 inline void X64_Movupd_Rm_Disp8(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_int8_t disp)
 {
+	jit->write_ubyte(0x66);
 	if (dest >= kREG_XMM8 || src >= kREG_XMM8)
 		jit->write_ubyte(x64_rex(false, dest, 0, src));
-	jit->write_ubyte(0x66);
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x10);
 	jit->write_ubyte(ia32_modrm(MOD_DISP8, dest & 7, src & 7));
@@ -475,24 +475,24 @@ inline void X64_Movupd_Rm_Disp8(JitWriter *jit, jit_uint8_t dest, jit_uint8_t sr
 
 inline void X64_Movapd_Rm_Disp32(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_int32_t disp)
 {
+	jit->write_ubyte(0x66);
 	if (dest >= kREG_XMM8 || src >= kREG_XMM8)
 		jit->write_ubyte(x64_rex(false, dest, 0, src));
-	jit->write_ubyte(0x66);
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x28);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, dest & 7, src & 7));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Movupd_Rm_Disp32(JitWriter *jit, jit_uint8_t dest, jit_uint8_t src, jit_int32_t disp)
 {
+	jit->write_ubyte(0x66);
 	if (dest >= kREG_XMM8 || src >= kREG_XMM8)
 		jit->write_ubyte(x64_rex(false, dest, 0, src));
-	jit->write_ubyte(0x66);
 	jit->write_ubyte(0x0F);
 	jit->write_ubyte(0x10);
 	jit->write_ubyte(ia32_modrm(MOD_DISP32, dest & 7, src & 7));
-	jit->write_byte(disp);
+	jit->write_int32(disp);
 }
 
 inline void X64_Cld(JitWriter *jit)


### PR DESCRIPTION
Some issues I discovered while working on #2546. Decided to submit them in their own PR since these are also present on `master`.

Some of the x64 codegen helpers forgot a required SIB byte when writing to the stack, so the JIT would spit out garbage instructions (and crash the server) any time a float argument didn't fit in the registers. It's pretty uncommon and only happens when the param spills to the stack due to the first four positional params already being taken. Fixed that, plus a nearby copy-paste bug.

It's a similar problem with Windows vararg calls. A float that overflowed the register budget could end up feeding a garbage "register" straight into the generated code.