### PR TITLE
Remove support for reloading extensions 

### DIFF
--- a/bridge/include/BridgeAPI.h
+++ b/bridge/include/BridgeAPI.h
@@ -35,7 +35,7 @@ namespace SourceMod {
 
 // Add 1 to the RHS of this expression to bump the intercom file
 // This is to prevent mismatching core/logic binaries
-static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 57;
+static const uint32_t SM_LOGIC_MAGIC = 0x0F47C0DE - 58;
 
 } // namespace SourceMod
 

--- a/bridge/include/IExtensionBridge.h
+++ b/bridge/include/IExtensionBridge.h
@@ -50,7 +50,6 @@ public:
 	virtual void CallOnCoreMapStart(edict_t *edictList, int edictCount, int maxClients) = 0;
 	virtual IExtension *GetExtensionFromIdent(IdentityToken_t *token) = 0;
 	virtual void BindChildPlugin(IExtension *ext, SMPlugin *plugin) = 0;
-	virtual void AddRawDependency(IExtension *myself, IdentityToken_t *token, void *iface) = 0;
 	virtual const CVector<IExtension *> *ListExtensions() = 0;
 	virtual void FreeExtensionList(const CVector<IExtension *> *list) = 0;
 	virtual void CallOnCoreMapEnd() = 0;

--- a/core/logic/Database.cpp
+++ b/core/logic/Database.cpp
@@ -691,8 +691,3 @@ std::string DBManager::GetDefaultDriverName()
 	ConfDbInfoList &list = m_Builder.GetConfigList();
 	return list.GetDefaultDriver();
 }
-
-void DBManager::AddDependency(IExtension *myself, IDBDriver *driver)
-{
-	/* Deprecated no-op, see IDBManager::AddDependency(). */
-}

--- a/core/logic/Database.cpp
+++ b/core/logic/Database.cpp
@@ -694,5 +694,5 @@ std::string DBManager::GetDefaultDriverName()
 
 void DBManager::AddDependency(IExtension *myself, IDBDriver *driver)
 {
-	g_Extensions.AddRawDependency(myself, driver->GetIdentity(), driver);
+	/* Deprecated no-op, see IDBManager::AddDependency(). */
 }

--- a/core/logic/Database.h
+++ b/core/logic/Database.h
@@ -80,7 +80,6 @@ public: //IDBManager
 	Handle_t CreateHandle(DBHandleType type, void *ptr, IdentityToken_t *pToken);
 	HandleError ReadHandle(Handle_t hndl, DBHandleType type, void **ptr);
 	HandleError ReleaseHandle(Handle_t hndl, DBHandleType type, IdentityToken_t *token);
-	void AddDependency(IExtension *myself, IDBDriver *driver);
 public: //ke::IRunnable
 	void Run();
 	void ThreadMain();

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -678,12 +678,6 @@ void CExtensionManager::OnPluginDestroyed(IPlugin *plugin)
 	}
 }
 
-bool CExtensionManager::UnloadExtension(IExtension *_pExt)
-{
-	/* Deprecated, see Shutdown() for the only path that unloads extensions. */
-	return false;
-}
-
 void CExtensionManager::MarkAllLoaded()
 {
 	List<CExtension *>::iterator iter;

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -374,22 +374,6 @@ bool CLocalExtension::IsLoaded()
 	return (m_pLib != NULL);
 }
 
-// note: dependency iteration deprecated since 1.10
-ITERATOR *CExtension::FindFirstDependency(IExtension **pOwner, SMInterface **pInterface)
-{
-	return nullptr;
-}
-
-bool CExtension::FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface)
-{
-	return false;
-}
-
-void CExtension::FreeDependencyIterator(ITERATOR *iter)
-{
-
-}
-
 void CExtension::AddInterface(SMInterface *pInterface)
 {
 	m_Interfaces.push_back(pInterface);
@@ -979,10 +963,7 @@ void CExtensionManager::CallOnCoreMapStart(edict_t *pEdictList, int edictCount, 
 		{
 			continue;
 		}
-		if (pAPI->GetExtensionVersion() > 3)
-		{
-			pAPI->OnCoreMapStart(pEdictList, edictCount, clientMax);
-		}
+		pAPI->OnCoreMapStart(pEdictList, edictCount, clientMax);
 	}
 }
 
@@ -997,10 +978,7 @@ void CExtensionManager::CallOnCoreMapEnd()
 		{
 			continue;
 		}
-		if (pAPI->GetExtensionVersion() > 7)
-		{
-			pAPI->OnCoreMapEnd();
-		}
+		pAPI->OnCoreMapEnd();
 	}
 }
 

--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -51,7 +51,6 @@ void CExtension::Initialize(const char *filename, const char *path, bool bRequir
 	m_bRequired = bRequired;
 	m_pAPI = NULL;
 	m_pIdentToken = NULL;
-	unload_code = 0;
 	m_bFullyLoaded = false;
 	m_File.assign(filename);
 	m_Path.assign(path);
@@ -244,23 +243,6 @@ void CLocalExtension::Unload()
 	m_bFullyLoaded = false;
 }
 
-bool CRemoteExtension::Reload(char *error, size_t maxlength)
-{
-	ke::SafeStrcpy(error, maxlength, "Remote extensions do not support reloading");
-	return false;
-}
-
-bool CLocalExtension::Reload(char *error, size_t maxlength)
-{
-	if (m_pLib == NULL) // FIXME: just load it instead?
-		return false;
-	
-	m_pAPI->OnExtensionUnload();
-	Unload();
-	
-	return Load(error, maxlength);
-}
-
 bool CRemoteExtension::IsExternal()
 {
 	return true;
@@ -392,35 +374,6 @@ bool CLocalExtension::IsLoaded()
 	return (m_pLib != NULL);
 }
 
-void CExtension::AddDependency(const IfaceInfo *pInfo)
-{
-	if (m_Deps.find(*pInfo) == m_Deps.end())
-	{
-		m_Deps.push_back(*pInfo);
-	}
-}
-
-void CExtension::AddChildDependent(CExtension *pOther, SMInterface *iface)
-{
-	IfaceInfo info;
-	info.iface = iface;
-	info.owner = pOther;
-
-	List<IfaceInfo>::iterator iter;
-	for (iter = m_ChildDeps.begin();
-		 iter != m_ChildDeps.end();
-		 iter++)
-	{
-		IfaceInfo &other = (*iter);
-		if (other == info)
-		{
-			return;
-		}
-	}
-
-	m_ChildDeps.push_back(info);
-}
-
 // note: dependency iteration deprecated since 1.10
 ITERATOR *CExtension::FindFirstDependency(IExtension **pOwner, SMInterface **pInterface)
 {
@@ -491,7 +444,37 @@ void CExtensionManager::Shutdown()
 
 	while ((iter = m_Libs.begin()) != m_Libs.end())
 	{
-		UnloadExtension((*iter));
+		CExtension *pExt = (*iter);
+		m_Libs.erase(iter);
+
+		/* Tell it to unload */
+		if (pExt->IsLoaded())
+			pExt->GetAPI()->OnExtensionUnload();
+
+		g_ShareSys.RemoveInterfaces(pExt);
+
+		/* Unbind our natives from Core */
+		if (pExt->IsLoaded())
+			pExt->DropEverything();
+
+		IdentityToken_t *pIdentity;
+		if ((pIdentity = pExt->GetIdentity()) != NULL)
+		{
+			SMGlobalClass *glob = SMGlobalClass::head;
+			while (glob)
+			{
+				glob->OnSourceModIdentityDropped(pIdentity);
+				glob = glob->m_pGlobalClassNext;
+			}
+		}
+
+		// Everything has been informed that we're unloading, so give the
+		// extension one last notification.
+		if (pExt->IsLoaded())
+			pExt->GetAPI()->OnDependenciesDropped();
+
+		pExt->Unload();
+		delete pExt;
 	}
 }
 
@@ -671,34 +654,6 @@ IExtension *CExtensionManager::LoadExtension(const char *file, char *error, size
 	return pExt;
 }
 
-void CExtensionManager::BindDependency(IExtension *pRequester, IfaceInfo *pInfo)
-{
-	CExtension *pExt = (CExtension *)pRequester;
-	CExtension *pOwner = (CExtension *)pInfo->owner;
-
-	pExt->AddDependency(pInfo);
-
-	IExtensionInterface *pAPI = pExt->GetAPI();
-	if (pAPI && !pAPI->QueryInterfaceDrop(pInfo->iface))
-	{
-		pOwner->AddChildDependent(pExt, pInfo->iface);
-	}
-}
-
-void CExtensionManager::AddRawDependency(IExtension *ext, IdentityToken_t *other, void *iface)
-{
-	CExtension *pExt = (CExtension *)ext;
-	CExtension *pOwner = GetExtensionFromIdent(other);
-
-	IfaceInfo info;
-
-	info.iface = (SMInterface *)iface;
-	info.owner = pOwner;
-
-	pExt->AddDependency(&info);
-	pOwner->AddChildDependent(pExt, (SMInterface *)iface);
-}
-
 void CExtensionManager::AddInterface(IExtension *pOwner, SMInterface *pInterface)
 {
 	CExtension *pExt = (CExtension *)pOwner;
@@ -723,146 +678,10 @@ void CExtensionManager::OnPluginDestroyed(IPlugin *plugin)
 	}
 }
 
-CExtension *CExtensionManager::FindByOrder(unsigned int num)
-{
-	if (num < 1 || num > m_Libs.size())
-	{
-		return NULL;
-	}
-
-	List<CExtension *>::iterator iter = m_Libs.begin();
-
-	while (iter != m_Libs.end())
-	{
-		if (--num == 0)
-		{
-			return (*iter);
-		}
-		iter++;
-	}
-
-	return NULL;
-}
-
 bool CExtensionManager::UnloadExtension(IExtension *_pExt)
 {
-	if (!_pExt)
-		return false;
-
-	CExtension *pExt = (CExtension *)_pExt;
-
-	if (m_Libs.find(pExt) == m_Libs.end())
-		return false;
-
-	/* Tell it to unload */
-	if (pExt->IsLoaded())
-		pExt->GetAPI()->OnExtensionUnload();
-
-	// Remove us from internal lists. Note that because we do this, it's
-	// possible that our extension could be added back if another plugin
-	// tries to load during this process. If we ever find this to happen,
-	// we can just block plugin loading.
-	g_ShareSys.RemoveInterfaces(_pExt);
-	m_Libs.remove(pExt);
-
-	List<CExtension *> UnloadQueue;
-
-	/* Handle dependencies */
-	if (pExt->IsLoaded())
-	{
-		/* Unload any dependent plugins */
-		List<CPlugin *>::iterator p_iter = pExt->m_Dependents.begin();
-		while (p_iter != pExt->m_Dependents.end())
-		{
-			/* We have to manually unlink ourselves here, since we're no longer being managed */
-			scripts->UnloadPlugin((*p_iter));
-			p_iter = pExt->m_Dependents.erase(p_iter);
-		}
-
-		List<String>::iterator s_iter;
-		for (s_iter = pExt->m_Libraries.begin();
-			 s_iter != pExt->m_Libraries.end();
-			 s_iter++)
-		{
-			scripts->OnLibraryAction((*s_iter).c_str(), LibraryAction_Removed);
-		}
-
-		/* Notify and/or unload all dependencies */
-		List<CExtension *>::iterator c_iter;
-		CExtension *pDep;
-		IExtensionInterface *pAPI;
-		for (c_iter = m_Libs.begin(); c_iter != m_Libs.end(); c_iter++)
-		{
-			pDep = (*c_iter);
-			if ((pAPI=pDep->GetAPI()) == NULL)
-				continue;
-			if (pDep == pExt)
-				continue;
-			/* Now, get its dependency list */
-			bool dropped = false;
-			List<IfaceInfo>::iterator i_iter = pDep->m_Deps.begin();
-			while (i_iter != pDep->m_Deps.end())
-			{
-				if ((*i_iter).owner == _pExt)
-				{
-					if (!pAPI->QueryInterfaceDrop((*i_iter).iface))
-					{
-						if (!dropped)
-						{
-							dropped = true;
-							UnloadQueue.push_back(pDep);
-						}
-					}
-					pAPI->NotifyInterfaceDrop((*i_iter).iface);
-					i_iter = pDep->m_Deps.erase(i_iter);
-				}
-				else
-				{
-					i_iter++;
-				}
-			}
-			/* Flush out any back references to this plugin */
-			i_iter = pDep->m_ChildDeps.begin();
-			while (i_iter != pDep->m_ChildDeps.end())
-			{
-				if ((*i_iter).owner == pExt)
-					i_iter = pDep->m_ChildDeps.erase(i_iter);
-				else
-					i_iter++;
-			}
-		}
-
-		/* Unbind our natives from Core */
-		pExt->DropEverything();
-	}
-
-	IdentityToken_t *pIdentity;
-	if ((pIdentity = pExt->GetIdentity()) != NULL)
-	{
-		SMGlobalClass *glob = SMGlobalClass::head;
-		while (glob)
-		{
-			glob->OnSourceModIdentityDropped(pIdentity);
-			glob = glob->m_pGlobalClassNext;
-		}
-	}
-
-	// Everything has been informed that we're unloading, so give the
-	// extension one last notification.
-	if (pExt->IsLoaded() && pExt->GetAPI()->GetExtensionVersion() >= 7)
-		pExt->GetAPI()->OnDependenciesDropped();
-
-	pExt->Unload();
-	delete pExt;
-
-	List<CExtension *>::iterator iter;
-	for (iter=UnloadQueue.begin(); iter!=UnloadQueue.end(); iter++)
-	{
-		/* NOTE: This is safe because the unload function backs out of anything not present */
-		UnloadExtension((*iter));
-	}
-
-	return true;
+	/* Deprecated, see Shutdown() for the only path that unloads extensions. */
+	return false;
 }
 
 void CExtensionManager::MarkAllLoaded()
@@ -1073,174 +892,12 @@ void CExtensionManager::OnRootConsoleCommand(const char *cmdname, const ICommand
 			}
 			return;
 		}
-		else if (strcmp(cmd, "unload") == 0)
-		{
-			if (argcount < 4)
-			{
-				rootmenu->ConsolePrint("[SM] Usage: sm exts unload <#> [code]");
-				return;
-			}
-
-			const char *arg = command->Arg(3);
-			unsigned int num = atoi(arg);
-			CExtension *pExt = FindByOrder(num);
-
-			if (!pExt)
-			{
-				rootmenu->ConsolePrint("[SM] Extension number %d was not found.", num);
-				return;
-			}
-
-			if (argcount > 4 && pExt->unload_code)
-			{
-				const char *unload = command->Arg(4);
-				if (pExt->unload_code == (unsigned)atoi(unload))
-				{
-					char filename[PLATFORM_MAX_PATH];
-					ke::SafeStrcpy(filename, PLATFORM_MAX_PATH, pExt->GetFilename());
-					UnloadExtension(pExt);
-					rootmenu->ConsolePrint("[SM] Extension %s is now unloaded.", filename);
-				}
-				else
-				{
-					rootmenu->ConsolePrint("[SM] Please try again, the correct unload code is \"%d\"", pExt->unload_code);
-				}
-				return;
-			}
-
-			if (!pExt->IsLoaded() 
-				|| (!pExt->m_ChildDeps.size() && !pExt->m_Dependents.size()))
-			{
-				char filename[PLATFORM_MAX_PATH];
-				ke::SafeStrcpy(filename, PLATFORM_MAX_PATH, pExt->GetFilename());
-				UnloadExtension(pExt);
-				rootmenu->ConsolePrint("[SM] Extension %s is now unloaded.", filename);
-				return;
-			}
-			else
-			{
-				List<CPlugin *> plugins;
-				if (pExt->m_ChildDeps.size())
-				{
-					rootmenu->ConsolePrint("[SM] Unloading %s will unload the following extensions: ", pExt->GetFilename());
-					List<CExtension *>::iterator iter;
-					CExtension *pOther;
-					/* Get list of all extensions */
-					for (iter=m_Libs.begin(); iter!=m_Libs.end(); iter++)
-					{
-						List<IfaceInfo>::iterator i_iter;
-						pOther = (*iter);
-						if (!pOther->IsLoaded() || pOther == pExt)
-						{
-							continue;
-						}
-						/* Get their dependencies */
-						for (i_iter=pOther->m_Deps.begin();
-							 i_iter!=pOther->m_Deps.end();
-							 i_iter++)
-						{
-							/* Is this dependency to us? */
-							if ((*i_iter).owner != pExt)
-							{
-								continue;
-							}
-							/* Will our dependent care? */
-							if (!pExt->GetAPI()->QueryInterfaceDrop((*i_iter).iface))
-							{
-								rootmenu->ConsolePrint(" -> %s", pOther->GetFilename());
-								/* Add to plugin unload list */
-								List<CPlugin *>::iterator p_iter;
-								for (p_iter=pOther->m_Dependents.begin();
-									 p_iter!=pOther->m_Dependents.end();
-									 p_iter++)
-								{
-									if (plugins.find((*p_iter)) == plugins.end())
-									{
-										plugins.push_back((*p_iter));
-									}
-								}
-							}
-						}
-					}
-				}
-				if (pExt->m_Dependents.size())
-				{
-					rootmenu->ConsolePrint("[SM] Unloading %s will unload the following plugins: ", pExt->GetFilename());
-					List<CPlugin *>::iterator iter;
-					CPlugin *pPlugin;
-					for (iter = pExt->m_Dependents.begin(); iter != pExt->m_Dependents.end(); iter++)
-					{
-						pPlugin = (*iter);
-						if (plugins.find(pPlugin) == plugins.end())
-						{
-							plugins.push_back(pPlugin);
-						}
-					}
-					for (iter = plugins.begin(); iter != plugins.end(); iter++)
-					{
-						pPlugin = (*iter);
-						rootmenu->ConsolePrint(" -> %s", pPlugin->GetFilename());
-					}
-				}
-				pExt->unload_code = (rand() % 877) + 123;	//123 to 999
-				rootmenu->ConsolePrint("[SM] To verify unloading %s, please use the following: ", pExt->GetFilename());
-				rootmenu->ConsolePrint("[SM] sm exts unload %d %d", num, pExt->unload_code);
-
-				return;
-			}
-		}
-		else if (strcmp(cmd, "reload") == 0)
-		{
-			if (argcount < 4)
-			{
-				rootmenu->ConsolePrint("[SM] Usage: sm exts reload <#>");
-				return;
-			}
-			
-			const char *arg = command->Arg(3);
-			unsigned int num = atoi(arg);
-			CExtension *pExt = FindByOrder(num);
-
-			if (!pExt)
-			{
-				rootmenu->ConsolePrint("[SM] Extension number %d was not found.", num);
-				return;
-			}
-			
-			if (pExt->IsLoaded())
-			{
-				char filename[PLATFORM_MAX_PATH];
-				char error[255];
-				
-				ke::SafeStrcpy(filename, PLATFORM_MAX_PATH, pExt->GetFilename());
-				
-				if (pExt->Reload(error, sizeof(error)))
-				{
-					rootmenu->ConsolePrint("[SM] Extension %s is now reloaded.", filename);
-				}
-				else
-				{
-					rootmenu->ConsolePrint("[SM] Extension %s failed to reload: %s", filename, error);
-				}
-					
-				return;
-			} 
-			else
-			{
-				rootmenu->ConsolePrint("[SM] Extension %s is not loaded.", pExt->GetFilename());
-				
-				return;
-			}
-			
-		}
 	}
 
 	rootmenu->ConsolePrint("SourceMod Extensions Menu:");
 	rootmenu->DrawGenericOption("info", "Extra extension information");
 	rootmenu->DrawGenericOption("list", "List extensions");
 	rootmenu->DrawGenericOption("load", "Load an extension");
-	rootmenu->DrawGenericOption("reload", "Reload an extension");
-	rootmenu->DrawGenericOption("unload", "Unload an extension");
 }
 
 CExtension *CExtensionManager::GetExtensionFromIdent(IdentityToken_t *ptr)

--- a/core/logic/ExtensionSys.h
+++ b/core/logic/ExtensionSys.h
@@ -68,9 +68,6 @@ public: //IExtension
 	const char *GetFilename();
 	const char *GetPath() const;
 	IdentityToken_t *GetIdentity();
-	ITERATOR *FindFirstDependency(IExtension **pOwner, SMInterface **pInterface);
-	bool FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface);
-	void FreeDependencyIterator(ITERATOR *iter);
 	bool IsRunning(char *error, size_t maxlength);
 public:
 	void SetError(const char *error);

--- a/core/logic/ExtensionSys.h
+++ b/core/logic/ExtensionSys.h
@@ -145,7 +145,6 @@ public: //IExtensionManager
 	IExtension *LoadExtension(const char *path, 
 		char *error,
 		size_t maxlength);
-	bool UnloadExtension(IExtension *pExt);
 	IExtension *FindExtensionByFile(const char *file);
 	IExtension *FindExtensionByName(const char *ext);
 	IExtension *LoadExternal(IExtensionInterface *pInterface,

--- a/core/logic/ExtensionSys.h
+++ b/core/logic/ExtensionSys.h
@@ -74,8 +74,6 @@ public: //IExtension
 	bool IsRunning(char *error, size_t maxlength);
 public:
 	void SetError(const char *error);
-	void AddDependency(const IfaceInfo *pInfo);
-	void AddChildDependent(CExtension *pOther, SMInterface *iface);
 	void AddInterface(SMInterface *pInterface);
 	void AddPlugin(CPlugin *pPlugin);
 	void MarkAllLoaded();
@@ -85,7 +83,6 @@ public:
 	virtual bool Load(char *error, size_t maxlength);
 	virtual bool IsLoaded() =0;
 	virtual void Unload() =0;
-	virtual bool Reload(char *error, size_t maxlength) =0;
 	virtual bool IsSameFile(const char* file) =0;
 protected:
 	void Initialize(const char *filename, const char *path, bool bRequired = true);
@@ -99,11 +96,8 @@ protected:
 	String m_RealFile;
 	String m_Path;
 	String m_Error;
-	List<IfaceInfo> m_Deps;			/** Dependencies */
-	List<IfaceInfo> m_ChildDeps;	/** Children who might depend on us */
 	List<SMInterface *> m_Interfaces;
 	List<String> m_Libraries;
-	unsigned int unload_code;
 	bool m_bFullyLoaded;
 	bool m_bRequired;
 };
@@ -116,7 +110,6 @@ public:
 	bool Load(char *error, size_t maxlength);
 	bool IsLoaded();
 	void Unload();
-	bool Reload(char *error, size_t maxlength);
 	bool IsExternal();
 	bool IsSameFile(const char *file);
 private:
@@ -132,7 +125,6 @@ public:
 	bool Load(char *error, size_t maxlength);
 	bool IsLoaded();
 	void Unload();
-	bool Reload(char *error, size_t maxlength);
 	bool IsExternal();
 	bool IsSameFile(const char *file);
 };
@@ -167,7 +159,6 @@ public: //IRootConsoleCommand
 	void OnRootConsoleCommand(const char *cmdname, const ICommandArgs *command) override;
 public:
 	IExtension *LoadAutoExtension(const char *path, bool bErrorOnMissing=true);
-	void BindDependency(IExtension *pOwner, IfaceInfo *pInfo);
 	void AddInterface(IExtension *pOwner, SMInterface *pInterface);
 	void BindChildPlugin(IExtension *pParent, SMPlugin *pPlugin);
 	void MarkAllLoaded();
@@ -177,7 +168,6 @@ public:
 	bool LibraryExists(const char *library);
 	void CallOnCoreMapStart(edict_t *pEdictList, int edictCount, int clientMax);
 	void CallOnCoreMapEnd();
-	void AddRawDependency(IExtension *ext, IdentityToken_t *other, void *iface);
 	const CVector<IExtension *> *ListExtensions();
 	void FreeExtensionList(const CVector<IExtension *> *list);
 public:
@@ -188,8 +178,6 @@ public:
 		CExtension *p = (CExtension *)pExt;
 		return p;
 	}
-private:
-	CExtension *FindByOrder(unsigned int num);
 private:
 	List<CExtension *> m_Libs;
 };

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -247,11 +247,6 @@ void ShareSystem::RegisterLibrary(IExtension *myself, const char *name)
 	g_Extensions.AddLibrary(myself, name);
 }
 
-void ShareSystem::OverrideNatives(IExtension *myself, const sp_nativeinfo_t *natives)
-{
-	assert(false);
-}
-
 RefPtr<Native> ShareSystem::FindNative(const char *name)
 {
 	NativeCache::Result r = m_NtvCache.find(name);

--- a/core/logic/ShareSys.cpp
+++ b/core/logic/ShareSys.cpp
@@ -167,7 +167,6 @@ bool ShareSystem::RequestInterface(const char *iface_name,
 {
 	/* See if the interface exists */
 	SMInterface *iface;
-	IExtension *iface_owner = nullptr;
 	bool found = false;
 	for (auto iter = m_Interfaces.begin(); iter!=m_Interfaces.end(); iter++)
 	{
@@ -177,7 +176,6 @@ bool ShareSystem::RequestInterface(const char *iface_name,
 		{
 			if (iface->GetInterfaceVersion() == iface_vers || iface->IsVersionCompatible(iface_vers))
 			{
-				iface_owner = info.owner;
 				found = true;
 				break;
 			}
@@ -187,15 +185,6 @@ bool ShareSystem::RequestInterface(const char *iface_name,
 	if (!found)
 	{
 		return false;
-	}
-
-	/* Add a dependency node */
-	if (iface_owner)
-	{
-		IfaceInfo info;
-		info.iface = iface;
-		info.owner = iface_owner;
-		g_Extensions.BindDependency(myself, &info);
 	}
 
 	if (pIface)

--- a/core/logic/ShareSys.h
+++ b/core/logic/ShareSys.h
@@ -98,7 +98,6 @@ public: //IShareSys
 	void DestroyIdentity(IdentityToken_t *identity);
 	void AddDependency(IExtension *myself, const char *filename, bool require, bool autoload);
 	void RegisterLibrary(IExtension *myself, const char *name);
-	void OverrideNatives(IExtension *myself, const sp_nativeinfo_t *natives);
 	void AddCapabilityProvider(IExtension *myself, IFeatureProvider *provider,
 		                       const char *name);
 	void DropCapabilityProvider(IExtension *myself, IFeatureProvider *provider,

--- a/extensions/clientprefs/extension.cpp
+++ b/extensions/clientprefs/extension.cpp
@@ -64,8 +64,6 @@ bool ClientPrefs::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	TQueryOp *op = new TQueryOp(Query_Connect, 0);
 	dbi->AddToThreadQueue(op, PrioQueue_High);
 
-	dbi->AddDependency(myself, Driver);
-
 	sharesys->AddNatives(myself, g_ClientPrefNatives);
 	sharesys->RegisterLibrary(myself, "clientprefs");
 	identity = sharesys->CreateIdentity(sharesys->CreateIdentType("ClientPrefs"), this);
@@ -160,22 +158,6 @@ void ClientPrefs::SDK_OnAllLoaded()
 	playerhelpers->AddClientListener(&g_CookieManager);
 }
 
-bool ClientPrefs::QueryInterfaceDrop(SMInterface *pInterface)
-{
-	if ((void *)pInterface == (void *)(Database->GetDriver()))
-	{
-		return false;
-	}
-
-	return true;
-}
-
-void ClientPrefs::NotifyInterfaceDrop(SMInterface *pInterface)
-{
-	if (Database && (void *)pInterface == (void *)(Database->GetDriver()))
-		Database = NULL;
-}
-
 void ClientPrefs::SDK_OnDependenciesDropped()
 {
 	// At this point, we're guaranteed that DBI has flushed the worker thread
@@ -234,7 +216,6 @@ void ClientPrefs::AttemptReconnection()
 	if (now < nextReconnectAttempt)
 		return;
 
-	IDBDriver *oldDriver = Driver;
 	char error[256];
 	if (!this->RefreshDatabaseInfo(error, sizeof(error)))
 	{
@@ -242,9 +223,6 @@ void ClientPrefs::AttemptReconnection()
 		nextReconnectAttempt = now + kReconnectRetryDelay;
 		return;
 	}
-
-	if (Driver != oldDriver)
-		dbi->AddDependency(myself, Driver);
 
 	g_pSM->LogMessage(myself, "Attempting to reconnect to database...");
 	databaseLoading = true;

--- a/extensions/clientprefs/extension.h
+++ b/extensions/clientprefs/extension.h
@@ -86,10 +86,6 @@ public:
 	 */
 	virtual void SDK_OnAllLoaded();
 
-	virtual bool QueryInterfaceDrop(SMInterface *pInterface);
-
-	virtual void NotifyInterfaceDrop(SMInterface *pInterface);
-
 	const char *GetExtensionVerString();
 	const char *GetExtensionDateString();
 

--- a/extensions/cstrike/extension.cpp
+++ b/extensions/cstrike/extension.cpp
@@ -202,21 +202,6 @@ bool CStrike::QueryRunning(char *error, size_t maxlength)
 	return true;
 }
 
-bool CStrike::QueryInterfaceDrop(SMInterface *pInterface)
-{
-	if (pInterface == g_pBinTools)
-	{
-		return false;
-	}
-
-	return IExtensionInterface::QueryInterfaceDrop(pInterface);
-}
-
-void CStrike::NotifyInterfaceDrop(SMInterface *pInterface)
-{
-	g_RegNatives.UnregisterAll();
-}
-
 size_t UTIL_Format(char *buffer, size_t maxlength, const char *fmt, ...)
 {
 	va_list ap;

--- a/extensions/cstrike/extension.h
+++ b/extensions/cstrike/extension.h
@@ -112,9 +112,6 @@ public:
 	 */
 	virtual bool QueryRunning(char *error, size_t maxlength);
 
-	void NotifyInterfaceDrop(SMInterface *pInterface);
-	bool QueryInterfaceDrop(SMInterface *pInterface);
-
 	const char *GetExtensionVerString();
 	const char *GetExtensionDateString();
 public:

--- a/extensions/dhooks/extension.cpp
+++ b/extensions/dhooks/extension.cpp
@@ -168,35 +168,10 @@ void DHooks::OnPluginUnloaded(IPlugin *plugin)
 		g_pEntityListener->CleanupListeners(plugin->GetBaseContext());
 	}
 }
-// The next 3 functions handle cleanup if our interfaces are going to be unloaded
 bool DHooks::QueryRunning(char *error, size_t maxlength)
 {
 	SM_CHECK_IFACE(SDKTOOLS, g_pSDKTools);
 	SM_CHECK_IFACE(BINTOOLS, g_pBinTools);
 	SM_CHECK_IFACE(SDKHOOKS, g_pSDKHooks);
 	return true;
-}
-void DHooks::NotifyInterfaceDrop(SMInterface *pInterface)
-{
-	if(strcmp(pInterface->GetInterfaceName(), SMINTERFACE_SDKHOOKS_NAME) == 0)
-	{
-		if(g_pEntityListener)
-		{
-			// If this fails, remove this line and just delete the ent listener instead
-			g_pSDKHooks->RemoveEntityListener(g_pEntityListener);
-
-			g_pEntityListener->CleanupListeners();
-			delete g_pEntityListener;
-			g_pEntityListener = NULL;
-		}
-		g_pSDKHooks = NULL;
-	}
-	else if(strcmp(pInterface->GetInterfaceName(), SMINTERFACE_BINTOOLS_NAME) == 0)
-	{
-		g_pBinTools = NULL;
-	}
-	else if(strcmp(pInterface->GetInterfaceName(), SMINTERFACE_SDKTOOLS_NAME) == 0)
-	{
-		g_pSDKTools = NULL;
-	}
 }

--- a/extensions/dhooks/extension.h
+++ b/extensions/dhooks/extension.h
@@ -91,8 +91,6 @@ public:
 	 * @return			True if working, false otherwise.
 	 */
 	virtual bool QueryRunning(char *error, size_t maxlength);
-	//virtual bool QueryInterfaceDrop(SMInterface *pInterface);
-	virtual void NotifyInterfaceDrop(SMInterface *pInterface);
 	virtual void OnCoreMapEnd();
 public:
 #if defined SMEXT_CONF_METAMOD

--- a/extensions/sdkhooks/extension.cpp
+++ b/extensions/sdkhooks/extension.cpp
@@ -336,16 +336,6 @@ bool SDKHooks::QueryRunning(char* error, size_t maxlength)
 	return true;
 }
 
-bool SDKHooks::QueryInterfaceDrop(SMInterface* pInterface)
-{
-	if (pInterface == g_pBinTools)
-	{
-		return false;
-	}
-
-	return IExtensionInterface::QueryInterfaceDrop(pInterface);
-}
-
 #define KILL_HOOK_IF_ACTIVE(hook) \
 	if (hook != 0) \
 	{ \

--- a/extensions/sdkhooks/extension.h
+++ b/extensions/sdkhooks/extension.h
@@ -195,8 +195,6 @@ public:
 	 */
 	virtual bool QueryRunning(char *error, size_t maxlength);
 
-	virtual bool QueryInterfaceDrop(SMInterface* pInterface);
-
 	/** Returns version string */
 	virtual const char *GetExtensionVerString();
 

--- a/extensions/sdktools/extension.cpp
+++ b/extensions/sdktools/extension.cpp
@@ -383,38 +383,6 @@ bool SDKTools::QueryRunning(char *error, size_t maxlength)
 	return true;
 }
 
-bool SDKTools::QueryInterfaceDrop(SMInterface *pInterface)
-{
-	if (pInterface == g_pBinTools)
-	{
-		return false;
-	}
-
-	return IExtensionInterface::QueryInterfaceDrop(pInterface);
-}
-
-void SDKTools::NotifyInterfaceDrop(SMInterface *pInterface)
-{
-	SourceHook::List<ValveCall *>::iterator iter;
-	for (iter = g_RegCalls.begin();
-		iter != g_RegCalls.end();
-		iter++)
-	{
-		delete (*iter);
-	}
-	g_RegCalls.clear();
-	ShutdownHelpers();
-
-	g_TEManager.Shutdown();
-	s_TempEntHooks.Shutdown();
-
-	if (g_pAcceptInput)
-	{
-		g_pAcceptInput->Destroy();
-		g_pAcceptInput = NULL;
-	}
-}
-
 bool SDKTools::RegisterConCommandBase(ConCommandBase *pVar)
 {
 	return g_SMAPI->RegisterConCommandBase(g_PLAPI, pVar);

--- a/extensions/sdktools/extension.h
+++ b/extensions/sdktools/extension.h
@@ -88,8 +88,6 @@ public: //public SDKExtension
 	virtual void SDK_OnAllLoaded();
 	//virtual void SDK_OnPauseChange(bool paused);
 	virtual bool QueryRunning(char *error, size_t maxlength);
-	virtual bool QueryInterfaceDrop(SMInterface *pInterface);
-	virtual void NotifyInterfaceDrop(SMInterface *pInterface);
 	virtual void OnCoreMapStart(edict_t *pEdictList, int edictCount, int clientMax);
 	const char *GetExtensionVerString();
 	const char *GetExtensionDateString();

--- a/extensions/tf2/extension.cpp
+++ b/extensions/tf2/extension.cpp
@@ -240,31 +240,6 @@ bool TF2Tools::QueryRunning(char *error, size_t maxlength)
 	return true;
 }
 
-bool TF2Tools::QueryInterfaceDrop(SMInterface *pInterface)
-{
-	if (pInterface == g_pBinTools)
-	{
-		return false;
-	}
-
-	if (pInterface == g_pSDKHooks)
-	{
-		return false;
-	}
-
-	if (pInterface == g_pSDKTools)
-	{
-		g_pSDKTools = NULL;
-	}
-
-	return IExtensionInterface::QueryInterfaceDrop(pInterface);
-}
-
-void TF2Tools::NotifyInterfaceDrop(SMInterface *pInterface)
-{
-	g_RegNatives.UnregisterAll();
-}
-
 void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
 {
 	g_resourceEntity = FindResourceEntity();

--- a/extensions/tf2/extension.h
+++ b/extensions/tf2/extension.h
@@ -88,9 +88,6 @@ public: //SDKExtension
 	 */
 	virtual bool QueryRunning(char *error, size_t maxlength);
 
-	void NotifyInterfaceDrop(SMInterface *pInterface);
-	bool QueryInterfaceDrop(SMInterface *pInterface);
-
 	const char *GetExtensionVerString();
 	const char *GetExtensionDateString();
 public: //ICommandTargetProcessor

--- a/extensions/updater/extension.cpp
+++ b/extensions/updater/extension.cpp
@@ -80,9 +80,6 @@ bool SmUpdater::SDK_OnLoad(char *error, size_t maxlength, bool late)
 
 void SmUpdater::SDK_OnUnload()
 {
-	/* An interface drop might have killed this thread.  
-	 * But if the handle is still there, we have to wait.
-	 */
 	if (update_thread != NULL)
 	{
 		update_thread->WaitForThread();
@@ -94,27 +91,6 @@ void SmUpdater::SDK_OnUnload()
 	while (iter != update_errors.end())
 	{
 		iter = update_errors.erase(iter);
-	}
-}
-
-bool SmUpdater::QueryInterfaceDrop(SourceMod::SMInterface *pInterface)
-{
-	if (pInterface == webternet)
-	{
-		return false;
-	}
-
-	return true;
-}
-
-void SmUpdater::NotifyInterfaceDrop(SMInterface *pInterface)
-{
-	if (pInterface == webternet)
-	{
-		/* Can't be in the thread if we're losing this extension. */
-		update_thread->WaitForThread();
-		update_thread->DestroyThis();
-		update_thread = NULL;
 	}
 }
 

--- a/extensions/updater/extension.h
+++ b/extensions/updater/extension.h
@@ -52,8 +52,6 @@ public: /* SDKExtension */
 	bool SDK_OnLoad(char *error, size_t maxlength, bool late);
 	void SDK_OnUnload();
 public: /* IExtension */
-	bool QueryInterfaceDrop(SMInterface *pInterface);
-	void NotifyInterfaceDrop(SMInterface *pInterface);
 	const char *GetExtensionVerString();
 	const char *GetExtensionDateString();
 public: /* IThread */

--- a/public/IDBDriver.h
+++ b/public/IDBDriver.h
@@ -42,7 +42,7 @@
  */
 
 #define SMINTERFACE_DBI_NAME		"IDBI"
-#define SMINTERFACE_DBI_VERSION		10
+#define SMINTERFACE_DBI_VERSION		11
 
 namespace SourceMod
 {
@@ -921,14 +921,6 @@ namespace SourceMod
 		 * @return				True on success, false on failure.
 		 */
 		virtual bool AddToThreadQueue(IDBThreadOperation *op, PrioQueueLevel prio) =0;
-
-		/**
-		 * @brief Deprecated, does nothing.
-		 *
-		 * @param myself		Unused.
-		 * @param driver		Unused.
-		 */
-		virtual void AddDependency(IExtension *myself, IDBDriver *driver) =0;
 	};
 }
 

--- a/public/IDBDriver.h
+++ b/public/IDBDriver.h
@@ -923,10 +923,10 @@ namespace SourceMod
 		virtual bool AddToThreadQueue(IDBThreadOperation *op, PrioQueueLevel prio) =0;
 
 		/**
-		 * @brief Adds a dependency from one extension to the owner of a driver.
-		 * 
-		 * @param myself		Extension that is using the IDBDriver.
-		 * @param driver		Driver that is being used.
+		 * @brief Deprecated, does nothing.
+		 *
+		 * @param myself		Unused.
+		 * @param driver		Unused.
 		 */
 		virtual void AddDependency(IExtension *myself, IDBDriver *driver) =0;
 	};

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -49,7 +49,6 @@ struct edict_t;
 namespace SourceMod
 {
 	class IExtensionInterface;
-	typedef void *		ITERATOR;		/**< Generic pointer for dependency iterators */
 
 	/** 
 	 * @brief Encapsulates an IExtensionInterface.
@@ -87,32 +86,6 @@ namespace SourceMod
 		virtual IdentityToken_t *GetIdentity() =0;
 
 		/**
-		 * @brief Deprecated, do not use.
-		 *
-		 * @param pOwner        Unused
-		 * @param pInterface    Unused
-		 * @return              nullptr
-		 */
-		virtual ITERATOR *FindFirstDependency(IExtension **pOwner, SMInterface **pInterface) =0;
-
-		/**
-		 * @brief Deprecated, do not use.
-		 *
-		 * @param iter          Unused
-		 * @param pOwner        Unused
-		 * @param pInterface    Unused
-		 * @return              false
-		 */
-		virtual bool FindNextDependency(ITERATOR *iter, IExtension **pOwner, SMInterface **pInterface) =0;
-
-		/**
-		 * @brief Deprecated, do not use.
-		 *
-		 * @param iter          Unused
-		 */
-		virtual void FreeDependencyIterator(ITERATOR *iter) =0;
-
-		/**
 		 * @brief Queries the extension to see its run state.
 		 *
 		 * @param error			Error buffer (may be NULL).
@@ -142,7 +115,7 @@ namespace SourceMod
 	 * V8 - added OnCoreMapEnd() to IExtensionInterface.
 	 * V9 - SourcePawn API revamp
 	 * V10 - SourcePawn 2 API.
-	 * V11 - removed UnloadExtension() from IExtensionManager.
+	 * V11 - removed deprecated unload, dependency, and native override APIs.
 	 */
 	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	11
 	#define SMINTERFACE_EXTENSIONAPI_VERSION		11
@@ -193,28 +166,6 @@ namespace SourceMod
 		 * @param pause		True if pausing, false if unpausing.
 		 */
 		virtual void OnExtensionPauseChange(bool pause) =0;
-
-		/**
-		 * @brief Deprecated, never called.  Clean up in OnExtensionUnload()
-		 * or OnDependenciesDropped() instead.
-		 *
-		 * @param pInterface		Unused.
-		 * @return					false
-		 */
-		virtual bool QueryInterfaceDrop(SMInterface *pInterface)
-		{
-			return false;
-		}
-
-		/**
-		 * @brief Deprecated, never called.  Clean up in OnExtensionUnload()
-		 * or OnDependenciesDropped() instead.
-		 *
-		 * @param pInterface		Unused.
-		 */
-		virtual void NotifyInterfaceDrop(SMInterface *pInterface)
-		{
-		}
 
 		/**
 		 * @brief Return false to tell Core that your extension should be considered unusable.

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -38,7 +38,10 @@
 
 /**
  * @file IExtensionSys.h
- * @brief Defines the interface for loading/unloading/managing extensions.
+ * @brief Defines the interface for loading and managing extensions.
+ *
+ * Extensions are loaded for the lifetime of SourceMod; they are only ever
+ * unloaded when SourceMod itself shuts down.
  */
 
 struct edict_t;
@@ -172,7 +175,8 @@ namespace SourceMod
 			bool late) =0;
 
 		/**
-		 * @brief Called when the extension is about to be unloaded.
+		 * @brief Called when the extension is about to be unloaded, during
+		 * SourceMod shutdown.
 		 */
 		virtual void OnExtensionUnload() =0;
 
@@ -190,20 +194,11 @@ namespace SourceMod
 		virtual void OnExtensionPauseChange(bool pause) =0;
 
 		/**
-		 * @brief Asks the extension whether it's safe to remove an external 
-		 * interface it's using.  If it's not safe, return false, and the 
-		 * extension will be unloaded afterwards.
+		 * @brief Deprecated, never called.  Clean up in OnExtensionUnload()
+		 * or OnDependenciesDropped() instead.
 		 *
-		 * NOTE: It is important to also hook NotifyInterfaceDrop() in order to clean 
-		 * up resources.
-		 *
-		 * @param pInterface		Pointer to interface being dropped.  This 
-		 * 							pointer may be opaque, and it should not 
-		 *							be queried using SMInterface functions unless 
-		 *							it can be verified to match an existing 
-		 *							pointer of known type.
-		 * @return					True to continue, false to unload this 
-		 * 							extension afterwards.
+		 * @param pInterface		Unused.
+		 * @return					false
 		 */
 		virtual bool QueryInterfaceDrop(SMInterface *pInterface)
 		{
@@ -211,12 +206,10 @@ namespace SourceMod
 		}
 
 		/**
-		 * @brief Notifies the extension that an external interface it uses is being removed.
+		 * @brief Deprecated, never called.  Clean up in OnExtensionUnload()
+		 * or OnDependenciesDropped() instead.
 		 *
-		 * @param pInterface		Pointer to interface being dropped.  This
-		 * 							pointer may be opaque, and it should not 
-		 *							be queried using SMInterface functions unless 
-		 *							it can be verified to match an existing 
+		 * @param pInterface		Unused.
 		 */
 		virtual void NotifyInterfaceDrop(SMInterface *pInterface)
 		{
@@ -321,11 +314,11 @@ namespace SourceMod
 		}
 
 		/**
-		 * @brief Called once all dependencies have been unloaded. This is
-		 * called AFTER OnExtensionUnload(), but before the extension library
-		 * has been unloaded. It can be used as an alternate unload hook for
-		 * cases where having no dependent plugins would make shutdown much
-		 * simplier.
+		 * @brief Called once all dependencies have been dropped during
+		 * shutdown. This is called AFTER OnExtensionUnload(), but before the
+		 * extension library has been unloaded. It can be used as an alternate
+		 * unload hook for cases where having no dependent plugins would make
+		 * shutdown much simplier.
 		 */
 		virtual void OnDependenciesDropped()
 		{
@@ -431,11 +424,11 @@ namespace SourceMod
 			size_t maxlength) =0;
 
 		/**
-		 * @brief Attempts to unload an extension.  External extensions must 
-		 * call this before unloading.
+		 * @brief Deprecated, always fails.  An external extension must refuse
+		 * to be unloaded once it has loaded.
 		 *
-		 * @param pExt			IExtension pointer.
-		 * @return				True if successful, false otherwise.
+		 * @param pExt			Unused.
+		 * @return				false
 		 */
 		virtual bool UnloadExtension(IExtension *pExt) =0;
 	};

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -52,7 +52,7 @@ namespace SourceMod
 	typedef void *		ITERATOR;		/**< Generic pointer for dependency iterators */
 
 	/** 
-	 * @brief Encapsulates an IExtensionInterface and its dependencies.
+	 * @brief Encapsulates an IExtensionInterface.
 	 */
 	class IExtension
 	{
@@ -142,9 +142,10 @@ namespace SourceMod
 	 * V8 - added OnCoreMapEnd() to IExtensionInterface.
 	 * V9 - SourcePawn API revamp
 	 * V10 - SourcePawn 2 API.
+	 * V11 - removed UnloadExtension() from IExtensionManager.
 	 */
-	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	10
-	#define SMINTERFACE_EXTENSIONAPI_VERSION		10
+	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	11
+	#define SMINTERFACE_EXTENSIONAPI_VERSION		11
 
 	/**
 	 * @brief The interface an extension must expose.
@@ -353,10 +354,10 @@ namespace SourceMod
 	#define SOURCEMOD_NOTICE_EXTENSIONS					"SM_ExtensionsAttachable"
 
 	#define SMINTERFACE_EXTENSIONMANAGER_NAME			"IExtensionManager"
-	#define SMINTERFACE_EXTENSIONMANAGER_VERSION		2
+	#define SMINTERFACE_EXTENSIONMANAGER_VERSION		3
 
 	/**
-	 * @brief Manages the loading/unloading of extensions.
+	 * @brief Manages the loading of extensions.
 	 */
 	class IExtensionManager : public SMInterface
 	{
@@ -371,7 +372,7 @@ namespace SourceMod
 		}
 		virtual bool IsVersionCompatible(unsigned int version)
 		{
-			if (version < 2)
+			if (version < 3)
 			{
 				return false;
 			}
@@ -422,15 +423,6 @@ namespace SourceMod
 			const char *filename,
 			char *error,
 			size_t maxlength) =0;
-
-		/**
-		 * @brief Deprecated, always fails.  An external extension must refuse
-		 * to be unloaded once it has loaded.
-		 *
-		 * @param pExt			Unused.
-		 * @return				false
-		 */
-		virtual bool UnloadExtension(IExtension *pExt) =0;
 	};
 
 	#define SM_IFACEPAIR(name) SMINTERFACE_##name##_NAME, SMINTERFACE_##name##_VERSION

--- a/public/IShareSys.h
+++ b/public/IShareSys.h
@@ -233,14 +233,6 @@ namespace SourceMod
 		virtual void RegisterLibrary(IExtension *myself, const char *name) =0;
 
 		/**
-		 * @brief Deprecated. Does nothing.
-		 *
-		 * @param myself        Ignored.
-		 * @param natives       Ignored.
-		 */
-		virtual void OverrideNatives(IExtension *myself, const sp_nativeinfo_t *natives) =0;
-
-		/**
 		 * @brief Adds a capability provider. Feature providers are used by
 		 * plugins to determine if a feature exists at runtime. This is
 		 * distinctly different from checking for a native, because natives

--- a/public/IShareSys.h
+++ b/public/IShareSys.h
@@ -121,7 +121,7 @@ namespace SourceMod
 	};
 
 	/**
-	 * @brief Tracks dependencies and fires dependency listeners.
+	 * @brief Tracks dependencies.
 	 */
 	class IShareSys
 	{
@@ -129,7 +129,7 @@ namespace SourceMod
 		/**
 		 * @brief Adds an interface to the global interface system.
 		 *
-		 * @param myself		Object adding this interface, in order to track dependencies.
+		 * @param myself		Object adding this interface, in order to track ownership.
 		 * @param iface			Interface pointer (must be unique).
 		 * @return				True on success, false otherwise.
 		 */
@@ -137,11 +137,10 @@ namespace SourceMod
 
 		/**
 		 * @brief Requests an interface from the global interface system.
-		 * If found, the interface's internal reference count will be increased.
 		 *
 		 * @param iface_name	Interface name.
 		 * @param iface_vers	Interface version to attempt to match.
-		 * @param myself		Object requesting this interface, in order to track dependencies.
+		 * @param myself		Unused.
 		 * @param pIface		Pointer to store the return value in.
 		 */
 		virtual bool RequestInterface(const char *iface_name, 

--- a/public/mms_sample_ext/sm_ext.cpp
+++ b/public/mms_sample_ext/sm_ext.cpp
@@ -77,11 +77,6 @@ bool SM_LoadExtension(char *error, size_t maxlength)
 	return true;
 }
 
-void SM_UnloadExtension()
-{
-	smexts->UnloadExtension(myself);	
-}
-
 bool MyExtension::OnExtensionLoad(IExtension *me,
 		IShareSys *sys, 
 		char *error, 

--- a/public/mms_sample_ext/sm_ext.h
+++ b/public/mms_sample_ext/sm_ext.h
@@ -59,7 +59,6 @@ public:
 };
 
 bool SM_LoadExtension(char *error, size_t maxlength);
-void SM_UnloadExtension();
 
 extern IShareSys *sharesys;
 extern IExtension *myself;

--- a/public/mms_sample_ext/stub_mm.cpp
+++ b/public/mms_sample_ext/stub_mm.cpp
@@ -48,7 +48,15 @@ bool StubPlugin::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bo
 
 bool StubPlugin::Unload(char *error, size_t maxlen)
 {
-	SM_UnloadExtension();
+	/* SourceMod does not support unloading extensions, so we cannot detach. */
+	if (myself != NULL)
+	{
+		if (error && maxlen)
+		{
+			UTIL_Format(error, maxlen, "This plugin cannot be unloaded while attached to SourceMod");
+		}
+		return false;
+	}
 
 	SH_REMOVE_HOOK(IServerGameDLL, ServerActivate, server, SH_STATIC(Hook_ServerActivate), true);
 


### PR DESCRIPTION
There are outstanding issues relating to extension loading / reloading. The feature is trivialized by `meta reload` - which is perfectly fine for iterating in development. 

Existing extensions will need to be recompiled. Might be a good time for it considering recent V10 version. We can't simply stub everything out like I thought previously since third party plugins copied from our example would disregard `UnloadExtension()`'s return value. Leading to CExtension holding a dangling m_pAPI

AI Disclosure: Used an LLM to workshop, help find references in code, as well as update any documentation that needed changing.