### PR TITLE
Prevent lock of main thread

### DIFF
--- a/extensions/mysql/mysql/MyDatabase.cpp
+++ b/extensions/mysql/mysql/MyDatabase.cpp
@@ -157,8 +157,6 @@ const char *MyDatabase::GetError(int *errCode)
 
 bool MyDatabase::QuoteString(const char *str, char buffer[], size_t maxlength, size_t *newSize)
 {
-	std::lock_guard<std::recursive_mutex> lock(m_FullLock);
-
 	unsigned long size = static_cast<unsigned long>(strlen(str));
 	unsigned long needed = size * 2 + 1;
 


### PR DESCRIPTION
if the seperate thread is making a query but the SQL server is busy, and if a that time the main thread is doing a SQL_EscapeString (in a sp plugin) then the main thread is waiting for the lock. It is no necessary to do this lock here, its not a query.