### PR TITLE
bintools (x64): Use an absolute call when the callee is more than 2 GB away

### DIFF
--- a/extensions/bintools/jit_call_x64.cpp
+++ b/extensions/bintools/jit_call_x64.cpp
@@ -891,8 +891,7 @@ inline void Write_CallFunction(JitWriter *jit, FuncAddrMethod method, CallWrappe
 	if (method == FuncAddr_Direct)
 	{
 		int64_t diff = (intptr_t)pWrapper->GetCalleeAddr() - ((intptr_t)jit->outbase + jit->get_outputpos() + 5);
-		int32_t upperBits = (diff >> 32);
-		if (upperBits == 0 || upperBits == -1) {
+		if (jit->outbase && diff == (int64_t)(int32_t)diff) {
 			//call <addr>
 			jitoffs_t call = X64_Call_Imm32(jit, 0);
 			X64_Write_Jump32_Abs(jit, call, pWrapper->GetCalleeAddr());


### PR DESCRIPTION
`Write_CallFunction` emits `call rel32` whenever `diff >> 32` is 0 or -1, which also accepts displacements between 2 and 4 GB. Those get sign-extended and the call lands 4 GB away from the callee.

This has been here for 9 years, but only triggers now because SP2 reserves 2 GB for virtual addresses, which pushes the code pools more than 2 GB away from server_srv.so. So currently, every direct SDKCall crashes on 64-bit Linux.

Fall back to an absolute call when the callee is out of reach, and size the stub for the longer form up front.