### PR TITLE
Adapt CVTableHookDetails to templated KHook::GetContext

### DIFF
--- a/public/vtable_hook_helper.h
+++ b/public/vtable_hook_helper.h
@@ -126,12 +126,12 @@ private:
 		}
 
 		RETURN _KHOOK_CALLBACK_PRE(ARGS... args) {
-			auto real_this = (Self*)KHook::GetContext();
+			auto real_this = KHook::GetContext<Self>();
 			return real_this->_KHOOK_CALLBACK(true, (CLASSNAME*)this, args...);
 		}
 
 		RETURN _KHOOK_CALLBACK_POST(ARGS... args) {
-			auto real_this = (Self*)KHook::GetContext();
+			auto real_this = KHook::GetContext<Self>();
 			return real_this->_KHOOK_CALLBACK(false, (CLASSNAME*)this, args...);
 		}
 
@@ -159,7 +159,7 @@ private:
 		}
 
 		static void _KHOOK_REMOVE(KHook::HookID_t) {
-			delete (Self*)KHook::GetContext();
+			delete KHook::GetContext<Self>();
 		}
 
 		KHook::HookID_t _id;


### PR DESCRIPTION
https://github.com/Kenzzer/KHook/commit/96f3c610ce2153905d9c6d7ff0941e1c55978249 templated some functions and it seems the SM side was not updated for it.