### PR TITLE
Fixes a crash when using SortCustom1D or SortCustom2D with SourcePawn v2 direct arrays

### DIFF
--- a/core/logic/smn_sorting.cpp
+++ b/core/logic/smn_sorting.cpp
@@ -319,7 +319,7 @@ static cell_t sm_SortStrings(IPluginContext *pContext, const cell_t *params)
 		return sm_SortStrings_Legacy(pContext, params);
 
 	sp::ARRAY_PTR handle;
-	if (rt->LocalToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
+	if (rt->ParamToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
 		return 0;
 
 	cell_t *array = (cell_t *)rt->GetArrayData(handle);
@@ -504,7 +504,7 @@ static cell_t sm_SortCustom2D(IPluginContext *pContext, const cell_t *params)
 		return sm_SortCustom2D_Legacy(pContext, params);
 
 	sp::ARRAY_PTR handle;
-	if (rt->LocalToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
+	if (rt->ParamToArrayPtr(params[1], &handle) != SP_ERROR_NONE)
 		return 0;
 
 	cell_t *array = (cell_t *)rt->GetArrayData(handle);


### PR DESCRIPTION
Fix the SourceMod `MockTest` workflow failure caused by sorting tests crashing with SourcePawn v2 direct arrays.

Based on the array parameter handling in [sourcepawn/vm/shell/shell.cpp](https://github.com/alliedmodders/sourcepawn/blob/9d52507f56c262cb5444fe15108daaa43172d05a/vm/shell/shell.cpp#L527), replace `LocalToArrayPtr()` with `ParamToArrayPtr()` in the affected sorting code.

This correctly handles array parameters and fixes the `MockTest` failure.