### PR TITLE
Add SourcePawn 2 support.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -680,6 +680,9 @@ for spcomp in SP.spcomp:
         SM.spcomp = spcomp
     SM.spcomp_bins.append(spcomp)
 
+for spcomp in SP.oldspcomp:
+    SM.spcomp_bins.append(spcomp)
+
 # If we have a universal binary, ignore all other spcomps.
 if SM.spcomp.target.arch == 'universal':
     SM.spcomp_bins = [SM.spcomp]

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -438,7 +438,7 @@ class SMConfig(object):
         return lambda builder, name: self.StaticLibrary(builder, cxx, name)
       extra_vars = {'Configure': get_configure_fn(cxx)}
       libamtl = builder.Build('public/amtl/amtl/AMBuilder', extra_vars)
-      self.libamtl[cxx.target.arch] = libamtl.binary
+      self.libamtl[cxx.target] = libamtl.binary
 
   def BinaryOutputName(self, binary, binary_type):
     target = binary.compiler.target

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -329,6 +329,10 @@ class SMConfig(object):
     if cxx.version >= 'clang-16.0' or cxx.version >= 'apple-clang-15.0':
         cxx.cxxflags += ['-Wno-deprecated-anon-enum-enum-conversion']
 
+    # C++20 deprecates volatile ++/-- and compound assignment (P1152R4).
+    if cxx.version >= 'clang-12.0' or cxx.version >= 'apple-clang-13.0':
+        cxx.cxxflags += ['-Wno-deprecated-volatile']
+
     if have_gcc:
       cxx.cflags += ['-Wno-maybe-uninitialized']
 

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -271,7 +271,7 @@ class SMConfig(object):
       '-fvisibility=hidden',
     ]
 
-    cxx.cxxflags += ['-std=c++17']
+    cxx.cxxflags += ['-std=c++20']
 
     cxx.cxxflags += [
       '-fno-threadsafe-statics',
@@ -326,6 +326,9 @@ class SMConfig(object):
     if cxx.version >= 'clang-21.0':
         cxx.cflags += ['-Wno-uninitialized-const-pointer']
 
+    if cxx.version >= 'clang-16.0' or cxx.version >= 'apple-clang-15.0':
+        cxx.cxxflags += ['-Wno-deprecated-anon-enum-enum-conversion']
+
     if have_gcc:
       cxx.cflags += ['-Wno-maybe-uninitialized']
 
@@ -356,7 +359,7 @@ class SMConfig(object):
       '/EHsc',
       '/GR-',
       '/TP',
-      '/std:c++17',
+      '/std:c++20',
     ]
     cxx.linkflags += [
       'kernel32.lib',

--- a/core/HalfLife2.cpp
+++ b/core/HalfLife2.cpp
@@ -1376,15 +1376,15 @@ public:
 
 	void Purge()
 	{
-		if (!IsExternallyAllocated())
+		if (!this->IsExternallyAllocated())
 		{
-			if (m_pMemory)
+			if (this->m_pMemory)
 			{
 				UTLMEMORY_TRACK_FREE();
-				g_pMemAlloc->Free((void*)m_pMemory);
-				m_pMemory = 0;
+				g_pMemAlloc->Free((void*)this->m_pMemory);
+				this->m_pMemory = 0;
 			}
-			m_nAllocationCount = 0;
+			this->m_nAllocationCount = 0;
 		}
 		BaseClass::Purge();
 	}

--- a/core/logic/AMBuilder
+++ b/core/logic/AMBuilder
@@ -8,6 +8,8 @@ for cxx in builder.targets:
     os.path.join(builder.sourcePath, 'core', 'logic'),
     os.path.join(builder.sourcePath, 'public'),
     os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
+    os.path.join(builder.sourcePath, 'sourcepawn'),
+    os.path.join(builder.sourcePath, 'sourcepawn', 'vm'),
     os.path.join(builder.sourcePath, 'public', 'amtl', 'amtl'),
     os.path.join(builder.sourcePath, 'public', 'amtl'),
     os.path.join(SM.mms_root, 'core', 'sourcehook')
@@ -24,11 +26,12 @@ for cxx in builder.targets:
     binary.compiler.cflags += ['-Wno-deprecated-declarations']
     binary.compiler.postlink += ['-framework', 'CoreServices', '-lm']
 
-  arch = binary.compiler.target.arch
+  target = binary.compiler.target
   binary.compiler.linkflags += [
-    SP.static_libsp[arch],
-    SP.libamtl[arch],
-    SP.zlib[arch],
+    SP.static_libsp[target],
+    SP.libamtl[target],
+    SP.zlib[target],
+    SP.mimalloc[target],
   ]
 
   if binary.compiler.family == 'gcc' or binary.compiler.family == 'clang':

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -259,14 +259,54 @@ void CPlugin::EvictWithError(PluginStatus status, const char *error_fmt, ...)
 	}
 }
 
+// Pstruct fields are stored in the .pstruct_glb table, not in .pubvars.
+// v1 images have no pstruct table, so callers fall back to legacy reads.
+static bool GetPstructStringField(sp::SmxImage* image, const sp::smx_pstruct_global* glb,
+                                  const char* field, std::string* out)
+{
+	std::variant<std::string, cell_t> v;
+	if (image->GetPstructValue(glb, field, &v) != SP_ERROR_NONE ||
+	    !std::holds_alternative<std::string>(v))
+	{
+		return false;
+	}
+	*out = std::get<std::string>(std::move(v));
+	return true;
+}
+
+static bool GetPstructBoolField(sp::SmxImage* image, const sp::smx_pstruct_global* glb,
+                                const char* field, bool* out)
+{
+	std::variant<std::string, cell_t> v;
+	if (image->GetPstructValue(glb, field, &v) != SP_ERROR_NONE ||
+	    !std::holds_alternative<cell_t>(v))
+	{
+		return false;
+	}
+	*out = std::get<cell_t>(v) != 0;
+	return true;
+}
+
 bool CPlugin::ReadInfo()
 {
 	/* Now grab the info */
 	uint32_t idx;
 	IPluginContext *base = GetBaseContext();
-	int err = base->FindPubvarByName("myinfo", &idx);
+	int err;
 
-	if (err == SP_ERROR_NONE) {
+	sp::SmxImage* image = base->GetBaseRuntime()->image();
+	if (const sp::smx_pstruct_global* myinfo = image->FindPstructGlobal("myinfo")) {
+		auto update_field = [&](const char* field, std::string *dest) {
+			if (!GetPstructStringField(image, myinfo, field, dest))
+				*dest = "";
+		};
+
+		update_field("name", &info_name_);
+		update_field("description", &info_description_);
+		update_field("author", &info_author_);
+		update_field("version", &info_version_);
+		update_field("url", &info_url_);
+	} else if ((err = base->FindPubvarByName("myinfo", &idx)) == SP_ERROR_NONE) {
 		struct sm_plugininfo_c_t
 		{
 			cell_t name;
@@ -1088,50 +1128,93 @@ bool CPluginManager::FindOrRequirePluginDeps(CPlugin *pPlugin)
 	uint32_t num = pBase->GetPubVarsNum();
 	sp_pubvar_t *pubvar;
 	char *name, *file;
-	char pathfile[PLATFORM_MAX_PATH];
 
-	for (uint32_t i=0; i<num; i++) {
-		if (pBase->GetPubvarByIndex(i, &pubvar) != SP_ERROR_NONE)
-			continue;
-		if (strncmp(pubvar->name, "__pl_", 5) == 0) {
+	char pathfile[PLATFORM_MAX_PATH];
+	libsys->GetFileFromPath(pathfile, sizeof(pathfile), pPlugin->GetFilename());
+
+	struct PluginDep
+	{
+		std::string pubvar_name;
+		std::string name;
+		std::string file;
+		bool required;
+	};
+
+	std::vector<PluginDep> deps;
+
+	sp::SmxImage* image = pBase->GetBaseRuntime()->image();
+
+	if (image->pstruct_global_count()) {
+		for (uint32_t i = 0; i < image->pstruct_global_count(); i++) {
+			const sp::smx_pstruct_global* glb = image->pstruct_globals() + i;
+			const char* pubvar_name = image->names() + glb->name;
+			if (strncmp(pubvar_name, "__pl_", 5) != 0)
+				continue;
+
+			PluginDep dep;
+			dep.pubvar_name = pubvar_name;
+			dep.required = false;
+			if (!GetPstructStringField(image, glb, "file", &dep.file))
+				continue;
+			if (!GetPstructStringField(image, glb, "name", &dep.name))
+				continue;
+			GetPstructBoolField(image, glb, "required", &dep.required);
+			deps.push_back(std::move(dep));
+		}
+	} else {
+		for (uint32_t i=0; i<num; i++) {
+			if (pBase->GetPubvarByIndex(i, &pubvar) != SP_ERROR_NONE)
+				continue;
+			if (strncmp(pubvar->name, "__pl_", 5) != 0)
+				continue;
+
 			pl = (_pl *)pubvar->offs;
 			if (pBase->LocalToString(pl->file, &file) != SP_ERROR_NONE)
 				continue;
 			if (pBase->LocalToString(pl->name, &name) != SP_ERROR_NONE)
 				continue;
-			libsys->GetFileFromPath(pathfile, sizeof(pathfile), pPlugin->GetFilename());
-			if (strcmp(pathfile, file) == 0)
-				continue;
-			if (pl->required == false) {
-				IPluginFunction *pFunc;
-				char buffer[64];
-				ke::SafeSprintf(buffer, sizeof(buffer), "__pl_%s_SetNTVOptional", &pubvar->name[5]);
-				if ((pFunc=pBase->GetFunctionByName(buffer))) {
-					cell_t res;
-					if (pFunc->Execute(&res) != SP_ERROR_NONE) {
-						pPlugin->EvictWithError(Plugin_Failed, "Fatal error during initializing plugin load");
-						return false;
-					}
-				}
-			} else {
-				/* Check that we aren't registering the same library twice */
-				pPlugin->AddRequiredLib(name);
 
-				CPlugin *found = nullptr;
-				for (PluginIter iter(m_plugins); !iter.done(); iter.next()) {
-					CPlugin *pl = (*iter);
-					if (pl->HasLibrary(name)) {
-						found = pl;
-						break;
-					}
-				}
-				if (!found) {
-					pPlugin->EvictWithError(Plugin_Failed, "Could not find required plugin \"%s\"", name);
+			PluginDep dep;
+			dep.pubvar_name = pubvar->name;
+			dep.name = name;
+			dep.file = file;
+			dep.required = !!pl->required;
+			deps.push_back(std::move(dep));
+		}
+	}
+
+	for (const PluginDep& dep : deps) {
+		if (strcmp(pathfile, dep.file.c_str()) == 0)
+			continue;
+		if (!dep.required) {
+			IPluginFunction *pFunc;
+			char buffer[64];
+			ke::SafeSprintf(buffer, sizeof(buffer), "__pl_%s_SetNTVOptional", &dep.pubvar_name[5]);
+			if ((pFunc=pBase->GetFunctionByName(buffer))) {
+				cell_t res;
+				if (pFunc->Execute(&res) != SP_ERROR_NONE) {
+					pPlugin->EvictWithError(Plugin_Failed, "Fatal error during initializing plugin load");
 					return false;
 				}
-
-				found->AddDependent(pPlugin);
 			}
+		} else {
+			/* Check that we aren't registering the same library twice */
+			pPlugin->AddRequiredLib(dep.name.c_str());
+
+			CPlugin *found = nullptr;
+			for (PluginIter iter(m_plugins); !iter.done(); iter.next()) {
+				CPlugin *other = (*iter);
+				if (other->HasLibrary(dep.name.c_str())) {
+					found = other;
+					break;
+				}
+			}
+			if (!found) {
+				pPlugin->EvictWithError(Plugin_Failed, "Could not find required plugin \"%s\"", dep.name.c_str());
+				return false;
+			}
+
+			found->AddDependent(pPlugin);
 		}
 	}
 
@@ -1149,6 +1232,31 @@ bool CPlugin::ForEachExtVar(const ExtVarCallback& callback)
 	} *ext;
 
 	IPluginContext *pBase = GetBaseContext();
+
+	sp::SmxImage* image = pBase->GetBaseRuntime()->image();
+	for (uint32_t i = 0; i < image->pstruct_global_count(); i++) {
+		const sp::smx_pstruct_global* glb = image->pstruct_globals() + i;
+		const char* pubvar_name = image->names() + glb->name;
+		if (strncmp(pubvar_name, "__ext_", 6) != 0)
+			continue;
+
+		ExtVar var;
+		var.autoload = false;
+		var.required = false;
+		if (!GetPstructStringField(image, glb, "file", &var.file))
+			continue;
+		if (!GetPstructStringField(image, glb, "name", &var.name))
+			continue;
+		GetPstructBoolField(image, glb, "autoload", &var.autoload);
+		GetPstructBoolField(image, glb, "required", &var.required);
+
+		if (!callback(pubvar_name, var))
+			return false;
+	}
+
+	if (image->pstruct_global_count())
+		return true;
+
 	for (uint32_t i = 0; i < pBase->GetPubVarsNum(); i++)
 	{
 		sp_pubvar_t *pubvar;
@@ -1161,14 +1269,17 @@ bool CPlugin::ForEachExtVar(const ExtVarCallback& callback)
 		ext = (_ext *)pubvar->offs;
 
 		ExtVar var;
-		if (pBase->LocalToString(ext->file, &var.file) != SP_ERROR_NONE)
+		char *str;
+		if (pBase->LocalToString(ext->file, &str) != SP_ERROR_NONE)
 			continue;
-		if (pBase->LocalToString(ext->name, &var.name) != SP_ERROR_NONE)
+		var.file = str;
+		if (pBase->LocalToString(ext->name, &str) != SP_ERROR_NONE)
 			continue;
+		var.name = str;
 		var.autoload = !!ext->autoload;
 		var.required = !!ext->required;
 
-		if (!callback(pubvar, var))
+		if (!callback(pubvar->name, var))
 			return false;
 	}
 	return true;
@@ -1210,12 +1321,12 @@ void CPlugin::SetWaitingToUnload(bool andReload)
 
 void CPluginManager::LoadExtensions(CPlugin *pPlugin)
 {
-	auto callback = [pPlugin] (const sp_pubvar_t *pubvar, const CPlugin::ExtVar& ext) -> bool
+	auto callback = [pPlugin] (const char *, const CPlugin::ExtVar& ext) -> bool
 	{
 		char path[PLATFORM_MAX_PATH];
 		/* Attempt to auto-load if necessary */
 		if (ext.autoload) {
-			libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", ext.file);
+			libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", ext.file.c_str());
 			g_Extensions.LoadAutoExtension(path, ext.required);
 		}
 		return true;
@@ -1226,24 +1337,24 @@ void CPluginManager::LoadExtensions(CPlugin *pPlugin)
 bool CPluginManager::RequireExtensions(CPlugin *pPlugin)
 {
 	auto callback = [pPlugin]
-                    (const sp_pubvar_t *pubvar, const CPlugin::ExtVar& ext) -> bool
+                    (const char *pubvar, const CPlugin::ExtVar& ext) -> bool
 	{
 		/* Is this required? */
 		if (ext.required) {
 			char path[PLATFORM_MAX_PATH];
-			libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", ext.file);
+			libsys->PathFormat(path, PLATFORM_MAX_PATH, "%s", ext.file.c_str());
 			IExtension *pExt = g_Extensions.FindExtensionByFile(path);
 			if (!pExt)
-				pExt = g_Extensions.FindExtensionByName(ext.name);
+				pExt = g_Extensions.FindExtensionByName(ext.name.c_str());
 
 			if (!pExt || !pExt->IsRunning(nullptr, 0)) {
-				pPlugin->EvictWithError(Plugin_Failed, "Required extension \"%s\" file(\"%s\") not running", ext.name, ext.file);
+				pPlugin->EvictWithError(Plugin_Failed, "Required extension \"%s\" file(\"%s\") not running", ext.name.c_str(), ext.file.c_str());
 				return false;
 			}
 			g_Extensions.BindChildPlugin(pExt, pPlugin);
 		} else {
 			char buffer[64];
-			ke::SafeSprintf(buffer, sizeof(buffer), "__ext_%s_SetNTVOptional", &pubvar->name[6]);
+			ke::SafeSprintf(buffer, sizeof(buffer), "__ext_%s_SetNTVOptional", &pubvar[6]);
 
 			if (IPluginFunction *pFunc = pPlugin->GetBaseContext()->GetFunctionByName(buffer)) {
 				cell_t res;

--- a/core/logic/PluginSys.cpp
+++ b/core/logic/PluginSys.cpp
@@ -486,10 +486,9 @@ bool CPlugin::TryCompile()
 	char fullpath[PLATFORM_MAX_PATH];
 	g_pSM->BuildPath(Path_SM, fullpath, sizeof(fullpath), "plugins/%s", m_filename);
 
-	char loadmsg[255];
-	m_pRuntime.reset(g_pPawnEnv->LoadBinaryFromFile(fullpath, loadmsg, sizeof(loadmsg)));
+	m_pRuntime.reset(g_pPawnEnv->LoadBinaryFromFile(fullpath));
 	if (!m_pRuntime) {
-		EvictWithError(Plugin_BadLoad, "Unable to load plugin (%s)", loadmsg);
+		EvictWithError(Plugin_BadLoad, "Unable to load plugin (%s)", m_filename);
 		return false;
 	}
 

--- a/core/logic/PluginSys.h
+++ b/core/logic/PluginSys.h
@@ -125,13 +125,13 @@ public:
 	}
 
 	struct ExtVar {
-		char *name;
-		char *file;
+		std::string name;
+		std::string file;
 		bool autoload;
 		bool required;
 	};
 
-	typedef ke::Function<bool(const sp_pubvar_t *, const ExtVar& ext)> ExtVarCallback;
+	typedef ke::Function<bool(const char *pubvar_name, const ExtVar& ext)> ExtVarCallback;
 	bool ForEachExtVar(const ExtVarCallback& callback);
 
 	void ForEachLibrary(ke::Function<void(const char *)> callback);

--- a/core/logic/RootConsoleMenu.cpp
+++ b/core/logic/RootConsoleMenu.cpp
@@ -236,7 +236,7 @@ void RootConsoleMenu::OnRootConsoleCommand(const char *cmdname, const ICommandAr
 	{
 		ConsolePrint(" SourceMod Version Information:");
 		ConsolePrint("    SourceMod Version: %s", SOURCEMOD_VERSION);
-		if (g_pPawnEnv->IsJitEnabled())
+		if (g_pPawnEnv->IsJitAllowed())
 			ConsolePrint("    SourcePawn Engine: %s (build %s)", g_pPawnEnv->GetEngineName(), g_pPawnEnv->GetVersionString());
 		else
 			ConsolePrint("    SourcePawn Engine: %s (build %s NO JIT)", g_pPawnEnv->GetEngineName(), g_pPawnEnv->GetVersionString());

--- a/core/logic/smn_sorting.cpp
+++ b/core/logic/smn_sorting.cpp
@@ -37,6 +37,7 @@
 #include "CellArray.h"
 #include <IHandleSys.h>
 #include <amtl/am-raii.h>
+#include <sourcepawn/vm/base-runtime.h>
 
 /***********************************
  *   About the double array hack   *
@@ -269,21 +270,21 @@ static cell_t sm_SortStrings_Legacy(IPluginContext *pContext, const cell_t *para
 	return 1;
 }
 
-static IPluginContext* sSortContext = nullptr;
+static sp::BaseRuntime* sSortRuntime = nullptr;
 
 int sort_strings_asc(const void *blk1, const void *blk2)
 {
 	cell_t str_addr1 = *(cell_t *)blk1;
 	cell_t str_addr2 = *(cell_t *)blk2;
 
-	ARRAY_PTR h1, h2;
-	if (sSortContext->LocalToArrayPtr(str_addr1, &h1) != SP_ERROR_NONE ||
-		sSortContext->LocalToArrayPtr(str_addr2, &h2) != SP_ERROR_NONE)
+	sp::ARRAY_PTR h1, h2;
+	if (sSortRuntime->LocalToArrayPtr(str_addr1, &h1) != SP_ERROR_NONE ||
+		sSortRuntime->LocalToArrayPtr(str_addr2, &h2) != SP_ERROR_NONE)
 	{
 		return 0;
 	}
-	char *str1 = (char *)sSortContext->GetArrayData(h1);
-	char *str2 = (char *)sSortContext->GetArrayData(h2);
+	char *str1 = (char *)sSortRuntime->GetArrayData(h1);
+	char *str2 = (char *)sSortRuntime->GetArrayData(h2);
 
 	if (!str1 || !str2)
 		return 0;
@@ -296,14 +297,14 @@ int sort_strings_desc(const void *blk1, const void *blk2)
 	cell_t str_addr1 = *(cell_t *)blk1;
 	cell_t str_addr2 = *(cell_t *)blk2;
 
-	ARRAY_PTR h1, h2;
-	if (sSortContext->LocalToArrayPtr(str_addr1, &h1) != SP_ERROR_NONE ||
-		sSortContext->LocalToArrayPtr(str_addr2, &h2) != SP_ERROR_NONE)
+	sp::ARRAY_PTR h1, h2;
+	if (sSortRuntime->LocalToArrayPtr(str_addr1, &h1) != SP_ERROR_NONE ||
+		sSortRuntime->LocalToArrayPtr(str_addr2, &h2) != SP_ERROR_NONE)
 	{
 		return 0;
 	}
-	char *str1 = (char *)sSortContext->GetArrayData(h1);
-	char *str2 = (char *)sSortContext->GetArrayData(h2);
+	char *str1 = (char *)sSortRuntime->GetArrayData(h1);
+	char *str2 = (char *)sSortRuntime->GetArrayData(h2);
 
 	if (!str1 || !str2)
 		return 0;
@@ -313,19 +314,19 @@ int sort_strings_desc(const void *blk1, const void *blk2)
 
 static cell_t sm_SortStrings(IPluginContext *pContext, const cell_t *params)
 {
-	auto rt = pContext->GetRuntime();
+	auto rt = pContext->GetBaseRuntime();
 	if (!rt->UsesDirectArrays())
 		return sm_SortStrings_Legacy(pContext, params);
 
-	ARRAY_PTR handle;
-	if (pContext->LocalToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
+	sp::ARRAY_PTR handle;
+	if (rt->LocalToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
 		return 0;
 
-	cell_t *array = (cell_t *)pContext->GetArrayData(handle);
+	cell_t *array = (cell_t *)rt->GetArrayData(handle);
 	cell_t array_size = params[2];
 	cell_t type = params[3];
 
-	ke::SaveAndSet<IPluginContext*> set_context(&sSortContext, pContext);
+	ke::SaveAndSet<sp::BaseRuntime*> set_runtime(&sSortRuntime, rt);
 
 	if (type == Sort_Ascending)
 	{
@@ -498,15 +499,15 @@ static int sort2d_amx_custom(const void *elem1, const void *elem2)
 
 static cell_t sm_SortCustom2D(IPluginContext *pContext, const cell_t *params)
 {
-	auto rt = pContext->GetRuntime();
+	auto rt = pContext->GetBaseRuntime();
 	if (!rt->UsesDirectArrays())
 		return sm_SortCustom2D_Legacy(pContext, params);
 
-	ARRAY_PTR handle;
-	if (pContext->LocalToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
+	sp::ARRAY_PTR handle;
+	if (rt->LocalToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
 		return 0;
 
-	cell_t *array = (cell_t *)pContext->GetArrayData(handle);
+	cell_t *array = (cell_t *)rt->GetArrayData(handle);
 	cell_t array_size = params[2];
 	IPluginFunction *pFunction;
 

--- a/core/logic/smn_sorting.cpp
+++ b/core/logic/smn_sorting.cpp
@@ -696,6 +696,7 @@ REGISTER_NATIVES(sortNatives)
 	{"SortStrings",             sm_SortStrings},
 	{"SortCustom1D",            sm_SortCustom1D},
 	{"SortCustom2D",            sm_SortCustom2D},
+	{"SortCustom2DStrings",     sm_SortCustom2D},
 	{"SortADTArray",            sm_SortADTArray},
 	{"SortADTArrayCustom",      sm_SortADTArrayCustom},
 	

--- a/core/logic/smn_string.cpp
+++ b/core/logic/smn_string.cpp
@@ -230,6 +230,9 @@ static cell_t sm_format(IPluginContext *pCtx, const cell_t *params)
 static char g_vformatbuf[2048];
 static cell_t sm_vformat(IPluginContext *pContext, const cell_t *params)
 {
+	if (pContext->GetBaseRuntime()->AsV2() != nullptr)
+		return pContext->ThrowNativeError("VFormat is not supported in SourcePawn 2 plugins");
+
 	int vargPos = static_cast<int>(params[4]);
 
 	/* Get the parent parameter array */

--- a/extensions/clientprefs/natives.cpp
+++ b/extensions/clientprefs/natives.cpp
@@ -29,6 +29,8 @@
  * Version: $Id$
  */
 
+#include <inttypes.h>
+
 #include "extension.h"
 #include "cookie.h"
 #include "menus.h"

--- a/extensions/dhooks/AMBuilder
+++ b/extensions/dhooks/AMBuilder
@@ -24,6 +24,7 @@ for cxx in builder.targets:
     os.path.join(SM.mms_root, 'core', 'sourcehook'),
     os.path.join(builder.sourcePath, 'extensions', 'dhooks'),
     os.path.join(builder.sourcePath, 'public', 'jit'),
+    os.path.join(builder.sourcePath, 'sourcepawn'),
     os.path.join(builder.sourcePath, 'sourcepawn', 'include'),
     os.path.join(builder.sourcePath, 'sourcepawn', 'vm'),
     os.path.join(builder.sourcePath, 'extensions', 'dhooks', 'DynamicHooks'),

--- a/plugins/admin-flatfile.sp
+++ b/plugins/admin-flatfile.sp
@@ -47,7 +47,6 @@ public Plugin myinfo =
 
 /** Various parsing globals */
 bool g_LoggedFileName = false;       /* Whether or not the file name has been logged */
-int g_ErrorCount = 0;                /* Current error count */
 int g_IgnoreLevel = 0;               /* Nested ignored section count, so users can screw up files safely */
 int g_CurrentLine = 0;               /* Current line we're on */
 char g_Filename[PLATFORM_MAX_PATH];  /* Used for error messages */
@@ -84,12 +83,10 @@ void ParseError(const char[] format, any ...)
 	
 	LogError(" (line %d) %s", g_CurrentLine, buffer);
 	
-	g_ErrorCount++;
 }
 
 void InitGlobalStates()
 {
-	g_ErrorCount = 0;
 	g_IgnoreLevel = 0;
 	g_CurrentLine = 0;
 	g_LoggedFileName = false;

--- a/plugins/admin-flatfile.sp
+++ b/plugins/admin-flatfile.sp
@@ -79,7 +79,7 @@ void ParseError(const char[] format, any ...)
 		g_LoggedFileName = true;
 	}
 	
-	VFormat(buffer, sizeof(buffer), format, 2);
+	FormatEx(buffer, sizeof(buffer), format, ...);
 	
 	LogError(" (line %d) %s", g_CurrentLine, buffer);
 	

--- a/plugins/basechat.sp
+++ b/plugins/basechat.sp
@@ -403,7 +403,7 @@ void SendChatToAdmins(int from, const char[] message)
 void SendDialogToOne(int client, int color, const char[] text, any ...)
 {
 	char message[100];
-	VFormat(message, sizeof(message), text, 4);	
+	FormatEx(message, sizeof(message), text, ...);
 	
 	KeyValues kv = new KeyValues("Stuff", "title", message);
 	kv.SetColor("color", g_Colors[color][0], g_Colors[color][1], g_Colors[color][2], 255);

--- a/plugins/include/console.inc
+++ b/plugins/include/console.inc
@@ -226,7 +226,11 @@ stock void PrintToConsoleAll(const char[] format, any ...)
 		if (IsClientInGame(i))
 		{
 			SetGlobalTransTarget(i);
+#if defined __sourcepawn2
+			FormatEx(buffer, sizeof(buffer), format, ...);
+#else
 			VFormat(buffer, sizeof(buffer), format, 2);
+#endif
 			PrintToConsole(i, "%s", buffer);
 		}
 	}

--- a/plugins/include/halflife.inc
+++ b/plugins/include/halflife.inc
@@ -391,7 +391,11 @@ stock void PrintToChatAll(const char[] format, any ...)
 		if (IsClientInGame(i))
 		{
 			SetGlobalTransTarget(i);
+#if defined __sourcepawn2
+			FormatEx(buffer, sizeof(buffer), format, ...);
+#else
 			VFormat(buffer, sizeof(buffer), format, 2);
+#endif
 			PrintToChat(i, "%s", buffer);
 		}
 	}
@@ -422,7 +426,11 @@ stock void PrintCenterTextAll(const char[] format, any ...)
 		if (IsClientInGame(i))
 		{
 			SetGlobalTransTarget(i);
+#if defined __sourcepawn2
+			FormatEx(buffer, sizeof(buffer), format, ...);
+#else
 			VFormat(buffer, sizeof(buffer), format, 2);
+#endif
 			PrintCenterText(i, "%s", buffer);
 		}
 	}
@@ -453,7 +461,11 @@ stock void PrintHintTextToAll(const char[] format, any ...)
 		if (IsClientInGame(i))
 		{
 			SetGlobalTransTarget(i);
+#if defined __sourcepawn2
+			FormatEx(buffer, sizeof(buffer), format, ...);
+#else
 			VFormat(buffer, sizeof(buffer), format, 2);
+#endif
 			PrintHintText(i, "%s", buffer);
 		}
 	}

--- a/plugins/include/sorting.inc
+++ b/plugins/include/sorting.inc
@@ -119,11 +119,15 @@ native void SortCustom1D(int[] array, int array_size, SortFunc1D sortfunc, Handl
  *                      0 if first is equal to second
  *                      1 if first should go after second
  */
+#if defined __sourcepawn2
+typedef SortFunc2D = function int (int[] elem1, int[] elem2, const int[][] array, Handle hndl);
+#else
 typeset SortFunc2D
 {
 	function int (int[] elem1, int[] elem2, const int[][] array, Handle hndl);
 	function int (char[] elem1, char[] elem2, const char[][] array, Handle hndl);
 };
+#endif
 
 /**
  * Sorts a custom 2D array.  You must pass in a comparison function.
@@ -134,6 +138,31 @@ typeset SortFunc2D
  * @param hndl          Optional Handle to pass through the comparison calls.
  */
 native void SortCustom2D(any[][] array, int array_size, SortFunc2D sortfunc, Handle hndl=INVALID_HANDLE);
+
+#if defined __sourcepawn2
+/**
+ * Sort comparison function for 2D char-array elements (sub-strings).
+ *
+ * @param elem1         First string to compare.
+ * @param elem2         Second string to compare.
+ * @param array         Array that is being sorted (order is undefined).
+ * @param hndl          Handle optionally passed in while sorting.
+ * @return              -1 if first should go before second
+ *                      0 if first is equal to second
+ *                      1 if first should go after second
+ */
+typedef SortFunc2DStrings = function int (char[] elem1, char[] elem2, const char[][] array, Handle hndl);
+
+/**
+ * Sorts a custom 2D char-array.  You must pass in a comparison function.
+ *
+ * @param array         Array to sort.
+ * @param array_size    Size of the major array to sort (first index, outermost).
+ * @param sortfunc      Sort comparison function to use.
+ * @param hndl          Optional Handle to pass through the comparison calls.
+ */
+native void SortCustom2DStrings(char[][] array, int array_size, SortFunc2DStrings sortfunc, Handle hndl=INVALID_HANDLE);
+#endif
 
 /**
  * Sort an ADT Array. Specify the type as Integer, Float, or String.

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -165,6 +165,7 @@ native int Format(char[] buffer, int maxlength, const char[] format, any ...);
  */
 native int FormatEx(char[] buffer, int maxlength, const char[] format, any ...);
 
+#if !defined __sourcepawn2
 /**
  * Formats a string according to the SourceMod format rules (see documentation).
  * @note This is the same as Format(), except it grabs parameters from a 
@@ -181,6 +182,7 @@ native int FormatEx(char[] buffer, int maxlength, const char[] format, any ...);
  * @error               Invalid argument index.
  */
 native int VFormat(char[] buffer, int maxlength, const char[] format, int varpos);
+#endif
 
 /**
  * Converts a string to an integer.

--- a/plugins/testsuite/mock/test_sorting.sp
+++ b/plugins/testsuite/mock/test_sorting.sp
@@ -163,7 +163,7 @@ void Test_Sort2D() {
         "sidluke",
         "sniperbeamer"
     };
-    SortCustom2D(view_as<any>(strarray), sizeof(strarray), Custom2DSortString);
+    SortCustom2DStrings(strarray, sizeof(strarray), Custom2DSortString);
     AssertStrArrayEq("SortCustom2D char[][] Ascending", strarray, expected_ascending, sizeof(strarray));
 }
 

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -138,9 +138,10 @@ namespace SourceMod
 	 * V7 - added OnDependenciesDropped() to IExtensionInterface.
 	 * V8 - added OnCoreMapEnd() to IExtensionInterface.
 	 * V9 - SourcePawn API revamp
+	 * V10 - SourcePawn 2 API.
 	 */
-	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	9
-	#define SMINTERFACE_EXTENSIONAPI_VERSION		9
+	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	10
+	#define SMINTERFACE_EXTENSIONAPI_VERSION		10
 
 	/**
 	 * @brief The interface an extension must expose.

--- a/tools/checkout-deps.sh
+++ b/tools/checkout-deps.sh
@@ -137,7 +137,7 @@ origin=
 checkout
 
 if [ -z ${sdks+x} ]; then
-  sdks=( csgo hl2dm nucleardawn l4d2 dods l4d css tf2 insurgency sdk2013 doi )
+  sdks=( csgo hl2dm nucleardawn l4d2 dods l4d css tf2 insurgency sdk2013 doi mcv )
 
   if [ $ismac -eq 0 ]; then
     # Add these SDKs for Windows or Linux


### PR DESCRIPTION
You can read more about the 2.0 changes here: https://github.com/alliedmodders/sourcepawn/blob/master/docs/SourcePawn2.md

SourceMod now requires a C++20 compiler. Also, we had to break the extension API again, since LocalToArrayPtr was removed from IPluginContext.

Note that SourceMod doesn't have access to new SP features yet. Natives cannot interact with closures or objects in any way. However, the new language features will still run locally within scripts, and now SourceMod can load v2 .smx binaries.

The spcomp bundled with SourceMod is now the v2 compiler. Most v1 era plugins will continue to compile and run fine. Usually only severe type errors will cause an old plugin to be rejected. For affected plugins, if fixing these issues is not desired, the 1.13 compiler is still provided as "oldspcomp". Bugs in this compiler will not be fixed, in order to preserve its behavior.

As always, please report language and runtime bugs in the [SourcePawn project](https://github.com/alliedmodders/sourcepawn). Language feature requests go there too.