### PR TITLE
Update SourcePawn.

### DIFF
--- a/core/logic/ExtensionSys.cpp
+++ b/core/logic/ExtensionSys.cpp
@@ -284,6 +284,11 @@ bool CExtension::PerformAPICheck(char *error, size_t maxlength)
 		return false;
 	}
 
+	if (m_pAPI->GetExtensionVersion() == 10) {
+		ke::SafeSprintf(error, maxlength, "Extension version %d is not supported", m_pAPI->GetExtensionVersion());
+		return false;
+	}
+
 	if (m_pAPI->GetExtensionVersion() < SMINTERFACE_EXTENSIONAPI_VERSION_MIN) {
 		ke::SafeSprintf(error, maxlength, "Extension version is too old to load (%d, max is %d)", m_pAPI->GetExtensionVersion(), SMINTERFACE_EXTENSIONAPI_VERSION_MIN);
 		return false;

--- a/public/IExtensionSys.h
+++ b/public/IExtensionSys.h
@@ -140,8 +140,8 @@ namespace SourceMod
 	 * V9 - SourcePawn API revamp
 	 * V10 - SourcePawn 2 API.
 	 */
-	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	10
-	#define SMINTERFACE_EXTENSIONAPI_VERSION		10
+	#define SMINTERFACE_EXTENSIONAPI_VERSION_MIN	9
+	#define SMINTERFACE_EXTENSIONAPI_VERSION		11
 
 	/**
 	 * @brief The interface an extension must expose.


### PR DESCRIPTION
This brings in some compiler fixes and the new ".size" property for arrays.

The extension loader will also now once again accept version 9 extensions. Version 10 has been blacklisted. The IPluginContext API has been restored to be compatible with v9.