### PR TITLE
GetFunctionByName: return the runtime's funcid instead of deriving it from the public index

### DIFF
--- a/core/logic/smn_functions.cpp
+++ b/core/logic/smn_functions.cpp
@@ -91,12 +91,6 @@ public:
 } g_ForwardNativeHelpers;
 
 
-/* Turn a public index into a function ID */
-inline funcid_t PublicIndexToFuncId(uint32_t idx)
-{
-	return (idx << 1) | (1 << 0);
-}
-
 /* Reset global function/forward call variables */
 inline void ResetCall()
 {
@@ -135,8 +129,13 @@ static cell_t sm_GetFunctionByName(IPluginContext *pContext, const cell_t *param
 		return pContext->GetNullFunctionValue();
 	}
 
+	/* Turn a public index into a function ID */
+	sp_public_t *func;
+	if (pPlugin->GetBaseContext()->GetBaseRuntime()->GetPublicByIndex(idx, &func) != SP_ERROR_NONE)
+		return pContext->GetNullFunctionValue();
+
 	/* Return function ID */
-	return PublicIndexToFuncId(idx);
+	return func->funcid;
 }
 
 static cell_t sm_CreateGlobalForward(IPluginContext *pContext, const cell_t *params)

--- a/plugins/testsuite/mock/test_function.sp
+++ b/plugins/testsuite/mock/test_function.sp
@@ -16,12 +16,13 @@ void Test_GetFunctionByName()
     SetTestContext("Test GetFunctionByName");
 
     Function func = GetFunctionByName(INVALID_HANDLE, "__Func");
-    AssertTrue("Valid function", func != INVALID_FUNCTION);
+    AssertTrue("Function is valid", func != INVALID_FUNCTION);
+    AssertTrue("Function is __Func", func == __Func);
 
-    int a = 1, b = 2, result = 0;
+    int result = 0;
     Call_StartFunction(INVALID_HANDLE, func);
-    Call_PushCell(a);
-    Call_PushCell(b);
+    Call_PushCell(1);
+    Call_PushCell(2);
     Call_Finish(result);
     AssertEq("Function result", result, 3);
 }
@@ -29,5 +30,7 @@ void Test_GetFunctionByName()
 
 public int __Func(int a, int b)
 {
+    AssertEq("__Func param a", a, 1);
+    AssertEq("__Func param b", b, 2);
     return a + b;
 }

--- a/plugins/testsuite/mock/test_function.sp
+++ b/plugins/testsuite/mock/test_function.sp
@@ -1,0 +1,33 @@
+#pragma semicolon 1
+#pragma newdecls required
+
+#include <sourcemod>
+#include <testing>
+
+
+public void OnPluginStart()
+{
+    Test_GetFunctionByName();
+}
+
+
+void Test_GetFunctionByName()
+{
+    SetTestContext("Test GetFunctionByName");
+
+    Function func = GetFunctionByName(INVALID_HANDLE, "__Func");
+    AssertTrue("Valid function", func != INVALID_FUNCTION);
+
+    int a = 1, b = 2, result = 0;
+    Call_StartFunction(INVALID_HANDLE, func);
+    Call_PushCell(a);
+    Call_PushCell(b);
+    Call_Finish(result);
+    AssertEq("Function result", result, 3);
+}
+
+
+public int __Func(int a, int b)
+{
+    return a + b;
+}


### PR DESCRIPTION
Resolved alliedmodders/sourcepawn#1168

[sm_GetFunctionByName()](https://github.com/alliedmodders/sourcemod/blob/d75d4101005895919308f0209deb58fa95ef2475/core/logic/smn_functions.cpp#L109) derived the function id from the public table index by reimplementing SourcePawn's (index << 1) | 1 encoding in a local [PublicIndexToFuncId()](https://github.com/alliedmodders/sourcemod/blob/d75d4101005895919308f0209deb58fa95ef2475/core/logic/smn_functions.cpp#L95) helper. That encoding is owned by the VM, and sp_public_t already carries the authoritative funcid, so the local copy duplicated it and could silently disagree with the runtime.

Fetch the public entry and return its funcid instead, and fall back to INVALID_FUNCTION if the index lookup fails rather than returning an id that was never validated against the public table.
