### PR TITLE
Update Orange Box gamedata

### DIFF
--- a/gamedata/sdkhooks.games/engine.ep2v.txt
+++ b/gamedata/sdkhooks.games/engine.ep2v.txt
@@ -203,31 +203,31 @@
 			}
 			"EndTouch"
 			{
-				"windows"	"102"
-				"windows64"	"102"
-				"linux"		"103"
-				"linux64"	"103"
+				"windows"	"103"
+				"windows64"	"103"
+				"linux"		"104"
+				"linux64"	"104"
 			}
 			"FireBullets"
 			{
-				"windows"	"114"
-				"windows64"	"114"
-				"linux"		"115"
-				"linux64"	"115"
+				"windows"	"115"
+				"windows64"	"115"
+				"linux"		"116"
+				"linux64"	"116"
 			}
 			"GetMaxHealth"
 			{
-				"windows"	"119"
-				"windows64"	"119"
-				"linux"		"120"
-				"linux64"	"120"
+				"windows"	"120"
+				"windows64"	"120"
+				"linux"		"121"
+				"linux64"	"121"
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"180"
-				"windows64"	"180"
-				"linux"		"182"
-				"linux64"	"182"
+				"windows"	"181"
+				"windows64"	"181"
+				"linux"		"183"
+				"linux64"	"183"
 			}
 			"OnTakeDamage"
 			{
@@ -238,31 +238,31 @@
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"278"
-				"windows64"	"278"
-				"linux"		"279"
-				"linux64"	"279"
+				"windows"	"279"
+				"windows64"	"279"
+				"linux"		"280"
+				"linux64"	"280"
 			}
 			"PreThink"
-			{
-				"windows"	"338"
-				"windows64"	"338"
-				"linux"		"339"
-				"linux64"	"339"
-			}
-			"PostThink"
 			{
 				"windows"	"339"
 				"windows64"	"339"
 				"linux"		"340"
 				"linux64"	"340"
 			}
+			"PostThink"
+			{
+				"windows"	"340"
+				"windows64"	"340"
+				"linux"		"341"
+				"linux64"	"341"
+			}
 			"Reload"
 			{
-				"windows"	"276"
-				"windows64"	"276"
-				"linux"		"277"
-				"linux64"	"277"
+				"windows"	"277"
+				"windows64"	"277"
+				"linux"		"278"
+				"linux64"	"278"
 			}
 			"SetTransmit"
 			{
@@ -287,10 +287,10 @@
 			}
 			"StartTouch"
 			{
-				"windows"	"100"
-				"windows64"	"100"
-				"linux"		"101"
-				"linux64"	"101"
+				"windows"	"101"
+				"windows64"	"101"
+				"linux"		"102"
+				"linux64"	"102"
 			}
 			"Think"
 			{
@@ -301,10 +301,10 @@
 			}
 			"Touch"
 			{
-				"windows"	"101"
-				"windows64"	"101"
-				"linux"		"102"
-				"linux64"	"102"
+				"windows"	"102"
+				"windows64"	"102"
+				"linux"		"103"
+				"linux64"	"103"
 			}
 			"TraceAttack"
 			{
@@ -315,59 +315,59 @@
 			}
 			"Use"
 			{
-				"windows"	"99"
-				"windows64"	"99"
-				"linux"		"100"
-				"linux64"	"100"
+				"windows"	"100"
+				"windows64"	"100"
+				"linux"		"101"
+				"linux64"	"101"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"160"
-				"windows64"	"160"
-				"linux"		"161"
-				"linux64"	"161"
+				"windows"	"161"
+				"windows64"	"161"
+				"linux"		"162"
+				"linux64"	"162"
 			}
 			"Blocked"
 			{
-				"windows"	"104"
-				"windows64"	"104"
-				"linux"		"105"
-				"linux64"	"105"
+				"windows"	"105"
+				"windows64"	"105"
+				"linux"		"106"
+				"linux64"	"106"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"272"
-				"windows64"	"272"
-				"linux"		"273"
-				"linux64"	"273"
+				"windows"	"273"
+				"windows64"	"273"
+				"linux"		"274"
+				"linux64"	"274"
 			}
 			"Weapon_CanUse"
-			{
-				"windows"	"266"
-				"windows64"	"266"
-				"linux"		"267"
-				"linux64"	"267"
-			}
-			"Weapon_Drop"
-			{
-				"windows"	"269"
-				"windows64"	"269"
-				"linux"		"270"
-				"linux64"	"270"
-			}
-			"Weapon_Equip"
 			{
 				"windows"	"267"
 				"windows64"	"267"
 				"linux"		"268"
 				"linux64"	"268"
 			}
-			"Weapon_Switch"
+			"Weapon_Drop"
 			{
 				"windows"	"270"
 				"windows64"	"270"
 				"linux"		"271"
 				"linux64"	"271"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"268"
+				"windows64"	"268"
+				"linux"		"269"
+				"linux64"	"269"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"271"
+				"windows64"	"271"
+				"linux"		"272"
+				"linux64"	"272"
 			}
 		}
 	}
@@ -567,38 +567,38 @@
 			}
 			"Blocked"
 			{
-				"windows"	"104"
-				"windows64"	"104"
-				"linux"		"105"
-				"linux64"	"105"
+				"windows"	"105"
+				"windows64"	"105"
+				"linux"		"106"
+				"linux64"	"106"
 			}
 			"EndTouch"
 			{
-				"windows"	"102"
-				"windows64"	"102"
-				"linux"		"103"
-				"linux64"	"103"
+				"windows"	"103"
+				"windows64"	"103"
+				"linux"		"104"
+				"linux64"	"104"
 			}
 			"FireBullets"
 			{
-				"windows"	"114"
-				"windows64"	"114"
-				"linux"		"115"
-				"linux64"	"115"
+				"windows"	"115"
+				"windows64"	"115"
+				"linux"		"116"
+				"linux64"	"116"
 			}
 			"GetMaxHealth"
 			{
-				"windows"	"119"
-				"windows64"	"119"
-				"linux"		"120"
-				"linux64"	"120"
+				"windows"	"120"
+				"windows64"	"120"
+				"linux"		"121"
+				"linux64"	"121"
 			}
 			"GroundEntChanged"
 			{
-				"windows"	"180"
-				"windows64"	"180"
-				"linux"		"182"
-				"linux64"	"182"
+				"windows"	"181"
+				"windows64"	"181"
+				"linux"		"183"
+				"linux64"	"183"
 			}
 			"OnTakeDamage"
 			{
@@ -609,31 +609,31 @@
 			}
 			"OnTakeDamage_Alive"
 			{
-				"windows"	"278"
-				"windows64"	"278"
-				"linux"		"279"
-				"linux64"	"279"
+				"windows"	"279"
+				"windows64"	"279"
+				"linux"		"280"
+				"linux64"	"280"
 			}
 			"PreThink"
-			{
-				"windows"	"338"
-				"windows64"	"338"
-				"linux"		"339"
-				"linux64"	"339"
-			}
-			"PostThink"
 			{
 				"windows"	"339"
 				"windows64"	"339"
 				"linux"		"340"
 				"linux64"	"340"
 			}
+			"PostThink"
+			{
+				"windows"	"340"
+				"windows64"	"340"
+				"linux"		"341"
+				"linux64"	"341"
+			}
 			"Reload"
 			{
-				"windows"	"276"
-				"windows64"	"276"
-				"linux"		"277"
-				"linux64"	"277"
+				"windows"	"277"
+				"windows64"	"277"
+				"linux"		"278"
+				"linux64"	"278"
 			}
 			"SetTransmit"
 			{
@@ -658,10 +658,10 @@
 			}
 			"StartTouch"
 			{
-				"windows"	"100"
-				"windows64"	"100"
-				"linux"		"101"
-				"linux64"	"101"
+				"windows"	"101"
+				"windows64"	"101"
+				"linux"		"102"
+				"linux64"	"102"
 			}
 			"Think"
 			{
@@ -672,10 +672,10 @@
 			}
 			"Touch"
 			{
-				"windows"	"101"
-				"windows64"	"101"
-				"linux"		"102"
-				"linux64"	"102"
+				"windows"	"102"
+				"windows64"	"102"
+				"linux"		"103"
+				"linux64"	"103"
 			}
 			"TraceAttack"
 			{
@@ -686,52 +686,52 @@
 			}
 			"Use"
 			{
-				"windows"	"99"
-				"windows64"	"99"
-				"linux"		"100"
-				"linux64"	"100"
+				"windows"	"100"
+				"windows64"	"100"
+				"linux"		"101"
+				"linux64"	"101"
 			}
 			"VPhysicsUpdate"
 			{
-				"windows"	"160"
-				"windows64"	"160"
-				"linux"		"161"
-				"linux64"	"161"
+				"windows"	"161"
+				"windows64"	"161"
+				"linux"		"162"
+				"linux64"	"162"
 			}
 			"Weapon_CanSwitchTo"
 			{
-				"windows"	"272"
-				"windows64"	"272"
-				"linux"		"273"
-				"linux64"	"273"
+				"windows"	"273"
+				"windows64"	"273"
+				"linux"		"274"
+				"linux64"	"274"
 			}
 			"Weapon_CanUse"
-			{
-				"windows"	"266"
-				"windows64"	"266"
-				"linux"		"267"
-				"linux64"	"267"
-			}
-			"Weapon_Drop"
-			{
-				"windows"	"269"
-				"windows64"	"269"
-				"linux"		"270"
-				"linux64"	"270"
-			}
-			"Weapon_Equip"
 			{
 				"windows"	"267"
 				"windows64"	"267"
 				"linux"		"268"
 				"linux64"	"268"
 			}
-			"Weapon_Switch"
+			"Weapon_Drop"
 			{
 				"windows"	"270"
 				"windows64"	"270"
 				"linux"		"271"
 				"linux64"	"271"
+			}
+			"Weapon_Equip"
+			{
+				"windows"	"268"
+				"windows64"	"268"
+				"linux"		"269"
+				"linux64"	"269"
+			}
+			"Weapon_Switch"
+			{
+				"windows"	"271"
+				"windows64"	"271"
+				"linux"		"272"
+				"linux64"	"272"
 			}
 		}
 	}

--- a/gamedata/sdktools.games/game.cstrike.txt
+++ b/gamedata/sdktools.games/game.cstrike.txt
@@ -36,66 +36,66 @@
 			}
 			"GiveNamedItem"
 			{
-				"windows"	"408"
-				"windows64"	"408"
-				"linux"		"409"
-				"linux64"	"409"
+				"windows"	"409"
+				"windows64"	"409"
+				"linux"		"410"
+				"linux64"	"410"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"276"
-				"windows64"	"276"
-				"linux"		"277"
-				"linux64"	"277"
+				"windows"	"277"
+				"windows64"	"277"
+				"linux"		"278"
+				"linux64"	"278"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"274"
-				"windows64"	"274"
-				"linux"		"275"
-				"linux64"	"275"
+				"windows"	"275"
+				"windows64"	"275"
+				"linux"		"276"
+				"linux64"	"276"
 			}
 			"Ignite"
 			{
-				"windows"	"215"
-				"windows64"	"215"
-				"linux"		"216"
-				"linux64"	"216"
+				"windows"	"216"
+				"windows64"	"216"
+				"linux"		"217"
+				"linux64"	"217"
 			}
 			"Extinguish"
 			{
-				"windows"	"219"
-				"windows64"	"219"
-				"linux"		"220"
-				"linux64"	"220"
+				"windows"	"220"
+				"windows64"	"220"
+				"linux"		"221"
+				"linux64"	"221"
 			}
 			"Teleport"
 			{
-				"windows"	"110"
-				"windows64"	"110"
-				"linux"		"111"
-				"linux64"	"111"
+				"windows"	"111"
+				"windows64"	"111"
+				"linux"		"112"
+				"linux64"	"112"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"447"
-				"windows64"	"447"
-				"linux"		"447"
-				"linux64"	"447"
+				"windows"	"448"
+				"windows64"	"448"
+				"linux"		"448"
+				"linux64"	"448"
 			}
 			"GetVelocity"
 			{
-				"windows"	"143"
-				"windows64"	"143"
-				"linux"		"144"
-				"linux64"	"144"
+				"windows"	"144"
+				"windows64"	"144"
+				"linux"		"145"
+				"linux64"	"145"
 			}
 			"EyeAngles"
 			{
-				"windows"	"134"
-				"windows64"	"134"
-				"linux"		"135"
-				"linux64"	"135"
+				"windows"	"135"
+				"windows64"	"135"
+				"linux"		"136"
+				"linux64"	"136"
 			}
 			"AcceptInput"
 			{
@@ -113,10 +113,10 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"267"
-				"windows64"	"267"
-				"linux"		"268"
-				"linux64"	"268"
+				"windows"	"268"
+				"windows64"	"268"
+				"linux"		"269"
+				"linux64"	"269"
 			}
 			"Activate"
 			{
@@ -127,24 +127,24 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"426"
-				"windows64"	"426"
-				"linux"		"427"
-				"linux64"	"427"
+				"windows"	"427"
+				"windows64"	"427"
+				"linux"		"428"
+				"linux64"	"428"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"258"
-				"windows64"	"258"
-				"linux"		"259"
-				"linux64"	"259"
+				"windows"	"259"
+				"windows64"	"259"
+				"linux"		"260"
+				"linux64"	"260"
 			}
 			"GetAttachment"
 			{
-				"windows"	"211"
-				"windows64"	"211"
-				"linux"		"212"
-				"linux64"	"212"
+				"windows"	"212"
+				"windows64"	"212"
+				"linux"		"213"
+				"linux64"	"213"
 			}
 		}
 

--- a/gamedata/sdktools.games/game.hl2mp.txt
+++ b/gamedata/sdktools.games/game.hl2mp.txt
@@ -41,66 +41,66 @@
 		{
 			"GiveNamedItem"
 			{
-				"windows"	"407"
-				"windows64"	"407"
-				"linux"		"408"
-				"linux64"	"408"
+				"windows"	"408"
+				"windows64"	"408"
+				"linux"		"409"
+				"linux64"	"409"
 			}
 			"RemovePlayerItem"
 			{
-				"windows"	"276"
-				"windows64"	"276"
-				"linux"		"277"
-				"linux64"	"277"
+				"windows"	"277"
+				"windows64"	"277"
+				"linux"		"278"
+				"linux64"	"278"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"	"274"
-				"windows64"	"274"
-				"linux"		"275"
-				"linux64"	"275"
+				"windows"	"275"
+				"windows64"	"275"
+				"linux"		"276"
+				"linux64"	"276"
 			}
 			"Ignite"
 			{
-				"windows"	"215"
-				"windows64"	"215"
-				"linux"		"216"
-				"linux64"	"216"
+				"windows"	"216"
+				"windows64"	"216"
+				"linux"		"217"
+				"linux64"	"217"
 			}
 			"Extinguish"
 			{
-				"windows"	"219"
-				"windows64"	"219"
-				"linux"		"220"
-				"linux64"	"220"
+				"windows"	"220"
+				"windows64"	"220"
+				"linux"		"221"
+				"linux64"	"221"
 			}
 			"Teleport"
 			{
-				"windows"	"110"
-				"windows64"	"110"
-				"linux"		"111"
-				"linux64"	"111"
+				"windows"	"111"
+				"windows64"	"111"
+				"linux"		"112"
+				"linux64"	"112"
 			}
 			"CommitSuicide"
 			{
-				"windows"	"446"
-				"windows64"	"446"
-				"linux"		"446"
-				"linux64"	"446"
+				"windows"	"447"
+				"windows64"	"447"
+				"linux"		"447"
+				"linux64"	"447"
 			}
 			"GetVelocity"
 			{
-				"windows"	"143"
-				"windows64"	"143"
-				"linux"		"144"
-				"linux64"	"144"
+				"windows"	"144"
+				"windows64"	"144"
+				"linux"		"145"
+				"linux64"	"145"
 			}
 			"EyeAngles"
 			{
-				"windows"	"134"
-				"windows64"	"134"
-				"linux"		"135"
-				"linux64"	"135"
+				"windows"	"135"
+				"windows64"	"135"
+				"linux"		"136"
+				"linux64"	"136"
 			}
 			"AcceptInput"
 			{
@@ -118,10 +118,10 @@
 			}
 			"WeaponEquip"
 			{
-				"windows"	"267"
-				"windows64"	"267"
-				"linux"		"268"
-				"linux64"	"268"
+				"windows"	"268"
+				"windows64"	"268"
+				"linux"		"269"
+				"linux64"	"269"
 			}
 			"Activate"
 			{
@@ -132,17 +132,17 @@
 			}
 			"PlayerRunCmd"
 			{
-				"windows"	"425"
-				"windows64"	"425"
-				"linux"		"426"
-				"linux64"	"426"
+				"windows"	"426"
+				"windows64"	"426"
+				"linux"		"427"
+				"linux64"	"427"
 			}
 			"GiveAmmo"
 			{
-				"windows"	"258"
-				"windows64"	"258"
-				"linux"		"259"
-				"linux64"	"259"
+				"windows"	"259"
+				"windows64"	"259"
+				"linux"		"260"
+				"linux64"	"260"
 			}
 			"SetOwnerEntity"
 			{
@@ -153,10 +153,10 @@
 			}
 			"GetAttachment"
 			{
-				"windows"	"211"
-				"windows64"	"211"
-				"linux"		"212"
-				"linux64"	"212"
+				"windows"	"212"
+				"windows64"	"212"
+				"linux"		"213"
+				"linux64"	"213"
 			}
 		}
 		


### PR DESCRIPTION
Latest update to orange box games[ added a new virtual function](https://github.com/ValveSoftware/source-sdk-2013/pull/988) in the `CBaseEntity` class on games that have NextBots.
Updated SDKTools and SDKHooks gamedata for Counter-Strike: Source and Half-Life 2 Deathmatch.
Day of Defeat: Source and Half-Life 1 Deathmatch Source not affected due to lack of NextBot code in those games.