### PR TITLE
Add `VFormat` macro for backwards compatibility

### DIFF
--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -165,7 +165,12 @@ native int Format(char[] buffer, int maxlength, const char[] format, any ...);
  */
 native int FormatEx(char[] buffer, int maxlength, const char[] format, any ...);
 
-#if !defined __sourcepawn2
+#if defined __sourcepawn2
+
+// #pragma deprecated VFormat got replaced by spreading the variable arguments in SourcePawn 2: Format(buffer, sizeof(buffer), format, ...)
+#define VFormat(%1,%2,%3,%4) Format(%1, %2, %3, ...)
+
+#else
 /**
  * Formats a string according to the SourceMod format rules (see documentation).
  * @note This is the same as Format(), except it grabs parameters from a 


### PR DESCRIPTION
`VFormat` was removed in 65ce00763aaee4e9888c1d449bad18b91519a675 since SourcePawn 2 supports passing the variable arguments through to another function natively. Instead of using `VFormat` you can just call `Format(buf, sizeof(buf), fmt, ...)` directly with the ellipsis `...`.

This broke plugins using VFormat when compiled with the SourcePawn 2 compiler. Add a macro to transparently replace `VFormat` with `Format` calls when compiling with the SourcePawn 2 compiler to keep the plugins from complaining about a missing `VFormat`.

Preprocessor macros are not affected by `#pragma deprecated` so we cannot warn about this yet.